### PR TITLE
Fix #1011 Non-localized stablecoin type

### DIFF
--- a/packages/web/components/complex/add-liquidity.tsx
+++ b/packages/web/components/complex/add-liquidity.tsx
@@ -187,7 +187,10 @@ export const AddLiquidity: FunctionComponent<
                     textClassName="w-full text-center"
                     message={t("addLiquidity.stablecoinWarning", {
                       denom: currency!.originCurrency!.coinDenom,
-                      mechanism: currency.originCurrency!.pegMechanism!,
+                      mechanism: t(
+                        `stablecoinTypes.${currency.originCurrency!
+                          .pegMechanism!}`
+                      ),
                     })}
                   />
                 )}

--- a/packages/web/localizations/dayjs-locale-es.js
+++ b/packages/web/localizations/dayjs-locale-es.js
@@ -1,20 +1,43 @@
-!(function (e, n) {
-  "object" == typeof exports && "undefined" != typeof module
-    ? (module.exports = n())
-    : "function" == typeof define && define.amd
-    ? define(n)
-    : ((e =
-        "undefined" != typeof globalThis
-          ? globalThis
-          : e || self).dayjs_locale_en = n());
-})(this, function () {
-  "use strict";
-  return {
-    name: "es",
-    weekdays: "Domingo_Lunes_Martes_Jueves_Viernes_Sabado_Domingo".split("_"),
-    months:
-      "Enero_Febrero_Marzo_Abril_Mayo_Junio_Julio_Augosto_Septiembre_Octubre_Noviembre_Diciembre".split(
-        "_"
-      ),
-  };
-});
+// Spanish [es]
+import dayjs from "dayjs";
+
+const locale = {
+  name: "es",
+  monthsShort: "ene_feb_mar_abr_may_jun_jul_ago_sep_oct_nov_dic".split("_"),
+  weekdays: "domingo_lunes_martes_miércoles_jueves_viernes_sábado".split("_"),
+  weekdaysShort: "dom._lun._mar._mié._jue._vie._sáb.".split("_"),
+  weekdaysMin: "do_lu_ma_mi_ju_vi_sá".split("_"),
+  months:
+    "enero_febrero_marzo_abril_mayo_junio_julio_agosto_septiembre_octubre_noviembre_diciembre".split(
+      "_"
+    ),
+  weekStart: 1,
+  formats: {
+    LT: "H:mm",
+    LTS: "H:mm:ss",
+    L: "DD/MM/YYYY",
+    LL: "D [de] MMMM [de] YYYY",
+    LLL: "D [de] MMMM [de] YYYY H:mm",
+    LLLL: "dddd, D [de] MMMM [de] YYYY H:mm",
+  },
+  relativeTime: {
+    future: "en %s",
+    past: "hace %s",
+    s: "unos segundos",
+    m: "un minuto",
+    mm: "%d minutos",
+    h: "una hora",
+    hh: "%d horas",
+    d: "un día",
+    dd: "%d días",
+    M: "un mes",
+    MM: "%d meses",
+    y: "un año",
+    yy: "%d años",
+  },
+  ordinal: (n) => `${n}º`,
+};
+
+dayjs.locale(locale, null, true);
+
+export default locale;

--- a/packages/web/localizations/dayjs-locale-ko.js
+++ b/packages/web/localizations/dayjs-locale-ko.js
@@ -1,17 +1,44 @@
-!(function (e, n) {
-  "object" == typeof exports && "undefined" != typeof module
-    ? (module.exports = n())
-    : "function" == typeof define && define.amd
-    ? define(n)
-    : ((e =
-        "undefined" != typeof globalThis
-          ? globalThis
-          : e || self).dayjs_locale_en = n());
-})(this, function () {
-  "use strict";
-  return {
-    name: "ko",
-    weekdays: "일요일_월요일_화요일_수요일_목요일_금요일_토요일".split("_"),
-    months: "1월_2월_3월_4월_5월_6월_7월_8월_9월_10월_11월_12월".split("_"),
-  };
-});
+// Korean [ko]
+import dayjs from "dayjs";
+
+const locale = {
+  name: "ko",
+  weekdays: "일요일_월요일_화요일_수요일_목요일_금요일_토요일".split("_"),
+  weekdaysShort: "일_월_화_수_목_금_토".split("_"),
+  weekdaysMin: "일_월_화_수_목_금_토".split("_"),
+  months: "1월_2월_3월_4월_5월_6월_7월_8월_9월_10월_11월_12월".split("_"),
+  monthsShort: "1월_2월_3월_4월_5월_6월_7월_8월_9월_10월_11월_12월".split("_"),
+  ordinal: (n) => n,
+  formats: {
+    LT: "A h:mm",
+    LTS: "A h:mm:ss",
+    L: "YYYY.MM.DD.",
+    LL: "YYYY년 MMMM D일",
+    LLL: "YYYY년 MMMM D일 A h:mm",
+    LLLL: "YYYY년 MMMM D일 dddd A h:mm",
+    l: "YYYY.MM.DD.",
+    ll: "YYYY년 MMMM D일",
+    lll: "YYYY년 MMMM D일 A h:mm",
+    llll: "YYYY년 MMMM D일 dddd A h:mm",
+  },
+  meridiem: (hour) => (hour < 12 ? "오전" : "오후"),
+  relativeTime: {
+    future: "%s 후",
+    past: "%s 전",
+    s: "몇 초",
+    m: "1분",
+    mm: "%d분",
+    h: "한 시간",
+    hh: "%d시간",
+    d: "하루",
+    dd: "%d일",
+    M: "한 달",
+    MM: "%d달",
+    y: "일 년",
+    yy: "%d년",
+  },
+};
+
+dayjs.locale(locale, null, true);
+
+export default locale;

