### PR TITLE
Add up all external incentive APYs for a specific duration

### DIFF
--- a/packages/stores/types/queries/pool-incentives/incentivized-pools.d.ts
+++ b/packages/stores/types/queries/pool-incentives/incentivized-pools.d.ts
@@ -29,7 +29,7 @@ export declare class ObservableQueryIncentivizedPools extends ObservableChainQue
      */
     readonly computeMostAPY: (poolId: string, priceStore: IPriceStore) => RatePretty;
     /**
-     * Computes external incentive APY for the given duration
+     * Computes all external incentive APY for the given duration
      */
     readonly computeExternalIncentiveAPYForSpecificDuration: (poolId: string, duration: Duration, priceStore: IPriceStore, fiatCurrency: FiatCurrency, allowedGauges: ExternalGauge[]) => RatePretty;
     /**


### PR DESCRIPTION
In continuation of #886, this adds up all external incentive APYs for the given duration rather than just calculating it from the first incentive.

![image](https://user-images.githubusercontent.com/5093058/197250612-63a3474b-23dd-4f17-8263-3720cb7c4777.png)
