### PR TITLE
add focus on search box when opening tokens select modal

### DIFF
--- a/packages/web/components/input/search-box.tsx
+++ b/packages/web/components/input/search-box.tsx
@@ -12,6 +12,7 @@ export const SearchBox: FunctionComponent<
   placeholder,
   type,
   disabled = false,
+  autoFocus,
   className,
 }) => {
   const [isFocused, setIsFocused] = useState(false);
@@ -35,6 +36,7 @@ export const SearchBox: FunctionComponent<
           className="w-full h-full appearance-none bg-transparent placeholder:body2 placeholder:text-osmoverse-500 transition-colors"
           value={currentValue}
           type={type}
+          autoFocus={autoFocus}
           placeholder={placeholder}
           autoComplete="off"
           onFocus={(e: any) => {

--- a/packages/web/components/types.ts
+++ b/packages/web/components/types.ts
@@ -14,6 +14,7 @@ export type MainLayoutMenu = {
 export interface InputProps<T> {
   currentValue: T;
   onInput: (value: T) => void;
+  autoFocus?: boolean;
   onFocus?: (e: any) => void;
   placeholder?: T;
 }

--- a/packages/web/modals/token-select.tsx
+++ b/packages/web/modals/token-select.tsx
@@ -35,6 +35,7 @@ export const TokenSelectModal: FunctionComponent<
     >
       <div className="p-4" onClick={(e) => e.stopPropagation()}>
         <SearchBox
+          autoFocus
           type="text"
           className="!w-full"
           placeholder={props.placeholder ?? t("components.searchTokens")}


### PR DESCRIPTION
Mostly for accessibility:

When swapping tokens, we can open a modal to select a new token in the token list. 
This modal has a search field, which should be focused right when the modal opens. 
This way, people can search for their tokens without clicking inside the input field. 