### PR TITLE
Remove the percentage multiplication to `singleAmountInPriceImpact`

### DIFF
--- a/packages/stores/src/ui-config/manage-liquidity/add-liquidity.ts
+++ b/packages/stores/src/ui-config/manage-liquidity/add-liquidity.ts
@@ -161,32 +161,30 @@ export class ObservableAddLiquidityConfig extends ManageLiquidityConfigBase {
       }
 
       /*
-			 The spot price is ( Bi / Wi ) / (Bo / Wo).
-			 And "single amount in" only changes the Bi or Bo.
-			 Others can be handles as constant.
-			 So, we can calculate the price impact by just consider the added amount of one asset.
-			 */
+       The spot price is ( Bi / Wi ) / (Bo / Wo).
+       And "single amount in" only changes the Bi or Bo.
+       Others can be handles as constant.
+       So, we can calculate the price impact by just consider the added amount of one asset.
+       */
       return new RatePretty(
-        new Dec(1)
-          .sub(
-            poolAsset.amount
-              .toDec()
-              .quo(
-                poolAsset.amount
-                  .toDec()
-                  .add(
-                    new CoinPretty(
-                      config.sendCurrency,
-                      new Dec(config.amount).mul(
-                        DecUtils.getTenExponentNInPrecisionRange(
-                          config.sendCurrency.coinDecimals
-                        )
+        new Dec(1).sub(
+          poolAsset.amount
+            .toDec()
+            .quo(
+              poolAsset.amount
+                .toDec()
+                .add(
+                  new CoinPretty(
+                    config.sendCurrency,
+                    new Dec(config.amount).mul(
+                      DecUtils.getTenExponentNInPrecisionRange(
+                        config.sendCurrency.coinDecimals
                       )
-                    ).toDec()
-                  )
-              )
-          )
-          .mul(new Dec(100))
+                    )
+                  ).toDec()
+                )
+            )
+        )
       );
     } catch (e) {
       console.error(e);


### PR DESCRIPTION
There is a problem that the price impact of adding single asset lp is too much.
The cause of the problem was to manually convert the value to a percentage by multiplying it by 100 while using `RatePretty`.

`RatePretty` is a function recently added to @keplr-wallet/unit, and it shows the value as a percentage when showing it to the user through toString() even if it uses the value without converting to percentage. This helps to code management by separating value ​​to display to the users and value ​​for internal logic.