### PR TITLE
Issue #61: Show pool composition in pool detail header

### DIFF
--- a/src/components/common/DisplayLeftTime.tsx
+++ b/src/components/common/DisplayLeftTime.tsx
@@ -3,15 +3,14 @@ import React, { FunctionComponent } from 'react';
 export const DisplayLeftTime: FunctionComponent<IDisplayLeftTime> = ({ day, hour, minute }) => {
 	return (
 		<h4 className="text-xl md:text-2xl flex items-center">
-			{
-				day &&
-				<>{day}
+			{day && (
+				<>
+					{day}
 					<div className="inline-block py-1 px-2 md:px-3 h-full rounded-lg bg-card mx-1">
 						<h5 className="text-lg md:text-xl">D</h5>
 					</div>
 				</>
-			}
-
+			)}
 			{hour}
 			<div className="inline-block py-1 px-2 md:px-3 h-full rounded-lg bg-card mx-1">
 				<h5 className="text-lg md:text-xl">H</h5>

--- a/src/pages/pool/components/PoolInfoHeader/index.tsx
+++ b/src/pages/pool/components/PoolInfoHeader/index.tsx
@@ -10,6 +10,7 @@ import { PoolSwapDialog } from 'src/pages/pool/components/PoolInfoHeader/PoolSwa
 import { colorPrimary } from 'src/emotionStyles/colors';
 import styled from '@emotion/styled';
 import useWindowSize from 'src/hooks/useWindowSize';
+import { useStore } from 'src/stores';
 
 interface Props {
 	poolId: string;
@@ -19,6 +20,17 @@ export const PoolInfoHeader = observer(function PoolInfoHeader({ poolId }: Props
 	const [isDialogOpen, setIsDialogOpen] = useState(false);
 	const [isSwapDialogOpen, setIsSwapDialogOpen] = useState(false);
 	const { isMobileView } = useWindowSize();
+	const { chainStore, queriesStore } = useStore();
+	const queries = queriesStore.get(chainStore.current.chainId);
+	const pool = queries.osmosis.queryGammPools.getPool(poolId);
+
+	const composition = pool?.poolRatios.reduce((str, poolRatio, i, poolRatios) => {
+		if (i === 0 || i === poolRatios.length) {
+			return `${str} ${poolRatio.amount.currency.coinDenom}`;
+		} else {
+			return `${str} / ${poolRatio.amount.currency.coinDenom}`;
+		}
+	}, ': ');
 
 	return (
 		<section>
@@ -37,7 +49,9 @@ export const PoolInfoHeader = observer(function PoolInfoHeader({ poolId }: Props
 
 			<PoolHeader>
 				<div className="mb-2.5 md:mb-0 md:mr-6">
-					<h5>Pool #{poolId}</h5>
+					<h5>
+						Pool #{poolId} {composition}
+					</h5>
 				</div>
 				<div className="flex mb-2.5 md:mb-0">
 					{!HideAddLiquidityPoolIds[poolId] && (

--- a/src/pages/pool/components/PoolInfoHeader/index.tsx
+++ b/src/pages/pool/components/PoolInfoHeader/index.tsx
@@ -24,11 +24,16 @@ export const PoolInfoHeader = observer(function PoolInfoHeader({ poolId }: Props
 	const queries = queriesStore.get(chainStore.current.chainId);
 	const pool = queries.osmosis.queryGammPools.getPool(poolId);
 
-	const composition = pool?.poolRatios.reduce((str, poolRatio, i, poolRatios) => {
-		if (i === 0 || i === poolRatios.length) {
-			return `${str} ${poolRatio.amount.currency.coinDenom}`;
+	const composition = pool?.poolAssets.reduce((str, poolAsset, i) => {
+		let denom = poolAsset.amount.currency.coinDenom;
+		if (denom.length >= 7) {
+			denom = denom.slice(0, 7) + '...';
+		}
+
+		if (i === 0) {
+			return `${str} ${denom}`;
 		} else {
-			return `${str} / ${poolRatio.amount.currency.coinDenom}`;
+			return `${str} / ${denom}`;
 		}
 	}, ': ');
 


### PR DESCRIPTION
This seems like a decent way to show an arbitrary number of denominations for a pool.

LMK what you think, we were thinking of using a '-' instead of a ':'.

<img width="886" alt="Screen Shot 2021-11-10 at 8 26 43 PM" src="https://user-images.githubusercontent.com/4606373/141232364-6186a7c0-7367-4ec5-90da-b15656ad7402.png">

Fixes #61 