### PR TITLE
Add user analytics events to use on Amplitude

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build
 yarn-error.log
 
 src/styles/index.scss
+.vercel

--- a/packages/web/components/cards/pool-card.tsx
+++ b/packages/web/components/cards/pool-card.tsx
@@ -15,6 +15,7 @@ export const PoolCard: FunctionComponent<
     poolMetrics: Metric[];
     isSuperfluid?: boolean;
     mobileShowFirstLabel?: boolean;
+    onClick?: () => void;
   } & CustomClasses
 > = observer(
   ({
@@ -23,6 +24,7 @@ export const PoolCard: FunctionComponent<
     poolMetrics,
     isSuperfluid,
     mobileShowFirstLabel = false,
+    onClick,
     className,
   }) => {
     const router = useRouter();
@@ -39,7 +41,10 @@ export const PoolCard: FunctionComponent<
             },
             className
           )}
-          onClick={() => router.push(`/pool/${poolId}`)}
+          onClick={() => {
+            onClick?.();
+            router.push(`/pool/${poolId}`);
+          }}
         >
           <div className="flex items-center place-content-between w-full h-full p-8 bg-card rounded-lginset">
             <div className="flex flex-col place-items-start gap-3">

--- a/packages/web/components/complex/all-pools-table-set.tsx
+++ b/packages/web/components/complex/all-pools-table-set.tsx
@@ -9,13 +9,14 @@ import {
   useEffect,
   useRef,
 } from "react";
-import { PoolsPageEvents } from "../../config";
+import { EventName, PoolsPageEvents } from "../../config";
 import {
   useFilteredData,
   usePaginatedData,
   useSortedData,
   useWindowSize,
   useMatomoAnalytics,
+  useAmplitudeAnalytics,
 } from "../../hooks";
 import { useStore } from "../../stores";
 import { Switch, MenuToggle, PageList, SortMenu } from "../control";
@@ -45,6 +46,7 @@ export const AllPoolsTableSet: FunctionComponent<{
   } = useStore();
   const { isMobile } = useWindowSize();
   const { trackEvent } = useMatomoAnalytics();
+  const { logEvent } = useAmplitudeAnalytics();
 
   const [activeOptionId, setActiveOptionId] = useState(tableSet);
   const selectOption = (optionId: string) => {
@@ -55,8 +57,19 @@ export const AllPoolsTableSet: FunctionComponent<{
     }
   };
   const [isPoolTvlFiltered, do_setIsPoolTvlFiltered] = useState(false);
