### PR TITLE
Added user redirect modal to official keplr site to install extension

### DIFF
--- a/packages/web/modals/index.tsx
+++ b/packages/web/modals/index.tsx
@@ -8,3 +8,4 @@ export * from "./wallet-connect";
 export * from "./menu-options";
 export * from "./pre-transfer";
 export * from "./trade-tokens";
+export * from "./install-keplr";

--- a/packages/web/modals/install-keplr.tsx
+++ b/packages/web/modals/install-keplr.tsx
@@ -1,0 +1,43 @@
+import Link from "next/link";
+import Image from "next/image";
+import React, { FunctionComponent } from "react";
+import { ModalBase, ModalBaseProps } from "./base";
+
+const KEPLER_OFFICIAL_URL = "https://www.keplr.app/";
+
+export const KeplrInstallModal: FunctionComponent<ModalBaseProps & {}> = ({
+  isOpen,
+  onRequestClose,
+}) => (
+  <ModalBase
+    isOpen={isOpen}
+    onRequestClose={onRequestClose}
+    className="max-w-[30.625rem]"
+    title={<h6 className="mb-4">Install Keplr Wallet Extension</h6>}
+  >
+    <p className="mb-5 caption text-white-mid">
+      To interact with the osmosis application you will need to install the
+      official keplr browser extenstion. You can do this by clicking on the
+      button below and finding the install keplr button.
+    </p>
+    <button
+      className="bg-background rounded-2xl p-5 flex items-center"
+      onClick={(e) => {
+        e.preventDefault();
+        window.open(KEPLER_OFFICIAL_URL, "_blank");
+        onRequestClose();
+      }}
+    >
+      <Image
+        src="/images/keplr-logo.png"
+        alt="keplr logo"
+        width={64}
+        height={64}
+      />
+      <div className="flex flex-col text-left ml-5">
+        <h6>Keplr&apos;s Official Website</h6>
+        <p className="body2 text-iconDefault mt-1">{KEPLER_OFFICIAL_URL}</p>
+      </div>
+    </button>
+  </ModalBase>
+);


### PR DESCRIPTION
This resolves the issue raised [https://github.com/osmosis-labs/osmosis-frontend/issues/412](here) It creates a new user modal that only appears when the keplr extension is not installed in the users browser. If this is the case it will appear with a new modal that contains a redirect to the official keplr website. You can see the result in the staging env and also in the gif below.

![Jun-12-2022 23-36-53](https://user-images.githubusercontent.com/33270926/173256679-4cf8c775-27ce-4d3d-8d67-47ca8fbc17cc.gif)
