### PR TITLE
Make NETA, BOOT unverified

### DIFF
--- a/packages/web/config/ibc-assets.ts
+++ b/packages/web/config/ibc-assets.ts
@@ -308,7 +308,6 @@ export const IBCAssetInfos: (IBCAsset & {
     sourceChannelId: "channel-95",
     destChannelId: "channel-2",
     coinMinimalDenom: "boot",
-    isVerified: true,
   },
   {
     counterpartyChainId: "comdex-1",
@@ -439,7 +438,6 @@ export const IBCAssetInfos: (IBCAsset & {
       "cw20:juno168ctmpyppk90d34p3jjy658zf5a5l3w8wk35wht6ccqj4mr0yv8s4j5awr",
     ics20ContractAddress:
       "juno1v4887y83d6g28puzvt8cl0f3cdhd3y6y9mpysnsp3k8krdm7l6jqgm0rkn",
-    isVerified: true,
   },
   {
     counterpartyChainId: "injective-1",


### PR DESCRIPTION
Removing a couple more assets (NETA, BOOT) from Main due to disqualification.