### PR TITLE
Fix pagination overflow issue

### DIFF
--- a/src/pages/pools/components/AllPools/AllPoolsPagination.tsx
+++ b/src/pages/pools/components/AllPools/AllPoolsPagination.tsx
@@ -13,69 +13,58 @@ export function AllPoolsPagination({ page: propPage, numberOfPools }: Props) {
 	const history = useHistory();
 
 	const numPages = Math.ceil((numberOfPools || 1) / PoolsPerPage);
-
-	const pageRender = [];
-
-	for (let i = 0; i < numPages; i++) {
-		const page = i + 1;
-
-		pageRender.push(
-			<LinkStyled key={page.toString()} to={`/pools?page=${page}`} index={page} page={propPage}>
-				<p>{page}</p>
-			</LinkStyled>
-		);
-	}
+	const pageRender = `${propPage} / ${numPages}`;
 
 	const isFirstPage = propPage <= 1;
 	const isLastPage = propPage >= numPages;
 
 	return (
 		<PaginationContainer>
-			{!isFirstPage ? (
-				<ButtonArrow
-					type="button"
-					onClick={e => {
+			<ButtonArrow
+				type="button"
+				onClick={e => {
+					if (!isFirstPage) {
 						e.preventDefault();
 						history.push(`/pools?page=${propPage - 1}`);
-					}}>
-					<svg
-						xmlns="http://www.w3.org/2000/svg"
-						width="28"
-						height="28"
-						fill="none"
-						viewBox="0 0 24 24"
-						transform="rotate(180) translate(-4, 0)">
+					}
+				}}>
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					width="28"
+					height="28"
+					fill="none"
+					viewBox="0 0 24 24"
+					transform="rotate(180) translate(-4, 0)">
+					<g>
 						<g>
-							<g>
-								<path
-									style={{ fill: 'currentcolor' }}
-									d="M9.759 7c.196 0 .391.072.54.214l4.437 4.18a.823.823 0 010 1.21l-4.433 4.184a.798.798 0 01-1.169-.094c-.222-.293-.157-.702.115-.96L13.206 12 9.253 8.267c-.288-.272-.341-.72-.077-1.014A.78.78 0 019.76 7z"
-								/>
-							</g>
+							<path
+								style={{ fill: 'currentcolor', fillOpacity: isFirstPage ? 0.5 : 1 }}
+								d="M9.759 7c.196 0 .391.072.54.214l4.437 4.18a.823.823 0 010 1.21l-4.433 4.184a.798.798 0 01-1.169-.094c-.222-.293-.157-.702.115-.96L13.206 12 9.253 8.267c-.288-.272-.341-.72-.077-1.014A.78.78 0 019.76 7z"
+							/>
 						</g>
-					</svg>
-				</ButtonArrow>
-			) : null}
-			{pageRender}
-			{!isLastPage ? (
-				<ButtonArrow
-					type="button"
-					onClick={e => {
+					</g>
+				</svg>
+			</ButtonArrow>
+			<PageCounts>{pageRender}</PageCounts>
+			<ButtonArrow
+				type="button"
+				onClick={e => {
+					if (!isLastPage) {
 						e.preventDefault();
 						history.push(`/pools?page=${propPage + 1}`);
-					}}>
-					<svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" fill="none" viewBox="0 0 24 24">
+					}
+				}}>
+				<svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" fill="none" viewBox="0 0 24 24">
+					<g>
 						<g>
-							<g>
-								<path
-									style={{ fill: 'currentcolor' }}
-									d="M9.759 7c.196 0 .391.072.54.214l4.437 4.18a.823.823 0 010 1.21l-4.433 4.184a.798.798 0 01-1.169-.094c-.222-.293-.157-.702.115-.96L13.206 12 9.253 8.267c-.288-.272-.341-.72-.077-1.014A.78.78 0 019.76 7z"
-								/>
-							</g>
+							<path
+								style={{ fill: 'currentcolor', fillOpacity: isLastPage ? 0.5 : 1 }}
+								d="M9.759 7c.196 0 .391.072.54.214l4.437 4.18a.823.823 0 010 1.21l-4.433 4.184a.798.798 0 01-1.169-.094c-.222-.293-.157-.702.115-.96L13.206 12 9.253 8.267c-.288-.272-.341-.72-.077-1.014A.78.78 0 019.76 7z"
+							/>
 						</g>
-					</svg>
-				</ButtonArrow>
-			) : null}
+					</g>
+				</svg>
+			</ButtonArrow>
 		</PaginationContainer>
 	);
 }
@@ -87,19 +76,14 @@ const ButtonArrow = styled.button`
 	height: 2.25rem;
 `;
 
-const PaginationContainer = styled(Center)`
-	width: 100%;
-	padding: 16px;
+const PageCounts = styled.div`
+	align-self: center;
+	padding: 5px;
 `;
 
-const LinkStyled = styled(Link)<{ index: number; page: number }>`
+const PaginationContainer = styled.div`
 	display: flex;
-	align-items: center;
-	border-radius: 0.375rem;
-	height: 2.25rem;
-	padding-left: 12px;
-	padding-right: 12px;
-	font-size: 14px;
-	color: rgba(196, 164, 106, 1);
-	${({ index, page }) => (index === page ? { borderWidth: '1px', borderColor: 'rgba(196, 164, 106, 1)' } : null)}
+	width: 100%;
+	justify-content: center;
+	padding: 5px;
 `;


### PR DESCRIPTION
## Problem
When toggling the 'Show pools less than $1,000 TVL' checkbox, the large number of pages would cause the list of page selectors to overflow off the page in a distracting way.

**Before**
<img width="1452" alt="Screen Shot 2021-10-10 at 12 52 25 PM" src="https://user-images.githubusercontent.com/4606373/136861361-0599da52-fee2-4187-b342-f0044e097c6c.png">

## Solution
I decided the simplest solution would be to emulate the pagination seen on the token tables on [osmosis info](https://info.osmosis.zone/), by using a fractional with next page buttons.

Pros
* Never have to worry about overflow of any kind
* Simple, requires less code

Cons
* Cant jump to specific page (except via the URL)

**After**
<img width="1525" alt="Screen Shot 2021-10-11 at 5 10 13 PM" src="https://user-images.githubusercontent.com/4606373/136861427-5c7f3f53-9350-4f66-b92f-8ef6c1465c0e.png">


