### PR TITLE
add xprt/usdc, xprt/osmo pool external incentives.

### DIFF
--- a/packages/web/config/feature-flag.ts
+++ b/packages/web/config/feature-flag.ts
@@ -52,6 +52,13 @@ export const ExternalIncentiveGaugeAllowList: {
         "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4",
     },
   ],
+  "15": [
+    {
+      gaugeId: "4521",
+      denom:
+        "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
+    },
+  ],
   "461": [
     {
       gaugeId: "1774",
@@ -866,6 +873,11 @@ export const ExternalIncentiveGaugeAllowList: {
   "719": [
     {
       gaugeId: "3528",
+      denom:
+        "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
+    },
+    {
+      gaugeId: "4520",
       denom:
         "ibc/A0CC0CF735BFB30E730C70019D4218A1244FF383503FF7579C9201AB93CA9293",
     },


### PR DESCRIPTION
Adds gauges to 
- pool 719 - https://www.mintscan.io/osmosis/txs/E5B6170A8E23F0EBEB612F307374B2D55AE0D559AB33489943F88EB90E5AAC62 -gaugeID - 4520

- pool 15 - https://www.mintscan.io/osmosis/txs/3195BED17E0C5E8B545FF1FFF68401A0F894849C297803E07F19B5266E2D5F62 - gaugeID - 4521
