### PR TITLE
Use testnet historical data (Imperator) API on testnet

### DIFF
--- a/packages/stores/src/queries-external/index.ts
+++ b/packages/stores/src/queries-external/index.ts
@@ -1,4 +1,2 @@
 export * from "./pool-fees";
 export * from "./store";
-
-export const IMPERATOR_API_DOMAIN = "https://api-osmosis.imperator.co";

--- a/packages/stores/src/queries-external/pool-fees/index.ts
+++ b/packages/stores/src/queries-external/pool-fees/index.ts
@@ -14,8 +14,8 @@ import {
 
 /** Queries Imperator pool fee history data. */
 export class ObservableQueryPoolFeesMetrics extends ObservableQueryExternal<PoolFees> {
-  constructor(kvStore: KVStore) {
-    super(kvStore, "/fees/v1/pools");
+  constructor(kvStore: KVStore, baseURL: string) {
+    super(kvStore, baseURL, "/fees/v1/pools");
 
     makeObservable(this);
   }
@@ -49,7 +49,9 @@ export class ObservableQueryPoolFeesMetrics extends ObservableQueryExternal<Pool
         (poolMetric) => poolMetric.pool_id === poolId
       );
       if (!poolFeesMetricsRaw) {
-        const zeroPrice = new PricePretty(fiatCurrency, new Dec(0));
+        const zeroPrice = new PricePretty(fiatCurrency, new Dec(0)).ready(
+          false
+        );
         return {
           volume24h: zeroPrice,
           volume7d: zeroPrice,

--- a/packages/stores/src/queries-external/store.ts
+++ b/packages/stores/src/queries-external/store.ts
@@ -3,11 +3,10 @@ import { HasMapStore, ObservableQuery } from "@keplr-wallet/stores";
 import { DeepReadonly } from "utility-types";
 import { ObservableQueryPoolFeesMetrics } from "./pool-fees";
 import Axios from "axios";
-import { IMPERATOR_API_DOMAIN } from "./index";
 
 export class QueriesExternalStore extends HasMapStore<QueriesExternal> {
-  constructor(protected readonly kvStore: KVStore) {
-    super(() => new QueriesExternal(this.kvStore));
+  constructor(protected readonly kvStore: KVStore, feeMetricsBaseURL?: string) {
+    super(() => new QueriesExternal(this.kvStore, feeMetricsBaseURL));
   }
 
   get(): QueriesExternal {
@@ -19,8 +18,14 @@ export class QueriesExternalStore extends HasMapStore<QueriesExternal> {
 export class QueriesExternal {
   public readonly queryGammPoolFeeMetrics: DeepReadonly<ObservableQueryPoolFeesMetrics>;
 
-  constructor(kvStore: KVStore) {
-    this.queryGammPoolFeeMetrics = new ObservableQueryPoolFeesMetrics(kvStore);
+  constructor(
+    kvStore: KVStore,
+    feeMetricsBaseURL = "https://api-osmosis.imperator.co"
+  ) {
+    this.queryGammPoolFeeMetrics = new ObservableQueryPoolFeesMetrics(
+      kvStore,
+      feeMetricsBaseURL
+    );
   }
 }
 
@@ -28,8 +33,8 @@ export class ObservableQueryExternal<
   T = unknown,
   E = unknown
 > extends ObservableQuery<T, E> {
-  constructor(kvStore: KVStore, urlPath: string) {
-    const instance = Axios.create({ baseURL: IMPERATOR_API_DOMAIN });
+  constructor(kvStore: KVStore, baseURL: string, urlPath: string) {
+    const instance = Axios.create({ baseURL });
 
     super(kvStore, instance, urlPath);
   }

--- a/packages/stores/types/queries-external/index.d.ts
+++ b/packages/stores/types/queries-external/index.d.ts
@@ -1,3 +1,2 @@
 export * from "./pool-fees";
 export * from "./store";
-export declare const IMPERATOR_API_DOMAIN = "https://api-osmosis.imperator.co";

--- a/packages/stores/types/queries-external/pool-fees/index.d.ts
+++ b/packages/stores/types/queries-external/pool-fees/index.d.ts
@@ -6,7 +6,7 @@ import { ObservableQueryExternal } from "../store";
 import { ObservablePoolWithFeeMetrics, PoolFeesMetrics, PoolFees } from "./types";
 /** Queries Imperator pool fee history data. */
 export declare class ObservableQueryPoolFeesMetrics extends ObservableQueryExternal<PoolFees> {
-    constructor(kvStore: KVStore);
+    constructor(kvStore: KVStore, baseURL: string);
     readonly makePoolWithFeeMetrics: (pool: ObservableQueryPool, priceStore: IPriceStore) => ObservablePoolWithFeeMetrics;
     readonly getPoolFeesMetrics: (poolId: string, priceStore: IPriceStore) => PoolFeesMetrics;
     /** Get pool non-incentivized return from fees based on past 7d of activity, compounded. */

--- a/packages/stores/types/queries-external/store.d.ts
+++ b/packages/stores/types/queries-external/store.d.ts
@@ -4,14 +4,14 @@ import { DeepReadonly } from "utility-types";
 import { ObservableQueryPoolFeesMetrics } from "./pool-fees";
 export declare class QueriesExternalStore extends HasMapStore<QueriesExternal> {
     protected readonly kvStore: KVStore;
-    constructor(kvStore: KVStore);
+    constructor(kvStore: KVStore, feeMetricsBaseURL?: string);
     get(): QueriesExternal;
 }
 /** Root store for queries external to any chain. */
 export declare class QueriesExternal {
     readonly queryGammPoolFeeMetrics: DeepReadonly<ObservableQueryPoolFeesMetrics>;
-    constructor(kvStore: KVStore);
+    constructor(kvStore: KVStore, feeMetricsBaseURL?: string);
 }
 export declare class ObservableQueryExternal<T = unknown, E = unknown> extends ObservableQuery<T, E> {
-    constructor(kvStore: KVStore, urlPath: string);
+    constructor(kvStore: KVStore, baseURL: string, urlPath: string);
 }

--- a/packages/web/pages/pools/index.tsx
+++ b/packages/web/pages/pools/index.tsx
@@ -516,9 +516,7 @@ const Pools: NextPage = observer(function () {
                             label: "Fees (7D)",
                             value: (
                               <MetricLoader
-                                isLoading={poolFeesMetrics.feesSpent7d
-                                  .toDec()
-                                  .isZero()}
+                                isLoading={!poolFeesMetrics.feesSpent7d.isReady}
                               >
                                 {poolFeesMetrics.feesSpent7d.toString()}
                               </MetricLoader>

--- a/packages/web/stores/root.ts
+++ b/packages/web/stores/root.ts
@@ -89,7 +89,8 @@ export class RootStore {
     })();
 
     this.queriesExternalStore = new QueriesExternalStore(
-      makeIndexedKVStore("store_web_queries")
+      makeIndexedKVStore("store_web_queries"),
+      IS_TESTNET ? "https://api.testnet.osmosis.zone/" : undefined
     );
 
     this.queriesStore = new QueriesStore(


### PR DESCRIPTION
Testing: you should be able to see in the frontier/main preview, it has the correct historical data for mainnet. For testnet preview, it has testnet data (I think it's returning all 0 right now).