### PR TITLE
Change custom withdraw warning from tooltip -> textbox

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -965,7 +965,7 @@ export const IBCAssetInfos: {
 		destChannelId: 'channel-8',
 		coinMinimalDenom: 'uctk',
 	},
-  {
+	{
 		counterpartyChainId: 'juno-1',
 		sourceChannelId: 'channel-169',
 		destChannelId: 'channel-47',

--- a/src/dialogs/Transfer.tsx
+++ b/src/dialogs/Transfer.tsx
@@ -47,10 +47,6 @@ export const TransferDialog = wrapBaseDialog(
 			const [customWithdrawAddr, isValidCustomWithdrawAddr, setCustomWithdrawAddr] = useCustomBech32Address();
 			const [isEditingWithdrawAddr, setIsEditingWithdrawAddr] = useState(false);
 
-			// withdraw advisory tooltip state
-			const [isMouseOverInfoIcon, setIsMouseOverInfoIcon] = useState(false);
-			const [isMouseOverToolTip, setIsMouseOverTooltip] = useState(false);
-
 			const bal = queriesStore
 				.get(chainStore.current.chainId)
 				.queryBalances.getQueryBech32Address(account.bech32Address)
@@ -155,33 +151,6 @@ export const TransferDialog = wrapBaseDialog(
 							<div className="flex place-content-between">
 								<div className="flex gap-2">
 									<p className="text-white-high">To</p>
-									{isEditingWithdrawAddr && (
-										<div className="relative">
-											<img
-												className="h-5 w-5 cursor-pointer"
-												src="/public/assets/Icons/Warning.svg"
-												onMouseEnter={() => setIsMouseOverInfoIcon(true)}
-												onMouseLeave={() => {
-													const timeoutId = window.setTimeout(() => {
-														setIsMouseOverInfoIcon(false);
-														window.clearTimeout(timeoutId);
-													}, 100);
-												}}
-											/>
-											{(isMouseOverInfoIcon || isMouseOverToolTip) && (
-												<div
-													className="absolute z-10 -left-0.5 md:-left-0.5 top-7 bg-wireframes-darkGrey border border-white-faint p-2 rounded-lg"
-													style={{ minWidth: '240px', maxWidth: '297px' }}
-													onMouseEnter={() => setIsMouseOverTooltip(true)}
-													onMouseLeave={() => setIsMouseOverTooltip(false)}>
-													<div className="text-white-high text-sm mb-1 leading-tight">
-														Incorrect withdrawal address could result in loss of funds. Avoid withdrawal to exchange
-														deposit address.
-													</div>
-												</div>
-											)}
-										</div>
-									)}
 								</div>
 								{!isValidCustomWithdrawAddr && <p className="text-error">Invalid address</p>}
 							</div>
@@ -216,6 +185,15 @@ export const TransferDialog = wrapBaseDialog(
 							)}
 						</div>
 					</section>
+					{isEditingWithdrawAddr && (
+						<div className="flex gap-3 w-full border border-secondary-200 rounded-xl p-2 mt-2">
+							<img className="h-5" src="/public/assets/Icons/Warning.svg" />
+							<p className="text-sm">
+								Warning: Incorrect withdrawal address could result in loss of funds. Do not withdraw into a centralized
+								exchange deposit address.
+							</p>
+						</div>
+					)}
 					<h6 className="text-base md:text-lg mt-7">Amount To {isWithdraw ? 'Withdraw' : 'Deposit'}</h6>
 					<div className="mt-3 md:mt-4 w-full p-0 md:p-5 border-0 md:border border-secondary-50 border-opacity-60 rounded-2xl">
 						<p className="text-sm md:text-base mb-2">

--- a/src/pages/assets/AssetBalancesList.tsx
+++ b/src/pages/assets/AssetBalancesList.tsx
@@ -98,9 +98,7 @@ export const AssetBalancesList = observer(function AssetBalancesList() {
 		<React.Fragment>
 			{dialogState.open ? (
 				<TransferDialog
-					dialogStyle={
-						isMobileView ? {} : { minHeight: '533px', maxHeight: '540px', minWidth: '656px', maxWidth: '656px' }
-					}
+					dialogStyle={isMobileView ? {} : { minHeight: '533px', minWidth: '656px', maxWidth: '656px' }}
 					isOpen={dialogState.open}
 					close={close}
 					currency={dialogState.currency}
@@ -398,7 +396,6 @@ const AssetBalanceTableRow = styled.tr`
 	align-items: center;
 	padding-left: 14px;
 	padding-right: 14px;
-
 	@media (min-width: 768px) {
 		padding-left: 30px;
 		padding-right: 30px;


### PR DESCRIPTION
### Problem

There have been complaints from the community support DAO that users have missed the warning and have deposited and lost funds to a CEX address.

![image](https://user-images.githubusercontent.com/4606373/158043000-ff642658-cc10-4ada-9555-b0d1c4beda50.png)

### Solution

Change warning from tooltip to large and prominent text box below the address boxes.

<img width="644" alt="Screen Shot 2022-03-12 at 8 57 53 PM" src="https://user-images.githubusercontent.com/4606373/158043029-6057fe5f-0d3c-4a09-b852-e239ddf3355b.png">