### PR TITLE
WBNB.axl to Main site

### DIFF
--- a/packages/web/config/ibc-assets.ts
+++ b/packages/web/config/ibc-assets.ts
@@ -108,7 +108,7 @@ export const IBCAssetInfos: (IBCAsset & {
     destChannelId: "channel-3",
     coinMinimalDenom: "wbnb-wei",
     sourceChainNameOverride: "Binance Smart Chain",
-    isVerified: false,
+    isVerified: true,
     originBridgeInfo: {
       bridge: "axelar" as const,
       wallets: ["metamask" as const],


### PR DESCRIPTION
Axelar's axlWBNB (WBNB.axl) aught to be listed on the Main site since at least one of its pools (#840 OSMO/WBNB) will be incentivized, as decided by Osmosis Governance. ([see passing vote on Keplr](https://wallet.keplr.app/chains/osmosis/proposals/360))
Will come into effect November 20, as per the proposal text. 