### PR TITLE
Auto-refresh when user returns from viewing another browser tab #579

### DIFF
--- a/packages/stores/src/price/pool.ts
+++ b/packages/stores/src/price/pool.ts
@@ -46,7 +46,11 @@ export class PoolFallbackPriceStore
     return result;
   }
 
-  getPrice(coinId: string, vsCurrency: string): number | undefined {
+  getPrice(coinId: string, vsCurrency?: string): number | undefined {
+    if (!vsCurrency) {
+      vsCurrency = this.defaultVsCurrency;
+    }
+
     try {
       const routes = this.intermediateRoutesMap;
       const route = routes.get(coinId);

--- a/packages/web/hooks/use-visibility-state/index.ts
+++ b/packages/web/hooks/use-visibility-state/index.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Return current `document.visibilityState`.
+ * Listen for "visibilitychange" event and update state whenever event emitted.
+ * In nextjs, there is no `visibilityState` because `document` does not exist on the server.
+ * In this case, it unconditionally returns "visible".
+ */
+export const useVisibilityState = () => {
+  const [state, setState] = useState<VisibilityState>(() => {
+    if (typeof document === "undefined") {
+      return "visible";
+    }
+
+    return document.visibilityState;
+  });
+
+  useEffect(() => {
+    const handler = () => {
+      setState(() => {
+        if (typeof document === "undefined") {
+          return "visible";
+        }
+
+        return document.visibilityState;
+      });
+    };
+
+    if (typeof document !== "undefined") {
+      document.addEventListener("visibilitychange", handler);
+    }
+
+    return () => {
+      if (typeof document !== "undefined") {
+        document.removeEventListener("visibilitychange", handler);
+      }
+    };
+  }, []);
+
+  return state;
+};

--- a/packages/web/stores/index.tsx
+++ b/packages/web/stores/index.tsx
@@ -1,4 +1,9 @@
-import React, { FunctionComponent, useEffect, useState } from "react";
+import React, {
+  FunctionComponent,
+  useCallback,
+  useEffect,
+  useState,
+} from "react";
 import { RootStore } from "./root";
 import { useKeplr } from "../hooks";
 import { AccountInitManagement } from "./account-init-management";
@@ -6,35 +11,62 @@ import { useVisibilityState } from "../hooks/use-visibility-state";
 
 const storeContext = React.createContext<RootStore | null>(null);
 
+// When the page is visible, refresh more often.
+const refreshIntervalOnVisible = 30 * 1000;
+// When the page is hidden, it refreshes less frequently.
+// Users may be looking at other tabs for a long time.
+// In this case, it is not necessary to refresh frequently, and if refresh frequently, it may burden the node.
+const refreshIntervalOnHidden = 5 * 60 * 1000;
+
 export const StoreProvider: FunctionComponent = ({ children }) => {
   const keplr = useKeplr();
 
   const [rootStore] = useState(() => new RootStore(keplr.getKeplr));
 
   const visibilityState = useVisibilityState();
+  const [refreshInterval, setRefreshInterval] = useState(
+    refreshIntervalOnVisible
+  );
 
-  useEffect(() => {
-    if (visibilityState === "visible") {
-      const queryPools = rootStore.queriesStore.get(
-        rootStore.chainStore.osmosis.chainId
-      ).osmosis!.queryGammPools;
+  const refresh = useCallback(() => {
+    const queryPools = rootStore.queriesStore.get(
+      rootStore.chainStore.osmosis.chainId
+    ).osmosis!.queryGammPools;
 
-      if (!queryPools.isFetching) {
-        queryPools.fetch();
-      }
+    if (!queryPools.isFetching) {
+      queryPools.fetch();
+    }
 
-      const priceStore = rootStore.priceStore;
+    const priceStore = rootStore.priceStore;
 
-      if (!priceStore.isFetching) {
-        priceStore.fetch();
-      }
+    if (!priceStore.isFetching) {
+      priceStore.fetch();
     }
   }, [
     rootStore.chainStore.osmosis.chainId,
     rootStore.priceStore,
     rootStore.queriesStore,
-    visibilityState,
   ]);
+
+  useEffect(() => {
+    if (visibilityState === "visible") {
+      // Refresh query pools and price whenever page becomes visible
+
+      refresh();
+
+      setRefreshInterval(refreshIntervalOnVisible);
+    } else {
+      setRefreshInterval(refreshIntervalOnHidden);
+    }
+  }, [refresh, visibilityState]);
+
+  useEffect(() => {
+    const disposer = setInterval(refresh, refreshInterval);
+
+    return () => {
+      clearInterval(disposer);
+    };
+  }, [refresh, refreshInterval]);
 
   return (
     <storeContext.Provider value={rootStore}>

--- a/packages/web/stores/root.ts
+++ b/packages/web/stores/root.ts
@@ -17,7 +17,6 @@ import {
   QueriesExternalStore,
   IBCTransferHistoryStore,
   OsmosisAccount,
-  IPriceStore,
   PoolFallbackPriceStore,
 } from "@osmosis-labs/stores";
 import { AppCurrency, Keplr } from "@keplr-wallet/types";
@@ -44,7 +43,7 @@ export class RootStore {
     [CosmosAccount, CosmwasmAccount, OsmosisAccount]
   >;
 
-  public readonly priceStore: IPriceStore;
+  public readonly priceStore: PoolFallbackPriceStore;
 
   public readonly ibcTransferHistoryStore: IBCTransferHistoryStore;
 


### PR DESCRIPTION
Most of the data depends on information from pools. Also, since prices change in real time, it is important to know the latest information of pools and prices.

The above two information should be refreshed periodically.

- Refresh when user views another tab and comes back to the frontend.
- If the user is viewing the frontend, it refreshes every 30 seconds.
- If the user is not viewing the frontend, it refreshes every 5 minutes.