+  const tvlFilterLabel = `Show pools less than ${new PricePretty(
+    priceStore.getFiatCurrency(priceStore.defaultVsCurrency)!,
+    TVL_FILTER_THRESHOLD
+  ).toString()}`;
   const setIsPoolTvlFiltered = useCallback(
     (isFiltered: boolean) => {
+      logEvent([
+        EventName.Pools.allPoolsListFiltered,
+        {
+          filteredBy: tvlFilterLabel,
+          isFilterOn: isFiltered,
+        },
+      ]);
       if (isFiltered) trackEvent(PoolsPageEvents.showLowTvlPools);
       do_setIsPoolTvlFiltered(isFiltered);
     },
@@ -189,12 +202,28 @@ export const AllPoolsTableSet: FunctionComponent<{
             onClickHeader: () => {
               switch (sortDirection) {
                 case "ascending":
-                  setSortDirection("descending");
+                  const newSortDirection = "descending";
+                  logEvent([
+                    EventName.Pools.allPoolsTableSorted,
+                    {
+                      sortedBy: keyPath,
+                      sortDirection: newSortDirection,
+                    },
+                  ]);
+                  setSortDirection(newSortDirection);
                   break;
                 case "descending":
+                  // default sort key toggles forever
                   if (sortKeyPath === initialKeyPath) {
-                    // default sort key toggles forever
-                    setSortDirection("ascending");
+                    const newSortDirection = "ascending";
+                    logEvent([
+                      EventName.Pools.allPoolsTableSorted,
+                      {
+                        sortedBy: keyPath,
+                        sortDirection: newSortDirection,
+                      },
+                    ]);
+                    setSortDirection(newSortDirection);
                   } else {
                     // other keys toggle then go back to default
                     setSortKeyPath(initialKeyPath);
@@ -205,8 +234,16 @@ export const AllPoolsTableSet: FunctionComponent<{
           }
         : {
             onClickHeader: () => {
+              const newSortDirection = "ascending";
+              logEvent([
+                EventName.Pools.allPoolsTableSorted,
+                {
+                  sortedBy: keyPath,
+                  sortDirection: newSortDirection,
+                },
+              ]);
               setSortKeyPath(keyPath);
-              setSortDirection("ascending");
+              setSortDirection(newSortDirection);
             },
           },
     [sortKeyPath, sortDirection, setSortDirection, setSortKeyPath]
@@ -253,6 +290,26 @@ export const AllPoolsTableSet: FunctionComponent<{
     () =>
       allData.map((poolWithFeeMetrics) => ({
         link: `/pool/${poolWithFeeMetrics.pool.id}`,
+        onClick: () => {
+          logEvent([
+            isIncentivizedPools
+              ? EventName.Pools.incentivizedPoolsItemClicked
+              : EventName.Pools.allPoolsItemClicked,
+            {
+              poolId: poolWithFeeMetrics.pool.id,
+              poolName: poolWithFeeMetrics.pool.poolAssets
+                .map((poolAsset) => poolAsset.amount.denom)
+                .join(" / "),
+              poolWeight: poolWithFeeMetrics.pool.poolAssets
+                .map((poolAsset) => poolAsset.weightFraction.toString())
+                .join(" / "),
+              isSuperfluidPool:
+                queriesOsmosis.querySuperfluidPools.isSuperfluidPool(
+                  poolWithFeeMetrics.pool.id
+                ),
+            },
+          ]);
+        },
       })),
     [allData]
   );
@@ -381,9 +438,10 @@ export const AllPoolsTableSet: FunctionComponent<{
                   },
             ],
           ],
-          isSuperfluid: queriesOsmosis.querySuperfluidPools.isSuperfluidPool(
-            poolData.pool.id
-          ),
+          isSuperfluidPool:
+            queriesOsmosis.querySuperfluidPools.isSuperfluidPool(
+              poolData.pool.id
+            ),
         }))}
         searchBoxProps={{
           currentValue: query,
@@ -407,10 +465,7 @@ export const AllPoolsTableSet: FunctionComponent<{
         minTvlToggleProps={{
           isOn: isPoolTvlFiltered,
           onToggle: setIsPoolTvlFiltered,
-          label: `Show pools less than ${new PricePretty(
-            priceStore.getFiatCurrency(priceStore.defaultVsCurrency)!,
-            TVL_FILTER_THRESHOLD
-          ).toString()}`,
+          label: tvlFilterLabel,
         }}
       />
     );
@@ -434,10 +489,7 @@ export const AllPoolsTableSet: FunctionComponent<{
             onToggle={setIsPoolTvlFiltered}
             className="mr-2"
           >
-            {`Show pools less than ${new PricePretty(
-              priceStore.getFiatCurrency(priceStore.defaultVsCurrency)!,
-              TVL_FILTER_THRESHOLD
-            ).toString()}`}
+            {tvlFilterLabel}
           </Switch>
           <div className="flex flex-wrap items-center gap-8 lg:w-full lg:place-content-between">
             <SearchBox
@@ -450,10 +502,33 @@ export const AllPoolsTableSet: FunctionComponent<{
             <SortMenu
               options={tableCols}
               selectedOptionId={sortKeyPath}
-              onSelect={(id) =>
-                id === sortKeyPath ? setSortKeyPath("") : setSortKeyPath(id)
-              }
-              onToggleSortDirection={toggleSortDirection}
+              onSelect={(id) => {
+                if (id === sortKeyPath) {
+                  setSortKeyPath("");
+                } else {
+                  logEvent([
+                    EventName.Pools.allPoolsListSorted,
+                    {
+                      sortedBy: id,
+                      sortDirection: sortDirection,
+                    },
+                  ]);
+                  setSortKeyPath(id);
+                }
+              }}
+              onToggleSortDirection={() => {
+                logEvent([
+                  EventName.Pools.allPoolsListSorted,
+                  {
+                    sortedBy: sortKeyPath,
+                    sortDirection:
+                      sortDirection === "ascending"
+                        ? "descending"
+                        : "ascending",
+                  },
+                ]);
+                toggleSortDirection();
+              }}
             />
           </div>
         </div>

--- a/packages/web/components/complex/all-pools-table-set.tsx
+++ b/packages/web/components/complex/all-pools-table-set.tsx
@@ -204,10 +204,11 @@ export const AllPoolsTableSet: FunctionComponent<{
                 case "ascending":
                   const newSortDirection = "descending";
                   logEvent([
-                    EventName.Pools.allPoolsTableSorted,
+                    EventName.Pools.allPoolsListSorted,
                     {
                       sortedBy: keyPath,
                       sortDirection: newSortDirection,
+                      sortedOn: "table",
                     },
                   ]);
                   setSortDirection(newSortDirection);
@@ -217,10 +218,12 @@ export const AllPoolsTableSet: FunctionComponent<{
                   if (sortKeyPath === initialKeyPath) {
                     const newSortDirection = "ascending";
                     logEvent([
-                      EventName.Pools.allPoolsTableSorted,
+                      EventName.Pools.allPoolsListSorted,
                       {
                         sortedBy: keyPath,
                         sortDirection: newSortDirection,
+
+                        sortedOn: "table",
                       },
                     ]);
                     setSortDirection(newSortDirection);
@@ -236,10 +239,12 @@ export const AllPoolsTableSet: FunctionComponent<{
             onClickHeader: () => {
               const newSortDirection = "ascending";
               logEvent([
-                EventName.Pools.allPoolsTableSorted,
+                EventName.Pools.allPoolsListSorted,
                 {
                   sortedBy: keyPath,
                   sortDirection: newSortDirection,
+
+                  sortedOn: "table",
                 },
               ]);
               setSortKeyPath(keyPath);
@@ -511,6 +516,7 @@ export const AllPoolsTableSet: FunctionComponent<{
                     {
                       sortedBy: id,
                       sortDirection: sortDirection,
+                      sortedOn: "dropdown",
                     },
                   ]);
                   setSortKeyPath(id);
@@ -525,6 +531,7 @@ export const AllPoolsTableSet: FunctionComponent<{
                       sortDirection === "ascending"
                         ? "descending"
                         : "ascending",
+                    sortedOn: "dropdown",
                   },
                 ]);
                 toggleSortDirection();

--- a/packages/web/components/complex/external-incentivized-pools-table-set.tsx
+++ b/packages/web/components/complex/external-incentivized-pools-table-set.tsx
@@ -199,10 +199,11 @@ export const ExternalIncentivizedPoolsTableSet: FunctionComponent = observer(
                   case "ascending":
                     const newSortDirection = "descending";
                     logEvent([
-                      EventName.Pools.externalIncentivePoolsTableSorted,
+                      EventName.Pools.externalIncentivePoolsListSorted,
                       {
                         sortedBy: keyPath,
                         sortDirection: newSortDirection,
+                        sortedOn: "table-head",
                       },
                     ]);
                     setSortDirection(newSortDirection);
@@ -213,10 +214,11 @@ export const ExternalIncentivizedPoolsTableSet: FunctionComponent = observer(
                     if (sortKeyPath === initialKeyPath) {
                       const newSortDirection = "ascending";
                       logEvent([
-                        EventName.Pools.externalIncentivePoolsTableSorted,
+                        EventName.Pools.externalIncentivePoolsListSorted,
                         {
                           sortedBy: keyPath,
                           sortDirection: newSortDirection,
+                          sortedOn: "table-head",
                         },
                       ]);
                       setSortDirection(newSortDirection);
@@ -233,10 +235,11 @@ export const ExternalIncentivizedPoolsTableSet: FunctionComponent = observer(
               onClickHeader: () => {
                 const newSortDirection = "ascending";
                 logEvent([
-                  EventName.Pools.externalIncentivePoolsTableSorted,
+                  EventName.Pools.externalIncentivePoolsListSorted,
                   {
                     sortedBy: keyPath,
                     sortDirection: newSortDirection,
+                    sortedOn: "table-head",
                   },
                 ]);
                 setSortKeyPath(keyPath);
@@ -420,6 +423,7 @@ export const ExternalIncentivizedPoolsTableSet: FunctionComponent = observer(
                     {
                       sortedBy: id,
                       sortDirection: sortDirection,
+                      sortedOn: "dropdown",
                     },
                   ]);
                   setSortKeyPath(id);

--- a/packages/web/components/complex/sidebar-bottom.tsx
+++ b/packages/web/components/complex/sidebar-bottom.tsx
@@ -3,13 +3,14 @@ import { FunctionComponent } from "react";
 import { observer } from "mobx-react-lite";
 import { WalletStatus } from "@keplr-wallet/stores";
 import { PricePretty, Dec } from "@keplr-wallet/unit";
-import { useMatomoAnalytics } from "../../hooks";
+import { useAmplitudeAnalytics, useMatomoAnalytics } from "../../hooks";
 import { useStore } from "../../stores";
-import { IS_FRONTIER, NavBarEvents } from "../../config";
+import { EventName, IS_FRONTIER, NavBarEvents } from "../../config";
 
 export const SidebarBottom: FunctionComponent = observer(() => {
   const { chainStore, accountStore, queriesStore, priceStore } = useStore();
   const { trackEvent } = useMatomoAnalytics();
+  const { logEvent, setUserProperty } = useAmplitudeAnalytics();
 
   const account = accountStore.getAccount(chainStore.osmosis.chainId);
   const queries = queriesStore.get(chainStore.osmosis.chainId);
@@ -71,6 +72,8 @@ export const SidebarBottom: FunctionComponent = observer(() => {
               onClick={(e) => {
                 e.preventDefault();
                 trackEvent(NavBarEvents.disconnectWallet);
+                logEvent([EventName.Sidebar.signOutClicked]);
+                setUserProperty("isWalletConnected", false);
                 account.disconnect();
               }}
               className="button bg-transparent border border-opacity-30 border-secondary-200 h-9 w-full rounded-md py-2 px-1 flex items-center justify-center mb-5"
@@ -92,6 +95,7 @@ export const SidebarBottom: FunctionComponent = observer(() => {
             onClick={(e) => {
               e.preventDefault();
               trackEvent(NavBarEvents.startConnectWallet);
+              logEvent([EventName.Sidebar.connectWalletClicked]);
               account.init();
             }}
           >
@@ -143,7 +147,10 @@ export const SidebarBottom: FunctionComponent = observer(() => {
               target="_blank"
               className="opacity-80 hover:opacity-100 cursor-pointer m-auto"
               rel="noreferrer"
-              onClick={() => trackEvent(NavBarEvents.twitterLink)}
+              onClick={() => {
+                trackEvent(NavBarEvents.twitterLink);
+                logEvent([EventName.Sidebar.twitterClicked]);
+              }}
             >
               <Image
                 src="/icons/twitter.svg"
@@ -157,7 +164,10 @@ export const SidebarBottom: FunctionComponent = observer(() => {
               target="_blank"
               className="opacity-80 hover:opacity-100 cursor-pointer px-1 m-auto"
               rel="noreferrer"
-              onClick={() => trackEvent(NavBarEvents.mediumLink)}
+              onClick={() => {
+                trackEvent(NavBarEvents.mediumLink);
+                logEvent([EventName.Sidebar.mediumClicked]);
+              }}
             >
               <Image
                 src="/icons/medium.svg"
@@ -171,7 +181,10 @@ export const SidebarBottom: FunctionComponent = observer(() => {
               target="_blank"
               className="opacity-80 hover:opacity-100 cursor-pointer m-auto"
               rel="noreferrer"
-              onClick={() => trackEvent(NavBarEvents.commonwealthLink)}
+              onClick={() => {
+                trackEvent(NavBarEvents.commonwealthLink);
+                logEvent([EventName.Sidebar.commonwealthClicked]);
+              }}
             >
               <Image
                 className="w-9 h-9"
@@ -186,7 +199,10 @@ export const SidebarBottom: FunctionComponent = observer(() => {
               target="_blank"
               className="opacity-80 hover:opacity-100 cursor-pointer m-auto"
               rel="noreferrer"
-              onClick={() => trackEvent(NavBarEvents.discordLink)}
+              onClick={() => {
+                trackEvent(NavBarEvents.discordLink);
+                logEvent([EventName.Sidebar.discordClicked]);
+              }}
             >
               <Image
                 src="/icons/discord.svg"
@@ -200,7 +216,10 @@ export const SidebarBottom: FunctionComponent = observer(() => {
               target="_blank"
               className="opacity-80 hover:opacity-100 cursor-pointer m-auto"
               rel="noreferrer"
-              onClick={() => trackEvent(NavBarEvents.telegramLink)}
+              onClick={() => {
+                trackEvent(NavBarEvents.telegramLink);
+                logEvent([EventName.Sidebar.telegramClicked]);
+              }}
             >
               <Image
                 src="/icons/telegram.svg"
@@ -216,7 +235,10 @@ export const SidebarBottom: FunctionComponent = observer(() => {
               href="https://support.osmosis.zone/"
               target="_blank"
               rel="noreferrer"
-              onClick={() => trackEvent(NavBarEvents.supportLabLink)}
+              onClick={() => {
+                trackEvent(NavBarEvents.supportLabLink);
+                logEvent([EventName.Sidebar.supportClicked]);
+              }}
             >
               <span className="opacity-30 hover:opacity-40">
                 Get Support Lab Help

--- a/packages/web/components/layouts/main.tsx
+++ b/packages/web/components/layouts/main.tsx
@@ -11,9 +11,10 @@ import {
   useBooleanWithWindowEvent,
   UserEvent,
   useMatomoAnalytics,
+  useAmplitudeAnalytics,
 } from "../../hooks";
 import { SidebarBottom } from "../complex/sidebar-bottom";
-import { IS_FRONTIER } from "../../config";
+import { AmplitudeEvent, IS_FRONTIER } from "../../config";
 
 export type MainLayoutMenu = {
   label: string;
@@ -22,6 +23,7 @@ export type MainLayoutMenu = {
   iconSelected?: string;
   selectionTest?: RegExp;
   userAnalyticsEvent?: UserEvent;
+  amplitudeEvent?: AmplitudeEvent;
 };
 
 export interface MainLayoutProps {
@@ -32,6 +34,7 @@ export const MainLayout: FunctionComponent<MainLayoutProps> = observer(
   ({ children, menus }) => {
     const router = useRouter();
     const { trackEvent } = useMatomoAnalytics();
+    const { logEvent } = useAmplitudeAnalytics();
 
     const { height, isMobile } = useWindowSize();
     const [_, isScrolledTop] = useWindowScroll();
@@ -73,6 +76,7 @@ export const MainLayout: FunctionComponent<MainLayoutProps> = observer(
                   iconSelected,
                   selectionTest,
                   userAnalyticsEvent,
+                  amplitudeEvent,
                 }) => {
                   const selected = selectionTest
                     ? selectionTest.test(router.pathname)
@@ -94,6 +98,9 @@ export const MainLayout: FunctionComponent<MainLayoutProps> = observer(
                           onClick={() => {
                             if (userAnalyticsEvent) {
                               trackEvent(userAnalyticsEvent);
+                            }
+                            if (amplitudeEvent) {
+                              logEvent(amplitudeEvent);
                             }
                           }}
                         >

--- a/packages/web/components/table/assets-table.tsx
+++ b/packages/web/components/table/assets-table.tsx
@@ -193,6 +193,8 @@ export const AssetsTable: FunctionComponent<Props> = ({
         {
           sortedBy: term,
           sortDirection,
+
+          sortedOn: "dropdown",
         },
       ]);
       do_setSortKey(term);
@@ -223,11 +225,12 @@ export const AssetsTable: FunctionComponent<Props> = ({
         onClickHeader: isSorting
           ? () => {
               logEvent([
-                EventName.Assets.assetsTableSorted,
+                EventName.Assets.assetsListSorted,
                 {
                   sortedBy: firstKey,
                   sortDirection:
                     sortDirection === "descending" ? "ascending" : "descending",
+                  sortedOn: "table-head",
                 },
               ]);
               toggleSortDirection();
@@ -235,10 +238,11 @@ export const AssetsTable: FunctionComponent<Props> = ({
           : () => {
               if (firstKey) {
                 logEvent([
-                  EventName.Assets.assetsTableSorted,
+                  EventName.Assets.assetsListSorted,
                   {
                     sortedBy: firstKey,
                     sortDirection: onClickSortDirection,
+                    sortedOn: "table-head",
                   },
                 ]);
                 setSortKey(firstKey);
@@ -393,6 +397,7 @@ export const AssetsTable: FunctionComponent<Props> = ({
                           sortDirection === "descending"
                             ? "ascending"
                             : "descending",
+                        sortedOn: "dropdown",
                       },
                     ]);
                     toggleSortDirection();

--- a/packages/web/components/table/assets-table.tsx
+++ b/packages/web/components/table/assets-table.tsx
@@ -12,6 +12,7 @@ import {
   useLocalStorageState,
   useWindowSize,
   useMatomoAnalytics,
+  useAmplitudeAnalytics,
 } from "../../hooks";
 import { ShowMoreButton } from "../buttons/show-more";
 import { SearchBox } from "../input";
@@ -28,6 +29,7 @@ import {
 import { TransferHistoryTable } from "./transfer-history";
 import { ColumnDef } from "./types";
 import { Table } from ".";
+import { EventName } from "../../config/user-analytics-v2";
 
 interface Props {
   nativeBalances: CoinBalance[];
@@ -38,8 +40,12 @@ interface Props {
   })[];
   onWithdrawIntent: () => void;
   onDepositIntent: () => void;
-  onWithdraw: (chainId: string, coinDenom: string) => void;
-  onDeposit: (chainId: string, coinDenom: string) => void;
+  onWithdraw: (
+    chainId: string,
+    coinDenom: string,
+    externalUrl?: string
+  ) => void;
+  onDeposit: (chainId: string, coinDenom: string, externalUrl?: string) => void;
 }
 
 export const AssetsTable: FunctionComponent<Props> = ({
@@ -53,17 +59,32 @@ export const AssetsTable: FunctionComponent<Props> = ({
   const { chainStore } = useStore();
   const { width, isMobile } = useWindowSize();
   const { trackEvent } = useMatomoAnalytics();
+  const { logEvent } = useAmplitudeAnalytics();
 
   const onDeposit = useCallback(
     (...depositParams: Parameters<typeof do_onDeposit>) => {
       do_onDeposit(...depositParams);
+      logEvent([
+        EventName.Assets.assetsItemDepositClicked,
+        {
+          tokenName: depositParams[1],
+          hasExternalUrl: !!depositParams[2],
+        },
+      ]);
       trackEvent(AssetsPageEvents.rowStartDeposit);
     },
     [do_onDeposit]
   );
   const onWithdraw = useCallback(
-    (...depositParams: Parameters<typeof do_onWithdraw>) => {
-      do_onWithdraw(...depositParams);
+    (...withdrawParams: Parameters<typeof do_onWithdraw>) => {
+      do_onWithdraw(...withdrawParams);
+      logEvent([
+        EventName.Assets.assetsItemWithdrawClicked,
+        {
+          tokenName: withdrawParams[1],
+          hasExternalUrl: !!withdrawParams[2],
+        },
+      ]);
       trackEvent(AssetsPageEvents.rowStartWithdraw);
     },
     [do_onWithdraw]
@@ -167,6 +188,13 @@ export const AssetsTable: FunctionComponent<Props> = ({
   const setSortKey = useCallback(
     (term: string) => {
       trackEvent(AssetsPageEvents.sortAssets);
+      logEvent([
+        EventName.Assets.assetsListSorted,
+        {
+          sortedBy: term,
+          sortDirection,
+        },
+      ]);
       do_setSortKey(term);
     },
     [trackEvent, sortDirection, do_setSortKey]
@@ -193,9 +221,26 @@ export const AssetsTable: FunctionComponent<Props> = ({
         // If it wasn't sorting (aka first time it is clicked), then it will sort on the first
         // key by default.
         onClickHeader: isSorting
-          ? toggleSortDirection
+          ? () => {
+              logEvent([
+                EventName.Assets.assetsTableSorted,
+                {
+                  sortedBy: firstKey,
+                  sortDirection:
+                    sortDirection === "descending" ? "ascending" : "descending",
+                },
+              ]);
+              toggleSortDirection();
+            }
           : () => {
               if (firstKey) {
+                logEvent([
+                  EventName.Assets.assetsTableSorted,
+                  {
+                    sortedBy: firstKey,
+                    sortDirection: onClickSortDirection,
+                  },
+                ]);
                 setSortKey(firstKey);
                 setSortDirection(onClickSortDirection);
               }
@@ -272,6 +317,13 @@ export const AssetsTable: FunctionComponent<Props> = ({
                   if (hideZeroBalances)
                     trackEvent(AssetsPageEvents.showZeroBalances);
                   else trackEvent(AssetsPageEvents.hideZeroBalances);
+                  logEvent([
+                    EventName.Assets.assetsListFiltered,
+                    {
+                      filteredBy: "Hide zero balances",
+                      isFilterOn: !hideZeroBalances,
+                    },
+                  ]);
 
                   setHideZeroBalances(!hideZeroBalances);
                 }}
@@ -332,7 +384,19 @@ export const AssetsTable: FunctionComponent<Props> = ({
                 <SortMenu
                   selectedOptionId={sortKey}
                   onSelect={setSortKey}
-                  onToggleSortDirection={toggleSortDirection}
+                  onToggleSortDirection={() => {
+                    logEvent([
+                      EventName.Assets.assetsListSorted,
+                      {
+                        sortedBy: sortKey,
+                        sortDirection:
+                          sortDirection === "descending"
+                            ? "ascending"
+                            : "descending",
+                      },
+                    ]);
+                    toggleSortDirection();
+                  }}
                   options={[
                     {
                       id: "coinDenom",
@@ -439,7 +503,15 @@ export const AssetsTable: FunctionComponent<Props> = ({
             <ShowMoreButton
               className="m-auto"
               isOn={showAllAssets}
-              onToggle={() => setShowAllAssets(!showAllAssets)}
+              onToggle={() => {
+                logEvent([
+                  EventName.Assets.assetsListMoreClicked,
+                  {
+                    isOn: !showAllAssets,
+                  },
+                ]);
+                setShowAllAssets(!showAllAssets);
+              }}
             />
           )}
         </div>

--- a/packages/web/components/table/cells/transfer-button.tsx
+++ b/packages/web/components/table/cells/transfer-button.tsx
@@ -26,7 +26,7 @@ export const TransferButtonCell: FunctionComponent<
         disabled={isUnstable}
         externalUrl={withdrawUrlOverride}
         label="Withdraw"
-        action={() => onWithdraw?.(chainId, coinDenom)}
+        action={() => onWithdraw?.(chainId, coinDenom, withdrawUrlOverride)}
       />
     ) : null
   ) : chainId && coinDenom && onDeposit ? (
@@ -34,7 +34,7 @@ export const TransferButtonCell: FunctionComponent<
       disabled={isUnstable}
       externalUrl={depositUrlOverride}
       label="Deposit"
-      action={() => onDeposit?.(chainId, coinDenom)}
+      action={() => onDeposit?.(chainId, coinDenom, depositUrlOverride)}
     />
   ) : null;
 
@@ -56,6 +56,7 @@ const TransferButton: FunctionComponent<{
       style={
         disabled ? { pointerEvents: "none", cursor: "default" } : undefined
       }
+      onClick={action}
     >
       {label}
       <Image

--- a/packages/web/components/table/cells/types.ts
+++ b/packages/web/components/table/cells/types.ts
@@ -15,8 +15,16 @@ export type AssetCell = BaseCell & {
    */
   queryTags?: string[];
   isUnstable?: boolean;
-  onWithdraw?: (chainId: string, coinDenom: string) => void;
-  onDeposit?: (chainId: string, coinDenom: string) => void;
+  onWithdraw?: (
+    chainId: string,
+    coinDenom: string,
+    externalUrl?: string
+  ) => void;
+  onDeposit?: (
+    chainId: string,
+    coinDenom: string,
+    externalUrl?: string
+  ) => void;
 };
 
 export interface ValidatorInfo extends BaseCell {

--- a/packages/web/components/table/index.tsx
+++ b/packages/web/components/table/index.tsx
@@ -151,7 +151,7 @@ export const Table = <TCell extends BaseCell>({
               onMouseEnter={() => setRowHovered(rowIndex, true)}
               onMouseLeave={() => setRowHovered(rowIndex, false)}
               onClick={() => {
-                if (rowIsButton) {
+                if (rowDef !== undefined) {
                   rowDef.onClick?.(rowIndex);
                 }
               }}

--- a/packages/web/components/trade-clipboard/index.tsx
+++ b/packages/web/components/trade-clipboard/index.tsx
@@ -19,6 +19,7 @@ import {
   PoolDetailEvents,
   SwapPageEvents,
   MakeSwapPageEvents,
+  EventName,
 } from "../../config";
 import {
   useBooleanWithWindowEvent,
@@ -28,6 +29,7 @@ import {
   useTradeTokenInConfig,
   useWindowSize,
   useMatomoAnalytics,
+  useAmplitudeAnalytics,
 } from "../../hooks";
 import { useStore } from "../../stores";
 import { Button } from "../buttons";
@@ -52,6 +54,7 @@ export const TradeClipboard: FunctionComponent<{
   const { chainId } = chainStore.osmosis;
   const { isMobile } = useWindowSize();
   const { trackEvent } = useMatomoAnalytics();
+  const { logEvent } = useAmplitudeAnalytics();
 
   const allTokenBalances = nativeBalances.concat(ibcBalances);
 
@@ -266,6 +269,14 @@ export const TradeClipboard: FunctionComponent<{
           onClick={(e) => {
             e.stopPropagation();
             setIsSettingOpen(!isSettingOpen);
+            logEvent([
+              EventName.Swap.settingClicked,
+              {
+                fromToken: tradeTokenInConfig.sendCurrency.coinDenom,
+                toToken: tradeTokenInConfig.outCurrency.coinDenom,
+                isOnHome: !isInModal,
+              },
+            ]);
             closeTokenSelectDropdowns();
           }}
         >
@@ -426,6 +437,14 @@ export const TradeClipboard: FunctionComponent<{
 
                   if (tradeTokenInConfig.fraction !== 1) {
                     trackEvent(SwapPageEvents.swapMaxAmount);
+                    logEvent([
+                      EventName.Swap.maxClicked,
+                      {
+                        fromToken: tradeTokenInConfig.sendCurrency.coinDenom,
+                        toToken: tradeTokenInConfig.outCurrency.coinDenom,
+                        isOnHome: !isInModal,
+                      },
+                    ]);
                     tradeTokenInConfig.setFraction(1);
                   } else {
                     tradeTokenInConfig.setFraction(undefined);
@@ -446,6 +465,14 @@ export const TradeClipboard: FunctionComponent<{
 
                   if (tradeTokenInConfig.fraction !== 0.5) {
                     trackEvent(SwapPageEvents.swapHalfAmount);
+                    logEvent([
+                      EventName.Swap.halfClicked,
+                      {
+                        fromToken: tradeTokenInConfig.sendCurrency.coinDenom,
+                        toToken: tradeTokenInConfig.outCurrency.coinDenom,
+                        isOnHome: !isInModal,
+                      },
+                    ]);
                     tradeTokenInConfig.setFraction(0.5);
                   } else {
                     tradeTokenInConfig.setFraction(undefined);
@@ -543,7 +570,17 @@ export const TradeClipboard: FunctionComponent<{
           onMouseLeave={() => {
             if (!isMobile) setHoveringSwitchButton(false);
           }}
-          onClick={() => setIsAnimatingSwitch(true)}
+          onClick={() => {
+            logEvent([
+              EventName.Swap.switchClicked,
+              {
+                fromToken: tradeTokenInConfig.sendCurrency.coinDenom,
+                toToken: tradeTokenInConfig.outCurrency.coinDenom,
+                isOnHome: !isInModal,
+              },
+            ]);
+            setIsAnimatingSwitch(true);
+          }}
         >
           <div
             className={classNames(
@@ -844,6 +881,14 @@ export const TradeClipboard: FunctionComponent<{
           if (account.walletStatus !== WalletStatus.Loaded) {
             return account.init();
           }
+          logEvent([
+            EventName.Swap.swapClicked,
+            {
+              fromToken: tradeTokenInConfig.sendCurrency.coinDenom,
+              toToken: tradeTokenInConfig.outCurrency.coinDenom,
+              isOnHome: !isInModal,
+            },
+          ]);
 
           if (tradeTokenInConfig.optimizedRoutePaths.length > 0) {
             const routes: {

--- a/packages/web/components/trade-clipboard/index.tsx
+++ b/packages/web/components/trade-clipboard/index.tsx
@@ -269,14 +269,6 @@ export const TradeClipboard: FunctionComponent<{
           onClick={(e) => {
             e.stopPropagation();
             setIsSettingOpen(!isSettingOpen);
-            logEvent([
-              EventName.Swap.settingClicked,
-              {
-                fromToken: tradeTokenInConfig.sendCurrency.coinDenom,
-                toToken: tradeTokenInConfig.outCurrency.coinDenom,
-                isOnHome: !isInModal,
-              },
-            ]);
             closeTokenSelectDropdowns();
           }}
         >
@@ -320,6 +312,12 @@ export const TradeClipboard: FunctionComponent<{
 
                       slippageConfig.select(slippage.index);
 
+                      logEvent([
+                        EventName.Swap.slippageToleranceSet,
+                        {
+                          percentage: slippageConfig.slippage.toString(),
+                        },
+                      ]);
                       trackEvent(
                         MakeSwapPageEvents.setSlippageTolerance(
                           tradeTokenInConfig.sendCurrency.coinDenom,
@@ -366,6 +364,12 @@ export const TradeClipboard: FunctionComponent<{
                   onInput={(value) => {
                     slippageConfig.setManualSlippage(value);
 
+                    logEvent([
+                      EventName.Swap.slippageToleranceSet,
+                      {
+                        percentage: slippageConfig.slippage.toString(),
+                      },
+                    ]);
                     trackEvent(
                       MakeSwapPageEvents.setSlippageTolerance(
                         tradeTokenInConfig.sendCurrency.coinDenom,

--- a/packages/web/config/index.ts
+++ b/packages/web/config/index.ts
@@ -14,3 +14,5 @@ export * from "./price";
 
 /** Config for user analytics events. Should be in sync with: https://www.notion.so/osmosiszone/8bbbabce67fa4c4289989632633b9052?v=7123ab7319054d9aa63ba9e40b6d6c51 */
 export * from "./user-analytics";
+
+export * from "./user-analytics-v2";

--- a/packages/web/config/user-analytics-v2.ts
+++ b/packages/web/config/user-analytics-v2.ts
@@ -2,6 +2,7 @@ export type EventProperties = {
   fromToken: string;
   toToken: string;
   isOnHome: boolean;
+  percentage: string;
   poolId: string;
   poolName: string;
   poolWeight: string;
@@ -50,7 +51,7 @@ export const EventName = {
     pageViewed: "Swap: Page viewed",
     maxClicked: "Swap: Max clicked",
     halfClicked: "Swap: Half clicked",
-    settingClicked: "Swap: Setting clicked",
+    slippageToleranceSet: "Swap: Slippage tolerance set",
     switchClicked: "Swap: Switch clicked",
     swapClicked: "Swap: Swap clicked",
   },

--- a/packages/web/config/user-analytics-v2.ts
+++ b/packages/web/config/user-analytics-v2.ts
@@ -10,6 +10,7 @@ export type EventProperties = {
   toToken: string;
   isOnHome: boolean;
   percentage: string;
+  isMultiHop: boolean;
   poolId: string;
   poolName: string;
   poolWeight: string;
@@ -60,7 +61,8 @@ export const EventName = {
     halfClicked: "Swap: Half clicked",
     slippageToleranceSet: "Swap: Slippage tolerance set",
     switchClicked: "Swap: Switch clicked",
-    swapClicked: "Swap: Swap clicked",
+    swapStarted: "Swap: Swap started",
+    swapCompleted: "Swap: Swap completed",
   },
   // Events in Sidebar UI
   Sidebar: {

--- a/packages/web/config/user-analytics-v2.ts
+++ b/packages/web/config/user-analytics-v2.ts
@@ -22,6 +22,7 @@ export type EventProperties = {
   isOn: boolean;
   tokenName: string;
   tokenAmount: number;
+  bridge: string;
   hasExternalUrl: boolean;
 };
 
@@ -114,9 +115,9 @@ export const EventName = {
     assetsListMoreClicked: "Assets: Assets list more clicked",
     assetsItemDepositClicked: "Assets: Assets item deposit clicked",
     assetsItemWithdrawClicked: "Assets: Assets item withdraw clicked",
-    depositIbcAssetStarted: "Deposit IBC asset: Deposit started",
-    depositIbcAssetCompleted: "Deposit IBC asset: Deposit completed",
-    withdrawIbcAssetStarted: "Withdraw IBC asset: Withdraw started",
-    withdrawIbcAssetCompleted: "Withdraw IBC asset: Withdraw completed",
+    depositAssetStarted: "Deposit asset: Deposit started",
+    depositAssetCompleted: "Deposit asset: Deposit completed",
+    withdrawAssetStarted: "Withdraw asset: Withdraw started",
+    withdrawAssetCompleted: "Withdraw asset: Withdraw completed",
   },
 };

--- a/packages/web/config/user-analytics-v2.ts
+++ b/packages/web/config/user-analytics-v2.ts
@@ -1,3 +1,10 @@
+/** # User Events Constants
+ *  Logged to Amplitude at https://analytics.amplitude.com/osmosis-zone/
+ */
+
+// Should be in sync with: https://docs.google.com/spreadsheets/d/18w8VwJmmRdb_E-XkE1UjkqhLxCyhqVVhWlzDgTtbRWo/edit?usp=sharing
+// For maintainability - all event logs should be in high level component
+
 export type EventProperties = {
   fromToken: string;
   toToken: string;

--- a/packages/web/config/user-analytics-v2.ts
+++ b/packages/web/config/user-analytics-v2.ts
@@ -17,6 +17,7 @@ export type EventProperties = {
   filteredBy: string;
   isFilterOn: boolean;
   sortedBy: string;
+  sortedOn: "table-head" | "dropdown";
   sortDirection: string;
   isSuperfluidPool: boolean;
   isSuperfluidEnabled: boolean;
@@ -86,13 +87,10 @@ export const EventName = {
     superfluidPoolsCardClicked: "Pools: Superfluid pools card clicked",
     allPoolsListFiltered: "Pools: All pools list filtered",
     allPoolsListSorted: "Pools: All pools list sorted",
-    allPoolsTableSorted: "Pools All pools table sorted",
     incentivizedPoolsItemClicked: "Pools: Incentivized pools item clicked",
     allPoolsItemClicked: "Pools: All pools item clicked",
     externalIncentivePoolsListSorted:
-      "Pools: External incentive pools item sorted",
-    externalIncentivePoolsTableSorted:
-      "Pools: External incentive pools table sorted",
+      "Pools: External incentive pools list sorted",
     externalIncentivePoolsItemClicked:
       "Pools: External incentive pools item clicked",
   },
@@ -123,7 +121,6 @@ export const EventName = {
     myPoolsMoreClicked: "Assets: My pools more clicked",
     assetsListFiltered: "Assets: Assets list filtered",
     assetsListSorted: "Assets: Assets list sorted",
-    assetsTableSorted: "Assets: Assets table sorted",
     assetsListMoreClicked: "Assets: Assets list more clicked",
     assetsItemDepositClicked: "Assets: Assets item deposit clicked",
     assetsItemWithdrawClicked: "Assets: Assets item withdraw clicked",

--- a/packages/web/config/user-analytics-v2.ts
+++ b/packages/web/config/user-analytics-v2.ts
@@ -107,6 +107,8 @@ export const EventName = {
   // Events in assets page
   Assets: {
     pageViewed: "Assets: Page viewed",
+    depositClicked: "Assets: Deposit clicked",
+    withdrawClicked: "Assets: Deposit clicked",
     myPoolsCardClicked: "Assets: My pools card clicked",
     myPoolsMoreClicked: "Assets: My pools more clicked",
     assetsListFiltered: "Assets: Assets list filtered",

--- a/packages/web/config/user-analytics-v2.ts
+++ b/packages/web/config/user-analytics-v2.ts
@@ -1,0 +1,122 @@
+export type EventProperties = {
+  fromToken: string;
+  toToken: string;
+  isOnHome: boolean;
+  poolId: string;
+  poolName: string;
+  poolWeight: string;
+  filteredBy: string;
+  isFilterOn: boolean;
+  sortedBy: string;
+  sortDirection: string;
+  isSuperfluidPool: boolean;
+  isSuperfluidEnabled: boolean;
+  isSingleAsset: boolean;
+  providingLiquidity: {
+    [denom: string]: number;
+  };
+  poolSharePercentage: number;
+  unbondingPeriod: number;
+  validatorName: string;
+  validatorCommission: number;
+  isOn: boolean;
+  tokenName: string;
+  tokenAmount: number;
+  hasExternalUrl: boolean;
+};
+
+export type UserProperties = {
+  isWalletConnected: boolean;
+  connectedWallet: string;
+  totalAssetsPrice: string;
+  unbondedAssetsPrice: string;
+  bondedAssetsPrice: string;
+  stakedOsmoPrice: string;
+  osmoBalance: string;
+  myPoolsCount: number;
+};
+
+export type AmplitudeEvent =
+  | [
+      eventName: string,
+      eventProperties: Partial<Record<keyof EventProperties, any>> | undefined
+    ]
+  | [eventName: string];
+
+export const EventName = {
+  // Events in Swap UI and page
+  Swap: {
+    pageViewed: "Swap: Page viewed",
+    maxClicked: "Swap: Max clicked",
+    halfClicked: "Swap: Half clicked",
+    settingClicked: "Swap: Setting clicked",
+    switchClicked: "Swap: Switch clicked",
+    swapClicked: "Swap: Swap clicked",
+  },
+  // Events in Sidebar UI
+  Sidebar: {
+    stakeClicked: "Sidebar: Stake clicked",
+    voteClicked: "Sidebar: Vote clicked",
+    infoClicked: "Sidebar: Info clicked",
+    connectWalletClicked: "Sidebar: Connect wallet clicked",
+    signOutClicked: "Sidebar: Sign out clicked",
+    twitterClicked: "Sidebar: Twitter clicked",
+    mediumClicked: "Sidebar: Medium clicked",
+    commonwealthClicked: "Sidebar: Commonwealth clicked",
+    discordClicked: "Sidebar: Discord clicked",
+    telegramClicked: "Sidebar: Telegram clicked",
+    supportClicked: "Sidebar: Support clicked",
+  },
+  // Events in Pools page
+  Pools: {
+    pageViewed: "Pools: Page viewed",
+    createNewPoolClicked: "Pools: Create new pool clicked",
+    myPoolsCardClicked: "Pools: My pools card clicked",
+    superfluidPoolsCardClicked: "Pools: Superfluid pools card clicked",
+    allPoolsListFiltered: "Pools: All pools list filtered",
+    allPoolsListSorted: "Pools: All pools list sorted",
+    allPoolsTableSorted: "Pools All pools table sorted",
+    incentivizedPoolsItemClicked: "Pools: Incentivized pools item clicked",
+    allPoolsItemClicked: "Pools: All pools item clicked",
+    externalIncentivePoolsListSorted:
+      "Pools: External incentive pools item sorted",
+    externalIncentivePoolsTableSorted:
+      "Pools: External incentive pools table sorted",
+    externalIncentivePoolsItemClicked:
+      "Pools: External incentive pools item clicked",
+  },
+  // Events in Pool detail page
+  PoolDetail: {
+    pageViewed: "Pool detail: Page viewed",
+    addOrRemoveLiquidityClicked: "Pool detail: Add/Remove liquidity clicked",
+    swapTokensClicked: "Pool detail: Swap tokens clicked",
+    startEarningClicked: "Pool detail: Start earning clicked",
+    unbondAllStarted: "Pool detail: Unbond all started",
+    unbondAllCompleted: "Pool detail: Unbond all completed",
+    singleAssetClicked: "Manage liquidity: Single asset clicked",
+    addLiquidityStarted: "Manage liquidity: Add liquidity started",
+    addLiquidityCompleted: "Manage liquidity: Add liquidity completed",
+    removeLiquidityStarted: "Manage liquidity: Remove liquidity started",
+    removeLiquidityCompleted: "Manage liquidity: Remove liquidity completed",
+    bondStarted: "Liquidity bonding: Bond started",
+    bondCompleted: "Liquidity bonding: Bond completed",
+    superfluidStakeStarted: "Liquidity bonding: Superfluid stake started",
+    superfluidStakeCompleted: "Liquidity bonding: Superfluid stake completed",
+  },
+  // Events in assets page
+  Assets: {
+    pageViewed: "Assets: Page viewed",
+    myPoolsCardClicked: "Assets: My pools card clicked",
+    myPoolsMoreClicked: "Assets: My pools more clicked",
+    assetsListFiltered: "Assets: Assets list filtered",
+    assetsListSorted: "Assets: Assets list sorted",
+    assetsTableSorted: "Assets: Assets table sorted",
+    assetsListMoreClicked: "Assets: Assets list more clicked",
+    assetsItemDepositClicked: "Assets: Assets item deposit clicked",
+    assetsItemWithdrawClicked: "Assets: Assets item withdraw clicked",
+    depositIbcAssetStarted: "Deposit IBC asset: Deposit started",
+    depositIbcAssetCompleted: "Deposit IBC asset: Deposit completed",
+    withdrawIbcAssetStarted: "Withdraw IBC asset: Withdraw started",
+    withdrawIbcAssetCompleted: "Withdraw IBC asset: Withdraw completed",
+  },
+};

--- a/packages/web/hooks/index.ts
+++ b/packages/web/hooks/index.ts
@@ -6,3 +6,4 @@ export * from "./use-keplr";
 export * from "./use-boolean-with-window-event";
 export * from "./use-ibc-transfer";
 export * from "./use-matomo-analytics";
+export * from "./use-amplitude-analytics";

--- a/packages/web/hooks/use-amplitude-analytics.ts
+++ b/packages/web/hooks/use-amplitude-analytics.ts
@@ -7,11 +7,14 @@ import {
 } from "@amplitude/analytics-browser";
 import { AmplitudeEvent, EventProperties, UserProperties } from "../config";
 
+/** Do-it-all hook for initting Amplitude and logging custom events on page load or at any time. */
 export function useAmplitudeAnalytics({
   onLoadEvent,
   init,
 }: {
+  /** Log this event when the component mounts once. */
   onLoadEvent?: AmplitudeEvent;
+  /** Init analytics environment. Done once per user session. */
   init?: true;
 } = {}) {
   const logEvent = ([eventName, eventProperties]:
@@ -35,6 +38,7 @@ export function useAmplitudeAnalytics({
         amplitudeInit(process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY);
       }
     }
+
     if (onLoadEvent) {
       logEvent(onLoadEvent);
     }

--- a/packages/web/hooks/use-amplitude-analytics.ts
+++ b/packages/web/hooks/use-amplitude-analytics.ts
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import {
+  init as amplitudeInit,
   identify,
   Identify,
   logEvent as amplitudeLogEvent,
@@ -8,8 +9,10 @@ import { AmplitudeEvent, EventProperties, UserProperties } from "../config";
 
 export function useAmplitudeAnalytics({
   onLoadEvent,
+  init,
 }: {
   onLoadEvent?: AmplitudeEvent;
+  init?: true;
 } = {}) {
   const logEvent = ([eventName, eventProperties]:
     | [string, Partial<Record<keyof EventProperties, any>> | undefined]
@@ -27,6 +30,11 @@ export function useAmplitudeAnalytics({
   };
 
   useEffect(() => {
+    if (init) {
+      if (process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY !== undefined) {
+        amplitudeInit(process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY);
+      }
+    }
     if (onLoadEvent) {
       logEvent(onLoadEvent);
     }

--- a/packages/web/hooks/use-amplitude-analytics.ts
+++ b/packages/web/hooks/use-amplitude-analytics.ts
@@ -1,0 +1,39 @@
+import { useEffect } from "react";
+import {
+  identify,
+  Identify,
+  logEvent as amplitudeLogEvent,
+} from "@amplitude/analytics-browser";
+import { AmplitudeEvent, EventProperties, UserProperties } from "../config";
+
+export function useAmplitudeAnalytics({
+  onLoadEvent,
+}: {
+  onLoadEvent?: AmplitudeEvent;
+} = {}) {
+  const logEvent = ([eventName, eventProperties]:
+    | [string, Partial<Record<keyof EventProperties, any>> | undefined]
+    | [string]) => {
+    amplitudeLogEvent(eventName, eventProperties);
+  };
+
+  const setUserProperty = (
+    key: keyof UserProperties,
+    value: UserProperties[keyof UserProperties]
+  ) => {
+    const newIdentify = new Identify();
+    newIdentify.set(key, value);
+    identify(newIdentify);
+  };
+
+  useEffect(() => {
+    if (onLoadEvent) {
+      logEvent(onLoadEvent);
+    }
+  }, []);
+
+  return {
+    logEvent,
+    setUserProperty,
+  };
+}

--- a/packages/web/hooks/use-keplr/context.tsx
+++ b/packages/web/hooks/use-keplr/context.tsx
@@ -18,6 +18,7 @@ import WalletConnect from "@walletconnect/client";
 import { KeplrWalletConnectV1 } from "@keplr-wallet/wc-client";
 import { isMobile } from "@walletconnect/browser-utils";
 import { useMatomoAnalytics } from "../use-matomo-analytics";
+import { useAmplitudeAnalytics } from "../use-amplitude-analytics";
 
 export async function sendTxWC(
   chainId: string,
@@ -81,6 +82,7 @@ export const GetKeplrProvider: FunctionComponent = ({ children }) => {
   const [isExtentionNotInstalled, setIsExtensionNotInstalled] = useState(false);
   const [wcUri, setWCUri] = useState("");
   const { trackEvent } = useMatomoAnalytics();
+  const { setUserProperty } = useAmplitudeAnalytics();
 
   const lastUsedKeplrRef = useRef<Keplr | undefined>();
   const defaultConnectionTypeRef = useRef<
@@ -199,6 +201,8 @@ export const GetKeplrProvider: FunctionComponent = ({ children }) => {
             lastUsedKeplrRef.current = keplr;
             setConnectionType("extension");
             trackEvent(NavBarEvents.connectKeplrSuccess);
+            setUserProperty("isWalletConnected", true);
+            setUserProperty("connectedWallet", "extension");
             resolve(keplr);
             cleanUp();
           });
@@ -231,6 +235,8 @@ export const GetKeplrProvider: FunctionComponent = ({ children }) => {
                 setIsExtensionSelectionModalOpen(false);
                 lastUsedKeplrRef.current = keplr;
                 setConnectionType("wallet-connect");
+                setUserProperty("isWalletConnected", true);
+                setUserProperty("connectedWallet", "wallet-connect");
                 resolve(keplr);
               }
             });
@@ -241,6 +247,8 @@ export const GetKeplrProvider: FunctionComponent = ({ children }) => {
             setIsExtensionSelectionModalOpen(false);
             lastUsedKeplrRef.current = keplr;
             setConnectionType("wallet-connect");
+            setUserProperty("isWalletConnected", true);
+            setUserProperty("connectedWallet", "wallet-connect");
             resolve(keplr);
             cleanUp();
           }

--- a/packages/web/integrations/axelar/transfer.tsx
+++ b/packages/web/integrations/axelar/transfer.tsx
@@ -33,6 +33,8 @@ import {
   EthClientChainIds_AxelarChainIdsMap,
   waitBySourceChain,
 } from ".";
+import { useAmplitudeAnalytics } from "../../hooks/use-amplitude-analytics";
+import { EventName } from "../../config/user-analytics-v2";
 
 /** Axelar-specific bridge transfer integration UI. */
 const AxelarTransfer: FunctionComponent<
@@ -68,6 +70,7 @@ const AxelarTransfer: FunctionComponent<
     const originCurrency = balanceOnOsmosis.balance.currency.originCurrency!;
 
     useTxEventToasts(ethWalletClient);
+    const { logEvent } = useAmplitudeAnalytics();
 
     // notify eth wallet of prev selected preferred chain
     useEffect(() => {
@@ -233,6 +236,20 @@ const AxelarTransfer: FunctionComponent<
     const [transferInitiated, setTransferInitiated] = useState(false);
     const doAxelarTransfer = useCallback(async () => {
       if (depositAddress) {
+        logEvent([
+          isWithdraw
+            ? EventName.Assets.withdrawAssetStarted
+            : EventName.Assets.depositAssetStarted,
+          {
+            tokenName: isWithdraw
+              ? withdrawAmountConfig.sendCurrency.coinDenom
+              : originCurrency.coinDenom,
+            tokenAmount: isWithdraw
+              ? Number(withdrawAmountConfig.amount)
+              : Number(depositAmount),
+            bridge: "axelar",
+          },
+        ]);
         if (isWithdraw) {
           // IBC transfer to generated axelar address
           try {
@@ -249,7 +266,17 @@ const AxelarTransfer: FunctionComponent<
               },
               withdrawAmountConfig,
               undefined,
-              (event) => trackTransferStatus(event.txHash)
+              (event) => {
+                trackTransferStatus(event.txHash);
+                logEvent([
+                  EventName.Assets.withdrawAssetCompleted,
+                  {
+                    tokenName: withdrawAmountConfig.sendCurrency.coinDenom,
+                    tokenAmount: Number(withdrawAmountConfig.amount),
+                    bridge: "axelar",
+                  },
+                ]);
+              }
             );
           } catch (e) {
             // errors are displayed as toasts from a handler in root store
@@ -272,6 +299,14 @@ const AxelarTransfer: FunctionComponent<
               ).then((txHash) => {
                 trackTransferStatus(txHash as string);
                 setLastDepositAccountAddress(ethWalletClient.accountAddress!);
+                logEvent([
+                  EventName.Assets.depositAssetCompleted,
+                  {
+                    tokenName: originCurrency.coinDenom,
+                    tokenAmount: Number(withdrawAmountConfig.amount),
+                    bridge: "axelar",
+                  },
+                ]);
               });
             } catch (e: any) {
               const msg = ethWalletClient.displayError?.(e);

--- a/packages/web/integrations/axelar/transfer.tsx
+++ b/packages/web/integrations/axelar/transfer.tsx
@@ -241,12 +241,8 @@ const AxelarTransfer: FunctionComponent<
             ? EventName.Assets.withdrawAssetStarted
             : EventName.Assets.depositAssetStarted,
           {
-            tokenName: isWithdraw
-              ? withdrawAmountConfig.sendCurrency.coinDenom
-              : originCurrency.coinDenom,
-            tokenAmount: isWithdraw
-              ? Number(withdrawAmountConfig.amount)
-              : Number(depositAmount),
+            tokenName: originCurrency.coinDenom,
+            tokenAmount: Number(amount),
             bridge: "axelar",
           },
         ]);
@@ -271,8 +267,8 @@ const AxelarTransfer: FunctionComponent<
                 logEvent([
                   EventName.Assets.withdrawAssetCompleted,
                   {
-                    tokenName: withdrawAmountConfig.sendCurrency.coinDenom,
-                    tokenAmount: Number(withdrawAmountConfig.amount),
+                    tokenName: originCurrency.coinDenom,
+                    tokenAmount: Number(amount),
                     bridge: "axelar",
                   },
                 ]);
@@ -303,7 +299,7 @@ const AxelarTransfer: FunctionComponent<
                   EventName.Assets.depositAssetCompleted,
                   {
                     tokenName: originCurrency.coinDenom,
-                    tokenAmount: Number(withdrawAmountConfig.amount),
+                    tokenAmount: Number(amount),
                     bridge: "axelar",
                   },
                 ]);

--- a/packages/web/modals/ibc-transfer.tsx
+++ b/packages/web/modals/ibc-transfer.tsx
@@ -6,9 +6,10 @@ import {
   IbcTransfer,
   useIbcTransfer,
   useConnectWalletModalRedirect,
+  useAmplitudeAnalytics,
   useMatomoAnalytics,
 } from "../hooks";
-import { AssetsPageEvents } from "../config";
+import { AssetsPageEvents, EventName } from "../config";
 import { ModalBase, ModalBaseProps } from ".";
 
 export const IbcTransferModal: FunctionComponent<ModalBaseProps & IbcTransfer> =
@@ -16,7 +17,9 @@ export const IbcTransferModal: FunctionComponent<ModalBaseProps & IbcTransfer> =
     const { currency, counterpartyChainId, isWithdraw } = props;
     const { chainStore, queriesStore, ibcTransferHistoryStore } = useStore();
     const { chainId: osmosisChainId } = chainStore.osmosis;
+
     const { trackEvent } = useMatomoAnalytics();
+    const { logEvent } = useAmplitudeAnalytics();
 
     const [
       account,
@@ -45,7 +48,16 @@ export const IbcTransferModal: FunctionComponent<ModalBaseProps & IbcTransfer> =
             amountConfig.error != undefined ||
             inTransit ||
             !isCustomWithdrawValid,
-          onClick: () =>
+          onClick: () => {
+            logEvent([
+              isWithdraw
+                ? EventName.Assets.withdrawIbcAssetStarted
+                : EventName.Assets.depositIbcAssetStarted,
+              {
+                tokenName: amountConfig.sendCurrency.coinDenom,
+                tokenAmount: Number(amountConfig.amount),
+              },
+            ]);
             // failure events are handled by the root store
             transfer(
               (txFullfillEvent) => {
@@ -57,12 +69,22 @@ export const IbcTransferModal: FunctionComponent<ModalBaseProps & IbcTransfer> =
                 props.onRequestClose();
               },
               (txBroadcastEvent) => {
+                logEvent([
+                  isWithdraw
+                    ? EventName.Assets.withdrawIbcAssetCompleted
+                    : EventName.Assets.depositIbcAssetCompleted,
+                  {
+                    tokenName: amountConfig.sendCurrency.coinDenom,
+                    tokenAmount: Number(amountConfig.amount),
+                  },
+                ]);
                 ibcTransferHistoryStore.pushUncommitedHistory(txBroadcastEvent);
               },
               () => {
                 trackEvent(AssetsPageEvents.ibcTransferFailure);
               }
-            ),
+            );
+          },
           loading: inTransit,
           children: (
             <h6 className="md:text-base text-lg">

--- a/packages/web/modals/ibc-transfer.tsx
+++ b/packages/web/modals/ibc-transfer.tsx
@@ -51,11 +51,12 @@ export const IbcTransferModal: FunctionComponent<ModalBaseProps & IbcTransfer> =
           onClick: () => {
             logEvent([
               isWithdraw
-                ? EventName.Assets.withdrawIbcAssetStarted
-                : EventName.Assets.depositIbcAssetStarted,
+                ? EventName.Assets.withdrawAssetStarted
+                : EventName.Assets.depositAssetStarted,
               {
                 tokenName: amountConfig.sendCurrency.coinDenom,
                 tokenAmount: Number(amountConfig.amount),
+                bridge: "IBC",
               },
             ]);
             // failure events are handled by the root store
@@ -71,11 +72,12 @@ export const IbcTransferModal: FunctionComponent<ModalBaseProps & IbcTransfer> =
               (txBroadcastEvent) => {
                 logEvent([
                   isWithdraw
-                    ? EventName.Assets.withdrawIbcAssetCompleted
-                    : EventName.Assets.depositIbcAssetCompleted,
+                    ? EventName.Assets.withdrawAssetCompleted
+                    : EventName.Assets.depositAssetCompleted,
                   {
                     tokenName: amountConfig.sendCurrency.coinDenom,
                     tokenAmount: Number(amountConfig.amount),
+                    bridge: "IBC",
                   },
                 ]);
                 ibcTransferHistoryStore.pushUncommitedHistory(txBroadcastEvent);

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -13,6 +13,7 @@
     "pre-commit": "lint-staged"
   },
   "dependencies": {
+    "@amplitude/analytics-browser": "^1.2.3",
     "@axelar-network/axelarjs-sdk": "^0.6.14",
     "@cosmjs/launchpad": "^0.26.5",
     "@ethersproject/abi": "^5.6.4",

--- a/packages/web/pages/_app.tsx
+++ b/packages/web/pages/_app.tsx
@@ -20,17 +20,12 @@ import {
   IS_FRONTIER,
   NavBarEvents,
 } from "../config";
-
-import * as amplitude from "@amplitude/analytics-browser";
+import { useAmplitudeAnalytics } from "../hooks/use-amplitude-analytics";
 
 dayjs.extend(relativeTime);
 dayjs.extend(duration);
 dayjs.extend(utc);
 enableStaticRendering(typeof window === "undefined");
-
-if (process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY !== undefined) {
-  amplitude.init(process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY);
-}
 
 function MyApp({ Component, pageProps }: AppProps) {
   const menus = [
@@ -79,6 +74,7 @@ function MyApp({ Component, pageProps }: AppProps) {
   ];
 
   useMatomoAnalytics({ init: true });
+  useAmplitudeAnalytics({ init: true });
 
   return (
     <GetKeplrProvider>

--- a/packages/web/pages/_app.tsx
+++ b/packages/web/pages/_app.tsx
@@ -14,12 +14,23 @@ import relativeTime from "dayjs/plugin/relativeTime";
 import utc from "dayjs/plugin/utc";
 import { GetKeplrProvider, useMatomoAnalytics } from "../hooks";
 import { IbcNotifier } from "../stores/ibc-notifier";
-import { IS_FRONTIER, NavBarEvents } from "../config";
+import {
+  AmplitudeEvent,
+  EventName,
+  IS_FRONTIER,
+  NavBarEvents,
+} from "../config";
+
+import * as amplitude from "@amplitude/analytics-browser";
 
 dayjs.extend(relativeTime);
 dayjs.extend(duration);
 dayjs.extend(utc);
 enableStaticRendering(typeof window === "undefined");
+
+if (process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY !== undefined) {
+  amplitude.init(process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY);
+}
 
 function MyApp({ Component, pageProps }: AppProps) {
   const menus = [
@@ -49,18 +60,21 @@ function MyApp({ Component, pageProps }: AppProps) {
       link: "https://wallet.keplr.app/chains/osmosis",
       icon: IS_FRONTIER ? "/icons/ticket-white.svg" : "/icons/ticket.svg",
       userAnalyticsEvent: NavBarEvents.stakeLink,
+      amplitudeEvent: [EventName.Sidebar.stakeClicked] as AmplitudeEvent,
     },
     {
       label: "Vote",
       link: "https://wallet.keplr.app/chains/osmosis?tab=governance",
       icon: IS_FRONTIER ? "/icons/vote-white.svg" : "/icons/vote.svg",
       userAnalyticsEvent: NavBarEvents.voteLink,
+      amplitudeEvent: [EventName.Sidebar.voteClicked] as AmplitudeEvent,
     },
     {
       label: "Info",
       link: "https://info.osmosis.zone",
       icon: IS_FRONTIER ? "/icons/chart-white.svg" : "/icons/chart.svg",
       userAnalyticsEvent: NavBarEvents.infoLink,
+      amplitudeEvent: [EventName.Sidebar.infoClicked] as AmplitudeEvent,
     },
   ];
 

--- a/packages/web/pages/assets/index.tsx
+++ b/packages/web/pages/assets/index.tsx
@@ -87,26 +87,12 @@ const Assets: NextPage = observer(() => {
         ibcBalances={ibcBalances}
         onDepositIntent={() => transferConfig.startTransfer("deposit")}
         onWithdrawIntent={() => transferConfig.startTransfer("withdraw")}
-        onDeposit={(chainId, coinDenom, externalUrl) => {
-          logEvent([
-            EventName.Assets.assetsItemDepositClicked,
-            {
-              tokenName: coinDenom,
-              hasExternalUrl: !!externalUrl,
-            },
-          ]);
-          transferConfig.transferAsset("deposit", chainId, coinDenom);
-        }}
-        onWithdraw={(chainId, coinDenom, externalUrl) => {
-          logEvent([
-            EventName.Assets.assetsItemWithdrawClicked,
-            {
-              tokenName: coinDenom,
-              hasExternalUrl: !!externalUrl,
-            },
-          ]);
-          transferConfig.transferAsset("withdraw", chainId, coinDenom);
-        }}
+        onDeposit={(chainId, coinDenom) =>
+          transferConfig.transferAsset("deposit", chainId, coinDenom)
+        }
+        onWithdraw={(chainId, coinDenom) =>
+          transferConfig.transferAsset("withdraw", chainId, coinDenom)
+        }
       />
       {!isMobile && <PoolAssets />}
       <section className="bg-surface">

--- a/packages/web/pages/assets/index.tsx
+++ b/packages/web/pages/assets/index.tsx
@@ -111,7 +111,7 @@ const AssetsOverview: FunctionComponent<{
 }> = observer(({ onDepositIntent, onWithdrawIntent }) => {
   const { assetsStore } = useStore();
   const { isMobile } = useWindowSize();
-  const { setUserProperty } = useAmplitudeAnalytics();
+  const { logEvent, setUserProperty } = useAmplitudeAnalytics();
 
   const totalAssetsValue = assetsStore.calcValueOf([
     ...assetsStore.availableBalance,
@@ -149,13 +149,19 @@ const AssetsOverview: FunctionComponent<{
           : [
               {
                 label: "Deposit",
-                onClick: onDepositIntent,
+                onClick: () => {
+                  logEvent([EventName.Assets.depositClicked]);
+                  onDepositIntent();
+                },
               },
               {
                 label: "Withdraw",
                 type: "outline",
                 className: "bg-primary-200/30",
-                onClick: onWithdrawIntent,
+                onClick: () => {
+                  logEvent([EventName.Assets.withdrawClicked]);
+                  onWithdrawIntent();
+                },
               },
             ]
       }

--- a/packages/web/pages/assets/index.tsx
+++ b/packages/web/pages/assets/index.tsx
@@ -37,7 +37,7 @@ const Assets: NextPage = observer(() => {
   const { nativeBalances, ibcBalances } = assetsStore;
   const account = accountStore.getAccount(chainId);
 
-  const { logEvent, setUserProperty } = useAmplitudeAnalytics({
+  const { setUserProperty } = useAmplitudeAnalytics({
     onLoadEvent: [EventName.Assets.pageViewed],
   });
 

--- a/packages/web/pages/assets/index.tsx
+++ b/packages/web/pages/assets/index.tsx
@@ -362,8 +362,14 @@ const PoolCardsDisplayer: FunctionComponent<{ poolIds: string[] }> = observer(
     return (
       <>
         {pools.map(([pool, _, metrics]) => (
-          <div
+          <PoolCard
             key={pool.id}
+            poolId={pool.id}
+            poolAssets={pool.poolAssets.map((asset) => asset.amount.currency)}
+            poolMetrics={metrics}
+            isSuperfluid={queriesOsmosis.querySuperfluidPools.isSuperfluidPool(
+              pool.id
+            )}
             onClick={() =>
               logEvent([
                 EventName.Assets.myPoolsCardClicked,
@@ -382,16 +388,7 @@ const PoolCardsDisplayer: FunctionComponent<{ poolIds: string[] }> = observer(
                 },
               ])
             }
-          >
-            <PoolCard
-              poolId={pool.id}
-              poolAssets={pool.poolAssets.map((asset) => asset.amount.currency)}
-              poolMetrics={metrics}
-              isSuperfluid={queriesOsmosis.querySuperfluidPools.isSuperfluidPool(
-                pool.id
-              )}
-            />
-          </div>
+          />
         ))}
       </>
     );

--- a/packages/web/pages/index.tsx
+++ b/packages/web/pages/index.tsx
@@ -3,9 +3,10 @@ import type { NextPage } from "next";
 import { ProgressiveSvgImage } from "../components/progressive-svg-image";
 import { TradeClipboard } from "../components/trade-clipboard";
 import { useStore } from "../stores";
-import { IS_FRONTIER } from "../config";
+import { EventName, IS_FRONTIER } from "../config";
 import { Dec } from "@keplr-wallet/unit";
 import { useMemo, useRef } from "react";
+import { useAmplitudeAnalytics } from "../hooks";
 
 const Home: NextPage = observer(function () {
   const { chainStore, queriesStore } = useStore();
@@ -106,6 +107,10 @@ const Home: NextPage = observer(function () {
         .map((pool) => pool.pool),
     [allPools]
   );
+
+  useAmplitudeAnalytics({
+    onLoadEvent: [EventName.Swap.pageViewed],
+  });
 
   return (
     <main className="relative bg-background h-screen">

--- a/packages/web/pages/pools/index.tsx
+++ b/packages/web/pages/pools/index.tsx
@@ -336,8 +336,18 @@ const Pools: NextPage = observer(function () {
                   }
 
                   return (
-                    <div
+                    <PoolCard
                       key={myPoolId}
+                      poolId={myPoolId}
+                      poolAssets={myPool.poolAssets.map((poolAsset) => ({
+                        coinImageUrl: poolAsset.amount.currency.coinImageUrl,
+                        coinDenom: poolAsset.amount.currency.coinDenom,
+                      }))}
+                      poolMetrics={myPoolMetrics}
+                      isSuperfluid={queryOsmosis.querySuperfluidPools.isSuperfluidPool(
+                        myPoolId
+                      )}
+                      mobileShowFirstLabel
                       onClick={() =>
                         logEvent([
                           EventName.Pools.myPoolsCardClicked,
@@ -361,20 +371,7 @@ const Pools: NextPage = observer(function () {
                           },
                         ])
                       }
-                    >
-                      <PoolCard
-                        poolId={myPoolId}
-                        poolAssets={myPool.poolAssets.map((poolAsset) => ({
-                          coinImageUrl: poolAsset.amount.currency.coinImageUrl,
-                          coinDenom: poolAsset.amount.currency.coinDenom,
-                        }))}
-                        poolMetrics={myPoolMetrics}
-                        isSuperfluid={queryOsmosis.querySuperfluidPools.isSuperfluidPool(
-                          myPoolId
-                        )}
-                        mobileShowFirstLabel
-                      />
-                    </div>
+                    />
                   );
                 }
               })}

--- a/packages/web/stores/account-init-management.tsx
+++ b/packages/web/stores/account-init-management.tsx
@@ -4,11 +4,13 @@ import { useStore } from "./index";
 import { getKeplrFromWindow, WalletStatus } from "@keplr-wallet/stores";
 import { useKeplr } from "../hooks";
 import { KeplrWalletConnectV1 } from "@keplr-wallet/wc-client";
+import { useAmplitudeAnalytics } from "../hooks/use-amplitude-analytics";
 
 /** Manages the initialization of the Osmosis account. */
 export const AccountInitManagement: FunctionComponent = observer(
   ({ children }) => {
     const { chainStore, accountStore } = useStore();
+    const { setUserProperty } = useAmplitudeAnalytics();
 
     const keplr = useKeplr();
 
@@ -25,6 +27,7 @@ export const AccountInitManagement: FunctionComponent = observer(
       getKeplrFromWindow().then((keplr) => {
         if (keplr && keplr.mode === "mobile-web") {
           account.init();
+          setUserProperty("isWalletConnected", true);
         }
       });
     }, []);
@@ -41,6 +44,8 @@ export const AccountInitManagement: FunctionComponent = observer(
             keplr.setDefaultConnectionType("extension");
           }
           account.init();
+          setUserProperty("isWalletConnected", true);
+          setUserProperty("connectedWallet", value);
         }
       }
     }, []);
@@ -61,6 +66,7 @@ export const AccountInitManagement: FunctionComponent = observer(
                 chainStore.chainInfos.forEach((chainInfo) => {
                   if (accountStore.hasAccount(chainInfo.chainId)) {
                     accountStore.getAccount(chainInfo.chainId).disconnect();
+                    setUserProperty("isWalletConnected", false);
                   }
                 });
               });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,42 @@
 # yarn lockfile v1
 
 
+"@amplitude/analytics-browser@^1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-browser/-/analytics-browser-1.2.3.tgz#7324ffd2cffb8abafe9eeee4289f6a040446612a"
+  integrity sha512-cJWnqD9ipfGXIPlOIXTEyYWvJq1zcOlYvZaFltPLd1t+nICnEvuAJytqV9e4afQaIh3B5iDNyZVS32xFXBVJZQ==
+  dependencies:
+    "@amplitude/analytics-connector" "^1.4.5"
+    "@amplitude/analytics-core" "^0.8.1"
+    "@amplitude/analytics-types" "^0.8.1"
+    "@amplitude/ua-parser-js" "^0.7.31"
+    tslib "^2.3.1"
+
+"@amplitude/analytics-connector@^1.4.5":
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-connector/-/analytics-connector-1.4.5.tgz#07e9375101332bd8b6f15e39e70f31f287e87ad0"
+  integrity sha512-ELAP6ivg+13uSk+TOirGZE/92M+tTbeiQ/i7eXgDO4Hiy00Abf/UxO/rp9WovtxCyeFYTILrujEYxPv5cRQmFw==
+  dependencies:
+    "@amplitude/ua-parser-js" "0.7.31"
+
+"@amplitude/analytics-core@^0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-core/-/analytics-core-0.8.1.tgz#7e81cf00744388f4cb5ccb625a45f450a856031b"
+  integrity sha512-9H/dh8kB/MBg90f9a5eVKhO4+WQ+RJQ9Ae9Xf2SLZcHdfJ5IhRr3U/fuhorFhhHPWsCHbiCNoCwmJJghupuHFg==
+  dependencies:
+    "@amplitude/analytics-types" "^0.8.1"
+    tslib "^2.3.1"
+
+"@amplitude/analytics-types@^0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@amplitude/analytics-types/-/analytics-types-0.8.1.tgz#2dd40cc52052cb4c5b4e3264aae20fd2f9e8fd43"
+  integrity sha512-DUzta7ZTMszzosPHS3hqagD3yRpXf0WJtJxdf54F+s70sXcSI0P7279yTvgx7K/TWJoZ3KXMkr0UTJbj3cdbhQ==
+
+"@amplitude/ua-parser-js@0.7.31", "@amplitude/ua-parser-js@^0.7.31":
+  version "0.7.31"
+  resolved "https://registry.yarnpkg.com/@amplitude/ua-parser-js/-/ua-parser-js-0.7.31.tgz#749bf7cb633cfcc7ff3c10805bad7c5f6fbdbc61"
+  integrity sha512-+z8UGRaj13Pt5NDzOnkTBy49HE2CX64jeL0ArB86HAtilpnfkPB7oqkigN7Lf2LxscMg4QhFD7mmCfedh3rqTg==
+
 "@axelar-network/axelarjs-sdk@^0.6.14":
   version "0.6.18"
   resolved "https://registry.yarnpkg.com/@axelar-network/axelarjs-sdk/-/axelarjs-sdk-0.6.18.tgz#132d3195c4373383eb02ab313dca45c1790b4659"
@@ -11061,6 +11097,11 @@ tslib@^2.1.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
+
+tslib@^2.3.1:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
We already are using Matomo for user analytics, but Josh and I recommend using Amplitude. It is scalable and has a lot of useful data analytics tools. Also, [It is highly secure and has a strict privacy policy.](https://amplitude.com/amplitude-security-and-privacy) Keplr Wallet is already using it. So Let's start with using both Matomo and Amplitude and eventually transitioning to Amplitude would be good.

## TODO
- [x] Add events
- [x] Add user properties