### PR TITLE
Update DOT Exponent

### DIFF
--- a/packages/web/config/chain-infos.ts
+++ b/packages/web/config/chain-infos.ts
@@ -1740,7 +1740,7 @@ chainInfos.push({
     {
       coinDenom: "DOT",
       coinMinimalDenom: "dot-planck",
-      coinDecimals: 18,
+      coinDecimals: 10,
       coinGeckoId: "polkadot",
       coinImageUrl: "/tokens/dot.svg",
     },


### PR DESCRIPTION
xcDOT appears to come across to Osmosis as a 10 exponent token.
Sent 12.17 xcDOT from Moonbeam to Osmosis with 0.17 charge.
Shows in Mintscan as 120,000.000000, shows on frontier as 0 available (<$0.01)

Tested WGLMR and that does appear to use 18.

![image](https://user-images.githubusercontent.com/97029546/180612703-fa8f085c-98cf-4aa6-9caa-a42217bd41f8.png)
![image](https://user-images.githubusercontent.com/97029546/180612705-f538538c-b8f4-4d69-a5f1-c8b6261193d7.png)
![image](https://user-images.githubusercontent.com/97029546/180612707-aa3008a7-8b68-4e52-aebe-96c60337bd72.png)
![image](https://user-images.githubusercontent.com/97029546/180612728-d047ac08-7ba4-406e-8896-cec5d82554f5.png)

