### PR TITLE
Add BOOT to priceStore

### DIFF
--- a/src/stores/root.ts
+++ b/src/stores/root.ts
@@ -223,6 +223,13 @@ export class RootStore {
 					destCoinId: 'pool:uosmo',
 				},
 				{
+					alternativeCoinId: 'pool:boot',
+					poolId: '597',
+					spotPriceSourceDenom: DenomHelper.ibcDenom([{ portId: 'transfer', channelId: 'channel-95' }], 'boot'),
+					spotPriceDestDenom: 'uosmo',
+					destCoinId: 'pool:uosmo',
+				},
+				{
 					alternativeCoinId: 'pool:ustars',
 					poolId: '604',
 					spotPriceSourceDenom: DenomHelper.ibcDenom([{ portId: 'transfer', channelId: 'channel-75' }], 'ustars'),


### PR DESCRIPTION
Add BOOT to priceStore via pool 597. On assets page, there is no usd price under boot token.