### PR TITLE
Fix color display and link sharing when `colorIndex` is zero

### DIFF
--- a/packages/web/pages/pixels/index.tsx
+++ b/packages/web/pages/pixels/index.tsx
@@ -143,7 +143,7 @@ const ShareModal: FunctionComponent<
           type="outline"
           className="flex items-center"
           onClick={async () => {
-            const copingLink = props.shareInfo?.colorIndex
+            const copingLink = typeof props.shareInfo?.colorIndex !== 'undefined'
               ? window.location.href
               : window.location.origin + "/pixels";
             await navigator.clipboard.writeText(copingLink);

--- a/packages/web/pages/pixels/index.tsx
+++ b/packages/web/pages/pixels/index.tsx
@@ -124,7 +124,7 @@ const ShareModal: FunctionComponent<
                 props.shareInfo.numDots ?? 0
               ).toLocaleString()} pixels so far`
             : `(${props.shareInfo.x}, ${props.shareInfo.y})`}
-          {props.shareInfo.colorIndex && (
+          {typeof props.shareInfo.colorIndex !== 'undefined' && (
             <div
               className="ml-2 w-[28px] h-[28px] rounded-full border-0"
               style={{ backgroundColor: COLOR_SET[props.shareInfo.colorIndex] }}


### PR DESCRIPTION
```diff
- props.shareInfo.colorIndex
+ typeof props.shareInfo.colorIndex !== 'undefined'
```

`colorIndex` is `0` when you select `white`, making some UIs unrendered

<img width="956" alt="스크린샷 2022-06-21 오후 5 21 13" src="https://user-images.githubusercontent.com/32605822/174752315-d157b9ff-4393-46ab-a334-09df87fb8c92.png">
