### PR TITLE
Filter non-mobile-enabled wallets

### DIFF
--- a/packages/web/hooks/ui-config/index.ts
+++ b/packages/web/hooks/ui-config/index.ts
@@ -5,3 +5,4 @@ export * from "./use-fake-fee-config";
 export * from "./use-remove-liquidity-config";
 export * from "./use-slippage-config";
 export * from "./use-trade-token-in-config";
+export * from "./use-transfer-config";

--- a/packages/web/hooks/ui-config/use-transfer-config.ts
+++ b/packages/web/hooks/ui-config/use-transfer-config.ts
@@ -1,0 +1,35 @@
+import { useState, useEffect } from "react";
+import { AccountSetBase } from "@keplr-wallet/stores";
+import {
+  ObservableAssets,
+  ObservableTransferUIConfig,
+} from "../../stores/assets";
+import { makeLocalStorageKVStore } from "../../stores/kv-store";
+import { useWindowSize } from "../window";
+
+export function useTransferConfig(
+  assetsStore: ObservableAssets,
+  account: AccountSetBase
+) {
+  const { isMobile } = useWindowSize();
+
+  const [transferConfig, setTransferConfig] =
+    useState<ObservableTransferUIConfig | null>(null);
+  const [transferKvStore] = useState(() =>
+    makeLocalStorageKVStore("transfer-ui-config")
+  );
+  useEffect(
+    () =>
+      setTransferConfig(
+        new ObservableTransferUIConfig(
+          assetsStore,
+          account,
+          transferKvStore,
+          isMobile
+        )
+      ),
+    [assetsStore, account, isMobile]
+  );
+
+  return transferConfig;
+}

