### PR TITLE
Update contract address for testnet $IBCX

### DIFF
--- a/packages/web/config/chain-infos.ts
+++ b/packages/web/config/chain-infos.ts
@@ -60,7 +60,7 @@ const chainInfos = (
         ...(IS_TESTNET ? [
           {
             coinDenom: "IBCX",
-            coinMinimalDenom: "factory/osmo1qsxmeayz5h00d75gtkevzpmne9rnc37fn5sw9eyxvueq9mm3z9hslch5rh/uibc",
+            coinMinimalDenom: "factory/osmo13t90mkyvdnmn9wm8hfen6jk3hnlt8uqx8savlvjd5xghy5z6ye2qymy6cy/uibcx",
             coinDecimals: 6,
             coinImageUrl: "/tokens/ibcx.svg",
           },


### PR DESCRIPTION
- Hi, we just updated our $IBCX core contract address for our testnet launch (#1149).
- Future updates for our testnet deployments will not PRs; We'll just migrate them into this address. Thanks!