### PR TITLE
fix: Bridge Transfer Status UI Instability

### DIFF
--- a/packages/stores/src/bridge-history/index.ts
+++ b/packages/stores/src/bridge-history/index.ts
@@ -9,7 +9,7 @@ import {
 import { computedFn } from "mobx-utils";
 import { KVStore } from "@keplr-wallet/common";
 import { IQueriesStore, CosmosQueries } from "@keplr-wallet/stores";
-import { TxStatus } from "./types";
+import { TxReason, TxStatus } from "./types";
 import { ITxStatusReceiver, ITxStatusSource } from "./types";
 
 /** Persistable data enough to identify a tx. */
@@ -19,7 +19,7 @@ type TxSnapshot = {
   prefixedKey: string;
   amount: string;
   status: TxStatus;
-  reason?: string;
+  reason?: TxReason;
   isWithdraw: boolean;
   accountAddress: string;
 };
@@ -71,7 +71,7 @@ export class NonIbcBridgeHistoryStore implements ITxStatusReceiver {
       sourceName?: string;
       status: TxStatus;
       amount: string;
-      reason?: string;
+      reason?: TxReason;
       explorerUrl: string;
       isWithdraw: boolean;
     }[] = [];
@@ -135,7 +135,7 @@ export class NonIbcBridgeHistoryStore implements ITxStatusReceiver {
   receiveNewTxStatus(
     prefixedKey: string,
     status: TxStatus,
-    reason: string | undefined
+    reason: TxReason | undefined
   ) {
     const snapshot = this.snapshots.find(
       (snapshot) => snapshot.prefixedKey === prefixedKey

--- a/packages/stores/src/bridge-history/types.ts
+++ b/packages/stores/src/bridge-history/types.ts
@@ -26,3 +26,4 @@ export interface ITxStatusReceiver {
 }
 
 export type TxStatus = "success" | "pending" | "failed";
+export type TxReason = "insufficientFee";

--- a/packages/web/components/table/transfer-history.tsx
+++ b/packages/web/components/table/transfer-history.tsx
@@ -7,6 +7,7 @@ import { CoinPretty } from "@keplr-wallet/unit";
 import {
   IBCTransferHistory,
   IBCTransferHistoryStatus,
+  TxReason,
 } from "@osmosis-labs/stores";
 import { useStore } from "../../stores";
 import { Table, BaseCell } from ".";
@@ -20,7 +21,7 @@ type History = {
   createdAtMs: number;
   explorerUrl: string;
   amount: string;
-  reason?: string;
+  reason?: TxReason;
   status: IBCTransferHistoryStatus | "failed";
   isWithdraw: boolean;
 };
@@ -160,8 +161,12 @@ const TxHashDisplayCell: FunctionComponent<
   );
 };
 
+const reasonToTranslationKey: Record<TxReason, string> = {
+  insufficientFee: "assets.historyTable.errors.insufficientFee",
+};
+
 const StatusDisplayCell: FunctionComponent<
-  BaseCell & { status?: IBCTransferHistoryStatus | "failed"; reason?: string }
+  BaseCell & { status?: IBCTransferHistoryStatus | "failed"; reason?: TxReason }
 > = ({ status, reason }) => {
   const t = useTranslation();
   if (status == null) {
@@ -236,7 +241,13 @@ const StatusDisplayCell: FunctionComponent<
       return (
         <div className="flex items-center gap-2">
           <Image alt="failed" src="/icons/error-x.svg" width={24} height={24} />
-          <span className="md:hidden">Failed{reason && `: ${reason}`}</span>
+          <span className="md:hidden">
+            {reason
+              ? t("assets.historyTable.failedWithReason", {
+                  reason: t(reasonToTranslationKey[reason]),
+                })
+              : t("assets.historyTable.failed")}
+          </span>
         </div>
       );
     default:

--- a/packages/web/integrations/axelar/queries.ts
+++ b/packages/web/integrations/axelar/queries.ts
@@ -21,7 +21,7 @@ export type TransferStep = {
 export type TransferStatus = Array<{
   id: string;
   /** Axelarscan: SEND ASSET */
-  source?: TransferStep & {
+  send?: TransferStep & {
     /** Decimal amount. Displayed by Axelarscan (doesn't sub fees). */
     amount: number;
     /** Decimal fee in `denom` denom. Displayed by Axelarscan. */

--- a/packages/web/integrations/axelar/transfer-status-source.ts
+++ b/packages/web/integrations/axelar/transfer-status-source.ts
@@ -66,31 +66,32 @@ export class AxelarTransferStatusSource implements ITxStatusSource {
     }
 
     const [data] = transferStatus;
+    const idWithoutSourceChain = data?.id.split("_")[0].toLowerCase();
 
     // insufficient fee
-    if (data.source && data.source.insufficient_fee) {
+    if (data.send && data.send.insufficient_fee) {
       return {
-        id: data.source.id.toLowerCase(),
+        id: idWithoutSourceChain,
         status: "failed",
         reason: "Insufficient fee",
       };
     }
 
     if (data.status === "executed") {
-      return { id: data.source?.id.toLowerCase(), status: "success" };
+      return { id: idWithoutSourceChain, status: "success" };
     }
 
     if (
       // any of all complete stages does not return success
-      data.source &&
+      data.send &&
       data.link &&
       data.confirm_deposit &&
       data.ibc_send && // transfer is complete
-      (data.source.status !== "success" ||
+      (data.send.status !== "success" ||
         data.confirm_deposit.status !== "success" ||
         data.ibc_send.status !== "success")
     ) {
-      return { id: data.source?.id.toLowerCase(), status: "failed" };
+      return { id: idWithoutSourceChain, status: "failed" };
     }
   }
 }

--- a/packages/web/integrations/axelar/transfer-status-source.ts
+++ b/packages/web/integrations/axelar/transfer-status-source.ts
@@ -1,4 +1,8 @@
-import { ITxStatusReceiver, ITxStatusSource } from "@osmosis-labs/stores";
+import {
+  ITxStatusReceiver,
+  ITxStatusSource,
+  TxReason,
+} from "@osmosis-labs/stores";
 import { poll } from "../../utils/promise";
 import { getTransferStatus, TransferStatus } from "./queries";
 
@@ -55,7 +59,7 @@ export class AxelarTransferStatusSource implements ITxStatusSource {
   protected makeResultStatusFromTransferStatus(
     transferStatus: TransferStatus
   ):
-    | { id?: string; status: "success" | "failed"; reason?: string }
+    | { id?: string; status: "success" | "failed"; reason?: TxReason }
     | undefined {
     // could be { message: "Internal Server Error" } TODO: display server errors or connection issues to user
     if (
@@ -73,7 +77,7 @@ export class AxelarTransferStatusSource implements ITxStatusSource {
       return {
         id: idWithoutSourceChain,
         status: "failed",
-        reason: "Insufficient fee",
+        reason: "insufficientFee",
       };
     }
 

--- a/packages/web/localizations/en.json
+++ b/packages/web/localizations/en.json
@@ -314,6 +314,11 @@
         "status": "Status",
         "deposit": "Deposit",
         "withdraw": "Withdraw"
+      },
+      "failed": "Failed",
+      "failedWithReason": "Failed: {reason}",
+      "errors": {
+        "insufficientFee": "Insufficient Fee"
       }
     }
   },

--- a/packages/web/localizations/es.json
+++ b/packages/web/localizations/es.json
@@ -314,6 +314,11 @@
         "status": "Estado",
         "deposit": "Depositar",
         "withdraw": "Retirar"
+      },
+      "failed": "Fallida",
+      "failedWithReason": "Fallida: {reason}",
+      "errors": {
+        "insufficientFee": "Tarifa insuficiente"
       }
     }
   },

--- a/packages/web/localizations/fr.json
+++ b/packages/web/localizations/fr.json
@@ -313,6 +313,11 @@
         "status": "Statut",
         "deposit": "Déposer",
         "withdraw": "Retirer"
+      },
+      "failed": "Échoué",
+      "failedWithReason": "Échoué: {reason}",
+      "errors": {
+        "insufficientFee": "Frais insuffisants"
       }
     }
   },

--- a/packages/web/localizations/ko.json
+++ b/packages/web/localizations/ko.json
@@ -314,6 +314,11 @@
         "status": "상태",
         "deposit": "입금",
         "withdraw": "출금"
+      },
+      "failed": "실패한",
+      "failedWithReason": "실패한: {reason}",
+      "errors": {
+        "insufficientFee": "부족한 수수료"
       }
     }
   },

