### PR TITLE
Frontier - Update Provenance gas prices

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -3078,9 +3078,9 @@ export const EmbedChainInfos: ChainInfoWithExplorer[] = [
 			},
 		],
 		gasPriceStep: {
-			low: 0.000001905,
-			average: 0.000002100,
-			high: 0.000002500,
+			low: 1905,
+			average: 2100,
+			high: 2500,
 		},
 		features: ['stargate', 'ibc-transfer', 'no-legacy-stdTx', 'ibc-go'],
 		explorerUrlToTx: 'https://www.mintscan.io/provenance/txs/{txHash}',


### PR DESCRIPTION
The gas prices for Provenance are incorrect. The values have been updated.