### PR TITLE
change Osmosis Blog link

### DIFF
--- a/packages/web/components/complex/sidebar-bottom.tsx
+++ b/packages/web/components/complex/sidebar-bottom.tsx
@@ -150,7 +150,7 @@ const Links: FunctionComponent = () => (
         <Image src="/icons/twitter.svg" alt="twitter" width={32} height={32} />
       </a>
       <a
-        href="https://medium.com/@Osmosis"
+        href="https://medium.com/osmosis"
         target="_blank"
         className="opacity-80 hover:opacity-100 cursor-pointer px-1 m-auto"
         rel="noreferrer"


### PR DESCRIPTION
Change from "https://medium.com/@Osmosis" (the author) to "https://medium.com/osmosis" (the publication).
The author's article are better at explaining fundamentals, but the publication keeps up to date, and so I'd argue makes a truer 'blog'.
Keeping the link as the author's page may have been intentional.