### PR TITLE
Update External Gauges Query

### DIFF
--- a/packages/web/pages/api/active-gauges.ts
+++ b/packages/web/pages/api/active-gauges.ts
@@ -14,7 +14,7 @@ export default async function activeGauges(
   _req: NextApiRequest,
   res: NextApiResponse<ExternalIncentiveGaugesResponse>
 ) {
-  const endpoint = `${ChainInfos[0].rest}osmosis/incentives/v1beta1/active_gauges?pagination.limit=100000`;
+  const endpoint = `${ChainInfos[0].rest}osmosis/incentives/v1beta1/gauges?pagination.limit=100000`;
   const resp = await fetch(endpoint);
   const { data } = (await resp.json()) as ExternalIncentiveGaugesResponse;
 


### PR DESCRIPTION
Change /active-gauges/ api call to /gauges/.
Instead of returning 28k 'active' gauges (only past start times), /gauges/ returns 30.5k gauges.
An alternative would be to append a query for just the upcoming gauges, which is much shorter (I saw only 4 gauges when I checked, 3x (a 1-day, 7-day, and 14-day) for a new pool + one new superfluid gauge). I figured the alternative with 2 queries would be worse than 9% more gauges having to be filtered from a single query.
-file name 'active-gauges' becomes somewhat a misnomer now...