### PR TITLE
Update gauge for likecoin pool 553 and 555 

### DIFF
--- a/packages/web/config/feature-flag.ts
+++ b/packages/web/config/feature-flag.ts
@@ -186,14 +186,7 @@ export const ExternalIncentiveGaugeAllowList: {
   ],
   "553": [
     {
-      gaugeId: "4276",
-      denom:
-        "ibc/9989AD6CCA39D1131523DB0617B50F6442081162294B4795E26746292467B525",
-    },
-  ],
-  "555": [
-    {
-      gaugeId: "4277",
+      gaugeId: "29762",
       denom:
         "ibc/9989AD6CCA39D1131523DB0617B50F6442081162294B4795E26746292467B525",
     },


### PR DESCRIPTION
https://www.mintscan.io/likecoin/proposals/57
We just renewed external incentive on LIKE/OSMOS(553) according to proposal, and gauge on LIKE/ATOM(555) would be removed

https://www.mintscan.io/osmosis/txs/A1B47107AB27423A94EC0CEA4B883EE69783ACEE294341874BD5E4C6AB55C6D7