### PR TITLE
Re-enable IXO

### DIFF
--- a/packages/web/config/chain-infos.ts
+++ b/packages/web/config/chain-infos.ts
@@ -768,7 +768,7 @@ const chainInfos = (
         },
       ],
       features: ["ibc-transfer"],
-      explorerUrlToTx: "https://blockscan.ixo.world/transactions/{txHash}",
+      explorerUrlToTx: "https://blockscan.ixo.world/txs/{txHash}",
     },
     {
       rpc: "https://rpc.bitcanna.io",

--- a/packages/web/config/chain-infos.ts
+++ b/packages/web/config/chain-infos.ts
@@ -749,7 +749,7 @@ const chainInfos = (
     {
       rpc: "https://rpc-impacthub.keplr.app",
       rest: "https://lcd-impacthub.keplr.app",
-      chainId: "impacthub-3",
+      chainId: "ixo-4",
       chainName: "IXO",
       bip44: {
         coinType: 118,

--- a/packages/web/config/ibc-assets.ts
+++ b/packages/web/config/ibc-assets.ts
@@ -1038,11 +1038,10 @@ export const IBCAssetInfos: (IBCAsset & {
     isVerified: true,
   },
   {
-    counterpartyChainId: "impacthub-3",
+    counterpartyChainId: "ixo-4",
     sourceChannelId: "channel-38",
     destChannelId: "channel-4",
     coinMinimalDenom: "uixo",
-    isUnstable: true,
   },
   {
     counterpartyChainId: "bitcanna-1",


### PR DESCRIPTION
Re-enable IXO. now that the ibc connection is restored.
Updatechain id from impacthub-3 to ixo-4
https://www.mintscan.io/osmosis/proposals/412
Validated that transfers work.