### PR TITLE
Internal math for stableswap

### DIFF
--- a/packages/math/src/pool/__tests__/stable.spec.ts
+++ b/packages/math/src/pool/__tests__/stable.spec.ts
@@ -1,5 +1,5 @@
 import * as StableMath from '../stable';
-import { Coin, Dec, Int } from '@keplr-wallet/unit';
+import { Coin, Dec, Int, DecUtils } from '@keplr-wallet/unit';
 
 describe('Test stableswap math', () => {
   describe('calcOutGivenIn', () => {
@@ -184,6 +184,125 @@ describe('Test stableswap math', () => {
       );
 
       expect(outAmount.equals(expectedTokenOut.amount)).toBeTruthy();
+    });
+    */
+  });
+
+  describe('calcSpotPrice', () => {
+    test('foo in terms of bar in even pool', () => {
+      const poolAssets: StableMath.StableSwapToken[] = [
+        {
+          amount: new Dec(1_000_000_000),
+          denom: 'foo',
+          scalingFactor: 1,
+        },
+        {
+          amount: new Dec(1_000_000_000),
+          denom: 'bar',
+          scalingFactor: 1,
+        },
+        {
+          amount: new Dec(1_000_000_000),
+          denom: 'baz',
+          scalingFactor: 1,
+        },
+      ];
+
+      const baseDenom = 'foo';
+      const quoteDenom = 'bar';
+
+      const expectedSpotPrice = new Dec(1.0);
+
+      const actualSpotPrice = StableMath.calcSpotPrice(
+        poolAssets,
+        baseDenom,
+        quoteDenom,
+      );
+
+      const tolerance = new Dec(1).quo(
+        DecUtils.getTenExponentNInPrecisionRange(3),
+      );
+      const comparison = StableMath.compare_checkMultErrorTolerance(
+        expectedSpotPrice,
+        actualSpotPrice,
+        tolerance,
+        'roundBankers',
+      );
+      expect(comparison == 0).toBeTruthy();
+    });
+
+    test('foo in terms of bar in uneven pool', () => {
+      const poolAssets: StableMath.StableSwapToken[] = [
+        {
+          amount: new Dec(10_000_000_000),
+          denom: 'foo',
+          scalingFactor: 1,
+        },
+        {
+          amount: new Dec(20_000_000_000),
+          denom: 'bar',
+          scalingFactor: 1,
+        },
+        {
+          amount: new Dec(30_000_000_000),
+          denom: 'baz',
+          scalingFactor: 1,
+        },
+      ];
+
+      // quote and base definitions following V2 Querier
+      const baseDenom = 'bar';
+      const quoteDenom = 'foo';
+
+      const expectedSpotPrice = new Dec(1.446096575818955898);
+
+      const actualSpotPrice = StableMath.calcSpotPrice(
+        poolAssets,
+        baseDenom,
+        quoteDenom,
+      );
+
+      const tolerance = new Dec(1).quo(
+        DecUtils.getTenExponentNInPrecisionRange(3),
+      );
+      const comparison = StableMath.compare_checkMultErrorTolerance(
+        expectedSpotPrice,
+        actualSpotPrice,
+        tolerance,
+        'roundBankers',
+      );
+
+      expect(comparison == 0).toBeTruthy();
+    });
+
+    /*
+    test('even large pool basic trade (precision test)', () => {
+      const poolAssets: StableMath.StableSwapToken[] = [
+        {
+          amount: new Dec(1_000_000_000_000),
+          denom: 'foo',
+          scalingFactor: 1,
+        },
+        {
+          amount: new Dec(1_000_000_000_000),
+          denom: 'bar',
+          scalingFactor: 1,
+        },
+      ];
+
+      const tokenOut = new Coin('bar', 100);
+      const swapFee = new Dec(0);
+
+      const expectedTokenIn = { denom: 'foo', amount: new Int(101) };
+
+      const inAmount = StableMath.calcInGivenOut(
+        poolAssets,
+        tokenOut,
+        expectedTokenIn.denom,
+        swapFee,
+      );
+
+      expect(inAmount.equals(expectedTokenIn.amount)).toBeTruthy();
     });
     */
   });

--- a/packages/math/src/pool/__tests__/stable.spec.ts
+++ b/packages/math/src/pool/__tests__/stable.spec.ts
@@ -31,6 +31,161 @@ describe('Test stableswap math', () => {
 
       expect(outAmount.equals(expectedTokenOut.amount)).toBeTruthy();
     });
+
+    test('even large pool basic trade (precision test)', () => {
+      const poolAssets: StableMath.StableSwapToken[] = [
+        {
+          amount: new Dec(1_000_000_000_000),
+          denom: 'foo',
+          scalingFactor: 1,
+        },
+        {
+          amount: new Dec(1_000_000_000_000),
+          denom: 'bar',
+          scalingFactor: 1,
+        },
+      ];
+
+      const tokenIn = new Coin('foo', 100);
+      const swapFee = new Dec(0);
+
+      const expectedTokenOut = { denom: 'bar', amount: new Int(99) };
+
+      const outAmount = StableMath.calcOutGivenIn(
+        poolAssets,
+        tokenIn,
+        expectedTokenOut.denom,
+        swapFee,
+      );
+
+      expect(outAmount.equals(expectedTokenOut.amount)).toBeTruthy();
+    });
+
+    // TODO: add swap fee tests
+
+    /* This test should pass
+    test('even large pool basic trade (precision test)', () => {
+      const poolAssets: StableMath.StableSwapToken[] = [
+        {
+          amount: new Dec(1_000_000_000_000_000),
+          denom: 'foo',
+          scalingFactor: 1,
+        },
+        {
+          amount: new Dec(1_000_000_000_000_000),
+          denom: 'bar',
+          scalingFactor: 1,
+        },
+      ];
+
+      const tokenIn = new Coin('foo', 100);
+      const swapFee = new Dec(0);
+
+      const expectedTokenOut = { denom: 'bar', amount: new Int(99) };
+
+      const outAmount = StableMath.calcOutGivenIn(
+        poolAssets,
+        tokenIn,
+        expectedTokenOut.denom,
+        swapFee,
+      );
+
+      expect(outAmount.equals(expectedTokenOut.amount)).toBeTruthy();
+    });
+    */
+  });
+
+  describe('calcInGivenOut', () => {
+    test('even pool basic trade', () => {
+      const poolAssets: StableMath.StableSwapToken[] = [
+        {
+          amount: new Dec(1_000_000_000),
+          denom: 'foo',
+          scalingFactor: 1,
+        },
+        {
+          amount: new Dec(1_000_000_000),
+          denom: 'bar',
+          scalingFactor: 1,
+        },
+      ];
+
+      const tokenOut = new Coin('bar', 100);
+      const swapFee = new Dec(0);
+
+      const expectedTokenIn = { denom: 'foo', amount: new Int(101) };
+
+      const inAmount = StableMath.calcInGivenOut(
+        poolAssets,
+        tokenOut,
+        expectedTokenIn.denom,
+        swapFee,
+      );
+
+      expect(inAmount.equals(expectedTokenIn.amount)).toBeTruthy();
+    });
+
+    test('even large pool basic trade (precision test)', () => {
+      const poolAssets: StableMath.StableSwapToken[] = [
+        {
+          amount: new Dec(1_000_000_000_000),
+          denom: 'foo',
+          scalingFactor: 1,
+        },
+        {
+          amount: new Dec(1_000_000_000_000),
+          denom: 'bar',
+          scalingFactor: 1,
+        },
+      ];
+
+      const tokenOut = new Coin('bar', 100);
+      const swapFee = new Dec(0);
+
+      const expectedTokenIn = { denom: 'foo', amount: new Int(101) };
+
+      const inAmount = StableMath.calcInGivenOut(
+        poolAssets,
+        tokenOut,
+        expectedTokenIn.denom,
+        swapFee,
+      );
+
+      expect(inAmount.equals(expectedTokenIn.amount)).toBeTruthy();
+    });
+
+    // TODO: add swap fee tests
+
+    /* This test should pass
+    test('even large pool basic trade (precision test)', () => {
+      const poolAssets: StableMath.StableSwapToken[] = [
+        {
+          amount: new Dec(1_000_000_000_000_000),
+          denom: 'foo',
+          scalingFactor: 1,
+        },
+        {
+          amount: new Dec(1_000_000_000_000_000),
+          denom: 'bar',
+          scalingFactor: 1,
+        },
+      ];
+
+      const tokenIn = new Coin('foo', 100);
+      const swapFee = new Dec(0);
+
+      const expectedTokenOut = { denom: 'bar', amount: new Int(99) };
+
+      const outAmount = StableMath.calcOutGivenIn(
+        poolAssets,
+        tokenIn,
+        expectedTokenOut.denom,
+        swapFee,
+      );
+
+      expect(outAmount.equals(expectedTokenOut.amount)).toBeTruthy();
+    });
+    */
   });
 
   describe('solver', () => {

--- a/packages/math/src/pool/__tests__/stable.spec.ts
+++ b/packages/math/src/pool/__tests__/stable.spec.ts
@@ -29,7 +29,6 @@ describe('Test stableswap math', () => {
         swapFee,
       );
 
-      // TODO: rounded amount is right, but decimals still have .999999
       expect(outAmount.equals(expectedTokenOut.amount)).toBeTruthy();
     });
   });

