### PR TITLE
OSMO price showing 3 digits

### DIFF
--- a/src/pages/pools/components/LabsOverview/OsmoPrice.tsx
+++ b/src/pages/pools/components/LabsOverview/OsmoPrice.tsx
@@ -7,7 +7,7 @@ import { useStore } from 'src/stores';
 export const OsmoPrice = observer(function OsmoPrice() {
 	const { chainStore, priceStore } = useStore();
 
-	const price = priceStore.calculatePrice(
+	const price = priceStore.getPricePretty(
 		new CoinPretty(
 			chainStore.current.stakeCurrency,
 			DecUtils.getPrecisionDec(chainStore.current.stakeCurrency.coinDecimals)
@@ -16,7 +16,7 @@ export const OsmoPrice = observer(function OsmoPrice() {
 
 	return (
 		<OverviewLabelValue label="OSMO Price">
-			<h4 className="text-xl md:text-2xl leading-7 md:leading-none">{price ? price.toString() : '$0'}</h4>
+			<h4 className="text-xl md:text-2xl leading-7 md:leading-none">{price}</h4>
 		</OverviewLabelValue>
 	);
 });

--- a/src/stores/price/index.ts
+++ b/src/stores/price/index.ts
@@ -3,7 +3,7 @@ import { KVStore } from '@keplr-wallet/common';
 import { FiatCurrency } from '@keplr-wallet/types';
 import { computed, makeObservable, observable } from 'mobx';
 import { ObservableQueryPools } from '../osmosis/query/pools';
-import { Dec } from '@keplr-wallet/unit';
+import { CoinPretty, Dec } from '@keplr-wallet/unit';
 
 export interface IntermidiateRoute {
 	readonly alternativeCoinId: string;
@@ -96,5 +96,19 @@ export class PoolIntermediatePriceStore extends CoinGeckoPriceStore {
 			console.log(`Failed to calculate price of (${coinId}, ${vsCurrency}): ${e?.message}`);
 			return undefined;
 		}
+	}
+
+	getPricePretty(coin: CoinPretty, vsCurrency?: string, decimals = 2): string {
+		const coinId = coin.currency.coinGeckoId;
+		const currency = vsCurrency ? vsCurrency : this.defaultVsCurrency;
+		const symbol = this.getFiatCurrency(currency)?.symbol;
+		let price = '0';
+
+		if (coinId) {
+			const raw = super.getPrice(coinId, currency);
+			price = raw ? raw.toFixed(decimals) : '0';
+		}
+
+		return `${symbol}${price}`;
 	}
 }


### PR DESCRIPTION
Fixes #194 

Added a new method to the `PoolIntermediatePriceStore` class with witch the previously used, `calculatePrice` method, can easily be swapped. Optional params include the currency type and the number of decimal points to include in the result (defaults to 2 if not provided).