### PR TITLE
Bug fix in iterKCalculator

### DIFF
--- a/packages/math/src/pool/stable.ts
+++ b/packages/math/src/pool/stable.ts
@@ -256,9 +256,9 @@ export function iterKCalculator(
   // output amount = initial reserve - final reserve
   const xOut = x0.sub(xf);
   // horners method
-  // ax^3 + bx^2 + cx = x(c + x(b + ax))
-  const term1 = cubicCoeff.mul(xOut);
-  const term2 = quadraticCoeff.mul(xOut);
+  // ax^3 + bx^2 + cx 
+  const term1 = cubicCoeff.mul(xOut).mul(xOut).mul(xOut);
+  const term2 = quadraticCoeff.mul(xOut).mul(xOut);
   const term3 = linearCoeff.mul(xOut);
 
   const res = term1.add(term2).add(term3);


### PR DESCRIPTION
Hi, formula was implemented a bit off. 

Previous implementation was like this:
```
  const term1 = cubicCoeff.mul(xOut); // ax 
  const term2 = quadraticCoeff.mul(xOut); //bx 
  const term3 = linearCoeff.mul(xOut); // cx

  const res = term1.add(term2).add(term3); // ax+bx+cx
``` 
But as commented above it calculates ax+bx+cx instead of ax^3+bx^2+cx

The fix can be like this as in this pr:

```
  // ax^3 + bx^2 + cx 
  const term1 = cubicCoeff.mul(xOut).mul(xOut).mul(xOut);
  const term2 = quadraticCoeff.mul(xOut).mul(xOut);
  const term3 = linearCoeff.mul(xOut);

  const res = term1.add(term2).add(term3)
```

or like this similar to horners method
```
  // horners method
  // ax^3 + bx^2 + cx = x(c + x(b + ax))
  let res = cubicCoeff.mul(xOut); // ax
  res = res.add(quadraticCoeff).mul(xOut); // (ax+b)x
  res = res.add(linearCoeff).mul(xOut);// ((ax+b)x +c)x

  return res
```
