### PR TITLE
Trim not worthwhile pools from swap router (with very temporal solution)

### DIFF
--- a/packages/web/components/trade-clipboard/index.tsx
+++ b/packages/web/components/trade-clipboard/index.tsx
@@ -9,7 +9,13 @@ import {
 import classNames from "classnames";
 import { observer } from "mobx-react-lite";
 import Image from "next/image";
-import React, { FunctionComponent, useEffect, useRef, useMemo } from "react";
+import React, {
+  FunctionComponent,
+  useEffect,
+  useRef,
+  useMemo,
+  useState,
+} from "react";
 import { ChainInfos, IS_FRONTIER } from "../../config";
 import {
   useBooleanWithWindowEvent,
@@ -24,7 +30,7 @@ import { InputBox } from "../input";
 import { InfoTooltip } from "../tooltip";
 
 export const TradeClipboard: FunctionComponent<{
-  // Should be memorized
+  // IMPORTANT: Pools should be memoized!!
   pools: Pool[];
 
   containerClassName?: string;
@@ -49,17 +55,20 @@ export const TradeClipboard: FunctionComponent<{
   const manualSlippageInputRef = useRef<HTMLInputElement | null>(null);
 
   const slippageConfig = useMemo(() => new ObservableSlippageConfig(), []);
-  const tradeTokenInConfig = useMemo(() => {
-    return new ObservableTradeTokenInConfig(
-      chainStore,
-      queriesStore,
-      chainId,
-      account.bech32Address,
-      undefined,
-      pools
-    );
-    // eslint-disable-next-line
-  }, [chainStore, chainId, account.bech32Address, pools.length]);
+  const [tradeTokenInConfig] = useState(
+    () =>
+      new ObservableTradeTokenInConfig(
+        chainStore,
+        queriesStore,
+        chainId,
+        account.bech32Address,
+        undefined,
+        pools
+      )
+  );
+  tradeTokenInConfig.setChain(chainId);
+  tradeTokenInConfig.setSender(account.bech32Address);
+  tradeTokenInConfig.setPools(pools);
 
   useTokenSwapQueryParams(tradeTokenInConfig, allTokenBalances, isInModal);
 

--- a/packages/web/pages/index.tsx
+++ b/packages/web/pages/index.tsx
@@ -4,6 +4,8 @@ import { ProgressiveSvgImage } from "../components/progressive-svg-image";
 import { TradeClipboard } from "../components/trade-clipboard";
 import { useStore } from "../stores";
 import { IS_FRONTIER } from "../config";
+import { Dec } from "@keplr-wallet/unit";
+import { useMemo, useRef } from "react";
 
 const Home: NextPage = observer(function () {
   const { chainStore, queriesStore } = useStore();
@@ -12,7 +14,75 @@ const Home: NextPage = observer(function () {
   const queries = queriesStore.get(chainId);
   const queryPools = queries.osmosis!.queryGammPools;
 
-  const pools = queryPools.getAllPools().map((pool) => pool.pool);
+  // If pool has already passed once, it will be passed immediately without recalculation.
+  const poolsPassed = useRef<Map<string, boolean>>(new Map());
+  const allPools = queryPools.getAllPools();
+  // Pools should be memoized before passing to trade in config
+  const pools = useMemo(
+    () =>
+      allPools
+        .filter((pool) => {
+          // TODO: If not on production environment, this logic should pass all pools (or other selection standard).
+
+          // Trim not useful pools.
+
+          const passed = poolsPassed.current.get(pool.id);
+          if (passed) {
+            return true;
+          }
+
+          // There is currently no good way to pick a pool that is worthwhile.
+          // For now, based on the mainnet, only those pools with assets above a certain value are calculated for swap.
+
+          let hasEnoughAssets = false;
+
+          for (const asset of pool.poolAssets) {
+            // Probably, the pools that include gamm token may be created mistakenly by users.
+            if (
+              asset.amount.currency.coinMinimalDenom.startsWith("gamm/pool/")
+            ) {
+              return false;
+            }
+
+            // Only pools with at least 1000 osmo are dealt with.
+            if (asset.amount.currency.coinMinimalDenom === "uosmo") {
+              if (asset.amount.toDec().gt(new Dec(1000))) {
+                hasEnoughAssets = true;
+                break;
+              }
+            }
+
+            // Only pools with at least 10 ion are dealt with.
+            if (asset.amount.currency.coinMinimalDenom === "uion") {
+              if (asset.amount.toDec().gt(new Dec(10))) {
+                hasEnoughAssets = true;
+                break;
+              }
+            }
+
+            // Only pools with at least 1000 atom are dealt with.
+            if (
+              "originChainId" in asset.amount.currency &&
+              asset.amount.currency.coinMinimalDenom ===
+                "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+            ) {
+              if (asset.amount.toDec().gt(new Dec(1000))) {
+                hasEnoughAssets = true;
+                break;
+              }
+            }
+          }
+
+          if (hasEnoughAssets) {
+            console.log(`${pool.id} will be included to swap router`);
+            poolsPassed.current.set(pool.id, true);
+          }
+
+          return hasEnoughAssets;
+        })
+        .map((pool) => pool.pool),
+    [allPools]
+  );
 
   return (
     <main className="relative bg-background h-screen">


### PR DESCRIPTION
It was deployed to Main earlier than I expected. Including all pools in the swap router makes it much more difficult to calculate a better swap. Therefore, pools that are not useful should be removed. There was no such logic. I'm adding a temporary solution because it's up on the main.

- The pools with gamm token will be removed from swap router. (probably, the pools that include gamm token may be created mistakenly by users)
- Only pools with at least 1000 osmo are dealt with.
- Only pools with at least 10 ion are dealt with.
- Only pools with at least 1000 atom are dealt with.

And, It's important not to use `useMemo` but use `useState` when using mobx objects. Since mobx objects are mutable and stateful, they should not be destroyed before they are no longer needed.