### PR TITLE
Raise Junø on the Assets Page ❤️ 

### DIFF
--- a/packages/web/config/ibc-assets.ts
+++ b/packages/web/config/ibc-assets.ts
@@ -78,6 +78,23 @@ export const IBCAssetInfos: (IBCAsset & {
     isVerified: true,
   },
   {
+    counterpartyChainId: "juno-1",
+    sourceChannelId: "channel-42",
+    destChannelId: "channel-0",
+    coinMinimalDenom: "ujuno",
+    isVerified: true,
+  },
+  {
+    counterpartyChainId: "juno-1",
+    sourceChannelId: "channel-169",
+    destChannelId: "channel-47",
+    coinMinimalDenom:
+      "cw20:juno168ctmpyppk90d34p3jjy658zf5a5l3w8wk35wht6ccqj4mr0yv8s4j5awr",
+    ics20ContractAddress:
+      "juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
+    isVerified: true,
+  },
+  {
     counterpartyChainId: "columbus-5",
     sourceChannelId: "channel-72",
     destChannelId: "channel-1",
@@ -98,23 +115,6 @@ export const IBCAssetInfos: (IBCAsset & {
     sourceChannelId: "channel-88",
     destChannelId: "channel-1",
     coinMinimalDenom: "uscrt",
-    isVerified: true,
-  },
-  {
-    counterpartyChainId: "juno-1",
-    sourceChannelId: "channel-42",
-    destChannelId: "channel-0",
-    coinMinimalDenom: "ujuno",
-    isVerified: true,
-  },
-  {
-    counterpartyChainId: "juno-1",
-    sourceChannelId: "channel-169",
-    destChannelId: "channel-47",
-    coinMinimalDenom:
-      "cw20:juno168ctmpyppk90d34p3jjy658zf5a5l3w8wk35wht6ccqj4mr0yv8s4j5awr",
-    ics20ContractAddress:
-      "juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
     isVerified: true,
   },
   {


### PR DESCRIPTION
## Summary 
Moves assets from Juno Network to a more user-friendly position on the Assets page.

## Changes  
Moves the insolvent UST and LUNA (now LUNAC) assets below the fold on the assets page, replacing them with JUNO and NETA. 

This change respects the network-based grouping standard, as well as the present promotion of Axelar's Ethereum-bridged assets, while continuing to provide members of the Cosmos ecosystem with the user-focused experience they have come to expect from Osmosis. 