### PR TITLE
Move some assets to pool prices (#1029)

### DIFF
--- a/packages/web/config/chain-infos.ts
+++ b/packages/web/config/chain-infos.ts
@@ -492,7 +492,7 @@ const chainInfos = (
           coinMinimalDenom:
             "cw20:juno1n7n7d5088qlzlj37e9mgmkhx6dfgtvt02hqxq66lcap4dxnzdhwqfmgng3:JOE",
           coinDecimals: 6,
-          //coinGeckoId: "pool:joe",
+          coinGeckoId: "pool:joe",
           coinImageUrl: "/tokens/joe.png",
         },
         {
@@ -503,7 +503,7 @@ const chainInfos = (
           coinMinimalDenom:
             "cw20:juno1j0a9ymgngasfn3l5me8qpd53l5zlm9wurfdk7r65s5mg6tkxal3qpgf5se:GLTO",
           coinDecimals: 6,
-          //coinGeckoId: "pool:glto",
+          coinGeckoId: "pool:glto",
           coinImageUrl: "/tokens/glto.svg",
         },
         {
@@ -514,7 +514,7 @@ const chainInfos = (
           coinMinimalDenom:
             "cw20:juno1gz8cf86zr4vw9cjcyyv432vgdaecvr9n254d3uwwkx9rermekddsxzageh:GKEY",
           coinDecimals: 6,
-          //coinGeckoId: "pool:gkey",
+          coinGeckoId: "pool:gkey",
           coinImageUrl: "/tokens/gkey.svg",
         },
         {
@@ -557,8 +557,8 @@ const chainInfos = (
           coinMinimalDenom:
             "cw20:juno19rqljkh95gh40s7qdx40ksx3zq5tm4qsmsrdz9smw668x9zdr3lqtg33mf:SEASY",
           coinDecimals: 6,
-          coinGeckoId: "seasy",
-          //coinGeckoId: "pool:seasy",
+          //coinGeckoId: "seasy",
+          coinGeckoId: "pool:seasy",
           coinImageUrl: "/tokens/seasy.svg",
         },
         {
@@ -829,7 +829,7 @@ const chainInfos = (
           coinMinimalDenom:
             "cw20:ki1dt3lk455ed360pna38fkhqn0p8y44qndsr77qu73ghyaz2zv4whq83mwdy:LVN",
           coinDecimals: 6,
-          //coinGeckoId: "pool:lvn",
+          coinGeckoId: "pool:lvn",
           coinImageUrl: "/tokens/lvn.png",
         },
       ],
@@ -967,7 +967,7 @@ const chainInfos = (
           coinDenom: "STARS",
           coinMinimalDenom: "ustars",
           coinDecimals: 6,
-          coinGeckoId: "stragaze",
+          coinGeckoId: "stargaze",
           //coinGeckoId: "pool:ustars",
           coinImageUrl: "/tokens/stars.png",
           isStakeCurrency: true,
@@ -1564,7 +1564,7 @@ const chainInfos = (
           coinDenom: "MEME",
           coinMinimalDenom: "umeme",
           coinDecimals: 6,
-          //coinGeckoId: "pool:umeme",
+          coinGeckoId: "pool:umeme",
           coinImageUrl: "/tokens/meme.png",
           isStakeCurrency: true,
           isFeeCurrency: true,
@@ -1867,8 +1867,8 @@ const chainInfos = (
           coinDenom: "GEO",
           coinMinimalDenom: "mGeo",
           coinDecimals: 6,
-          coinGeckoId: "geodb",
-          //coinGeckoId: "pool:geo",
+          //coinGeckoId: "geodb",
+          coinGeckoId: "pool:geo",
           coinImageUrl: "/tokens/geo.svg",
         },
         {
@@ -1937,7 +1937,7 @@ const chainInfos = (
           coinDenom: "LUMEN",
           coinMinimalDenom: "ulumen",
           coinDecimals: 6,
-          //coinGeckoId: "pool:ulumen",
+          coinGeckoId: "pool:ulumen",
           coinImageUrl: "/tokens/lumen.png",
           isStakeCurrency: true,
           isFeeCurrency: true,
@@ -2032,7 +2032,7 @@ const chainInfos = (
           coinDenom: "IST",
           coinMinimalDenom: "uist",
           coinDecimals: 6,
-          //coinGeckoId: "pool:uist",
+          coinGeckoId: "pool:uist",
           coinImageUrl: "/tokens/ist.png",
         },
       ],
@@ -2071,21 +2071,21 @@ const chainInfos = (
           coinDenom: "stSTARS",
           coinMinimalDenom: "stustars",
           coinDecimals: 6,
-          //coinGeckoId: "pool:stustars",
+          coinGeckoId: "pool:stustars",
           coinImageUrl: "/tokens/ststars.svg",
         },
         {
           coinDenom: "stOSMO",
           coinMinimalDenom: "stuosmo",
           coinDecimals: 6,
-          //coinGeckoId: "pool:stuosmo",
+          coinGeckoId: "pool:stuosmo",
           coinImageUrl: "/tokens/stosmo.svg",
         },
         {
           coinDenom: "stJUNO",
           coinMinimalDenom: "stujuno",
           coinDecimals: 6,
-          //coinGeckoId: "pool:stujuno",
+          coinGeckoId: "pool:stujuno",
           coinImageUrl: "/tokens/stjuno.svg",
         },
         {
@@ -2225,7 +2225,7 @@ const chainInfos = (
           coinDenom: "JKL",
           coinMinimalDenom: "ujkl",
           coinDecimals: 6,
-          //coinGeckoId: "pool:jkl",
+          coinGeckoId: "pool:jkl",
           coinImageUrl: "/tokens/jkl.svg",
           isStakeCurrency: true,
           isFeeCurrency: true,

--- a/packages/web/config/price.ts
+++ b/packages/web/config/price.ts
@@ -190,7 +190,7 @@ export const PoolPriceRoutes: IntermediateRoute[] = [
     ),
     spotPriceDestDenom: "uosmo",
     destCoinId: "pool:uosmo",
-  },
+  },*/
   {
     alternativeCoinId: "pool:lvn",
     poolId: "774",
@@ -200,7 +200,7 @@ export const PoolPriceRoutes: IntermediateRoute[] = [
     ),
     spotPriceDestDenom: "uosmo",
     destCoinId: "pool:uosmo",
-  },
+  },/*
   {
     alternativeCoinId: "pool:umed",
     poolId: "586",
@@ -463,7 +463,7 @@ export const PoolPriceRoutes: IntermediateRoute[] = [
     ),
     spotPriceDestDenom: "uosmo",
     destCoinId: "pool:uosmo",
-  },
+  },*/
   {
     alternativeCoinId: "pool:umeme",
     poolId: "701",
@@ -473,7 +473,7 @@ export const PoolPriceRoutes: IntermediateRoute[] = [
     ),
     spotPriceDestDenom: "uosmo",
     destCoinId: "pool:uosmo",
-  },
+  },/*
   {
     alternativeCoinId: "pool:utick",
     poolId: "547",
@@ -586,7 +586,7 @@ export const PoolPriceRoutes: IntermediateRoute[] = [
     ),
     spotPriceDestDenom: "uosmo",
     destCoinId: "pool:uosmo",
-  },
+  },*/
   {
     alternativeCoinId: "pool:ulumen",
     poolId: "788",
@@ -596,7 +596,7 @@ export const PoolPriceRoutes: IntermediateRoute[] = [
     ),
     spotPriceDestDenom: "uosmo",
     destCoinId: "pool:uosmo",
-  },
+  },/*
   {
     alternativeCoinId: "pool:acudos",
     poolId: "796",
@@ -640,6 +640,7 @@ export const PoolPriceRoutes: IntermediateRoute[] = [
     ),
     destCoinId: "pool:rowan",
   },
+  */
   {
     alternativeCoinId: "pool:joe",
     poolId: "718",
@@ -669,7 +670,7 @@ export const PoolPriceRoutes: IntermediateRoute[] = [
     ),
     spotPriceDestDenom: "uosmo",
     destCoinId: "pool:uosmo",
-  },
+  },/*
   {
     alternativeCoinId: "pool:odin",
     poolId: "777",
@@ -709,7 +710,7 @@ export const PoolPriceRoutes: IntermediateRoute[] = [
     ),
     spotPriceDestDenom: "uosmo",
     destCoinId: "pool:uosmo",
-  },
+  },*/
   {
     alternativeCoinId: "pool:geo",
     poolId: "787",
@@ -719,7 +720,7 @@ export const PoolPriceRoutes: IntermediateRoute[] = [
     ),
     spotPriceDestDenom: "uosmo",
     destCoinId: "pool:uosmo",
-  },
+  },/*
   {
     alternativeCoinId: "pool:stuatom",
     poolId: "803",
@@ -752,7 +753,7 @@ export const PoolPriceRoutes: IntermediateRoute[] = [
     ),
     spotPriceDestDenom: "uosmo",
     destCoinId: "pool:uosmo",
-  },
+  },*/
   {
     alternativeCoinId: "pool:stustars",
     poolId: "810",
@@ -764,8 +765,8 @@ export const PoolPriceRoutes: IntermediateRoute[] = [
       [{ portId: "transfer", channelId: "channel-75" }],
       "ustars"
     ),
-    destCoinId: "pool:ustars",
-  },
+    destCoinId: "stargaze",
+  },/*
   {
     alternativeCoinId: "pool:sejuno",
     poolId: "793",
@@ -775,7 +776,7 @@ export const PoolPriceRoutes: IntermediateRoute[] = [
     ),
     spotPriceDestDenom: "uosmo",
     destCoinId: "pool:uosmo",
-  },
+  },*/
   {
     alternativeCoinId: "pool:seasy",
     poolId: "808",
@@ -785,7 +786,7 @@ export const PoolPriceRoutes: IntermediateRoute[] = [
     ),
     spotPriceDestDenom: "uosmo",
     destCoinId: "pool:uosmo",
-  },
+  },/*
   {
     alternativeCoinId: "pool:arebus",
     poolId: "813",
@@ -815,7 +816,7 @@ export const PoolPriceRoutes: IntermediateRoute[] = [
     ),
     spotPriceDestDenom: "uosmo",
     destCoinId: "pool:uosmo",
-  },
+  },*/
   {
     alternativeCoinId: "pool:stujuno",
     poolId: "817",
@@ -827,7 +828,7 @@ export const PoolPriceRoutes: IntermediateRoute[] = [
       [{ portId: "transfer", channelId: "channel-42" }],
       "ujuno"
     ),
-    destCoinId: "pool:ujuno",
+    destCoinId: "juno-network",
   },
   {
     alternativeCoinId: "pool:stuosmo",
@@ -837,8 +838,8 @@ export const PoolPriceRoutes: IntermediateRoute[] = [
       "stuosmo"
     ),
     spotPriceDestDenom: "uosmo",
-    destCoinId: "pool:uosmo",
-  },
+    destCoinId: "osmosis",
+  },/*
   {
     alternativeCoinId: "pool:rowan",
     poolId: "629",
@@ -868,7 +869,7 @@ export const PoolPriceRoutes: IntermediateRoute[] = [
     ),
     spotPriceDestDenom: "uosmo",
     destCoinId: "pool:uosmo",
-  },
+  },*/
   {
     alternativeCoinId: "pool:jkl",
     poolId: "832",
@@ -878,7 +879,7 @@ export const PoolPriceRoutes: IntermediateRoute[] = [
     ),
     spotPriceDestDenom: "uosmo",
     destCoinId: "pool:uosmo",
-  },
+  },/*
   {
     alternativeCoinId: "pool:ubld",
     poolId: "795",
@@ -888,7 +889,7 @@ export const PoolPriceRoutes: IntermediateRoute[] = [
     ),
     spotPriceDestDenom: "uosmo",
     destCoinId: "pool:uosmo",
-  },
+  },*/
   {
     alternativeCoinId: "pool:uist",
     poolId: "837",
@@ -898,7 +899,7 @@ export const PoolPriceRoutes: IntermediateRoute[] = [
     ),
     spotPriceDestDenom: "uosmo",
     destCoinId: "pool:uosmo",
-  },
+  },/*
   {
     alternativeCoinId: "pool:uusdc.grv",
     poolId: "633",


### PR DESCRIPTION
Some assets weren't displaying proper fiat prices. Moved to utilize pool prices. Should solve ( #1029)

Assets in question:
- [x] JKL
- [x] stOSMO
- [x] stJUNO
- [x] stSTARS
- [x] IST
- [x] LUMEN
- [x] GKEY
- [x] GLTO
- [x] MEME
- [x] LVN

Unique problem:
- GEO coingecko price was causing the Liquidity in the 787 pool to reflect 18k when in reality it is around 12k.
- Updated to utilize pool as reference point.