### PR TITLE
Bump lock tokens gas due to Boron chain upgrade

### DIFF
--- a/src/stores/osmosis/account/index.ts
+++ b/src/stores/osmosis/account/index.ts
@@ -70,7 +70,7 @@ export class AccountWithCosmosAndOsmosis
 		},
 		lockTokens: {
 			type: 'osmosis/lockup/lock-tokens',
-			gas: 140000,
+			gas: 400000,
 		},
 		beginUnlocking: {
 			type: 'osmosis/lockup/begin-unlock-period-lock',


### PR DESCRIPTION
The upgrade did a patch to create fewer locks. However there was a regression in gas amounts for folks who already have many locks pre-upgrade. We didn't catch this, really sorry :/

(We wrote a test for testing this ... just we tested the Keeper LockTokens function, not the `LockTokens` message. Hence we missed this)

Testing on mainnet, I get ~130k gas needed, so 400k should be more than enough for people with way too high gas params