### PR TITLE
Add NETA coingecko id

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1352,7 +1352,7 @@ export const EmbedChainInfos: ChainInfoWithExplorer[] = [
 				coinDenom: 'NETA',
 				coinMinimalDenom: 'cw20:juno168ctmpyppk90d34p3jjy658zf5a5l3w8wk35wht6ccqj4mr0yv8s4j5awr:NETA',
 				coinDecimals: 6,
-				coinGeckoId: 'pool:neta',
+				coinGeckoId: 'neta',
 				coinImageUrl: window.location.origin + '/public/assets/tokens/neta.svg',
 			},
 		],


### PR DESCRIPTION
Adding NETA coingecko id as per {"id":"neta","symbol":"neta","name":"NETA"} in [CoinGecko APIv3 List](https://api.coingecko.com/api/v3/coins/list), which goes to [NETA CoinGecko Page](https://www.coingecko.com/en/coins/neta)