### PR TITLE
Hotfix

### DIFF
--- a/packages/stores/src/queries-external/filtered-pools/filtered-pools.ts
+++ b/packages/stores/src/queries-external/filtered-pools/filtered-pools.ts
@@ -78,23 +78,29 @@ export class ObservableQueryFilteredPools
       const existingQueryPool = this._pools.get(
         filteredPoolRaw.pool_id.toString()
       );
+      let poolRaw: ReturnType<typeof makePoolRawFromFilteredPool> | undefined;
       try {
-        const poolRaw = makePoolRawFromFilteredPool(filteredPoolRaw);
-        if (existingQueryPool) {
-          existingQueryPool.setRaw(poolRaw);
-        } else {
-          this._pools.set(
-            poolRaw.id,
-            new ObservableQueryPool(
-              this.kvStore,
-              this.chainId,
-              this.chainGetter,
-              poolRaw
-            )
-          );
-        }
-      } catch {
-        console.error("Failed to make pool raw from filtered pool raw.");
+        poolRaw = makePoolRawFromFilteredPool(filteredPoolRaw);
+      } catch (e: any) {
+        console.error(
+          `Failed to make pool raw from filtered pool raw. ID: ${filteredPoolRaw.pool_id}, ${e.message}`
+        );
+      }
+
+      if (!poolRaw) continue;
+
+      if (existingQueryPool) {
+        existingQueryPool.setRaw(poolRaw);
+      } else {
+        this._pools.set(
+          poolRaw.id,
+          new ObservableQueryPool(
+            this.kvStore,
+            this.chainId,
+            this.chainGetter,
+            poolRaw
+          )
+        );
       }
     }
   }

--- a/packages/stores/src/queries-external/filtered-pools/filtered-pools.ts
+++ b/packages/stores/src/queries-external/filtered-pools/filtered-pools.ts
@@ -10,6 +10,8 @@ import { ObservableQueryExternalBase } from "../base";
 import { Filters, objToQueryParams, Pagination, FilteredPools } from "./types";
 import { makePoolRawFromFilteredPool } from "./utils";
 
