### PR TITLE
Fix bond card (single pool view) content overflow when APR value is 3 digits

### DIFF
--- a/packages/web/components/cards/bond-card.tsx
+++ b/packages/web/components/cards/bond-card.tsx
@@ -186,7 +186,7 @@ const Drawer: FunctionComponent<{
           <span className="subtitle1 text-osmoverse-200">
             {t("pool.incentives")}
           </span>
-          <div className="flex items-center gap-4 md:gap-1.5">
+          <div className="flex items-center gap-2 md:gap-1.5">
             <h5
               className={classNames(
                 superfluid ? "text-superfluid-gradient" : "text-bullish-400"


### PR DESCRIPTION
This happens on prod OSMO/STARS

### Before
![Screenshot 2022-11-11 at 10 39 43](https://user-images.githubusercontent.com/1018543/201251327-af49218a-d1c5-479b-8845-47729967c5d7.png)

### After
![Screenshot 2022-11-11 at 10 40 06](https://user-images.githubusercontent.com/1018543/201251340-c40c3f61-7cb2-496d-9f57-34f456237e7a.png)