--- a/packages/web/localizations/es.json
+++ b/packages/web/localizations/es.json
@@ -374,5 +374,8 @@
   "Amount is empty": "La cantidad está vacía",
   "Insufficient amount": "Cantidad insuficiente",
   "Amount is zero": "La cantidad es cero",
-  "Minimum of 2 assets required": "Mínimo de 2 activos requeridos"
+  "Minimum of 2 assets required": "Mínimo de 2 activos requeridos",
+  "stablecoinTypes": {
+    "collateralized": "colateralizado"
+  }
 }

--- a/packages/web/modals/keplr-connection-selection.tsx
+++ b/packages/web/modals/keplr-connection-selection.tsx
@@ -41,7 +41,7 @@ export const KeplrConnectionSelectModal: FunctionComponent<
           />
           <div className="flex flex-col text-left ml-5">
             <div className="flex items-center gap-2">
-              <h6>{t("installKeplr")}</h6>
+              <h6>{t("keplr.install")}</h6>
               <Image
                 src="/icons/external-link-white.svg"
                 alt="external link"

--- a/packages/web/pages/_app.tsx
+++ b/packages/web/pages/_app.tsx
@@ -12,6 +12,7 @@ import { OgpMeta } from "../components/ogp-meta";
 import { MainLayoutMenu } from "../components/types";
 import dayjs from "dayjs";
 import duration from "dayjs/plugin/duration";
+import updateLocale from "dayjs/plugin/updateLocale";
 import relativeTime from "dayjs/plugin/relativeTime";
 import utc from "dayjs/plugin/utc";
 import { GetKeplrProvider } from "../hooks";
@@ -32,10 +33,15 @@ import {
 
 import en from "../localizations/en.json";
 import { Formatted } from "../components/localization";
+import dayjsLocaleEs from "../localizations/dayjs-locale-es.js";
+import dayjsLocaleKo from "../localizations/dayjs-locale-ko.js";
 
 dayjs.extend(relativeTime);
 dayjs.extend(duration);
 dayjs.extend(utc);
+dayjs.extend(updateLocale);
+dayjs.updateLocale("es", dayjsLocaleEs);
+dayjs.updateLocale("ko", dayjsLocaleKo);
 enableStaticRendering(typeof window === "undefined");
 
 const DEFAULT_LANGUAGE = "en";


### PR DESCRIPTION
Fix #1011 Non-localized stablecoin type
`add-liquidity.tsx`
* use collateral type to key into localization file

`dayjs-locale-es.js`
* update to Day.js locale object as detailed in [docs](https://day.js.org/docs/en/i18n/i18n)

`dayjs-locale-ko.js`
* same as above

`es.json`
* add stablecoin type translation

`_app.tsx`
* set locale object for day.js localization as detailed in [docs](https://day.js.org/docs/en/customization/customization)

Would like a sanity check that this is the way to go for the above solutions. If so, I can update all the localization json specific to day.js, but will need additional translations for stablecoin types to add to general localization files.

Could not replicate bug of "Unbonded" not being translated, although it's wrapping in certain languages.
<img width="1552" alt="Screenshot 2022-11-19 at 6 56 59 PM" src="https://user-images.githubusercontent.com/41171808/202883341-d73547c6-fb3b-4e6a-8610-a022ae25c567.png">