### PR TITLE
Accessibility improvements

### DIFF
--- a/packages/web/components/alert/frontier-banner.tsx
+++ b/packages/web/components/alert/frontier-banner.tsx
@@ -17,15 +17,17 @@ export const FrontierBanner: FunctionComponent = () => {
       }}
       className="fixed flex place-content-evenly right-3 top-3 py-3 text-white-high md:w-[330px] w-[596px] z-50 rounded-2xl"
     >
-      <div className="absolute w-[20px] -top-1.5 -left-1.5 cursor-pointer">
+      <button
+        className="absolute w-[20px] -top-1.5 -left-1.5 cursor-pointer"
+        onClick={() => setShowBanner(false)}
+      >
         <Image
           alt="close"
           src="/icons/close-circle.svg"
-          onClick={() => setShowBanner(false)}
           height={20}
           width={20}
         />
-      </div>
+      </button>
       <div className="flex items-center md:px-1 px-2 md:gap-1 gap-4">
         <div className="shrink-0">
           <Image

--- a/packages/web/components/buttons/button.tsx
+++ b/packages/web/components/buttons/button.tsx
@@ -23,7 +23,7 @@ export const Button: FunctionComponent<Props> = ({
 }) => (
   <button
     className={classNames(
-      "flex justify-center items-center rounded-lg base",
+      "button flex justify-center items-center rounded-lg base",
       {
         "opacity-50": disabled && !loading,
         "opacity-70": disabled && loading,

--- a/packages/web/components/buttons/show-more.tsx
+++ b/packages/web/components/buttons/show-more.tsx
@@ -10,7 +10,7 @@ export const ShowMoreButton: FunctionComponent<ToggleProps & CustomClasses> = ({
   className,
 }) => (
   <button
-    className={classNames("flex flex-col gap-1", className)}
+    className={classNames("flex flex-col gap-1 button", className)}
     onClick={() => onToggle(isOn)}
   >
     <span className="body2 md:caption text-white-mid">

--- a/packages/web/components/cards/go-superfluid.tsx
+++ b/packages/web/components/cards/go-superfluid.tsx
@@ -20,7 +20,7 @@ export const GoSuperfluidCard: FunctionComponent<
       </div>
     </div>
     <button
-      className="bg-superfluid rounded-lg py-2 px-8 text-white-high font-semibold text-sm shadow-elevation-04dp"
+      className="button bg-superfluid rounded-lg py-2 px-8 text-white-high font-semibold text-sm shadow-elevation-04dp"
       type="button"
       onClick={goSuperfluid}
     >

--- a/packages/web/components/cards/pool-card.tsx
+++ b/packages/web/components/cards/pool-card.tsx
@@ -76,9 +76,9 @@ export const PoolCard: FunctionComponent<
     }
 
     return (
-      <div
+      <button
         className={classNames(
-          "w-full max-w-md p-px rounded-2xl hover:bg-enabledGold",
+          "w-full max-w-md p-px rounded-2xl hover:bg-enabledGold text-left",
           {
             "bg-card": !isSuperfluid,
             "bg-superfluid hover:bg-none": isSuperfluid,
@@ -115,7 +115,7 @@ export const PoolCard: FunctionComponent<
             ))}
           </div>
         </div>
-      </div>
+      </button>
     );
   }
 );

--- a/packages/web/components/complex/pool/create/step1-set-ratios.tsx
+++ b/packages/web/components/complex/pool/create/step1-set-ratios.tsx
@@ -58,7 +58,7 @@ export const Step1SetRatios: FunctionComponent<StepProps> = observer(
               </div>
             </div>
           ))}
-          <div
+          <button
             className={classNames(
               "h-24 md:h-auto flex gap-5 md:p-2.5 px-7 items-center border border-white-faint rounded-2xl select-none",
               config.canAddAsset
@@ -87,7 +87,7 @@ export const Step1SetRatios: FunctionComponent<StepProps> = observer(
             ) : (
               <h6>Add new token</h6>
             )}
-          </div>
+          </button>
         </div>
       </StepBase>
     );

--- a/packages/web/components/complex/sidebar-bottom.tsx
+++ b/packages/web/components/complex/sidebar-bottom.tsx
@@ -70,7 +70,7 @@ export const SidebarBottom: FunctionComponent = observer(() => {
                 e.preventDefault();
                 account.disconnect();
               }}
