### PR TITLE
Allow users to specify custom withdraw address

### DIFF
--- a/src/dialogs/Transfer.tsx
+++ b/src/dialogs/Transfer.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { observer } from 'mobx-react-lite';
 import { IBCCurrency } from '@keplr-wallet/types';
 import { AmountInput } from '../components/form/Inputs';
+import { ButtonPrimary } from '../components/layouts/Buttons';
 import { colorWhiteEmphasis } from '../emotionStyles/colors';
 import { useStore } from '../stores';
 import { Bech32Address } from '@keplr-wallet/cosmos';
@@ -11,6 +12,7 @@ import { useFakeFeeConfig } from '../hooks/tx';
 import { useBasicAmountConfig } from '../hooks/tx/basic-amount-config';
 import { wrapBaseDialog } from './base';
 import { useAccountConnection } from '../hooks/account/useAccountConnection';
+import { useCustomBech32Address } from '../hooks/account/useCustomBech32Address';
 import { ConnectAccountButton } from '../components/ConnectAccountButton';
 import { Buffer } from 'buffer/';
 
@@ -41,6 +43,13 @@ export const TransferDialog = wrapBaseDialog(
 
 			const account = accountStore.getAccount(chainStore.current.chainId);
 			const counterpartyAccount = accountStore.getAccount(counterpartyChainId);
+			const counterpartyBech32Prefix = chainStore.getChain(counterpartyChainId).bech32Config.bech32PrefixAccAddr;
+			const [customWithdrawAddr, isValidCustomWithdrawAddr, setCustomWithdrawAddr] = useCustomBech32Address();
+			const [isEditingWithdrawAddr, setIsEditingWithdrawAddr] = useState(false);
+
+			// withdraw advisory tooltip state
+			const [isMouseOverInfoIcon, setIsMouseOverInfoIcon] = useState(false);
+			const [isMouseOverToolTip, setIsMouseOverTooltip] = useState(false);
 
 			const bal = queriesStore
 				.get(chainStore.current.chainId)
@@ -57,7 +66,8 @@ export const TransferDialog = wrapBaseDialog(
 			useEffect(() => {
 				if (counterpartyInitAttempted && counterpartyAccount.walletStatus === WalletStatus.NotInit) {
 					counterpartyAccount.disconnect();
-					close();
+					setIsEditingWithdrawAddr(true);
+					setCustomWithdrawAddr(counterpartyAccount.bech32Address, counterpartyBech32Prefix);
 				} else if (
 					account.bech32Address &&
 					counterpartyAccount.walletStatus === WalletStatus.NotInit &&
@@ -66,7 +76,16 @@ export const TransferDialog = wrapBaseDialog(
 					counterpartyAccount.init();
 					setCounterpartyInitAttempted(true);
 				}
-			}, [account.bech32Address, counterpartyAccount.walletStatus]);
+			}, [
+				account.bech32Address,
+				counterpartyAccount.walletStatus,
+				counterpartyAccount,
+				counterpartyBech32Prefix,
+				counterpartyInitAttempted,
+				setIsEditingWithdrawAddr,
+				setCustomWithdrawAddr,
+				setCounterpartyInitAttempted,
+			]);
 
 			const amountConfig = useBasicAmountConfig(
 				chainStore,
@@ -129,15 +148,72 @@ export const TransferDialog = wrapBaseDialog(
 						<div className="flex justify-center items-center w-10 my-2 md:my-0">
 							<img src={`/public/assets/Icons/Arrow-${isMobileView ? 'Down' : 'Right'}.svg`} />
 						</div>
-						<div className="w-full flex-1 p-3 md:p-4 border border-white-faint rounded-2xl">
-							<p className="text-white-high">To</p>
-							<p className="text-white-disabled truncate overflow-ellipsis">
-								{pickOne(
-									Bech32Address.shortenAddress(counterpartyAccount.bech32Address, 25),
-									Bech32Address.shortenAddress(account.bech32Address, 25),
-									isWithdraw
-								)}
-							</p>
+						<div
+							className={`w-full flex-1 p-3 md:p-4 border ${
+								isValidCustomWithdrawAddr ? 'border-white-faint' : 'border-missionError'
+							} rounded-2xl`}>
+							<div className="flex place-content-between">
+								<div className="flex gap-2">
+									<p className="text-white-high">To</p>
+									{isEditingWithdrawAddr && (
+										<div className="relative">
+											<img
+												className="h-5 w-5 cursor-pointer"
+												src="/public/assets/Icons/Warning.svg"
+												onMouseEnter={() => setIsMouseOverInfoIcon(true)}
+												onMouseLeave={() => {
+													const timeoutId = window.setTimeout(() => {
+														setIsMouseOverInfoIcon(false);
+														window.clearTimeout(timeoutId);
+													}, 100);
+												}}
+											/>
+											{(isMouseOverInfoIcon || isMouseOverToolTip) && (
+												<div
+													className="absolute z-10 -left-0.5 md:-left-0.5 top-7 bg-wireframes-darkGrey border border-white-faint p-2 rounded-lg"
+													style={{ minWidth: '240px', maxWidth: '297px' }}
+													onMouseEnter={() => setIsMouseOverTooltip(true)}
+													onMouseLeave={() => setIsMouseOverTooltip(false)}>
+													<div className="text-white-high text-sm mb-1 leading-tight">
+														Incorrect withdrawal address could result in loss of funds. Avoid withdrawal to exchange
+														deposit address.
+													</div>
+												</div>
+											)}
+										</div>
+									)}
+								</div>
+								{!isValidCustomWithdrawAddr && <p className="text-error">Invalid address</p>}
+							</div>
+							{isEditingWithdrawAddr ? (
+								<div className="bg-background rounded-lg" style={{ padding: '0 8px' }}>
+									<AmountInput
+										style={{ fontSize: '14px', textAlign: 'left' }}
+										value={customWithdrawAddr}
+										onChange={(e: any) => setCustomWithdrawAddr(e.target.value, counterpartyBech32Prefix)}
+									/>
+								</div>
+							) : (
+								<p className="text-white-disabled truncate overflow-ellipsis">
+									{pickOne(
+										Bech32Address.shortenAddress(counterpartyAccount.bech32Address, 25),
+										Bech32Address.shortenAddress(account.bech32Address, 25),
+										isWithdraw
+									)}
+									{isWithdraw && !isEditingWithdrawAddr && counterpartyAccount.walletStatus === WalletStatus.Loaded && (
+										<ButtonPrimary
+											className="ml-1 text-white-emphasis"
+											style={{ fontSize: '11px', padding: '6px 8px' }}
+											onClick={e => {
+												e.preventDefault();
+												setIsEditingWithdrawAddr(true);
+												setCustomWithdrawAddr(counterpartyAccount.bech32Address, counterpartyBech32Prefix);
+											}}>
+											Edit
+										</ButtonPrimary>
+									)}
+								</p>
+							)}
 						</div>
 					</section>
 					<h6 className="text-base md:text-lg mt-7">Amount To {isWithdraw ? 'Withdraw' : 'Deposit'}</h6>
@@ -198,16 +274,22 @@ export const TransferDialog = wrapBaseDialog(
 								disabled={
 									!account.isReadyToSendMsgs ||
 									!counterpartyAccount.isReadyToSendMsgs ||
-									amountConfig.getError() != null
+									amountConfig.getError() != null ||
+									!isValidCustomWithdrawAddr
 								}
 								onClick={async e => {
 									e.preventDefault();
 
 									try {
 										if (isWithdraw) {
-											if (account.isReadyToSendMsgs && counterpartyAccount.bech32Address) {
+											if (
+												account.isReadyToSendMsgs &&
+												(counterpartyAccount.bech32Address || (customWithdrawAddr && isValidCustomWithdrawAddr))
+											) {
 												const sender = account.bech32Address;
-												const recipient = counterpartyAccount.bech32Address;
+												const recipient = isEditingWithdrawAddr
+													? customWithdrawAddr
+													: counterpartyAccount.bech32Address;
 
 												await account.cosmos.sendIBCTransferMsg(
 													{

--- a/src/dialogs/Transfer.tsx
+++ b/src/dialogs/Transfer.tsx
@@ -1,5 +1,5 @@
 import cn from 'clsx';
-import React, { useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { observer } from 'mobx-react-lite';
 import { IBCCurrency } from '@keplr-wallet/types';
 import { AmountInput } from '../components/form/Inputs';
@@ -51,9 +51,20 @@ export const TransferDialog = wrapBaseDialog(
 				.queryBalances.getQueryBech32Address(counterpartyAccount.bech32Address)
 				.getBalanceFromCurrency(currency.originCurrency!);
 
+			// detect if a user rejects connection to a chain account in Keplr
+			const [counterpartyInitAttempted, setCounterpartyInitAttempted] = useState(false);
+
 			useEffect(() => {
-				if (account.bech32Address && counterpartyAccount.walletStatus === WalletStatus.NotInit) {
+				if (counterpartyInitAttempted && counterpartyAccount.walletStatus === WalletStatus.NotInit) {
+					counterpartyAccount.disconnect();
+					close();
+				} else if (
+					account.bech32Address &&
+					counterpartyAccount.walletStatus === WalletStatus.NotInit &&
+					!counterpartyInitAttempted
+				) {
 					counterpartyAccount.init();
+					setCounterpartyInitAttempted(true);
 				}
 			}, [account.bech32Address, counterpartyAccount.walletStatus]);
 

--- a/src/dialogs/manage-liquidity.tsx
+++ b/src/dialogs/manage-liquidity.tsx
@@ -747,8 +747,7 @@ const AddLiquidity: FunctionComponent<{
 						onMouseEnter={() => setIsMouseOverTooltip(true)}
 						onMouseLeave={() => setIsMouseOverTooltip(false)}>
 						<div className="text-white-high text-sm mb-1 leading-tight">
-							Single Asset LP allows you to provide liquidity using one asset. However, this will impact the pool price
-							of the asset you’re providing liquidity with.
+							Incorrect withdrawal address could result in loss of funds. Avoid withdrawal to exchange deposit address.
 						</div>
 					</div>
 				)}

--- a/src/dialogs/manage-liquidity.tsx
+++ b/src/dialogs/manage-liquidity.tsx
@@ -747,7 +747,8 @@ const AddLiquidity: FunctionComponent<{
 						onMouseEnter={() => setIsMouseOverTooltip(true)}
 						onMouseLeave={() => setIsMouseOverTooltip(false)}>
 						<div className="text-white-high text-sm mb-1 leading-tight">
-							Incorrect withdrawal address could result in loss of funds. Avoid withdrawal to exchange deposit address.
+							Single Asset LP allows you to provide liquidity using one asset. However, this will impact the pool price
+							of the asset you’re providing liquidity with.
 						</div>
 					</div>
 				)}

--- a/src/hooks/account/useCustomBech32Address.ts
+++ b/src/hooks/account/useCustomBech32Address.ts
@@ -1,0 +1,32 @@
+import { useState, useCallback } from 'react';
+import { Bech32Address } from '@keplr-wallet/cosmos';
+
+/**
+ * Store state for using a custom & validated Bech32 address.
+ * @returns [customBech32Address, isValid, setCustomBech32Address]
+ */
+export function useCustomBech32Address(): [string, boolean, (newCustomBech32Address: string, prefix: string) => void] {
+	const [customBech32Address, setCustomBech32Address] = useState<string>('');
+	const [isValid, setIsValid] = useState(true);
+
+	return [
+		customBech32Address,
+		isValid,
+		useCallback(
+			(newCustomBech32Address: string, prefix: string) => {
+				let didThrow = false;
+				try {
+					Bech32Address.validate(newCustomBech32Address, prefix);
+				} catch (e) {
+					setIsValid(false);
+					didThrow = true;
+				}
+				if (!didThrow) {
+					setIsValid(true);
+				}
+				setCustomBech32Address(newCustomBech32Address);
+			},
+			[setIsValid, setCustomBech32Address]
+		),
+	];
+}


### PR DESCRIPTION
Closes: #71 

### Problem
Currently in the frontend, IBC Withdraw functionality doesn't allow users to specify the counter-party chain account address. They are limited to the relevant chain account  in their Keplr wallet. For many users this needlessly results in them having to send and pay for another transaction to reach their desired account.

### Solution
Provide an edit button to allow users to specify a valid bech32 address on the counter-party chain for withdrawal. Warn users about the risk of wrong addresses and exchange deposit addresses.

New dialog:
<img width="656" alt="Screen Shot 2022-03-06 at 8 28 44 PM" src="https://user-images.githubusercontent.com/4606373/156957541-4b23e689-fd92-4ed1-910f-cbea2ed3c3e7.png">

Editing:
<img width="656" alt="Screen Shot 2022-03-06 at 8 29 03 PM" src="https://user-images.githubusercontent.com/4606373/156957557-0f9e3666-810b-4382-bd69-7c845e29effc.png">

Invalid address (disables withdraw button):
<img width="657" alt="Screen Shot 2022-03-06 at 8 30 09 PM" src="https://user-images.githubusercontent.com/4606373/156957660-6685e06a-c153-4cc6-9006-1e863cfab562.png">

Warning message:
<img width="660" alt="Screen Shot 2022-03-06 at 8 29 48 PM" src="https://user-images.githubusercontent.com/4606373/156957625-542ec216-4112-422c-bcb3-02c55a900eaa.png">

