### PR TITLE
Improve the wallet connection process on mobile environment

### DIFF
--- a/packages/web/hooks/use-keplr/context.tsx
+++ b/packages/web/hooks/use-keplr/context.tsx
@@ -18,6 +18,7 @@ import { ChainInfos } from "../../config";
 import { Buffer } from "buffer";
 import WalletConnect from "@walletconnect/client";
 import { KeplrWalletConnectV1 } from "@keplr-wallet/wc-client";
+import { isMobile } from "@walletconnect/browser-utils";
 
 export async function sendTxWC(
   chainId: string,
@@ -157,7 +158,11 @@ export const GetKeplrProvider: FunctionComponent = ({ children }) => {
     }
 
     return new Promise((resolve, reject) => {
-      setIsModalOpen(true);
+      if (!isMobile()) {
+        // If on mobile browser environment,
+        // no need to open select modal.
+        setIsModalOpen(true);
+      }
 
       const cleanUp = () => {
         eventListener.off("modal_close");
@@ -223,6 +228,11 @@ export const GetKeplrProvider: FunctionComponent = ({ children }) => {
           cleanUp();
         }
       });
+
+      if (isMobile()) {
+        // Force emit "select_wallet_connect" event if on mobile browser environment.
+        eventListener.emit("select_wallet_connect");
+      }
     });
   });
 

--- a/packages/web/hooks/use-keplr/context.tsx
+++ b/packages/web/hooks/use-keplr/context.tsx
@@ -234,7 +234,7 @@ export const GetKeplrProvider: FunctionComponent = ({ children }) => {
         });
 
         if (isMobile()) {
-          if (keplrFromWindow) {
+          if (keplrFromWindow && keplrFromWindow.mode === "mobile-web") {
             // If mobile with `keplr` in `window`, it means that user enters frontend from keplr app's in app browser.
             // So, their is no need to use wallet connect, and it resembles extension's usages.
             eventListener.emit("select_extension");

--- a/packages/web/stores/account-init-management.tsx
+++ b/packages/web/stores/account-init-management.tsx
@@ -1,7 +1,7 @@
 import React, { FunctionComponent, useEffect, useRef, useState } from "react";
 import { observer } from "mobx-react-lite";
 import { useStore } from "./index";
-import { WalletStatus } from "@keplr-wallet/stores";
+import { getKeplrFromWindow, WalletStatus } from "@keplr-wallet/stores";
 import { useKeplr } from "../hooks";
 import { KeplrWalletConnectV1 } from "@keplr-wallet/wc-client";
 
@@ -16,6 +16,19 @@ export const AccountInitManagement: FunctionComponent = observer(
     const account = accountStore.getAccount(chainInfo.chainId);
 
     const [accountHasInit, setAccountHasInit] = useState(false);
+
+    useEffect(() => {
+      // Initially, try to get keplr from window, and keplr's mode is "mobile-web",
+      // it means that user enters the website via keplr app's in app browser.
+      // And, it means explicitly press the osmosis button on the keplr's dApps introduction page.
+      // So, try to init account immediately.
+      getKeplrFromWindow().then((keplr) => {
+        if (keplr && keplr.mode === "mobile-web") {
+          account.init();
+        }
+      });
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
 
     // Init Osmosis account w/ desired connection type (wallet connect, extension)
     // if prev connected Keplr in this browser.


### PR DESCRIPTION
- Skip the selection of wallet type modal on mobile browser environment (there is no other way to connect wallet other than wallet connect)
- If user enters frontend from keplr app, force to init account immediately.