### PR TITLE
Only allow token select drop down with > 1 token

### DIFF
--- a/src/components/SwapToken/TokenSelect/index.tsx
+++ b/src/components/SwapToken/TokenSelect/index.tsx
@@ -55,6 +55,7 @@ export function TokenSelect({
 	);
 
 	const { isMobileView } = useWindowSize();
+	const isSingleToken = options.length === 1;
 
 	return (
 		<TokenSelectContainer {...props}>
@@ -67,16 +68,20 @@ export function TokenSelect({
 					{channelShown && <ChannelText isMobileView={isMobileView} currency={value} />}
 				</div>
 
-				<DownArrowImg onClick={handleDropdownArrowClicked} isActive={options.length === 0 ? false : isDropdownOpen} />
+				{!isSingleToken && (
+					<DownArrowImg onClick={handleDropdownArrowClicked} isActive={options.length === 0 ? false : isDropdownOpen} />
+				)}
 			</CenterV>
 
-			<TokenSelectList
-				style={{ ...dropdownStyle, display: !isDropdownOpen ? 'none' : undefined }}
-				className={dropdownClassName}
-				currencies={options}
-				shouldScrollIntoView={isDropdownOpen}
-				onSelect={handleTokenSelected}
-			/>
+			{!isSingleToken && (
+				<TokenSelectList
+					style={{ ...dropdownStyle, display: !isDropdownOpen ? 'none' : undefined }}
+					className={dropdownClassName}
+					currencies={options}
+					shouldScrollIntoView={isDropdownOpen}
+					onSelect={handleTokenSelected}
+				/>
+			)}
 		</TokenSelectContainer>
 	);
 }

--- a/src/components/SwapToken/TokenSelect/index.tsx
+++ b/src/components/SwapToken/TokenSelect/index.tsx
@@ -77,7 +77,7 @@ export function TokenSelect({
 				<TokenSelectList
 					style={{ ...dropdownStyle, display: !isDropdownOpen ? 'none' : undefined }}
 					className={dropdownClassName}
-					currencies={options}
+					currencies={options.filter(currency => currency.coinDenom !== value.coinDenom)}
 					shouldScrollIntoView={isDropdownOpen}
 					onSelect={handleTokenSelected}
 				/>


### PR DESCRIPTION
## Problem
It seems strange to be able to select from only one available token that is also one that is already selected.

<img width="560" alt="Screen Shot 2021-12-11 at 5 12 57 PM" src="https://user-images.githubusercontent.com/4606373/145694446-555cf207-85f1-4030-af08-a330f66ddc2d.png">

## Solution
In LBP scenarios and from pool detail view, it is cleaner to not allow the empty token select dropdown to be used in the swap clipboard.

<img width="557" alt="Screen Shot 2021-12-11 at 4 55 27 PM" src="https://user-images.githubusercontent.com/4606373/145694174-43a9072f-d950-418b-8c4e-97941f504f1a.png">

Additionally, I've removed the already selected token from the dropdown list. 