### PR TITLE
Updating external incentives gauges for CRBRUS

### DIFF
--- a/packages/web/config/feature-flag.ts
+++ b/packages/web/config/feature-flag.ts
@@ -771,17 +771,12 @@ export const ExternalIncentiveGaugeAllowList: {
   ],
   "662": [
     {
-      gaugeId: "2591",
+      gaugeId: "29666",
       denom:
         "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
     },
     {
-      gaugeId: "2592",
-      denom:
-        "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
-    },
-    {
-      gaugeId: "2593",
+      gaugeId: "29667",
       denom:
         "ibc/41999DF04D9441DAC0DF5D8291DF4333FBCBA810FFD63FDCE34FDF41EF37B6F7",
     },


### PR DESCRIPTION
Updating external incentives gauges for Cerberus $CRBRUS

Removing gauge for 1 day bonding period

Adding new gauge ID 29666 - 7 day bonding period - 360 epochs

Adding new gauge ID 29667 - 14 day bonding period - 360 epochs