### PR TITLE
Add polygon.USDC and avalanche.USDC

### DIFF
--- a/packages/web/config/chain-infos.ts
+++ b/packages/web/config/chain-infos.ts
@@ -2795,6 +2795,22 @@ chainInfos.push({
       coinGeckoId: "pool:wftm-wei",
       coinImageUrl: "/tokens/ftm.png",
     },
+    {
+      coinDenom: "Polygon USDC",
+      coinMinimalDenom: "polygon-uusdc",
+      coinDecimals: 6,
+      coinGeckoId: "usd-coin",
+      coinImageUrl: "/tokens/usdc.svg",
+      pegMechanism: "collateralized",
+    },
+    {
+      coinDenom: "Avalanche USDC",
+      coinMinimalDenom: "avalanche-uusdc",
+      coinDecimals: 6,
+      coinGeckoId: "usd-coin",
+      coinImageUrl: "/tokens/usdc.svg",
+      pegMechanism: "collateralized",
+    },
   ],
   feeCurrencies: [
     {

--- a/packages/web/config/chain-infos.ts
+++ b/packages/web/config/chain-infos.ts
@@ -2796,7 +2796,7 @@ chainInfos.push({
       coinImageUrl: "/tokens/ftm.png",
     },
     {
-      coinDenom: "Polygon USDC",
+      coinDenom: "polygon.USDC",
       coinMinimalDenom: "polygon-uusdc",
       coinDecimals: 6,
       coinGeckoId: "usd-coin",
@@ -2804,7 +2804,7 @@ chainInfos.push({
       pegMechanism: "collateralized",
     },
     {
-      coinDenom: "Avalanche USDC",
+      coinDenom: "avalanche.USDC",
       coinMinimalDenom: "avalanche-uusdc",
       coinDecimals: 6,
       coinGeckoId: "usd-coin",

--- a/packages/web/config/ibc-assets.ts
+++ b/packages/web/config/ibc-assets.ts
@@ -233,38 +233,6 @@ export const IBCAssetInfos: (IBCAsset & {
     counterpartyChainId: "axelar-dojo-1",
     sourceChannelId: "channel-208",
     destChannelId: "channel-3",
-    coinMinimalDenom: "polygon-uusdc",
-    sourceChainNameOverride: "Polygon",
-    isVerified: false,
-    originBridgeInfo: {
-      bridge: "axelar" as const,
-      wallets: ["metamask" as const, "walletconnect" as const],
-      method: "deposit-address" as const,
-      sourceChains: [
-        AxelarSourceChainConfigs.polygonusdc.polygon,
-      ],
-    }
-  },
-  {
-    counterpartyChainId: "axelar-dojo-1",
-    sourceChannelId: "channel-208",
-    destChannelId: "channel-3",
-    coinMinimalDenom: "avalanche-uusdc",
-    sourceChainNameOverride: "Avalanche",
-    isVerified: false,
-    originBridgeInfo: {
-      bridge: "axelar" as const,
-      wallets: ["metamask" as const, "walletconnect" as const],
-      method: "deposit-address" as const,
-      sourceChains: [
-        AxelarSourceChainConfigs.avalancheusdc.avalanche,
-      ],
-    }
-  },
-  {
-    counterpartyChainId: "axelar-dojo-1",
-    sourceChannelId: "channel-208",
-    destChannelId: "channel-3",
     coinMinimalDenom: "wbnb-wei",
     sourceChainNameOverride: "Binance Smart Chain",
     isVerified: true,
@@ -658,6 +626,38 @@ export const IBCAssetInfos: (IBCAsset & {
     destChannelId: "channel-3",
     coinMinimalDenom: "uaxl",
     isVerified: true,
+  },
+  {
+    counterpartyChainId: "axelar-dojo-1",
+    sourceChannelId: "channel-208",
+    destChannelId: "channel-3",
+    coinMinimalDenom: "polygon-uusdc",
+    sourceChainNameOverride: "Polygon",
+    isVerified: false,
+    originBridgeInfo: {
+      bridge: "axelar" as const,
+      wallets: ["metamask" as const, "walletconnect" as const],
+      method: "deposit-address" as const,
+      sourceChains: [
+        AxelarSourceChainConfigs.polygonusdc.polygon,
+      ],
+    }
+  },
+  {
+    counterpartyChainId: "axelar-dojo-1",
+    sourceChannelId: "channel-208",
+    destChannelId: "channel-3",
+    coinMinimalDenom: "avalanche-uusdc",
+    sourceChainNameOverride: "Avalanche",
+    isVerified: false,
+    originBridgeInfo: {
+      bridge: "axelar" as const,
+      wallets: ["metamask" as const, "walletconnect" as const],
+      method: "deposit-address" as const,
+      sourceChains: [
+        AxelarSourceChainConfigs.avalancheusdc.avalanche,
+      ],
+    }
   },
   {
     counterpartyChainId: "kaiyo-1",

--- a/packages/web/config/ibc-assets.ts
+++ b/packages/web/config/ibc-assets.ts
@@ -233,6 +233,38 @@ export const IBCAssetInfos: (IBCAsset & {
     counterpartyChainId: "axelar-dojo-1",
     sourceChannelId: "channel-208",
     destChannelId: "channel-3",
+    coinMinimalDenom: "polygon-uusdc",
+    sourceChainNameOverride: "Polygon",
+    isVerified: false,
+    originBridgeInfo: {
+      bridge: "axelar" as const,
+      wallets: ["metamask" as const, "walletconnect" as const],
+      method: "deposit-address" as const,
+      sourceChains: [
+        AxelarSourceChainConfigs.polygonusdc.polygon,
+      ],
+    }
+  },
+  {
+    counterpartyChainId: "axelar-dojo-1",
+    sourceChannelId: "channel-208",
+    destChannelId: "channel-3",
+    coinMinimalDenom: "avalanche-uusdc",
+    sourceChainNameOverride: "Avalanche",
+    isVerified: false,
+    originBridgeInfo: {
+      bridge: "axelar" as const,
+      wallets: ["metamask" as const, "walletconnect" as const],
+      method: "deposit-address" as const,
+      sourceChains: [
+        AxelarSourceChainConfigs.avalancheusdc.avalanche,
+      ],
+    }
+  },
+  {
+    counterpartyChainId: "axelar-dojo-1",
+    sourceChannelId: "channel-208",
+    destChannelId: "channel-3",
     coinMinimalDenom: "wbnb-wei",
     sourceChainNameOverride: "Binance Smart Chain",
     isVerified: true,

--- a/packages/web/integrations/axelar/source-chain-config.ts
+++ b/packages/web/integrations/axelar/source-chain-config.ts
@@ -218,10 +218,10 @@ export const SourceChainConfigs: {
     },
   },
   polygonusdc: {
-    avalanche: {
+    polygon: {
       id: "Polygon" as const,
       erc20ContractAddress: "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
-      logoUrl: "/networks/avalanche.svg",
+      logoUrl: "/networks/polygon.svg",
     },
   },
   avalancheusdc: {

--- a/packages/web/integrations/axelar/source-chain-config.ts
+++ b/packages/web/integrations/axelar/source-chain-config.ts
@@ -217,4 +217,18 @@ export const SourceChainConfigs: {
       logoUrl: "/networks/fantom.svg",
     },
   },
+  polygonusdc: {
+    avalanche: {
+      id: "Polygon" as const,
+      erc20ContractAddress: "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+      logoUrl: "/networks/avalanche.svg",
+    },
+  },
+  avalancheusdc: {
+    avalanche: {
+      id: "Avalanche" as const,
+      erc20ContractAddress: "0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E",
+      logoUrl: "/networks/avalanche.svg",
+    },
+  },
 };


### PR DESCRIPTION
-bridged via Axelar
-there are native USDC variants--not already bridged variants.
-frontier for now, just below Ethereum USDC 
-I see no indication that the name is too long for any UI element, but cannot verify swaps without any pools (although, I don't think that will be an issue, either)
-QA Validation complete