### PR TITLE
PREVIEW ONLY: Unbond native assets button+tooltip in assets table

### DIFF
--- a/packages/web/components/table/cells/index.ts
+++ b/packages/web/components/table/cells/index.ts
@@ -4,4 +4,5 @@ export * from "./transfer-button";
 export * from "./pool-composition";
 export * from "./metric-loader-cell";
 export * from "./types";
+export * from "./unbond-native-asset";
 export * from "./validator-info";

--- a/packages/web/components/table/cells/types.ts
+++ b/packages/web/components/table/cells/types.ts
@@ -1,5 +1,6 @@
 import { BaseCell } from "../types";
 import { Currency } from "@keplr-wallet/types";
+import { CoinPretty } from "@keplr-wallet/unit";
 
 export type AssetCell = BaseCell & {
   currency: Currency;
@@ -10,6 +11,7 @@ export type AssetCell = BaseCell & {
   amount: string;
   fiatValue?: string;
   isCW20: boolean;
+  lockedNativeBalance?: CoinPretty;
   /** Used by `useFilteredData` to provide user query terms to help users find this cell in the table.
    *  Be sure to add `"queryTags"` to the keys param.
    */

--- a/packages/web/components/table/cells/unbond-native-asset.tsx
+++ b/packages/web/components/table/cells/unbond-native-asset.tsx
@@ -1,0 +1,80 @@
+import { FunctionComponent } from "react";
+import { observer } from "mobx-react-lite";
+import moment from "dayjs";
+import { CoinPretty } from "@keplr-wallet/unit";
+import { useStore } from "../../../stores";
+import { Button } from "../../buttons";
+import { InfoTooltip } from "../../tooltip";
+
+/** Table cell that fully handles querying and unbonding of native assets: OSMO, ION. */
+export const UnbondNativeAssetCell: FunctionComponent<{
+  lockedNativeBalance?: CoinPretty;
+}> = observer(({ lockedNativeBalance }) => {
+  const {
+    chainStore: {
+      osmosis: { chainId },
+    },
+    accountStore,
+    queriesStore,
+  } = useStore();
+
+  if (!lockedNativeBalance || lockedNativeBalance.toDec().isZero()) {
+    return null;
+  }
+
+  const account = accountStore.getAccount(chainId);
+
+  const queriesOsmosis = queriesStore.get(chainId).osmosis!;
+  const lockableDurations =
+    queriesOsmosis.queryLockableDurations.lockableDurations;
+  const accountLocked = queriesOsmosis.queryAccountLocked.get(
+    account.bech32Address
+  );
+
+  let lockIds: string[] = [];
+  let unlockingAmounts: { amount: CoinPretty; endTime: Date }[] = [];
+
+  // get all locks and unbonding amounts for this currency
+  for (const duration of lockableDurations) {
+    const lock = accountLocked.getLockedCoinWithDuration(
+      lockedNativeBalance.currency,
+      duration
+    );
+    const unlocks = accountLocked.getUnlockingCoinWithDuration(
+      lockedNativeBalance.currency,
+      duration
+    );
+    lockIds = lockIds.concat(lock.lockIds);
+    unlockingAmounts = unlockingAmounts.concat(unlocks);
+  }
+
+  // allow unbond
+  return (
+    <div className="flex items-center">
+      {unlockingAmounts.length > 0 && (
+        <InfoTooltip
+          content={`Unbonding: ${unlockingAmounts
+            .map(
+              (lock) =>
+                `${lock.amount.toString()} ${moment(lock.endTime).fromNow()}`
+            )
+            .join(", ")}`}
+        />
+      )}
+      {lockIds.length > 0 && (
+        <Button
+          size="xs"
+          type="arrow-sm"
+          onClick={async () => {
+            console.log("click unbond");
+            try {
+              await account.osmosis.sendBeginUnlockingMsg(lockIds);
+            } catch {}
+          }}
+        >
+          Unbond
+        </Button>
+      )}
+    </div>
+  );
+});


### PR DESCRIPTION
### Problem
Some users, due to a fixed refactor UI bug, managed to lock native OSMO assets.

### Solution
Added a simple tooltip in assets table showing current unbonding amounts and end times for native OSMO and ION, as well as an "Unbond" button to let the user initiate an unlock for any outstanding native locks.

We will NOT be merging this into prod, we will just use this PR to generate Vercel Preview links that users can get from the support team on discord.

Will close #580 on open.