### PR TITLE
update stargaze endpoints

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1594,8 +1594,8 @@ export const EmbedChainInfos: ChainInfoWithExplorer[] = [
 		explorerUrlToTx: 'https://cheqd.didx.co.za/transactions/{txHash}',
 	},
 	{
-		rpc: 'https://rpc.stargaze.publicawesome.dev',
-		rest: 'https://rest.stargaze.publicawesome.dev',
+		rpc: 'https://rpc.stargaze-apis.com',
+		rest: 'https://rest.stargaze-apis.com',
 		chainId: 'stargaze-1',
 		chainName: 'Stargaze',
 		stakeCurrency: {


### PR DESCRIPTION
Stargaze is improving QoS for public endpoints but unfortunately needs a DNS change.

We confirmed these changes with a build preview https://aad93b15.osmosis-frontend-6za.pages.dev/assets