### PR TITLE
remove steth

### DIFF
--- a/packages/web/config/ibc-assets.ts
+++ b/packages/web/config/ibc-assets.ts
@@ -682,17 +682,6 @@ export const IBCAssetInfos: (IBCAsset & {
     counterpartyChainId: "axelar-dojo-1",
     sourceChannelId: "channel-208",
     destChannelId: "channel-3",
-    coinMinimalDenom: "steth-wei",
-    depositUrlOverride:
-      "https://satellite.money/?source=ethereum&destination=osmosis&asset_denom=steth-wei",
-    withdrawUrlOverride:
-      "https://satellite.money/?source=osmosis&destination=ethereum&asset_denom=steth-wei",
-    sourceChainNameOverride: "Ethereum",
-  },
-  {
-    counterpartyChainId: "axelar-dojo-1",
-    sourceChannelId: "channel-208",
-    destChannelId: "channel-3",
     coinMinimalDenom: "uni-wei",
     depositUrlOverride:
       "https://satellite.money/?source=ethereum&destination=osmosis&asset_denom=uni-wei",


### PR DESCRIPTION
because it doesn't rebase on Osmosis, so users don't get staking rewards. Hence, virtually pointless, and potentially confusing.