### PR TITLE
Limit swap amount

### DIFF
--- a/src/pages/main/components/TokenAmountInput.tsx
+++ b/src/pages/main/components/TokenAmountInput.tsx
@@ -10,6 +10,7 @@ import { cssAlignRightInput, cssNumberTextInput } from 'src/emotionStyles/forms'
 import { cssFontPoppins } from 'src/emotionStyles/texts';
 import { useStore } from 'src/stores';
 import useWindowSize from 'src/hooks/useWindowSize';
+import { ChangeEvent } from 'react';
 
 interface Props {
 	amount: string;
@@ -20,6 +21,13 @@ interface Props {
 export const TokenAmountInput = observer(({ amount, currency, onChange }: Props) => {
 	const { priceStore } = useStore();
 	const { isMobileView } = useWindowSize();
+
+	const handleOnChange = (e: ChangeEvent<HTMLInputElement>) => {
+		const value = e.currentTarget.value;
+		if (Number(value) <= Number.MAX_SAFE_INTEGER) {
+			onChange(value);
+		}
+	};
 
 	const coinPretty = (() => {
 		if (amount) {
@@ -41,12 +49,7 @@ export const TokenAmountInput = observer(({ amount, currency, onChange }: Props)
 
 	return (
 		<TokenAmountInputContainer>
-			<AmountInput
-				type="number"
-				onChange={e => onChange(e.currentTarget.value)}
-				value={amount !== '0' ? amount : ''}
-				placeholder="0"
-			/>
+			<AmountInput type="number" onChange={handleOnChange} value={amount !== '0' ? amount : ''} placeholder="0" />
 			<Text
 				weight="semiBold"
 				size="sm"


### PR DESCRIPTION
This is regarding issue [#240](https://github.com/osmosis-labs/osmosis-frontend/issues/240).

The swap amount has been limited to `MAX_SAFE_INTEGER` value which is 9007199254740991.

The app is not crashing anymore when inputting a very large number.