### PR TITLE
Fix transaction url for some explorers

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -653,7 +653,7 @@ export const EmbedChainInfos: ChainInfoWithExplorer[] = [
 			high: 1,
 		},
 		features: ['stargate', 'ibc-transfer'],
-		explorerUrlToTx: 'https://emoney.bigdipper.live/transactions/${txHash}',
+		explorerUrlToTx: 'https://emoney.bigdipper.live/transactions/{txHash}',
 	},
 	{
 		rpc: 'https://rpc-juno.itastakers.com',
@@ -727,7 +727,7 @@ export const EmbedChainInfos: ChainInfoWithExplorer[] = [
 			},
 		],
 		features: ['stargate', 'ibc-transfer'],
-		explorerUrlToTx: 'https://explorer.microtick.zone/transactions/${txHash}',
+		explorerUrlToTx: 'https://explorer.microtick.zone/transactions/{txHash}',
 	},
 	{
 		rpc: 'https://mainnet-node.like.co/rpc',
@@ -764,7 +764,7 @@ export const EmbedChainInfos: ChainInfoWithExplorer[] = [
 			},
 		],
 		features: ['stargate', 'ibc-transfer'],
-		explorerUrlToTx: 'https://likecoin.bigdipper.live/transactions/${txHash}',
+		explorerUrlToTx: 'https://likecoin.bigdipper.live/transactions/{txHash}',
 	},
 	{
 		rpc: 'https://rpc-impacthub.keplr.app',
@@ -801,7 +801,7 @@ export const EmbedChainInfos: ChainInfoWithExplorer[] = [
 			},
 		],
 		features: ['stargate', 'ibc-transfer'],
-		explorerUrlToTx: 'https://blockscan.ixo.world/transactions/${txHash}',
+		explorerUrlToTx: 'https://blockscan.ixo.world/transactions/{txHash}',
 	},
 	{
 		rpc: 'https://rpc-columbus.keplr.app',


### PR DESCRIPTION
Few explorers (namely terra, emoney, tick, like, ixo) have broken confirmation explorer urls. Needless dollar sign is used to reference `txHash` value.

Cleaned it up.

Broken URL example: https://finder.terra.money/columbus-5/tx/$9430DD419C0BCC9EC9B199A19A7931E631E63F5A0D62F1E05F8CBEF0E25E3DCF

Valid URL: https://finder.terra.money/columbus-5/tx/9430DD419C0BCC9EC9B199A19A7931E631E63F5A0D62F1E05F8CBEF0E25E3DCF