### PR TITLE
Reduce upcoming gauge days

### DIFF
--- a/packages/web/pages/api/active-gauges.ts
+++ b/packages/web/pages/api/active-gauges.ts
@@ -32,7 +32,7 @@ export default async function activeGauges(
 }
 
 const DURATION_1_DAY = 86400000;
-const DURATION_UPCOMING_SOON = DURATION_1_DAY * 7;
+const DURATION_UPCOMING_SOON = DURATION_1_DAY * 1;
 const MAX_NEW_GAUGES_PER_DAY = 100;
 
 function checkForStaleness(gauge: Gauge, lastGaugeId: number) {


### PR DESCRIPTION
Lowers the threshold of how many days in advance a gauge will appear from 7 days to just 1 day.
It would be nice to extend to show gauges upcoming several days in advance, but we'll need additional design to add start a date. For now, just 1 day in advance is the only way to not mislead people into thinking they'd get incentives at next epoch even when it wouldn't start for another week.