### PR TITLE
Allow to withdraw EVMOS asset

### DIFF
--- a/packages/web/config/ibc-assets.ts
+++ b/packages/web/config/ibc-assets.ts
@@ -109,7 +109,6 @@ export const IBCAssetInfos: (IBCAsset & {
     destChannelId: "channel-0",
     coinMinimalDenom: "aevmos",
     depositUrlOverride: "https://app.evmos.org/transfer",
-    withdrawUrlOverride: "https://app.evmos.org/transfer",
     isVerified: true,
   },
   {


### PR DESCRIPTION
Currently many users have to use Keplr to transfer EVMOS from osmosis, due to evmos app congestion.

Enabling the withdrawal option will be helpful to evmos users

![image](https://user-images.githubusercontent.com/14926587/189273939-202667a5-7a6e-4f88-889a-d182638eb011.png)

> for deposits, users have other options in addition to the evmos app