### PR TITLE
Remove 562 LUNA/UST from Trade page

### DIFF
--- a/src/stores/root.ts
+++ b/src/stores/root.ts
@@ -687,21 +687,6 @@ export class RootStore {
 				],
 			},
 			{
-				poolId: '562',
-				currencies: [
-					{
-						coinMinimalDenom: DenomHelper.ibcDenom([{ portId: 'transfer', channelId: 'channel-72' }], 'uluna'),
-						coinDenom: 'LUNA',
-						coinDecimals: 6,
-					},
-					{
-						coinMinimalDenom: DenomHelper.ibcDenom([{ portId: 'transfer', channelId: 'channel-72' }], 'uusd'),
-						coinDenom: 'UST',
-						coinDecimals: 6,
-					},
-				],
-			},
-			{
 				poolId: '571',
 				currencies: [
 					{


### PR DESCRIPTION
Remove 562 LUNA/UST from Trade page, because it provide no value to traders.

This pool with Swap Fee 0.535% and liquidity less than OSMO/UST (0.2%) and OSMO/LUNA (0.2%), it will never be able to offer a better trade than a double hop. This liquidity is not serving Osmosis, rather draining rewards and needlessly costing novice users.

To be clear, the reason for this removal has nothing to do with trying to enforce OSMO as a middle currency.

Addresses the original concern of Issue #154 (now closed)
https://github.com/osmosis-labs/osmosis-frontend/issues/154