### PR TITLE
Revert "V14 - Update LCD"

### DIFF
--- a/packages/web/config/chain-infos.ts
+++ b/packages/web/config/chain-infos.ts
@@ -22,7 +22,7 @@ const chainInfos = (
         OSMOSIS_REST_OVERWRITE ??
         (IS_TESTNET
           ? "https://lcd.testnet.osmosis.zone/"
-          : "https://lcd.osmosis.zone/"),
+          : "https://lcd-osmosis.keplr.app/"),
       chainId:
         OSMOSIS_CHAIN_ID_OVERWRITE ??
         (IS_TESTNET ? "osmo-test-4" : "osmosis-1"),


### PR DESCRIPTION
## Motivation

Reverting this change as Users have pointed out that their transactions are failing after this change. I did some testing, and whenever I use this new LCD endpoint, I get this error. 

![telegram-cloud-photo-size-4-5947103973842467557-x](https://user-images.githubusercontent.com/21092519/214426126-f3dd091e-b3a6-4223-ba90-4d76f7e8ca36.jpg)

## Next Steps

1. Do more testing for the new LCD and pinpoint the error cause (note sequence mismatch error)
2. Open Bug Issue
