### PR TITLE
Fix errors in docker CI

### DIFF
--- a/.github/workflows/push-docker-images.yaml
+++ b/.github/workflows/push-docker-images.yaml
@@ -45,6 +45,10 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Get current date
+        run:  |
+          echo "DATE=$(date +%s)" >> $GITHUB_ENV
       - 
         name: Build and push (main)
         uses: docker/build-push-action@v3
@@ -55,7 +59,7 @@ jobs:
           platforms: linux/amd64
           tags: |
             ${{ env.FRONTEND_DOCKER_REPOSITORY }}:${{ env.SHA }}
-            ${{ env.FRONTEND_DOCKER_REPOSITORY }}:${{ env.SHA }}-$(date +%s)
+            ${{ env.FRONTEND_DOCKER_REPOSITORY }}:${{ env.SHA }}-${{ env.DATE }}
             ${{ env.FRONTEND_DOCKER_REPOSITORY }}:latest
       -
         name: Build and push (frontier)
@@ -67,7 +71,7 @@ jobs:
           platforms: linux/amd64
           tags: |
             ${{ env.FRONTIER_DOCKER_REPOSITORY }}:${{ env.SHA }}
-            ${{ env.FRONTIER_DOCKER_REPOSITORY }}:${{ env.SHA }}-$(date +%s)
+            ${{ env.FRONTIER_DOCKER_REPOSITORY }}:${{ env.SHA }}-${{ env.DATE }}
             ${{ env.FRONTIER_DOCKER_REPOSITORY }}:latest
       -
         name: Build and push (testnet)
@@ -79,5 +83,5 @@ jobs:
           platforms: linux/amd64
           tags: |
             ${{ env.TESTNET_DOCKER_REPOSITORY }}:${{ env.SHA }}
-            ${{ env.TESTNET_DOCKER_REPOSITORY }}:${{ env.SHA }}-$(date +%s)
+            ${{ env.TESTNET_DOCKER_REPOSITORY }}:${{ env.SHA }}-${{ env.DATE }}
             ${{ env.TESTNET_DOCKER_REPOSITORY }}:latest

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.12.1 as build
+FROM node:16.19.0 as build
 
 WORKDIR /app
 
@@ -8,7 +8,7 @@ COPY packages /app/packages/
 RUN yarn
 RUN yarn build
 
-FROM node:18.12.1-alpine3.15
+FROM node:16.19.0-alpine3.16
 
 WORKDIR /app
 COPY --from=build /app .

--- a/docker/Dockerfile.frontier
+++ b/docker/Dockerfile.frontier
@@ -1,4 +1,4 @@
-FROM node:18.12.1 as build
+FROM node:16.19.0 as build
 
 WORKDIR /app
 
@@ -8,7 +8,7 @@ COPY packages /app/packages/
 RUN yarn
 RUN yarn build:frontier
 
-FROM node:18.12.1-alpine3.15
+FROM node:16.19.0-alpine3.16
 
 WORKDIR /app
 COPY --from=build /app .

--- a/docker/Dockerfile.testnet
+++ b/docker/Dockerfile.testnet
@@ -1,4 +1,4 @@
-FROM node:18.12.1 as build
+FROM node:16.19.0 as build
 
 WORKDIR /app
 
@@ -8,7 +8,7 @@ COPY packages /app/packages/
 RUN yarn
 RUN yarn build:testnet
 
-FROM node:18.12.1-alpine3.15
+FROM node:16.19.0-alpine3.16
 
 WORKDIR /app
 COPY --from=build /app .


### PR DESCRIPTION
This PR fixes the errors related to the docker image build:

- It downgrades node to use `16.19.0` due to the following error when building:

```bash
#12 2.488 [2/4] Fetching packages...
#12 100.0 error @axelar-network/axelar-cgp-solidity@4.3.1: The engine "node" is incompatible with this module. Expected version ">=16 <17". Got "18.12.1"
#12 100.1 error Found incompatible module.
#12 100.1 info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```

- Fixes problems in the workflow when using the date in the image tag