### PR TITLE
Change CRBRUS to unstable, unverified

### DIFF
--- a/packages/web/config/ibc-assets.ts
+++ b/packages/web/config/ibc-assets.ts
@@ -416,7 +416,7 @@ export const IBCAssetInfos: (IBCAsset & {
     sourceChannelId: "channel-212",
     destChannelId: "channel-1",
     coinMinimalDenom: "ucrbrus",
-    isVerified: true,
+    isUnstable: true,
   },
   {
     counterpartyChainId: "fetchhub-4",


### PR DESCRIPTION
Change CRBRUS to unstable since users are losing funds trying to IBC between chains (Cerberus chain needs to update their IBC client)
Unverified because CRBRUS no longer receives incentives.