-              className="bg-transparent border border-opacity-30 border-secondary-200 h-9 w-full rounded-md py-2 px-1 flex items-center justify-center mb-5"
+              className="button bg-transparent border border-opacity-30 border-secondary-200 h-9 w-full rounded-md py-2 px-1 flex items-center justify-center mb-5"
             >
               <Image
                 src="/icons/sign-out-secondary.svg"
@@ -85,7 +85,7 @@ export const SidebarBottom: FunctionComponent = observer(() => {
           </div>
         ) : (
           <button
-            className="flex items-center justify-center w-full h-9 py-3.5 rounded-md bg-primary-200 mb-5"
+            className="button flex items-center justify-center w-full h-9 py-3.5 rounded-md bg-primary-200 mb-5"
             onClick={(e) => {
               e.preventDefault();
               account.init();

--- a/packages/web/components/control/menu-dropdown.tsx
+++ b/packages/web/components/control/menu-dropdown.tsx
@@ -36,9 +36,9 @@ export const MenuDropdown: FunctionComponent<Props> = ({
     )}
   >
     {options.map(({ id, display }, index) => (
-      <span
+      <button
         className={classNames(
-          "px-2 cursor-pointer w-full hover:bg-white-faint",
+          "px-2 cursor-pointer w-full hover:bg-white-faint text-left",
           {
             "bg-white-faint text-white-full": id === selectedOptionId,
             "text-iconDefault": id !== selectedOptionId,
@@ -50,7 +50,7 @@ export const MenuDropdown: FunctionComponent<Props> = ({
         onClick={() => onSelect(id)}
       >
         {display}
-      </span>
+      </button>
     ))}
   </div>
 );

--- a/packages/web/components/control/pool-token-select.tsx
+++ b/packages/web/components/control/pool-token-select.tsx
@@ -40,7 +40,7 @@ export const PoolTokenSelect: FunctionComponent<
           className
         )}
       >
-        <div
+        <button
           className="relative flex md:gap-1 gap-3"
           onClick={() => setToggleOpen(!isToggleOpen)}
         >
@@ -61,7 +61,7 @@ export const PoolTokenSelect: FunctionComponent<
               width={isMobile ? 15 : 20}
             />
           </div>
-        </div>
+        </button>
       </div>
       {isToggleOpen && (
         <TokensDropdown
@@ -87,7 +87,7 @@ const TokensDropdown: FunctionComponent<
 > = ({ tokens, onSelect, isMobile = false }) => (
   <div className="absolute flex flex-col bg-card rounded-b-xl z-50 md:w-52 w-64">
     {tokens.map((token, index) => (
-      <div
+      <button
         className={classNames(
           "hover:bg-white-faint cursor-pointer p-5 md:p-2 border-t border-dashed border-white-faint",
           { "rounded-b-xl": index === tokens.length - 1 }
@@ -96,7 +96,7 @@ const TokensDropdown: FunctionComponent<
         onClick={() => onSelect(token.coinDenom)}
       >
         <Token {...token} ringColorIndex={index} isMobile={isMobile} />
-      </div>
+      </button>
     ))}
   </div>
 );

--- a/packages/web/components/control/sort-menu.tsx
+++ b/packages/web/components/control/sort-menu.tsx
@@ -43,11 +43,8 @@ export const SortMenu: FunctionComponent<Props> = ({
           className
         )}
       >
-        <Image
-          alt="sort"
-          src="/icons/up-down-arrow.svg"
-          height={isMobile ? 12 : 18}
-          width={isMobile ? 12 : 18}
+        <button
+          className="flex items-center"
           onClick={(e) => {
             e.stopPropagation();
             if (onToggleSortDirection && selectedOption) {
@@ -56,9 +53,16 @@ export const SortMenu: FunctionComponent<Props> = ({
               setDropdownOpen(!dropdownOpen);
             }
           }}
-        />
-        <div
-          className="flex"
+        >
+          <Image
+            alt="sort"
+            src="/icons/up-down-arrow.svg"
+            height={isMobile ? 12 : 18}
+            width={isMobile ? 12 : 18}
+          />
+        </button>
+        <button
+          className="flex items-center"
           onClick={(e) => {
             e.stopPropagation();
             if (!disabled) {
@@ -79,7 +83,7 @@ export const SortMenu: FunctionComponent<Props> = ({
             height={isMobile ? 12 : 15}
             width={isMobile ? 12 : 15}
           />
-        </div>
+        </button>
       </div>
       {isMobile ? (
         <MenuOptionsModal

--- a/packages/web/components/control/tab-box.tsx
+++ b/packages/web/components/control/tab-box.tsx
@@ -42,7 +42,7 @@ export const TabBox: FunctionComponent<
     <div className={classNames(className)}>
       <div className="flex py-4 whitespace-nowrap overflow-x-auto no-scrollbar">
         {tabs.map(({ title, className: tabClassName }, index) => (
-          <div
+          <button
             id={`tab-box-${index}`}
             ref={tabscrollRef}
             key={index}
@@ -67,7 +67,7 @@ export const TabBox: FunctionComponent<
             ) : (
               <>{title}</>
             )}
-          </div>
+          </button>
         ))}
       </div>
       <div>

--- a/packages/web/components/control/token-select.tsx
+++ b/packages/web/components/control/token-select.tsx
@@ -59,8 +59,8 @@ export const TokenSelect: FunctionComponent<
   return (
     <div className="flex md:justify-start justify-center items-center relative">
       {selectedCurrency && (
-        <div
-          className={`flex items-center group ${
+        <button
+          className={`flex items-center text-left group ${
             hasNeedTokenSelect ? "cursor-pointer" : ""
           }`}
           onClick={(e) => {
@@ -104,7 +104,7 @@ export const TokenSelect: FunctionComponent<
               {getChainNetworkName?.(selectedCurrency.coinDenom)}
             </div>
           </div>
-        </div>
+        </button>
       )}
 
       {isSelectOpen && (
@@ -131,7 +131,7 @@ export const TokenSelect: FunctionComponent<
             />
           </div>
 
-          <div className="token-item-list overflow-y-scroll max-h-80">
+          <ul className="token-item-list overflow-y-scroll max-h-80">
             {searchedTokens.map((token, index) => {
               const currency =
                 token instanceof CoinPretty ? token.currency : token;
@@ -147,7 +147,7 @@ export const TokenSelect: FunctionComponent<
               const showChannel = coinDenom.includes("channel");
 
               return (
-                <div
+                <li
                   key={index}
                   className="flex justify-between items-center rounded-2xl py-2.5 px-3 my-1 hover:bg-card cursor-pointer mr-3"
                   onClick={(e) => {
@@ -156,7 +156,7 @@ export const TokenSelect: FunctionComponent<
                     setIsSelectOpen(false);
                   }}
                 >
-                  <div className="flex items-center justify-between w-full">
+                  <button className="flex items-center justify-between text-left w-full">
                     <div className="flex items-center">
                       {coinImageUrl && (
                         <div className="w-9 h-9 rounded-full mr-3">
@@ -170,7 +170,7 @@ export const TokenSelect: FunctionComponent<
                       )}
                       <div>
                         <h6 className="text-white-full">{justDenom}</h6>
-                        <div className="text-iconDefault md:caption font-semibold">
+                        <div className="text-iconDefault text-left md:caption font-semibold">
                           {showChannel ? channel : networkName}
                         </div>
                       </div>
@@ -179,11 +179,11 @@ export const TokenSelect: FunctionComponent<
                       {token instanceof CoinPretty &&
                         token.trim(true).hideDenom(true).toString()}
                     </div>
-                  </div>
-                </div>
+                  </button>
+                </li>
               );
             })}
-          </div>
+          </ul>
         </div>
       )}
     </div>

--- a/packages/web/components/input/input-box.tsx
+++ b/packages/web/components/input/input-box.tsx
@@ -125,7 +125,7 @@ export const InputBox: FunctionComponent<Props> = ({
                   <button
                     key={index}
                     className={classNames(
-                      "h-[1.375rem] border-2 border-primary-200 rounded-lg mt-2.5 bg-primary-200/30 select-none",
+                      "button h-[1.375rem] border-2 border-primary-200 rounded-lg mt-2.5 bg-primary-200/30 select-none",
                       {
                         "opacity-30": disabled || labelButtonDisabled,
                         "hover:bg-primary-200/60":

--- a/packages/web/components/table/index.tsx
+++ b/packages/web/components/table/index.tsx
@@ -1,6 +1,11 @@
 import Image from "next/image";
 import Link from "next/link";
-import React, { PropsWithoutRef, useState, useCallback } from "react";
+import React, {
+  PropsWithoutRef,
+  useState,
+  useCallback,
+  FunctionComponent,
+} from "react";
 import classNames from "classnames";
 import { InfoTooltip } from "../tooltip";
 import { CustomClasses } from "../types";
@@ -73,39 +78,43 @@ export const Table = <TCell extends BaseCell>({
                 )}
                 onClick={() => colDef?.sort?.onClickHeader(colIndex)}
               >
-                <span>
-                  {colDef?.display ? (
-                    typeof colDef.display === "string" ? (
-                      colDef.display
+                <ClickableContent
+                  isButton={colDef?.sort?.onClickHeader !== undefined}
+                >
+                  <span>
+                    {colDef?.display ? (
+                      typeof colDef.display === "string" ? (
+                        colDef.display
+                      ) : (
+                        <>{colDef.display}</>
+                      )
                     ) : (
-                      <>{colDef.display}</>
-                    )
-                  ) : (
-                    ""
-                  )}
-                  {colDef?.sort && (
-                    <div className="inline pl-1 align-middle">
-                      {colDef?.sort?.currentDirection === "ascending" ? (
-                        <Image
-                          alt="ascending"
-                          src="/icons/sort-up.svg"
-                          height={16}
-                          width={16}
-                        />
-                      ) : colDef?.sort?.currentDirection === "descending" ? (
-                        <Image
-                          alt="descending"
-                          src="/icons/sort-down.svg"
-                          height={16}
-                          width={16}
-                        />
-                      ) : undefined}
-                    </div>
-                  )}
-                  {colDef.infoTooltip && (
-                    <InfoTooltip content={colDef.infoTooltip} />
-                  )}
-                </span>
+                      ""
+                    )}
+                    {colDef?.sort && (
+                      <div className="inline pl-1 align-middle">
+                        {colDef?.sort?.currentDirection === "ascending" ? (
+                          <Image
+                            alt="ascending"
+                            src="/icons/sort-up.svg"
+                            height={16}
+                            width={16}
+                          />
+                        ) : colDef?.sort?.currentDirection === "descending" ? (
+                          <Image
+                            alt="descending"
+                            src="/icons/sort-down.svg"
+                            height={16}
+                            width={16}
+                          />
+                        ) : undefined}
+                      </div>
+                    )}
+                    {colDef.infoTooltip && (
+                      <InfoTooltip content={colDef.infoTooltip} />
+                    )}
+                  </span>
+                </ClickableContent>
               </th>
             );
           })}
@@ -116,6 +125,8 @@ export const Table = <TCell extends BaseCell>({
           const rowDef =
             rowDefs && Array.isArray(rowDefs) ? rowDefs[rowIndex] : rowDefs;
           const rowHovered = rowsHovered[rowIndex] ?? false;
+          const rowIsButton =
+            rowDef !== undefined && rowDef.onClick && !rowDef.link;
 
           return (
             <tr
@@ -134,8 +145,8 @@ export const Table = <TCell extends BaseCell>({
               onMouseEnter={() => setRowHovered(rowIndex, true)}
               onMouseLeave={() => setRowHovered(rowIndex, false)}
               onClick={() => {
-                if (rowDef && rowDef.onClick && !rowDef.link) {
-                  rowDef.onClick(rowIndex);
+                if (rowIsButton) {
+                  rowDef.onClick?.(rowIndex);
                 }
               }}
             >
@@ -150,24 +161,26 @@ export const Table = <TCell extends BaseCell>({
 
                 return (
                   <td className={customClass} key={`${rowIndex}${columnIndex}`}>
-                    {rowDef?.link ? (
-                      <Link href={rowDef?.link}>
-                        <a
-                          className="focus:outline-none"
-                          tabIndex={columnIndex > 0 ? -1 : 0}
-                        >
-                          {DisplayCell ? (
-                            <DisplayCell rowHovered={rowHovered} {...cell} />
-                          ) : (
-                            cell.value
-                          )}
-                        </a>
-                      </Link>
-                    ) : DisplayCell ? (
-                      <DisplayCell rowHovered={rowHovered} {...cell} />
-                    ) : (
-                      cell.value
-                    )}
+                    <ClickableContent isButton={rowIsButton}>
+                      {rowDef?.link ? (
+                        <Link href={rowDef?.link}>
+                          <a
+                            className="focus:outline-none"
+                            tabIndex={columnIndex > 0 ? -1 : 0}
+                          >
+                            {DisplayCell ? (
+                              <DisplayCell rowHovered={rowHovered} {...cell} />
+                            ) : (
+                              cell.value
+                            )}
+                          </a>
+                        </Link>
+                      ) : DisplayCell ? (
+                        <DisplayCell rowHovered={rowHovered} {...cell} />
+                      ) : (
+                        cell.value
+                      )}
+                    </ClickableContent>
                   </td>
                 );
               })}
@@ -178,5 +191,11 @@ export const Table = <TCell extends BaseCell>({
     </table>
   );
 };
+
+/** Wrap non-link non-visual content in a button for Ax users. */
+const ClickableContent: FunctionComponent<{ isButton?: boolean }> = ({
+  isButton = false,
+  children,
+}) => (isButton ? <button>{children}</button> : <>{children}</>);
 
 export * from "./types";

--- a/packages/web/components/trade-clipboard/index.tsx
+++ b/packages/web/components/trade-clipboard/index.tsx
@@ -174,7 +174,7 @@ export const TradeClipboard: FunctionComponent<{
                         slippageConfig.select(slippage.index);
                       }}
                     >
-                      {slippage.slippage.toString()}
+                      <button>{slippage.slippage.toString()}</button>
                     </li>
                   );
                 })}

--- a/packages/web/components/trade-clipboard/index.tsx
+++ b/packages/web/components/trade-clipboard/index.tsx
@@ -242,7 +242,7 @@ export const TradeClipboard: FunctionComponent<{
                 <button
                   type="button"
                   className={classNames(
-                    "text-white-full text-xs py-1 px-1.5 rounded-md ml-2",
+                    "button text-white-full text-xs py-1 px-1.5 rounded-md ml-2",
                     tradeTokenInConfig && tradeTokenInConfig.fraction === 1
                       ? "bg-primary-200"
                       : "bg-white-faint"
@@ -266,7 +266,7 @@ export const TradeClipboard: FunctionComponent<{
                 <button
                   type="button"
                   className={classNames(
-                    "text-white-full text-xs py-1 px-1.5 rounded-md ml-1",
+                    "button text-white-full text-xs py-1 px-1.5 rounded-md ml-1",
                     tradeTokenInConfig && tradeTokenInConfig.fraction === 0.5
                       ? "bg-primary-200"
                       : "bg-white-faint"

--- a/packages/web/modals/base.tsx
+++ b/packages/web/modals/base.tsx
@@ -46,7 +46,8 @@ export const ModalBase: FunctionComponent<ModalBaseProps> = ({
       )}
     >
       {!hideCloseButton && (
-        <div
+        <button
+          aria-label="close"
           className="absolute md:top-4 md:right-4 top-5 right-5 cursor-pointer z-50"
           onClick={onRequestClose}
         >
@@ -56,7 +57,7 @@ export const ModalBase: FunctionComponent<ModalBaseProps> = ({
             width={isMobile ? 24 : 32}
             height={isMobile ? 24 : 32}
           />
-        </div>
+        </button>
       )}
       {typeof title === "string" ? (
         isMobile ? (

--- a/packages/web/modals/lock-tokens.tsx
+++ b/packages/web/modals/lock-tokens.tsx
@@ -137,7 +137,7 @@ export const LockTokensModal: FunctionComponent<
             labelButtons={[
               {
                 label: "MAX",
-                onClick: () => config.setFraction(1),
+                onClick: () => config.toggleIsMax(),
                 className: "!my-auto !h-6 !bg-primary-200 !caption",
               },
             ]}
@@ -168,7 +168,7 @@ const LockupItem: FunctionComponent<
   superfluidApr,
   isMobile = false,
 }) => (
-  <div
+  <button
     onClick={onSelect}
     className={classNames(
       {
@@ -223,5 +223,5 @@ const LockupItem: FunctionComponent<
         </div>
       </div>
     </div>
-  </div>
+  </button>
 );

--- a/packages/web/modals/manage-liquidity.tsx
+++ b/packages/web/modals/manage-liquidity.tsx
@@ -176,7 +176,7 @@ export const ManageLiquidityModal: FunctionComponent<Props> = observer(
                                 )}
                                 <button
                                   className={classNames(
-                                    "py-1 px-1.5 my-1 text-xs rounded-md bg-white-faint",
+                                    "button py-1 px-1.5 my-1 text-xs rounded-md bg-white-faint",
                                     {
                                       "opacity-30": assetBalance
                                         ?.toDec()
@@ -194,7 +194,7 @@ export const ManageLiquidityModal: FunctionComponent<Props> = observer(
                               {isMobile && (
                                 <button
                                   className={classNames(
-                                    "py-1 px-1.5 my-1 text-xs rounded-md bg-white-faint",
+                                    "button py-1 px-1.5 my-1 text-xs rounded-md bg-white-faint",
                                     {
                                       "opacity-30": assetBalance
                                         ?.toDec()
@@ -312,7 +312,7 @@ export const ManageLiquidityModal: FunctionComponent<Props> = observer(
                       disabled={removeLiquidityConfig.poolShareWithPercentage
                         .toDec()
                         .equals(new Dec(0))}
-                      className="w-full h-full rounded-md border border-secondary-200 flex justify-center items-center hover:opacity-75 disabled:opacity-30"
+                      className="button w-full h-full rounded-md border border-secondary-200 flex justify-center items-center hover:opacity-75 disabled:opacity-30"
                     >
                       <p className="text-secondary-200">25%</p>
                     </button>
@@ -321,7 +321,7 @@ export const ManageLiquidityModal: FunctionComponent<Props> = observer(
                       disabled={removeLiquidityConfig.poolShareWithPercentage
                         .toDec()
                         .equals(new Dec(0))}
-                      className="w-full h-full rounded-md border border-secondary-200 flex justify-center items-center hover:opacity-75 disabled:opacity-30"
+                      className="button w-full h-full rounded-md border border-secondary-200 flex justify-center items-center hover:opacity-75 disabled:opacity-30"
                     >
                       <p className="text-secondary-200">50%</p>
                     </button>
@@ -330,7 +330,7 @@ export const ManageLiquidityModal: FunctionComponent<Props> = observer(
                       disabled={removeLiquidityConfig.poolShareWithPercentage
                         .toDec()
                         .equals(new Dec(0))}
-                      className="w-full h-full rounded-md border border-secondary-200 flex justify-center items-center hover:opacity-75 disabled:opacity-30"
+                      className="button w-full h-full rounded-md border border-secondary-200 flex justify-center items-center hover:opacity-75 disabled:opacity-30"
                     >
                       <p className="text-secondary-200">75%</p>
                     </button>
@@ -339,7 +339,7 @@ export const ManageLiquidityModal: FunctionComponent<Props> = observer(
                       disabled={removeLiquidityConfig.poolShareWithPercentage
                         .toDec()
                         .equals(new Dec(0))}
-                      className="w-full h-full rounded-md border border-secondary-200 flex justify-center items-center hover:opacity-75 disabled:opacity-30"
+                      className="button w-full h-full rounded-md border border-secondary-200 flex justify-center items-center hover:opacity-75 disabled:opacity-30"
                     >
                       <p className="text-secondary-200">MAX</p>
                     </button>

--- a/packages/web/styles/globals.css
+++ b/packages/web/styles/globals.css
@@ -41,7 +41,7 @@
   .body2 {
     @apply text-body2 font-body2;
   }
-  button {
+  .button {
     @apply text-button font-button;
   }
   .caption {


### PR DESCRIPTION
### Problem
We've received comments that some visually impaired users are having trouble navigating some of the clickable UI elements since release of refactor.

### Solution
Use native HTML `button` elements to let clickable items be tab-able. This PR changes:
* Frontier banner
* Slippage settings dropdown
* Modal close button
* Pool token select, in create pool and add liquidity modals
* Tab box (in manage liquidity modal)
* Token select, and it's dropdown tokens
* Gauges in lock tokens modal
* All pool cards
* Sort menu and it's dropdown's sort items
* Table elements, only if they're clickable and not linkable (links are also tab-able)