### PR TITLE
Revert "Fix IXO Chain ID"

### DIFF
--- a/packages/web/config/chain-infos.ts
+++ b/packages/web/config/chain-infos.ts
@@ -720,7 +720,7 @@ const chainInfos = (
     {
       rpc: "https://rpc-impacthub.keplr.app",
       rest: "https://lcd-impacthub.keplr.app",
-      chainId: "ixo-4",
+      chainId: "impacthub-3",
       chainName: "IXO",
       bip44: {
         coinType: 118,

--- a/packages/web/config/ibc-assets.ts
+++ b/packages/web/config/ibc-assets.ts
@@ -289,7 +289,7 @@ export const IBCAssetInfos: (IBCAsset & {
     isVerified: true,
   },
   {
-    counterpartyChainId: "ixo-4",
+    counterpartyChainId: "impacthub-3",
     sourceChannelId: "channel-38",
     destChannelId: "channel-4",
     coinMinimalDenom: "uixo",


### PR DESCRIPTION
Reverts osmosis-labs/osmosis-frontend#1135

Seems to have made IXO amounts disappear...

The currency registrar seems to have counterparty chain still as impacthub-3 instead of the new ixo-4
<img width="226" alt="image" src="https://user-images.githubusercontent.com/95667791/207462687-b5c24cbc-6be6-45a3-9725-7e91aa89f529.png">
