### PR TITLE
Enable operations for Lum Network

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -578,7 +578,6 @@ export const IBCAssetInfos: {
 		sourceChannelId: 'channel-115',
 		destChannelId: 'channel-3',
 		coinMinimalDenom: 'ulum',
-		isUnstable: true, // Until Dec. 24 17:00 UTC
 	},
 ];
 


### PR DESCRIPTION
This simple PR only intends to enables back the IBC operations for Lum Network, which is now operational after client update proposal.