+const ENDPOINT = "/stream/pool/v1/all";
+
 /** TEMPORARY: use imperator query to fetch filtered, sorted pools.
  *
  *  Avoids fetching pools until necessary. Will fetch pools individually until all pools are requested,
@@ -52,7 +54,7 @@ export class ObservableQueryFilteredPools
     super(
       kvStore,
       baseUrl,
-      `/stream/pool/v1/all?${objToQueryParams({
+      `${ENDPOINT}?${objToQueryParams({
         ...initialFilters,
         ...initialPagination,
       })}`
@@ -175,7 +177,7 @@ export class ObservableQueryFilteredPools
 
   protected updateUrlAndFetch() {
     this.setUrl(
-      `${this.baseUrl}/pools/v2beta3/all?${objToQueryParams(this._queryParams)}`
+      `${this.baseUrl}${ENDPOINT}?${objToQueryParams(this._queryParams)}`
     );
     return this.waitFreshResponse();
   }

--- a/packages/stores/src/queries-external/filtered-pools/utils.ts
+++ b/packages/stores/src/queries-external/filtered-pools/utils.ts
@@ -4,7 +4,12 @@ import { FilteredPools } from "./types";
 
 export function makePoolRawFromFilteredPool(
   filteredPool: FilteredPools["pools"][0]
-): PoolRaw {
+): PoolRaw | undefined {
+  // deny pools contianing tokens with gamm denoms
+  if (filteredPool.pool_tokens.some((token) => token.denom.includes("gamm"))) {
+    return;
+  }
+
   const base = {
     "@type": `/${filteredPool.type}`,
     id: filteredPool.pool_id.toString(),
@@ -44,7 +49,7 @@ export function makePoolRawFromFilteredPool(
       scaling_factors: filteredPool.pool_tokens.map((token) =>
         token.weight_or_scaling.toString()
       ),
-      scaling_factor_controller: "", // TOOD: add scaling factor controller in imperator query
+      scaling_factor_controller: "", // TODO: add scaling factor controller in imperator query
     };
   }
 

--- a/packages/web/components/alert/tx-event-toast.ts
+++ b/packages/web/components/alert/tx-event-toast.ts
@@ -61,7 +61,7 @@ export function toastOnFulfill(
             "{txHash}",
             tx.hash.toUpperCase()
           ),
-          learnMoreUrlCaption: "viewExplorerr",
+          learnMoreUrlCaption: "viewExplorer",
         },
         ToastType.SUCCESS
       );

--- a/packages/web/components/control/token-select-with-drawer.tsx
+++ b/packages/web/components/control/token-select-with-drawer.tsx
@@ -39,10 +39,10 @@ export const TokenSelectWithDrawer: FunctionComponent<{
     const setIsSelectOpen =
       setDropdownState === undefined ? setIsSelectOpenLocal : setDropdownState;
 
-    const selectedToken = tokens.find((token) =>
-      (token instanceof CoinPretty ? token.denom : token.coinDenom).includes(
+    const selectedToken = tokens.find(
+      (token) =>
+        (token instanceof CoinPretty ? token.denom : token.coinDenom) ===
         selectedTokenDenom
-      )
     );
 
     const dropdownTokens = tokens

--- a/packages/web/components/trade-clipboard/index.tsx
+++ b/packages/web/components/trade-clipboard/index.tsx
@@ -142,10 +142,31 @@ export const TradeClipboard: FunctionComponent<{
     }, [isSettingOpen]);
 
     // token select dropdown
-    const [showFromTokenSelectDropdown, setFromTokenSelectDropdownLocal] =
+    const fetchedRemainingPoolsRef = useRef(false);
+    const fetchRemainingPoolsOnce = useCallback(() => {
+      if (!fetchedRemainingPoolsRef.current) {
+        fetchedRemainingPoolsRef.current = true;
+        queries.osmosis?.queryGammPools.fetchRemainingPools();
+      }
+    }, [fetchedRemainingPoolsRef]);
+    const [showFromTokenSelectDropdown, _setFromTokenSelectDropdownLocal] =
       useState(false);
-    const [showToTokenSelectDropdown, setToTokenSelectDropdownLocal] =
+    const setFromTokenSelectDropdownLocal = useCallback(
+      (val: boolean) => {
+        fetchRemainingPoolsOnce();
+        _setFromTokenSelectDropdownLocal(val);
+      },
+      [fetchRemainingPoolsOnce]
+    );
+    const [showToTokenSelectDropdown, _setToTokenSelectDropdownLocal] =
       useState(false);
+    const setToTokenSelectDropdownLocal = useCallback(
+      (val: boolean) => {
+        fetchRemainingPoolsOnce();
+        _setToTokenSelectDropdownLocal(val);
+      },
+      [fetchRemainingPoolsOnce]
+    );
     const setOneTokenSelectOpen = (dropdown: "to" | "from") => {
       if (dropdown === "to") {
         setToTokenSelectDropdownLocal(true);

--- a/packages/web/components/trade-clipboard/index.tsx
+++ b/packages/web/components/trade-clipboard/index.tsx
@@ -148,7 +148,7 @@ export const TradeClipboard: FunctionComponent<{
         fetchedRemainingPoolsRef.current = true;
         queries.osmosis?.queryGammPools.fetchRemainingPools();
       }
-    }, [fetchedRemainingPoolsRef]);
+    }, []);
     const [showFromTokenSelectDropdown, _setFromTokenSelectDropdownLocal] =
       useState(false);
     const setFromTokenSelectDropdownLocal = useCallback(

--- a/packages/web/localizations/en.json
+++ b/packages/web/localizations/en.json
@@ -392,7 +392,7 @@
   "transactionBroadcasting": "Transaction Broadcasting",
   "swapFailed": "Swap failed. Liquidity may not be sufficient. Try adjusting the allowed slippage.",
   "waitingForTransaction": "Waiting for transaction to be included in the block",
-  "viewExplorer": "view explorer",
+  "viewExplorer": "View explorer",
   "unknownError": "Unknown error",
   "requestRejected": "Request rejected",
   "stablecoinTypes": {

--- a/packages/web/pages/index.tsx
+++ b/packages/web/pages/index.tsx
@@ -32,6 +32,11 @@ const Home: NextPage = observer(function () {
             return true;
           }
 
+          // https://github.com/osmosis-labs/osmosis-frontend/issues/843
+          if (pool.id === "800") {
+            return false;
+          }
+
           // There is currently no good way to pick a pool that is worthwhile.
           // For now, based on the mainnet, only those pools with assets above a certain value are calculated for swap.
 


### PR DESCRIPTION
* Use correct (same) endpoint for filtered pools
* Remove high fee LUNA pool - Closes #843 

Later
* Fix issue with some tokens not being in swap tool (mostly frontier) by loading remaining pools when the drawer is opened
  * Fixes #1240 
* Fix token select token being similar name but not same token (`.includes()` => `===` for Denom)
  * Fixes #1244 
  * Fixes #1226 
* Fix translation in completed tx toast