### PR TITLE
Add XPRT/OSMO Pool to Trade Page

### DIFF
--- a/src/stores/root.ts
+++ b/src/stores/root.ts
@@ -432,6 +432,21 @@ export class RootStore {
 				],
 			},
 			{
+				poolId: '15',
+				currencies: [
+					{
+						coinMinimalDenom: 'uosmo',
+						coinDenom: 'OSMO',
+						coinDecimals: 6,
+					},
+					{
+						coinMinimalDenom: DenomHelper.ibcDenom([{ portId: 'transfer', channelId: 'channel-4' }], 'uxprt'),
+						coinDenom: 'XPRT',
+						coinDecimals: 6,
+					},
+				],
+			},
+			{
 				poolId: '22',
 				currencies: [
 					{


### PR DESCRIPTION
Adding Pool #15 XPRT/OSMO to the Trade page. Pool is onboarded for Osmosis incentives, has sufficient liquidity (>$10M), low swap fee (0.2%), and there's no reason to force unbeknownst users to trade through ATOM when there is plenty of OSMO liquidity paired with XPRT.