### PR TITLE
Update default fees and add features for Kichain

### DIFF
--- a/packages/web/config/chain-infos.ts
+++ b/packages/web/config/chain-infos.ts
@@ -595,7 +595,12 @@ const chainInfos = (
           isFeeCurrency: true,
         },
       ],
-      features: ["stargate", "ibc-transfer"],
+      gasPriceStep: {
+        low: 0.025,
+        average: 0.030,
+        high: 0.050,
+      },
+      features: ["stargate", "ibc-transfer", "ibc-go", "wasmd_0.24+", "cosmwasm"],
       explorerUrlToTx: "https://www.mintscan.io/ki-chain/txs/{txHash}",
     },
     {


### PR DESCRIPTION
Changes:
1. Added `gasPriceStep` field for the Kichain in `chain-configs` to fix unusable low fees in keplr. Kichain's recommended `minimum-gas-price` is 0.025uxki.
2. Added new features as Kichain has upgraded to include Cosmwasm v0.26.  


