### PR TITLE
arrow hovering behavior

### DIFF
--- a/src/components/SwapToken/SwapDirectionButton.tsx
+++ b/src/components/SwapToken/SwapDirectionButton.tsx
@@ -38,6 +38,11 @@ const SwitchImg = styled.img`
 	width: 1.3rem;
 	height: 1.3rem;
 
+	:hover {
+		width: 1.7rem;
+		height: 1.7rem;
+	}
+
 	@media (min-width: 768px) {
 		width: 1.5rem;
 		height: 1.5rem;

--- a/src/components/SwapToken/TokenSelect/index.tsx
+++ b/src/components/SwapToken/TokenSelect/index.tsx
@@ -10,6 +10,7 @@ import { colorGold, colorTextIcon } from 'src/emotionStyles/colors';
 import useWindowSize from 'src/hooks/useWindowSize';
 import { MISC } from 'src/constants';
 import cn from 'clsx';
+import { ARROW_HOVER_SCALE } from 'src/constants';
 
 const EMPTY_CURRENCY_LIST: AppCurrency[] = [];
 
@@ -219,7 +220,10 @@ const DownArrowImg = styled(Img)<{ isActive: boolean; isHovering: boolean }>`
 	transition: transform 0.1s;
 
 	${({ isActive }) => ({ transform: isActive ? `rotate(180deg)` : `rotate(0deg)` })}
-	${({ isHovering }) => ({ opacity: isHovering ? 1 : 0.4 })}
+	${({ isHovering }) => ({
+		opacity: isHovering ? 1 : 0.4,
+		transform: isHovering ? `scale(${ARROW_HOVER_SCALE})` : `scale(1)`,
+	})}
 
 	@media (min-width: 768px) {
 		margin-left: 12px;

--- a/src/constants/layout.ts
+++ b/src/constants/layout.ts
@@ -87,4 +87,6 @@ export type TSIDEBAR_ITEM = {
 	LINK: string;
 };
 
+export const ARROW_HOVER_SCALE = 1.3;
+
 export type TSIDEBAR_SELECTED_CHECK = string | (string | RegExp)[];

--- a/src/pages/pools/components/AllPools/AllPoolsPagination.tsx
+++ b/src/pages/pools/components/AllPools/AllPoolsPagination.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Link, useHistory } from 'react-router-dom';
 import { Center } from 'src/components/layouts/Containers';
 import { PoolsPerPage } from 'src/config';
+import { ARROW_HOVER_SCALE } from 'src/constants';
 
 interface Props {
 	page: number;
@@ -21,6 +22,8 @@ export function AllPoolsPagination({ page: propPage, numberOfPools }: Props) {
 	return (
 		<PaginationContainer>
 			<ButtonArrow
+				isFirst={isFirstPage}
+				isLast={false}
 				type="button"
 				onClick={e => {
 					if (!isFirstPage) {
@@ -39,6 +42,8 @@ export function AllPoolsPagination({ page: propPage, numberOfPools }: Props) {
 			</ButtonArrow>
 			<PageCounts>{pageRender}</PageCounts>
 			<ButtonArrow
+				isFirst={false}
+				isLast={isLastPage}
 				type="button"
 				onClick={e => {
 					if (!isLastPage) {
@@ -58,12 +63,22 @@ export function AllPoolsPagination({ page: propPage, numberOfPools }: Props) {
 		</PaginationContainer>
 	);
 }
+type ButtonProps = {
+	isFirst: boolean;
+	isLast: boolean;
+};
 
-const ButtonArrow = styled.button`
+const ButtonArrow = styled.button<ButtonProps>`
+//	border: ${props => (props.isFirst || props.isLast ? '1px solid gold' : '1px solid hotpink')};
 	display: flex;
 	align-items: center;
 	color: rgba(196, 164, 106, 1);
 	height: 2.25rem;
+	:hover {
+	color: ${props => (props.isFirst || props.isLast ? '' : 'white')};
+		transform: ${props => (props.isFirst || props.isLast ? `scale(1)` : `scale(${ARROW_HOVER_SCALE})`)};
+		transition: transform 30ms ease-in;
+	}
 `;
 
 const PageCounts = styled.div`


### PR DESCRIPTION
Just a start to the callout for more obvious hover responses over arrows on the site. 

Started with the Trade page. The down arrows next to the From ATOM v and the To OSMO v now scale slightly on hover by a factor of 1.3, which is stored as a constant ARROW_HOVER_SCALE in layout.ts.  The pagination arrows at the bottom of the Tools page also use that same scale to grow on hover when the arrow can be clicked. I also added a small hover to the button that switches direction on the Trade page - wasn’t sure it was a strong match to the current UI, though.

 Other areas on the site have pagination arrows as well. I couldn’t figure out where they were in the code - but thinking they could possibly make use of the same <ButtonArrow> styling used in the AllPoolsPagination.
 
This was fun - my first contribution to an open source project. Anyone more familiar with the code base is welcome to edit/add on!