### PR TITLE
Set zero fee for the swap tx only if user doesn't have enough OSMO

### DIFF
--- a/packages/stores/types/ui-config/fake-fee-config.d.ts
+++ b/packages/stores/types/ui-config/fake-fee-config.d.ts
@@ -12,6 +12,7 @@ import { StdFee } from "@cosmjs/launchpad";
  */
 export declare class FakeFeeConfig extends TxChainSetter implements IFeeConfig {
     protected _gas: number;
+    protected _shouldZero: boolean;
     constructor(chainGetter: ChainGetter, initialChainId: string, gas: number);
     get gas(): number;
     get fee(): CoinPretty | undefined;
@@ -19,6 +20,8 @@ export declare class FakeFeeConfig extends TxChainSetter implements IFeeConfig {
     get feeCurrency(): Currency | undefined;
     feeType: FeeType | undefined;
     get error(): Error | undefined;
+    get shouldZero(): boolean;
+    setShouldZero(value: boolean): void;
     readonly getFeePrimitive: () => CoinPrimitive | undefined;
     getFeeTypePretty(_feeType: FeeType): CoinPretty;
     setFeeType(_feeType: FeeType | undefined): void;

--- a/packages/web/hooks/ui-config/use-fake-fee-config.ts
+++ b/packages/web/hooks/ui-config/use-fake-fee-config.ts
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { ChainGetter } from "@keplr-wallet/stores";
 import { FakeFeeConfig } from "@osmosis-labs/stores";
-import { FeeType } from "@keplr-wallet/hooks";
 
 /** Maintains a single instance of `FakeFeeConfig` for React view lifecycle.
  *  Updates `chainId` and `feeType` on render.
@@ -10,12 +9,12 @@ export function useFakeFeeConfig(
   chainGetter: ChainGetter,
   chainId: string,
   gas: number,
-  feeType?: FeeType
+  shouldZero: boolean = false
 ) {
   const [feeConfig] = useState(
     () => new FakeFeeConfig(chainGetter, chainId, gas)
   );
   feeConfig.setChain(chainId);
-  feeConfig.setFeeType(feeType);
+  feeConfig.setShouldZero(shouldZero);
   return feeConfig;
 }


### PR DESCRIPTION
Users can send tx with 0 fee because some validators allow to include the tx with 0 fee to the block.

However, these validators are becoming fewer and fewer. Therefore, 0 fee tx is processed slowly.

To decrease this problem, users who have OSMO pay a fee by default.

- Add `shouldZero` option to `FakeFeeConfig`
- On the trade clipboard, check the user's OSMO balance and send tx without fee if it is less than 0.001 OSMO.
- When not paying a fee, set `shouldZero` in `FakeFeeConfig`.