### PR TITLE
Update VDL external incentives gauge-id

### DIFF
--- a/packages/web/config/feature-flag.ts
+++ b/packages/web/config/feature-flag.ts
@@ -529,17 +529,12 @@ export const ExternalIncentiveGaugeAllowList: {
   ],
   "613": [
     {
-      gaugeId: "3193",
+      gaugeId: "4340",
       denom:
         "ibc/E7B35499CFBEB0FF5778127ABA4FB2C4B79A6B8D3D831D4379C4048C238796BD",
     },
     {
-      gaugeId: "3194",
-      denom:
-        "ibc/E7B35499CFBEB0FF5778127ABA4FB2C4B79A6B8D3D831D4379C4048C238796BD",
-    },
-    {
-      gaugeId: "3195",
+      gaugeId: "4341",
       denom:
         "ibc/E7B35499CFBEB0FF5778127ABA4FB2C4B79A6B8D3D831D4379C4048C238796BD",
     },


### PR DESCRIPTION
- Removed expired gauge-ids
+ Added new 7 and 14 day unbond guage-ids