### PR TITLE
Update Cheq external incentives and bonding

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -54,6 +54,7 @@ export const LockupAbledPoolIds: {
 	'604': true,
 	'611': true,
 	'613': true,
+	'617': true,
 	'618': true,
 	'619': true,
 	'629': true,
@@ -434,11 +435,11 @@ export const ExtraGaugeInPool: {
 	],
 	'602': [
 		{
-			gaugeId: '1909',
+			gaugeId: '2041',
 			denom: 'ibc/7A08C6F11EF0F59EB841B9F788A87EC9F2361C7D9703157EC13D940DC53031FA',
 		},
 		{
-			gaugeId: '1910',
+			gaugeId: '2042',
 			denom: 'ibc/7A08C6F11EF0F59EB841B9F788A87EC9F2361C7D9703157EC13D940DC53031FA',
 		},
 	],
@@ -498,6 +499,20 @@ export const ExtraGaugeInPool: {
 			denom: 'ibc/987C17B11ABC2B20019178ACE62929FE9840202CE79498E29FE8E5CB02B7C0A4',
 		},
 	],
+	'613': [
+		{
+			gaugeId: '1982',
+			denom: 'ibc/E7B35499CFBEB0FF5778127ABA4FB2C4B79A6B8D3D831D4379C4048C238796BD',
+		},
+		{
+			gaugeId: '2013',
+			denom: 'ibc/E7B35499CFBEB0FF5778127ABA4FB2C4B79A6B8D3D831D4379C4048C238796BD',
+		},
+		{
+			gaugeId: '2014',
+			denom: 'ibc/E7B35499CFBEB0FF5778127ABA4FB2C4B79A6B8D3D831D4379C4048C238796BD',
+		},
+	],
 	'617': [
 		{
 			gaugeId: '2039',
@@ -534,20 +549,6 @@ export const ExtraGaugeInPool: {
 		{
 			gaugeId: '2009',
 			denom: 'ibc/EA4C0A9F72E2CEDF10D0E7A9A6A22954DB3444910DB5BE980DF59B05A46DAD1C',
-		},
-	],
-	'613': [
-		{
-			gaugeId: '1982',
-			denom: 'ibc/E7B35499CFBEB0FF5778127ABA4FB2C4B79A6B8D3D831D4379C4048C238796BD',
-		},
-		{
-			gaugeId: '2013',
-			denom: 'ibc/E7B35499CFBEB0FF5778127ABA4FB2C4B79A6B8D3D831D4379C4048C238796BD',
-		},
-		{
-			gaugeId: '2014',
-			denom: 'ibc/E7B35499CFBEB0FF5778127ABA4FB2C4B79A6B8D3D831D4379C4048C238796BD',
 		},
 	],
 	'629': [


### PR DESCRIPTION
Add pool 617 (CHEQ/ATOM) to lockupAblePoolIds so users can bond to it.
Upgrade External incentive gauges for pool 602 (CHEQ/OSMO).
Reorder Pool 613 to be in numeric ascending order amongst the other externally incentivized pools.