### PR TITLE
Update LIKE config with new prefix and no-legacy-stdTx

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1593,7 +1593,7 @@ export const EmbedChainInfos: ChainInfoWithExplorer[] = [
 		bip44: {
 			coinType: 118,
 		},
-		bech32Config: Bech32Address.defaultBech32Config('cosmos'),
+		bech32Config: Bech32Address.defaultBech32Config('like'),
 		currencies: [
 			{
 				coinDenom: 'LIKE',
@@ -1612,7 +1612,7 @@ export const EmbedChainInfos: ChainInfoWithExplorer[] = [
 				coinImageUrl: window.location.origin + '/public/assets/tokens/like.svg',
 			},
 		],
-		features: ['stargate', 'ibc-transfer'],
+		features: ['stargate', 'ibc-transfer', 'no-legacy-stdTx', 'ibc-go'],
 		explorerUrlToTx: 'https://likecoin.bigdipper.live/transactions/{txHash}',
 	},
 	{


### PR DESCRIPTION
We are seeing `Request failed with status code 501` when depositing LIKE to Osmosis after upgrading our chain with sdk 0.44 and dual prefix support. Would this PR fix the issue?