--- a/packages/math/src/pool/__tests__/stable.spec.ts
+++ b/packages/math/src/pool/__tests__/stable.spec.ts
@@ -1,41 +1,41 @@
-import * as StableMath from "../stable";
-import { Coin, Dec } from "@keplr-wallet/unit";
+import * as StableMath from '../stable';
+import { Coin, Dec, Int } from '@keplr-wallet/unit';
 
-describe("Test stableswap math", () => {
-  describe("calcOutGivenIn", () => {
-    test("even pool basic trade", () => {
+describe('Test stableswap math', () => {
+  describe('calcOutGivenIn', () => {
+    test('even pool basic trade', () => {
       const poolAssets: StableMath.StableSwapToken[] = [
         {
           amount: new Dec(1_000_000_000),
-          denom: "foo",
+          denom: 'foo',
           scalingFactor: 1,
         },
         {
           amount: new Dec(1_000_000_000),
-          denom: "bar",
+          denom: 'bar',
           scalingFactor: 1,
         },
       ];
 
-      const tokenIn = new Coin("foo", 100);
+      const tokenIn = new Coin('foo', 100);
       const swapFee = new Dec(0);
 
-      const expectedTokenOut = { denom: "bar", amount: new Dec(99) };
+      const expectedTokenOut = { denom: 'bar', amount: new Int(99) };
 
       const outAmount = StableMath.calcOutGivenIn(
         poolAssets,
         tokenIn,
         expectedTokenOut.denom,
-        swapFee
+        swapFee,
       );
 
       // TODO: rounded amount is right, but decimals still have .999999
-      expect(outAmount.gte(expectedTokenOut.amount)).toBeTruthy();
+      expect(outAmount.equals(expectedTokenOut.amount)).toBeTruthy();
     });
   });
 
-  describe("solver", () => {
-    test("even 3-asset small pool, small input", () => {
+  describe('solver', () => {
+    test('even 3-asset small pool, small input', () => {
       const xReserve = new Dec(100);
       const yReserve = new Dec(100);
       const remReserves = [new Dec(100)];
@@ -43,7 +43,7 @@ describe("Test stableswap math", () => {
 
       StableMath.solveCfmm(xReserve, yReserve, remReserves, yIn);
     });
-    test("even 3-asset medium pool, small input", () => {
+    test('even 3-asset medium pool, small input', () => {
       const xReserve = new Dec(100_000);
       const yReserve = new Dec(100_000);
       const remReserves = [new Dec(100_000)];
@@ -51,7 +51,7 @@ describe("Test stableswap math", () => {
 
       StableMath.solveCfmm(xReserve, yReserve, remReserves, yIn);
     });
-    test("even 4-asset small pool, small input", () => {
+    test('even 4-asset small pool, small input', () => {
       const xReserve = new Dec(100);
       const yReserve = new Dec(100);
       const remReserves = [new Dec(100), new Dec(100)];
@@ -59,7 +59,7 @@ describe("Test stableswap math", () => {
 
       StableMath.solveCfmm(xReserve, yReserve, remReserves, yIn);
     });
-    test("even 4-asset medium pool, small input", () => {
+    test('even 4-asset medium pool, small input', () => {
       const xReserve = new Dec(100_000);
       const yReserve = new Dec(100_000);
       const remReserves = [new Dec(100_000), new Dec(100_000)];
@@ -67,7 +67,7 @@ describe("Test stableswap math", () => {
 
       StableMath.solveCfmm(xReserve, yReserve, remReserves, yIn);
     });
-    test("even 4-asset large pool (100M each), small input", () => {
+    test('even 4-asset large pool (100M each), small input', () => {
       const xReserve = new Dec(100_000_000);
       const yReserve = new Dec(100_000_000);
       const remReserves = [new Dec(100_000_000), new Dec(100_000_000)];
@@ -75,7 +75,7 @@ describe("Test stableswap math", () => {
 
       StableMath.solveCfmm(xReserve, yReserve, remReserves, yIn);
     });
-    test("even 4-asset pool (10B each post-scaled), small input", () => {
+    test('even 4-asset pool (10B each post-scaled), small input', () => {
       const xReserve = new Dec(10_000_000_000);
       const yReserve = new Dec(10_000_000_000);
       const remReserves = [new Dec(10_000_000_000), new Dec(10_000_000_000)];
@@ -83,7 +83,7 @@ describe("Test stableswap math", () => {
 
       StableMath.solveCfmm(xReserve, yReserve, remReserves, yIn);
     });
-    test("even 10-asset pool (10B each post-scaled), small input", () => {
+    test('even 10-asset pool (10B each post-scaled), small input', () => {
       const xReserve = new Dec(10_000_000_000);
       const yReserve = new Dec(10_000_000_000);
       const remReserves = [
@@ -100,7 +100,7 @@ describe("Test stableswap math", () => {
 
       StableMath.solveCfmm(xReserve, yReserve, remReserves, yIn);
     });
-    test("even 10-asset pool (100B each post-scaled), large input", () => {
+    test('even 10-asset pool (100B each post-scaled), large input', () => {
       const xReserve = new Dec(100_000_000_000);
       const yReserve = new Dec(100_000_000_000);
       const remReserves = [
@@ -119,7 +119,7 @@ describe("Test stableswap math", () => {
     });
 
     // uneven pools
-    test("uneven 3-asset pool, even swap assets as pool minority", () => {
+    test('uneven 3-asset pool, even swap assets as pool minority', () => {
       const xReserve = new Dec(100);
       const yReserve = new Dec(100);
       const remReserves = [new Dec(100_000)];
@@ -127,7 +127,7 @@ describe("Test stableswap math", () => {
 
       StableMath.solveCfmm(xReserve, yReserve, remReserves, yIn);
     });
-    test("uneven 3-asset pool, uneven swap assets as pool minority, y > x", () => {
+    test('uneven 3-asset pool, uneven swap assets as pool minority, y > x', () => {
       const xReserve = new Dec(100);
       const yReserve = new Dec(200);
       const remReserves = [new Dec(100_000)];
@@ -135,7 +135,7 @@ describe("Test stableswap math", () => {
 
       StableMath.solveCfmm(xReserve, yReserve, remReserves, yIn);
     });
-    test("uneven 3-asset pool, uneven swap assets as pool minority, x > y", () => {
+    test('uneven 3-asset pool, uneven swap assets as pool minority, x > y', () => {
       const xReserve = new Dec(200);
       const yReserve = new Dec(100);
       const remReserves = [new Dec(100_000)];
@@ -143,7 +143,7 @@ describe("Test stableswap math", () => {
 
       StableMath.solveCfmm(xReserve, yReserve, remReserves, yIn);
     });
-    test("uneven 3-asset pool, no round numbers", () => {
+    test('uneven 3-asset pool, no round numbers', () => {
       const xReserve = new Dec(1178349);
       const yReserve = new Dec(8329743);
       const remReserves = [new Dec(329847)];
@@ -151,7 +151,7 @@ describe("Test stableswap math", () => {
 
       StableMath.solveCfmm(xReserve, yReserve, remReserves, yIn);
     });
-    test("uneven 4-asset pool, small input and swap assets in pool minority", () => {
+    test('uneven 4-asset pool, small input and swap assets in pool minority', () => {
       const xReserve = new Dec(100);
       const yReserve = new Dec(100);
       const remReserves = [new Dec(100_000), new Dec(100_000)];
@@ -159,7 +159,7 @@ describe("Test stableswap math", () => {
 
       StableMath.solveCfmm(xReserve, yReserve, remReserves, yIn);
     });
-    test("uneven 4-asset pool, even swap assets in pool majority", () => {
+    test('uneven 4-asset pool, even swap assets in pool majority', () => {
       const xReserve = new Dec(100_000);
       const yReserve = new Dec(100_000);
       const remReserves = [new Dec(100), new Dec(100)];
@@ -167,7 +167,7 @@ describe("Test stableswap math", () => {
 
       StableMath.solveCfmm(xReserve, yReserve, remReserves, yIn);
     });
-    test("uneven 4-asset pool, even swap assets in pool majority", () => {
+    test('uneven 4-asset pool, even swap assets in pool majority', () => {
       const xReserve = new Dec(100_000);
       const yReserve = new Dec(100_000);
       const remReserves = [new Dec(100), new Dec(100)];
@@ -175,7 +175,7 @@ describe("Test stableswap math", () => {
 
       StableMath.solveCfmm(xReserve, yReserve, remReserves, yIn);
     });
-    test("uneven 4-asset pool, uneven swap assets in pool majority, y > x", () => {
+    test('uneven 4-asset pool, uneven swap assets in pool majority, y > x', () => {
       const xReserve = new Dec(100_000);
       const yReserve = new Dec(200_000);
       const remReserves = [new Dec(100), new Dec(100)];
@@ -183,7 +183,7 @@ describe("Test stableswap math", () => {
 
       StableMath.solveCfmm(xReserve, yReserve, remReserves, yIn);
     });
-    test("uneven 4-asset pool, uneven swap assets in pool majority, y < x", () => {
+    test('uneven 4-asset pool, uneven swap assets in pool majority, y < x', () => {
       const xReserve = new Dec(200_000);
       const yReserve = new Dec(100_000);
       const remReserves = [new Dec(100), new Dec(100)];
@@ -191,7 +191,7 @@ describe("Test stableswap math", () => {
 
       StableMath.solveCfmm(xReserve, yReserve, remReserves, yIn);
     });
-    test("uneven 4-asset pool, no round numbers", () => {
+    test('uneven 4-asset pool, no round numbers', () => {
       const xReserve = new Dec(1178349);
       const yReserve = new Dec(8329743);
       const remReserves = [new Dec(329847), new Dec(4372897)];
@@ -201,34 +201,34 @@ describe("Test stableswap math", () => {
     });
 
     // check for expected exceptions to be thrown
-    test("negative xReserve", () => {
+    test('negative xReserve', () => {
       const xReserve = new Dec(-100);
       const yReserve = new Dec(100);
       const remReserves = [new Dec(100), new Dec(100)];
       const yIn = new Dec(1);
 
       expect(() =>
-        StableMath.solveCfmm(xReserve, yReserve, remReserves, yIn)
+        StableMath.solveCfmm(xReserve, yReserve, remReserves, yIn),
       ).toThrowError();
     });
-    test("negative yReserve", () => {
+    test('negative yReserve', () => {
       const xReserve = new Dec(100);
       const yReserve = new Dec(-100);
       const remReserves = [new Dec(100), new Dec(100)];
       const yIn = new Dec(1);
 
       expect(() =>
-        StableMath.solveCfmm(xReserve, yReserve, remReserves, yIn)
+        StableMath.solveCfmm(xReserve, yReserve, remReserves, yIn),
       ).toThrowError();
     });
-    test("input greater than pool reserves (even 4-asset pool)", () => {
+    test('input greater than pool reserves (even 4-asset pool)', () => {
       const xReserve = new Dec(100);
       const yReserve = new Dec(100);
       const remReserves = [new Dec(100), new Dec(100)];
       const yIn = new Dec(1000);
 
       expect(() =>
-        StableMath.solveCfmm(xReserve, yReserve, remReserves, yIn)
+        StableMath.solveCfmm(xReserve, yReserve, remReserves, yIn),
       ).toThrowError();
     });
   });

--- a/packages/math/src/pool/stable.ts
+++ b/packages/math/src/pool/stable.ts
@@ -1,4 +1,4 @@
-import { Coin, Dec, DecUtils } from "@keplr-wallet/unit";
+import { Coin, Dec, DecUtils } from '@keplr-wallet/unit';
 
 const oneDec = new Dec(1);
 
@@ -12,43 +12,43 @@ export function calcOutGivenIn(
   tokens: StableSwapToken[],
   tokenIn: Coin,
   tokenOutDenom: string,
-  swapFee: Dec
+  swapFee: Dec,
 ) {
   const scaledTokens = scaleTokens(tokens);
 
   const tokenInScalingFactor = tokens.find(
-    ({ denom }) => denom === tokenIn.denom
+    ({ denom }) => denom === tokenIn.denom,
   )?.scalingFactor;
 
-  if (!tokenInScalingFactor) throw Error("tokenIn denom not in pool tokens");
+  if (!tokenInScalingFactor) throw Error('tokenIn denom not in pool tokens');
 
   const tokenInScaled = new Dec(tokenIn.amount).quoTruncate(
-    new Dec(tokenInScalingFactor)
+    new Dec(tokenInScalingFactor),
   );
 
   const tokenInLessFee = tokenInScaled.mul(oneDec.sub(swapFee));
 
   const tokenOutSupply = scaledTokens.find(
-    ({ denom }) => denom === tokenOutDenom
+    ({ denom }) => denom === tokenOutDenom,
   );
   const tokenInSupply = scaledTokens.find(
-    ({ denom }) => denom === tokenIn.denom
+    ({ denom }) => denom === tokenIn.denom,
   );
   const remReserves = scaledTokens
     .filter(({ denom }) => denom !== tokenIn.denom && denom !== tokenOutDenom)
     .map(({ amount }) => amount);
 
   if (!tokenOutSupply || !tokenInSupply)
-    throw new Error("token supply incorrect");
+    throw new Error('token supply incorrect');
 
   const cfmmOut = solveCfmm(
     tokenOutSupply.amount,
     tokenInSupply.amount,
     remReserves,
-    tokenInLessFee
+    tokenInLessFee,
   );
 
-  return cfmmOut.mul(new Dec(tokenOutSupply.scalingFactor));
+  return cfmmOut.mul(new Dec(tokenOutSupply.scalingFactor)).truncate();
 }
 
 export function calcInGivenOut() {}
@@ -64,7 +64,7 @@ export function solveCfmm(
   xReserve: Dec,
   yReserve: Dec,
   remReserves: Dec[],
-  yIn: Dec
+  yIn: Dec,
 ): Dec {
   let wSumSquares = new Dec(0);
   remReserves.forEach((reserve) => {
@@ -78,23 +78,23 @@ function solveCfmmBinarySearchMulti(
   xReserve: Dec,
   yReserve: Dec,
   wSumSquares: Dec,
-  yIn: Dec
+  yIn: Dec,
 ): Dec {
   if (
     !xReserve.isPositive() ||
     !yReserve.isPositive() ||
     wSumSquares.isNegative()
   )
-    throw Error("reserves and squares must be positive");
+    throw Error('reserves and squares must be positive');
   else if (yIn.abs().gt(yReserve))
-    throw Error("cannot input more than y reserve");
+    throw Error('cannot input more than y reserve');
 
   const yFinal = yReserve.add(yIn);
   let xLowEst = xReserve;
   let xHighEst = xReserve;
   const k0 = cfmmConstantMultiNoV(xReserve, yFinal, wSumSquares);
   const k = cfmmConstantMultiNoV(xReserve, yReserve, wSumSquares);
-  if (k0.isZero() || k.isZero()) throw Error("k should never be zero");
+  if (k0.isZero() || k.isZero()) throw Error('k should never be zero');
 
   // find change in k
   const kRatio = k0.quo(k);
@@ -114,7 +114,7 @@ function solveCfmmBinarySearchMulti(
   const xOut = xReserve.sub(xEst);
 
   if (xOut.abs().gte(xReserve))
-    throw Error("invalid output: greater than full pool reserves");
+    throw Error('invalid output: greater than full pool reserves');
 
   return xOut;
 }
@@ -129,14 +129,14 @@ function solveCfmmBinarySearchMulti(
 function cfmmConstantMultiNoV(
   xReserve: Dec,
   yReserve: Dec,
-  vSumSquares: Dec
+  vSumSquares: Dec,
 ): Dec {
   if (
     !xReserve.isPositive() ||
     !yReserve.isPositive() ||
     vSumSquares.isNegative()
   )
-    throw Error("reserves must be positive");
+    throw Error('reserves must be positive');
 
   const xy = xReserve.mul(yReserve);
   const x2 = xReserve.mul(xReserve);
@@ -150,7 +150,7 @@ export function binarySearch(
   upperBound: Dec,
   targetOutput: Dec,
   maxIterations = 256,
-  errorTolerance = oneDec.quo(DecUtils.getTenExponentNInPrecisionRange(12))
+  errorTolerance = oneDec.quo(DecUtils.getTenExponentNInPrecisionRange(12)),
 ): Dec {
   // base of loop
   let curEstimate = lowerBound.add(upperBound).quo(new Dec(2));
@@ -162,7 +162,7 @@ export function binarySearch(
     const compare = compare_checkMultErrorTolerance(
       targetOutput,
       curOutput,
-      errorTolerance
+      errorTolerance,
     );
     if (compare < 0) {
       upperBound = curEstimate;
@@ -181,7 +181,7 @@ export function binarySearch(
 function compare_checkMultErrorTolerance(
   expected: Dec,
   actual: Dec,
-  tolerance: Dec
+  tolerance: Dec,
 ) {
   let comparison = 0;
   if (expected.gt(actual)) {

--- a/packages/math/types/pool/stable.d.ts
+++ b/packages/math/types/pool/stable.d.ts
@@ -1,10 +1,10 @@
-import { Coin, Dec } from "@keplr-wallet/unit";
+import { Coin, Dec } from '@keplr-wallet/unit';
 export declare type StableSwapToken = {
     amount: Dec;
     denom: string;
     scalingFactor: number;
 };
-export declare function calcOutGivenIn(tokens: StableSwapToken[], tokenIn: Coin, tokenOutDenom: string, swapFee: Dec): Dec;
+export declare function calcOutGivenIn(tokens: StableSwapToken[], tokenIn: Coin, tokenOutDenom: string, swapFee: Dec): import("@keplr-wallet/unit").Int;
 export declare function calcInGivenOut(): void;
 export declare function solveCfmm(xReserve: Dec, yReserve: Dec, remReserves: Dec[], yIn: Dec): Dec;
 export declare function binarySearch(makeOutput: (est: Dec) => Dec, lowerBound: Dec, upperBound: Dec, targetOutput: Dec, maxIterations?: number, errorTolerance?: Dec): Dec;

--- a/packages/math/types/pool/stable.d.ts
+++ b/packages/math/types/pool/stable.d.ts
@@ -5,6 +5,6 @@ export declare type StableSwapToken = {
     scalingFactor: number;
 };
 export declare function calcOutGivenIn(tokens: StableSwapToken[], tokenIn: Coin, tokenOutDenom: string, swapFee: Dec): import("@keplr-wallet/unit").Int;
-export declare function calcInGivenOut(): void;
+export declare function calcInGivenOut(tokens: StableSwapToken[], tokenOut: Coin, tokenInDenom: string, swapFee: Dec): import("@keplr-wallet/unit").Int;
 export declare function solveCfmm(xReserve: Dec, yReserve: Dec, remReserves: Dec[], yIn: Dec): Dec;
 export declare function binarySearch(makeOutput: (est: Dec) => Dec, lowerBound: Dec, upperBound: Dec, targetOutput: Dec, maxIterations?: number, errorTolerance?: Dec): Dec;

--- a/packages/math/types/pool/stable.d.ts
+++ b/packages/math/types/pool/stable.d.ts
@@ -4,7 +4,9 @@ export declare type StableSwapToken = {
     denom: string;
     scalingFactor: number;
 };
+export declare function solveCalcOutGivenIn(tokens: StableSwapToken[], tokenIn: Coin, tokenOutDenom: string, swapFee: Dec): Dec;
 export declare function calcOutGivenIn(tokens: StableSwapToken[], tokenIn: Coin, tokenOutDenom: string, swapFee: Dec): import("@keplr-wallet/unit").Int;
 export declare function calcInGivenOut(tokens: StableSwapToken[], tokenOut: Coin, tokenInDenom: string, swapFee: Dec): import("@keplr-wallet/unit").Int;
+export declare function calcSpotPrice(tokens: StableSwapToken[], baseDenom: string, quoteDenom: string): Dec;
 export declare function solveCfmm(xReserve: Dec, yReserve: Dec, remReserves: Dec[], yIn: Dec): Dec;
 export declare function binarySearch(makeOutput: (est: Dec) => Dec, lowerBound: Dec, upperBound: Dec, targetOutput: Dec, maxIterations?: number, errorTolerance?: Dec): Dec;

--- a/packages/math/types/pool/stable.d.ts
+++ b/packages/math/types/pool/stable.d.ts
@@ -4,9 +4,9 @@ export declare type StableSwapToken = {
     denom: string;
     scalingFactor: number;
 };
-export declare function solveCalcOutGivenIn(tokens: StableSwapToken[], tokenIn: Coin, tokenOutDenom: string, swapFee: Dec): Dec;
 export declare function calcOutGivenIn(tokens: StableSwapToken[], tokenIn: Coin, tokenOutDenom: string, swapFee: Dec): import("@keplr-wallet/unit").Int;
 export declare function calcInGivenOut(tokens: StableSwapToken[], tokenOut: Coin, tokenInDenom: string, swapFee: Dec): import("@keplr-wallet/unit").Int;
 export declare function calcSpotPrice(tokens: StableSwapToken[], baseDenom: string, quoteDenom: string): Dec;
 export declare function solveCfmm(xReserve: Dec, yReserve: Dec, remReserves: Dec[], yIn: Dec): Dec;
 export declare function binarySearch(makeOutput: (est: Dec) => Dec, lowerBound: Dec, upperBound: Dec, targetOutput: Dec, maxIterations?: number, errorTolerance?: Dec): Dec;
+export declare function compare_checkMultErrorTolerance(expected: Dec, actual: Dec, tolerance: Dec, roundingMode: string): number;


### PR DESCRIPTION
This PR implements relevant math/calc functions for stableswap. Specifically, it implements the following:
* `calcOutGivenIn`
* `calcInGivenOut`
* `calcSpotPrice`
* `solveCfmm`

To align precision bounds with our Go implementation, we also implement a wider precision decimal type for internal calculations

TODO:
* More calc tests
* Basic spot price tests
* BigDec implementation
* Precision issue fixes