### PR TITLE
Update ECH IBC Channels

### DIFF
--- a/packages/web/config/chain-infos.ts
+++ b/packages/web/config/chain-infos.ts
@@ -1736,42 +1736,14 @@ const chainInfos = (
       rpc: "https://rpc-echelon.whispernode.com/",
       rest: "https://lcd-echelon.whispernode.com/",
       chainId: "echelon_3000-3",
-      chainName: "Echelon (current)",
+      chainName: "Echelon",
       bip44: {
         coinType: 60,
       },
       bech32Config: Bech32Address.defaultBech32Config("echelon"),
       currencies: [
         {
-          coinDenom: "ECH (current)",
-          coinMinimalDenom: "aechelon",
-          coinDecimals: 18,
-          coinGeckoId: "echelon",
-          coinImageUrl: "/tokens/ech.png",
-          isStakeCurrency: true,
-          isFeeCurrency: true,
-        },
-      ],
-      gasPriceStep: {
-        low: 10000000000,
-        average: 25000000000,
-        high: 40000000000,
-      },
-      features: ["stargate", "ibc-transfer", "no-legacy-stdTx", "ibc-go"],
-      explorerUrlToTx: "https://ping.pub/echelon/tx/{txHash}",
-    },
-    {//legacy
-      rpc: "https://rpc-echelon.whispernode.com/",
-      rest: "https://lcd-echelon.whispernode.com/",
-      chainId: "echelon_3000-2",
-      chainName: "Echelon (legacy)",
-      bip44: {
-        coinType: 60,
-      },
-      bech32Config: Bech32Address.defaultBech32Config("echelon"),
-      currencies: [
-        {
-          coinDenom: "ECH (legacy)",
+          coinDenom: "ECH",
           coinMinimalDenom: "aechelon",
           coinDecimals: 18,
           coinGeckoId: "echelon",

--- a/packages/web/config/chain-infos.ts
+++ b/packages/web/config/chain-infos.ts
@@ -1760,6 +1760,34 @@ const chainInfos = (
       features: ["stargate", "ibc-transfer", "no-legacy-stdTx", "ibc-go"],
       explorerUrlToTx: "https://ping.pub/echelon/tx/{txHash}",
     },
+    {//legacy
+      rpc: "https://rpc-echelon.whispernode.com/",
+      rest: "https://lcd-echelon.whispernode.com/",
+      chainId: "echelon_3000-2",
+      chainName: "Echelon",
+      bip44: {
+        coinType: 60,
+      },
+      bech32Config: Bech32Address.defaultBech32Config("echelon"),
+      currencies: [
+        {
+          coinDenom: "ECH (legacy)",
+          coinMinimalDenom: "aechelon",
+          coinDecimals: 18,
+          coinGeckoId: "echelon",
+          coinImageUrl: "/tokens/ech.png",
+          isStakeCurrency: true,
+          isFeeCurrency: true,
+        },
+      ],
+      gasPriceStep: {
+        low: 10000000000,
+        average: 25000000000,
+        high: 40000000000,
+      },
+      features: ["stargate", "ibc-transfer", "no-legacy-stdTx", "ibc-go"],
+      explorerUrlToTx: "https://ping.pub/echelon/tx/{txHash}",
+    },
     {
       rpc: "https://node.odin-freya-website.odinprotocol.io/mainnet/a/",
       rest: "https://node.odin-freya-website.odinprotocol.io/mainnet/a/api/",

--- a/packages/web/config/chain-infos.ts
+++ b/packages/web/config/chain-infos.ts
@@ -1736,14 +1736,14 @@ const chainInfos = (
       rpc: "https://rpc-echelon.whispernode.com/",
       rest: "https://lcd-echelon.whispernode.com/",
       chainId: "echelon_3000-3",
-      chainName: "Echelon",
+      chainName: "Echelon (current)",
       bip44: {
         coinType: 60,
       },
       bech32Config: Bech32Address.defaultBech32Config("echelon"),
       currencies: [
         {
-          coinDenom: "ECH",
+          coinDenom: "ECH (current)",
           coinMinimalDenom: "aechelon",
           coinDecimals: 18,
           coinGeckoId: "echelon",
@@ -1764,7 +1764,7 @@ const chainInfos = (
       rpc: "https://rpc-echelon.whispernode.com/",
       rest: "https://lcd-echelon.whispernode.com/",
       chainId: "echelon_3000-2",
-      chainName: "Echelon",
+      chainName: "Echelon (legacy)",
       bip44: {
         coinType: 60,
       },

--- a/packages/web/config/ibc-assets.ts
+++ b/packages/web/config/ibc-assets.ts
@@ -804,7 +804,7 @@ export const IBCAssetInfos: (IBCAsset & {
     withdrawUrlOverride: "https://app.ech.network/ibc",
   },
   {
-    counterpartyChainId: "echelon_3000-3",
+    counterpartyChainId: "echelon_3000-2",
     sourceChannelId: "channel-262",
     destChannelId: "channel-8",
     coinMinimalDenom: "aechelon",

--- a/packages/web/config/ibc-assets.ts
+++ b/packages/web/config/ibc-assets.ts
@@ -797,8 +797,8 @@ export const IBCAssetInfos: (IBCAsset & {
   },
   {
     counterpartyChainId: "echelon_3000-3",
-    sourceChannelId: "channel-262",
-    destChannelId: "channel-8",
+    sourceChannelId: "channel-403",
+    destChannelId: "channel-11",
     coinMinimalDenom: "aechelon",
     depositUrlOverride: "https://app.ech.network/ibc",
     withdrawUrlOverride: "https://app.ech.network/ibc",

--- a/packages/web/config/ibc-assets.ts
+++ b/packages/web/config/ibc-assets.ts
@@ -802,15 +802,17 @@ export const IBCAssetInfos: (IBCAsset & {
     coinMinimalDenom: "aechelon",
     depositUrlOverride: "https://app.ech.network/ibc",
     withdrawUrlOverride: "https://app.ech.network/ibc",
-  },
+    },
+  /*
   {
-    counterpartyChainId: "echelon_3000-2",
+    counterpartyChainId: "echelon_3000-3",
     sourceChannelId: "channel-262",
     destChannelId: "channel-8",
     coinMinimalDenom: "aechelon",
     sourceChainNameOverride: "Echelon (legacy)",
     isUnstable: true,
   },
+  */
   {
     counterpartyChainId: "odin-mainnet-freya",
     sourceChannelId: "channel-258",

--- a/packages/web/config/ibc-assets.ts
+++ b/packages/web/config/ibc-assets.ts
@@ -804,6 +804,14 @@ export const IBCAssetInfos: (IBCAsset & {
     withdrawUrlOverride: "https://app.ech.network/ibc",
   },
   {
+    counterpartyChainId: "echelon_3000-3",
+    sourceChannelId: "channel-262",
+    destChannelId: "channel-8",
+    coinMinimalDenom: "aechelon",
+    sourceChainNameOverride: "Echelon (legacy)",
+    isUnstable: true,
+  },
+  {
     counterpartyChainId: "odin-mainnet-freya",
     sourceChannelId: "channel-258",
     destChannelId: "channel-3",


### PR DESCRIPTION
src: channel-403, dst: channel-11

New IBC denom hash can be confirmed by using their transfer website: https://app.ech.network/ibc
SHA256("transfer/channel-403/aechelon") = ibc/47EE...177D
This will make the old denom unofficial. Users' old ECH tokens would then be unlisted in the Assets page (should we change it to "ECH (old)"?

Currently looks like this:
<img width="203" alt="image" src="https://user-images.githubusercontent.com/95667791/203636261-3e973562-50e3-49e7-9bfd-c006f4a2142c.png">

Getting odd behaviour from the token search:
<img width="149" alt="image" src="https://user-images.githubusercontent.com/95667791/203646143-4f082fe4-e22f-40ac-93f0-21655f453c24.png">

Edit: The complexity of this seemingly simple change as blown up massively. It might be more easily possible if there were a way to change between channels (but still only seeing 1 version at a time). But at this point it is my recommendation to consider abandoning the idea of displaying 2 version at once, and simply ask users to view pools containing ECH to see, trade, and LP their old-channel ECH (it cannot be withdrawn anyway).

We could simply update the the latest channel, removing the old-channel token. The biggest downsides to this are no longer seeing it in the Asset page, and not finding in the Swap page.

Pool 747 (old-channel ECH/OSMO) would look like this (now with the channel name included):
<img width="331" alt="image" src="https://user-images.githubusercontent.com/95667791/205431504-6ed7fafb-44cf-4f3c-a8d9-9eee87a3bf44.png">

While 848 (new-channel ECH/OSMO) would appear canonical, and is included in the Swap page trade router:
<img width="281" alt="image" src="https://user-images.githubusercontent.com/95667791/205431591-7203b725-a431-47aa-8382-a5dfae11af49.png">