--- a/packages/web/integrations/ethereum/metamask.ts
+++ b/packages/web/integrations/ethereum/metamask.ts
@@ -21,6 +21,7 @@ const IS_TESTNET = process.env.NEXT_PUBLIC_IS_TESTNET === "true";
 
 export class ObservableMetamask implements EthWallet {
   readonly key: WalletKey = "metamask";
+  readonly mobileEnabled = false;
 
   readonly displayInfo: WalletDisplay = {
     iconUrl: "/icons/metamask-fox.svg",

--- a/packages/web/integrations/ethereum/walletconnect.ts
+++ b/packages/web/integrations/ethereum/walletconnect.ts
@@ -17,7 +17,8 @@ const CONNECTED_ACCOUNT_KEY = "wc-eth-connected-account";
 const CONNECTED_ACCOUNT_CHAINID = "wc-eth-connected-chainId";
 
 export class ObservableWalletConnect implements EthWallet {
-  key: WalletKey = "walletconnect";
+  readonly key: WalletKey = "walletconnect";
+  readonly mobileEnabled = false;
 
   displayInfo: WalletDisplay = {
     iconUrl: "/icons/walletconnect.svg",

--- a/packages/web/integrations/wallets.ts
+++ b/packages/web/integrations/wallets.ts
@@ -19,6 +19,9 @@ export interface Wallet<
   readonly key: WalletKey;
   readonly displayInfo: WalletDisplay;
 
+  /** Works on mobile browsers. */
+  readonly mobileEnabled: boolean;
+
   readonly accountAddress?: string;
   /** Human readable chain, falls back to hex ID (`0x...`) if unknown. */
   readonly chainId?: string;

--- a/packages/web/modals/connect-non-ibc-wallet.tsx
+++ b/packages/web/modals/connect-non-ibc-wallet.tsx
@@ -15,11 +15,14 @@ export const ConnectNonIbcWallet: FunctionComponent<
     onSelectWallet: (key: string) => void;
   }
 > = observer((props) => {
+  const { initiallySelectedWalletId, isWithdraw, wallets, onSelectWallet } =
+    props;
+
   const [selectedWalletKey, setSelectedWalletId] = useState<string | null>(
-    props.initiallySelectedWalletId ?? null
+    initiallySelectedWalletId ?? null
   );
 
-  const selectedWallet = props.wallets.find((w) => w.key === selectedWalletKey);
+  const selectedWallet = wallets.find((w) => w.key === selectedWalletKey);
   const canOnboardSelectedWallet =
     selectedWallet && !selectedWallet.isInstalled && selectedWallet.onboard;
 
@@ -28,12 +31,13 @@ export const ConnectNonIbcWallet: FunctionComponent<
       className: "h-14 md:w-full w-96 mt-3 mx-auto !px-1",
       size: "lg",
       disabled:
-        props.initiallySelectedWalletId === undefined && !selectedWalletKey,
+        (initiallySelectedWalletId === undefined && !selectedWalletKey) ||
+        wallets.length === 0,
       onClick: () => {
         if (canOnboardSelectedWallet) {
           selectedWallet!.onboard?.();
         } else if (selectedWalletKey) {
-          props.onSelectWallet(selectedWalletKey);
+          onSelectWallet(selectedWalletKey);
         } else {
           console.error(
             "Wallet selection invalid state: selectedWalletKey undefined"
@@ -44,6 +48,8 @@ export const ConnectNonIbcWallet: FunctionComponent<
         <h6 className="md:text-base text-lg">
           {canOnboardSelectedWallet
             ? `Install ${selectedWallet.displayInfo.displayName}`
+            : wallets.length === 0
+            ? "None available"
             : "Next"}
         </h6>
       ),
@@ -56,19 +62,30 @@ export const ConnectNonIbcWallet: FunctionComponent<
     <ModalBase
       {...props}
       isOpen={props.isOpen && showModalBase}
-      title={props.isWithdraw ? "Withdraw to" : "Deposit from"}
+      title={isWithdraw ? "Withdraw to" : "Deposit from"}
     >
       <div className="grid grid-cols-3 md:grid-cols-2 gap-4 m-4">
-        {props.wallets.map((wallet, i) => (
+        {props.wallets.length === 0 ? (
           <WalletCard
-            key={i}
-            id={wallet.key}
-            {...wallet.displayInfo}
-            isConnected={wallet.isConnected}
-            isSelected={wallet.key === selectedWalletKey}
-            onClick={() => setSelectedWalletId(wallet.key)}
+            className="opacity-30"
+            id="placeholder"
+            displayName="None"
+            iconUrl="/icons/error-x.svg"
           />
-        ))}
+        ) : (
+          <>
+            {wallets.map((wallet, i) => (
+              <WalletCard
+                key={i}
+                id={wallet.key}
+                {...wallet.displayInfo}
+                isConnected={wallet.isConnected}
+                isSelected={wallet.key === selectedWalletKey}
+                onClick={() => setSelectedWalletId(wallet.key)}
+              />
+            ))}
+          </>
+        )}
       </div>
       {accountActionButton}
     </ModalBase>

--- a/packages/web/pages/assets/index.tsx
+++ b/packages/web/pages/assets/index.tsx
@@ -9,9 +9,7 @@ import {
 } from "react";
 import { PricePretty } from "@keplr-wallet/unit";
 import { ObservableQueryPool } from "@osmosis-labs/stores";
-import { makeLocalStorageKVStore } from "../../stores/kv-store";
 import { useStore } from "../../stores";
-import { ObservableTransferUIConfig } from "../../stores/assets";
 import { Overview } from "../../components/overview";
 import { AssetsTable } from "../../components/table/assets-table";
 import { DepoolingTable } from "../../components/table/depooling-table";
@@ -26,7 +24,11 @@ import {
   TransferAssetSelectModal,
 } from "../../modals";
 import { ConnectNonIbcWallet, PreTransferModal } from "../../modals";
-import { useWindowSize, useAmplitudeAnalytics } from "../../hooks";
+import {
+  useWindowSize,
+  useAmplitudeAnalytics,
+  useTransferConfig,
+} from "../../hooks";
 import { WalletConnectQRModal } from "../../modals";
 import { EventName } from "../../config";
 
@@ -47,15 +49,7 @@ const Assets: NextPage = observer(() => {
   const { setUserProperty } = useAmplitudeAnalytics({
     onLoadEvent: [EventName.Assets.pageViewed],
   });
-
-  const [transferConfig] = useState(
-    () =>
-      new ObservableTransferUIConfig(
-        assetsStore,
-        account,
-        makeLocalStorageKVStore("transfer-ui-config")
-      )
-  );
+  const transferConfig = useTransferConfig(assetsStore, account);
 
   // mobile only
   const [preTransferModalProps, setPreTransferModalProps] =
@@ -77,7 +71,7 @@ const Assets: NextPage = observer(() => {
         isUnstable: ibcBalance.isUnstable,
         onSelectToken: launchPreTransferModal,
         onWithdraw: () => {
-          transferConfig.transferAsset(
+          transferConfig?.transferAsset(
             "withdraw",
             ibcBalance.chainInfo.chainId,
             coinDenom
@@ -85,7 +79,7 @@ const Assets: NextPage = observer(() => {
           setPreTransferModalProps(null);
         },
         onDeposit: () => {
-          transferConfig.transferAsset(
+          transferConfig?.transferAsset(
             "deposit",
             ibcBalance.chainInfo.chainId,
             coinDenom
@@ -110,25 +104,25 @@ const Assets: NextPage = observer(() => {
   return (
     <main className="bg-background">
       <AssetsOverview
-        onDepositIntent={() => transferConfig.startTransfer("deposit")}
-        onWithdrawIntent={() => transferConfig.startTransfer("withdraw")}
+        onDepositIntent={() => transferConfig?.startTransfer("deposit")}
+        onWithdrawIntent={() => transferConfig?.startTransfer("withdraw")}
       />
       {isMobile && preTransferModalProps && (
         <PreTransferModal {...preTransferModalProps} />
       )}
-      {transferConfig.assetSelectModal && (
+      {transferConfig?.assetSelectModal && (
         <TransferAssetSelectModal {...transferConfig.assetSelectModal} />
       )}
-      {transferConfig.connectNonIbcWalletModal && (
+      {transferConfig?.connectNonIbcWalletModal && (
         <ConnectNonIbcWallet {...transferConfig.connectNonIbcWalletModal} />
       )}
-      {transferConfig.ibcTransferModal && (
+      {transferConfig?.ibcTransferModal && (
         <IbcTransferModal {...transferConfig.ibcTransferModal} />
       )}
-      {transferConfig.bridgeTransferModal && (
+      {transferConfig?.bridgeTransferModal && (
         <BridgeTransferModal {...transferConfig.bridgeTransferModal} />
       )}
-      {transferConfig.walletConnectEth.sessionConnectUri && (
+      {transferConfig?.walletConnectEth.sessionConnectUri && (
         <WalletConnectQRModal
           isOpen={true}
           uri={transferConfig.walletConnectEth.sessionConnectUri || ""}
@@ -138,18 +132,18 @@ const Assets: NextPage = observer(() => {
       <AssetsTable
         nativeBalances={nativeBalances}
         ibcBalances={ibcBalances}
-        onDepositIntent={() => transferConfig.startTransfer("deposit")}
-        onWithdrawIntent={() => transferConfig.startTransfer("withdraw")}
+        onDepositIntent={() => transferConfig?.startTransfer("deposit")}
+        onWithdrawIntent={() => transferConfig?.startTransfer("withdraw")}
         onDeposit={(chainId, coinDenom, externalDepositUrl) => {
           if (!externalDepositUrl) {
             isMobile
               ? launchPreTransferModal(coinDenom)
-              : transferConfig.transferAsset("deposit", chainId, coinDenom);
+              : transferConfig?.transferAsset("deposit", chainId, coinDenom);
           }
         }}
         onWithdraw={(chainId, coinDenom, externalWithdrawUrl) => {
           if (!externalWithdrawUrl) {
-            transferConfig.transferAsset("withdraw", chainId, coinDenom);
+            transferConfig?.transferAsset("withdraw", chainId, coinDenom);
           }
         }}
       />

--- a/packages/web/stores/assets/transfer-ui-config.ts
+++ b/packages/web/stores/assets/transfer-ui-config.ts
@@ -69,7 +69,8 @@ export class ObservableTransferUIConfig {
   constructor(
     protected readonly assetsStore: ObservableAssets,
     protected readonly account: AccountSetBase,
-    protected readonly kvStore: KVStore
+    protected readonly kvStore: KVStore,
+    protected readonly isMobile: boolean
   ) {
     makeObservable(this);
   }
@@ -84,7 +85,9 @@ export class ObservableTransferUIConfig {
   );
 
   protected get _ethClientWallets(): EthWallet[] {
-    return [this.metamask, this.walletConnectEth];
+    return [this.metamask, this.walletConnectEth].filter((wallet) =>
+      this.isMobile ? wallet.mobileEnabled : true
+    );
   }
 
   /** ### GLOBAL DEPOSIT/WITHDRAW BUTTONS AT TOP
@@ -172,13 +175,8 @@ export class ObservableTransferUIConfig {
             this.launchWalletSelectModal(direction, balance, sourceChainKey);
           }
         );
-      } else if (applicableWallets.length > 0) {
-        this.launchWalletSelectModal(direction, balance, sourceChainKey);
       } else {
-        console.warn(
-          "No non-Keplr wallets found for this bridged asset:",
-          balance.balance.currency.coinDenom
-        );
+        this.launchWalletSelectModal(direction, balance, sourceChainKey);
       }
     } else {
       this.launchIbcTransferModal(direction, balance);
@@ -299,6 +297,8 @@ export class ObservableTransferUIConfig {
     const alreadyConnectedWallet = applicableWallets.find(
       (wallet) => wallet.isConnected
     );
+
+    console.log("launchWalletSelectModal");
 
     this._connectNonIbcWalletModal = {
       isOpen: true,

--- a/packages/web/stores/assets/transfer-ui-config.ts
+++ b/packages/web/stores/assets/transfer-ui-config.ts
@@ -298,8 +298,6 @@ export class ObservableTransferUIConfig {
       (wallet) => wallet.isConnected
     );
 
-    console.log("launchWalletSelectModal");
-
     this._connectNonIbcWalletModal = {
       isOpen: true,
       initiallySelectedWalletId: alreadyConnectedWallet?.key,


### PR DESCRIPTION
Filters the bridge integration wallet list from containing non-mobile supported wallets, and notifies the user that this asset is not selected:

Closes #883
Closes #867 

<img width="388" alt="Screen Shot 2022-10-09 at 2 33 06 PM" src="https://user-images.githubusercontent.com/4606373/194776049-9af1b79c-7567-41ac-bda6-01db300b918d.png">


Later, may be able to enable mobile MetaMask (in the MetaMask mobile browser) if MetaMask mobile would let us send deeplinks to Keplr. See: https://github.com/MetaMask/metamask-mobile/issues/4615.

Or, perhaps we could use WalletConnect to deep link to MetaMask as described in issue 867.