### PR TITLE
add xprt/usdc pool external incentives.

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -74,6 +74,7 @@ export const LockupAbledPoolIds: {
 	'662': true,
 	'678': true,
 	'681': true,
+	'719': true,
 
 	'560': true,
 	'561': true,
@@ -789,6 +790,12 @@ export const ExtraGaugeInPool: {
 		{
 			gaugeId: '3016',
 			denom: 'uosmo',
+		},
+	],
+	'719': [
+		{
+			gaugeId: '3528',
+			denom: 'ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293',
 		},
 	],
 };


### PR DESCRIPTION
Created gauge: incentives kick in from 24th May 2022.
https://www.mintscan.io/osmosis/txs/AAF999B38F8AD79CF44D8EFA8038C3C56452AADA32F40EA92B941E8C34351EF4

same as #525 but targetted towards frontier