### PR TITLE
update hasPoolAsset return condition

### DIFF
--- a/packages/pools/src/weighted.ts
+++ b/packages/pools/src/weighted.ts
@@ -124,7 +124,7 @@ export class WeightedPool implements Pool {
 
   hasPoolAsset(denom: string): boolean {
     const poolAsset = this.poolAssets.find((asset) => asset.denom === denom);
-    return poolAsset != null;
+    return poolAsset !== undefined;
   }
 
   get totalWeight(): Int {


### PR DESCRIPTION
`poolAssets` is defined as `WeightedPool.poolAssets` which is an array of objects. from the definition of [`Array.prototype.find()
` ](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find), `.find` returns **undefined** if there is no matched element from the given array.