### PR TITLE
Remove dashes from GravityBridge tokens

### DIFF
--- a/packages/web/config/chain-infos.ts
+++ b/packages/web/config/chain-infos.ts
@@ -995,21 +995,21 @@ const chainInfos = (
           coinImageUrl: "/tokens/pstake.png",
         },
         {
-          coinDenom: "g-WBTC",
+          coinDenom: "gWBTC",
           coinMinimalDenom: "gravity0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
           coinDecimals: 8,
           coinGeckoId: "wrapped-bitcoin",
           coinImageUrl: "/tokens/gwbtc.png",
         },
         {
-          coinDenom: "g-WETH",
+          coinDenom: "gWETH",
           coinMinimalDenom: "gravity0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
           coinDecimals: 18,
           coinGeckoId: "ethereum",
           coinImageUrl: "/tokens/gweth.png",
         },
         {
-          coinDenom: "g-USDC",
+          coinDenom: "gUSDC",
           coinMinimalDenom: "gravity0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
           coinDecimals: 6,
           coinGeckoId: "usd-coin",
@@ -1017,7 +1017,7 @@ const chainInfos = (
           pegMechanism: "collateralized",
         },
         {
-          coinDenom: "g-DAI",
+          coinDenom: "gDAI",
           coinMinimalDenom: "gravity0x6B175474E89094C44Da98b954EedeAC495271d0F",
           coinDecimals: 18,
           coinGeckoId: "dai",
@@ -1025,7 +1025,7 @@ const chainInfos = (
           pegMechanism: "collateralized",
         },
         {
-          coinDenom: "g-USDT",
+          coinDenom: "gUSDT",
           coinMinimalDenom: "gravity0xdAC17F958D2ee523a2206206994597C13D831ec7",
           coinDecimals: 6,
           coinGeckoId: "tether",


### PR DESCRIPTION
-now that the Trade page, Pools page, and other interfaces can display lower and upper case, we no longer need the dash between tokens like g-USDC -> gUSDC.