--- a/packages/web/localizations/pl.json
+++ b/packages/web/localizations/pl.json
@@ -314,6 +314,11 @@
         "status": "Status",
         "deposit": "Wpłata",
         "withdraw": "Wypłata"
+      },
+      "failed": "Przegrany",
+      "failedWithReason": "Przegrany: {reason}",
+      "errors": {
+        "insufficientFee": "Niewystarczająca opłata"
       }
     }
   },

--- a/packages/web/localizations/ro.json
+++ b/packages/web/localizations/ro.json
@@ -314,6 +314,11 @@
         "status": "Status",
         "deposit": "Depozit",
         "withdraw": "Retragere"
+      },
+      "failed": "A eșuat",
+      "failedWithReason": "A eșuat: {reason}",
+      "errors": {
+        "insufficientFee": "Taxa insuficienta"
       }
     }
   },

--- a/packages/web/localizations/tr.json
+++ b/packages/web/localizations/tr.json
@@ -314,6 +314,11 @@
         "status": "Durum",
         "deposit": "Yatır",
         "withdraw": "Çek"
+      },
+      "failed": "Arızalı",
+      "failedWithReason": "Arızalı: {reason}",
+      "errors": {
+        "insufficientFee": "yetersiz ücret"
       }
     }
   },

--- a/packages/web/localizations/zh-cn.json
+++ b/packages/web/localizations/zh-cn.json
@@ -313,6 +313,11 @@
         "status": "状态",
         "deposit": "存入",
         "withdraw": "提币"
+      },
+      "failed": "失败的",
+      "failedWithReason": "失败的: {reason}",
+      "errors": {
+        "insufficientFee": "费用不足"
       }
     }
   },

--- a/packages/web/localizations/zh-hk.json
+++ b/packages/web/localizations/zh-hk.json
@@ -314,6 +314,11 @@
         "status": "狀態",
         "deposit": "存入",
         "withdraw": "轉出"
+      },
+      "failed": "失敗的",
+      "failedWithReason": "失敗的: {reason}",
+      "errors": {
+        "insufficientFee": "費用不足"
       }
     }
   },

--- a/packages/web/localizations/zh-tw.json
+++ b/packages/web/localizations/zh-tw.json
@@ -314,6 +314,11 @@
         "status": "狀態",
         "deposit": "存入",
         "withdraw": "轉出"
+      },
+      "failed": "失敗的",
+      "failedWithReason": "失敗的: {reason}",
+      "errors": {
+        "insufficientFee": "費用不足"
       }
     }
   },


### PR DESCRIPTION
Axelar changed its API schema: https://docs.axelarscan.io/cross-chain/transfers-status.

Notable changes: 

- `data.source` No longer exists. It's instead called `data.send`
- We must use `data.id`  instead. 
- Id includes the source chain. So to get the id, we have to: `data.id.split("_")[0]`
- insufficient_fee Is now located in `data.send`
