### PR TITLE
Fix axelar chain map, chainlist names, add usdc to moonbase

### DIFF
--- a/packages/web/config/ibc-assets.ts
+++ b/packages/web/config/ibc-assets.ts
@@ -31,13 +31,16 @@ export const IBCAssetInfos: (IBCAsset & {
     sourceChannelId: IS_TESTNET ? "channel-312" : "channel-208",
     destChannelId: IS_TESTNET ? "channel-22" : "channel-3",
     coinMinimalDenom: IS_TESTNET ? "uausdc" : "uusdc",
-    sourceChainNameOverride: IS_TESTNET ? "Ropsten Ethereum" : "Ethereum",
+    sourceChainNameOverride: IS_TESTNET ? "Goerli Ethereum" : "Ethereum",
     isVerified: true,
     originBridgeInfo: {
       bridge: "axelar" as const,
       wallets: ["metamask" as const, "walletconnect" as const],
       method: "deposit-address" as const,
-      sourceChains: [AxelarSourceChainConfigs.usdc.ethereum],
+      sourceChains: [
+        AxelarSourceChainConfigs.usdc.ethereum,
+        AxelarSourceChainConfigs.usdc.moonbeam
+      ],
     },
   },
   {
@@ -47,7 +50,7 @@ export const IBCAssetInfos: (IBCAsset & {
     sourceChannelId: IS_TESTNET ? "channel-312" : "channel-208",
     destChannelId: IS_TESTNET ? "channel-22" : "channel-3",
     coinMinimalDenom: "weth-wei",
-    sourceChainNameOverride: IS_TESTNET ? "Ropsten Ethereum" : "Ethereum",
+    sourceChainNameOverride: IS_TESTNET ? "Goerli Ethereum" : "Ethereum",
     isVerified: true,
     originBridgeInfo: {
       bridge: "axelar" as const,
@@ -814,7 +817,7 @@ export const IBCAssetInfos: (IBCAsset & {
       bridge: "axelar" as const,
       wallets: ["metamask" as const, "walletconnect" as const],
       method: "deposit-address" as const,
-      sourceChains: [AxelarSourceChainConfigs.glmr.moonbeam],
+      sourceChains: [AxelarSourceChainConfigs.wglmr.moonbeam],
     },
   },  
   {

--- a/packages/web/integrations/axelar/source-chain-config.ts
+++ b/packages/web/integrations/axelar/source-chain-config.ts
@@ -11,62 +11,70 @@ export const SourceChainConfigs: {
   usdc: {
     ethereum: {
       id: IS_TESTNET
-        ? ("Ropsten Test Network" as const)
+        ? ("ethereum-2" as const)
         : ("Ethereum" as const),
       erc20ContractAddress: IS_TESTNET
-        ? "0x526f0A95EDC3DF4CBDB7bb37d4F7Ed451dB8e369"
+        ? "0x254d06f33bDc5b8ee05b2ea472107E300226659A"
         : "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // test: 'aUSDC' on metamask/etherscan
       logoUrl: "/networks/ethereum.svg",
       transferFeeMinAmount: IS_TESTNET ? "150000" : "10500000", // From https://docs.axelar.dev/resources/mainnet#cross-chain-relayer-gas-fee
     },
-    bnbChain: {
-      id: "Binance" as const,
-      erc20ContractAddress: "0x4268B8F0B87b6Eae5d897996E6b845ddbD99Adf3",
-      logoUrl: "/networks/binance.svg",
-      transferFeeMinAmount: IS_TESTNET ? "150000" : "1500000",
-    },
     avalanche: {
       id: "Avalanche" as const,
-      erc20ContractAddress: "0xfaB550568C688d5D8A52C7d794cb93Edc26eC0eC",
+      erc20ContractAddress: IS_TESTNET
+        ? "0x57F1c63497AEe0bE305B8852b354CEc793da43bB"
+        : "0xfaB550568C688d5D8A52C7d794cb93Edc26eC0eC",
       logoUrl: "/networks/avalanche.svg",
       transferFeeMinAmount: IS_TESTNET ? "150000" : "1500000",
     },
-    polygon: {
-      id: "Polygon" as const,
-      erc20ContractAddress: "0x750e4C4984a9e0f12978eA6742Bc1c5D248f40ed",
-      logoUrl: "/networks/polygon.svg",
+    binance: {
+      id: "binance" as const,
+      erc20ContractAddress: IS_TESTNET
+        ? "0xc2fA98faB811B785b81c64Ac875b31CC9E40F9D2"
+        : "0x4268B8F0B87b6Eae5d897996E6b845ddbD99Adf3",
+      logoUrl: "/networks/binance.svg",
       transferFeeMinAmount: IS_TESTNET ? "150000" : "1500000",
     },
     fantom: {
       id: "Fantom" as const,
-      erc20ContractAddress: "0x1B6382DBDEa11d97f24495C9A90b7c88469134a4",
+      erc20ContractAddress: IS_TESTNET
+        ? "0x75Cc4fDf1ee3E781C1A3Ee9151D5c6Ce34Cf5C61"
+        : "0x1B6382DBDEa11d97f24495C9A90b7c88469134a4",
       logoUrl: "/networks/fantom.svg",
       transferFeeMinAmount: IS_TESTNET ? "150000" : "1500000",
     },
     moonbeam: {
       id: "Moonbeam" as const,
-      erc20ContractAddress: "0xCa01a1D0993565291051daFF390892518ACfAD3A",
+      erc20ContractAddress: IS_TESTNET
+        ? "0xD1633F7Fb3d716643125d6415d4177bC36b7186b"
+        : "0xCa01a1D0993565291051daFF390892518ACfAD3A",
       logoUrl: "/networks/moonbeam.svg",
+      transferFeeMinAmount: IS_TESTNET ? "150000" : "1500000",
+    },
+    polygon: {
+      id: "Polygon" as const,
+      erc20ContractAddress: IS_TESTNET
+        ? "0x2c852e740B62308c46DD29B982FBb650D063Bd07"
+        : "0x750e4C4984a9e0f12978eA6742Bc1c5D248f40ed",
+      logoUrl: "/networks/polygon.svg",
       transferFeeMinAmount: IS_TESTNET ? "150000" : "1500000",
     },
   },
   weth: {
     ethereum: {
       id: IS_TESTNET
-        ? ("Ropsten Test Network" as const)
+        ? ("ethereum-2" as const)
         : ("Ethereum" as const),
       erc20ContractAddress: IS_TESTNET
-        ? "0xc778417E063141139Fce010982780140Aa0cD5Ab"
+        ? "0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6"
         : "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
       logoUrl: "/networks/ethereum.svg",
-      transferFeeMinAmount: IS_TESTNET ? "60000000000000" : "6300000000000000",
+      transferFeeMinAmount: IS_TESTNET ? "100000000000000" : "6300000000000000",
     },
   },
-  glmr: {
+  wglmr: {
     moonbeam: {
-      id: IS_TESTNET
-        ? ("Moonbase Alpha" as const)
-        : ("Moonbeam" as const),
+      id: "Moonbeam" as const,
       erc20ContractAddress: IS_TESTNET
         ? "0x1436aE0dF0A8663F18c0Ec51d7e2E46591730715"
         : "0xAcc15dC74880C9944775448304B263D191c6077F",

--- a/packages/web/integrations/axelar/types.ts
+++ b/packages/web/integrations/axelar/types.ts
@@ -1,3 +1,5 @@
+const IS_TESTNET = process.env.NEXT_PUBLIC_IS_TESTNET === "true";
+
 export interface AxelarBridgeConfig {
   /** Currently just via deposit address, future could be gateway contract call. */
   method: "deposit-address";
@@ -15,17 +17,18 @@ export interface AxelarBridgeConfig {
 }
 
 /** See: https://docs.axelar.dev/dev/build/chain-names/mainnet
+ *  See: https://docs.axelar.dev/dev/build/chain-names/testnet
  *  Testnet: https://axelartest-lcd.quickapi.com/axelar/nexus/v1beta1/chains?status=1
  */
 export type SourceChain =
-  | "Ethereum"
-  | "Ropsten Test Network"
+  | "aurora"
   | "Avalanche"
+  | "binance"
+  | "Ethereum"
+  | "ethereum-2"
   | "Fantom"
-  | "Polygon"
   | "Moonbeam"
-  | "Moonbase Alpha"
-  | "Binance";
+  | "Polygon";
 
 /** Maps eth client chainIDs => axelar chain ids.
  *
@@ -37,11 +40,23 @@ export type SourceChain =
  */
 export const EthClientChainIds_AxelarChainIdsMap: {
   [ethClientChainIds: string]: SourceChain;
-} = {
-  "Avalanche C-Chain": "Avalanche",
-  "Binance Smart Chain": "Binance",
-  "Fantom Opera": "Fantom",
-};
+} = IS_TESTNET ?
+  {
+    "Aurora Testnet": "aurora",
+    "Avalanche Fuji Testnet": "Avalanche",
+    "Binance Smart Chain Testnet": "binance",
+    "Goerli Test Network": "ethereum-2",
+    "Fantom Testnet": "Fantom",
+    "Moonbase Alpha": "Moonbeam",
+    "Mumbai": "Polygon",
+  } : {
+    "Avalanche C-Chain": "Avalanche",
+    "Binance Smart Chain Mainnet": "binance",
+    "Ethereum Main Network": "Ethereum",
+    "Fantom Opera": "Fantom",
+    "Moonbeam Mainnet": "Moonbeam",
+    "Polygon Mainnet": "Polygon",
+  };
 
 export type SourceChainConfig = {
   /** Axelar-defined identifier. */

--- a/packages/web/integrations/ethereum/types.ts
+++ b/packages/web/integrations/ethereum/types.ts
@@ -26,22 +26,27 @@ export type SendFn = Pick<EthWallet, "send">["send"];
 
 export const ChainNames: { [chainId: string]: string } = {
   /** Ethereum chains: https://docs.metamask.io/guide/ethereum-provider.html#chain-ids */
-  "0x1": "Ethereum",
+  "0x1": "Ethereum Main Network",
   "0x3": "Ropsten Test Network",
   "0x4": "Rinkeby Test Network",
   "0x5": "Goerli Test Network",
   "0x2a": "Kovan Test Network",
 
   // manually searched and added. Source: https://chainlist.org/
-  "0x38": "Binance Smart Chain",
+  "0x38": "Binance Smart Chain Mainnet",
+  "0x61": "Binance Smart Chain Testnet",
   "0x64": "Gnosis",
-  "0x89": "Polygon",
+  "0x89": "Polygon Mainnet",
+  "0x13881": "Mumbai",
   "0xfa": "Fantom Opera",
-  "0x504": "Moonbeam",
+  "0xfa2": "Fantom Testnet",
+  "0x504": "Moonbeam Mainnet",
   "0x507": "Moonbase Alpha",
   "0x2329": "Evmos",
   "0xa86a": "Avalanche C-Chain",
-  "0x4e454152": "Aurora",
+  "0xa869": "Avalanche Fuji Testnet",
+  "0x4e454152": "Aurora Mainnet",
+  "0x4e454153": "Aurora Testnet",
 };
 
 export const ChainNetworkConfigs: { [chainId: string]: object } = {};


### PR DESCRIPTION
Update Ropsten to Goerli
Update sourceChain names list to those accepted by Axelar
Update Chainlist Networks list
Add Moonbase and USDC withdraw/deposit network
Add IS_TESTNET var for eth<>Axl network name mapping
Add contract address for USDC on other networks (not yet withdrawable)

Builds successfully, USDC deposit switches Metamask to correct network for Ethereum, Mooneam on Mainnet, and to Goerli and Moonbase on Testnet.