### PR TITLE
Disable ROWAN transfers

### DIFF
--- a/packages/web/config/ibc-assets.ts
+++ b/packages/web/config/ibc-assets.ts
@@ -332,6 +332,7 @@ export const IBCAssetInfos: (IBCAsset & {
     destChannelId: "channel-17",
     coinMinimalDenom: "rowan",
     isVerified: true,
+    isUnstable: true,
   },
   {
     counterpartyChainId: "laozi-mainnet",


### PR DESCRIPTION
It appears Sifchain is experiencing an exploit, and is no longer producing blocks.

[Link to Telegram message](https://t.me/c/1430596792/14115)

[Mintscan](https://www.mintscan.io/sifchain)