### PR TITLE
Fallback to node pools query if main query store fails

### DIFF
--- a/packages/stores/src/queries/fallback-query-store.ts
+++ b/packages/stores/src/queries/fallback-query-store.ts
@@ -1,0 +1,34 @@
+import { observable, autorun, makeObservable, runInAction } from "mobx";
+import { ObservableQuery } from "@keplr-wallet/stores";
+
+/** Wraps an ordered list of similar query stores and falls back to the first store that returns a valid response. */
+export class FallbackStore<TStore extends ObservableQuery> {
+  @observable.ref
+  protected _responsiveStore: TStore;
+
+  constructor(readonly orderedStores: TStore[]) {
+    this._responsiveStore = orderedStores[0];
+
+    // Runs any time error changes in current store.
+    autorun(() => {
+      if (this._responsiveStore.error) {
+        // If the current store has an error, fallback to the next store.
+        const index = orderedStores.indexOf(this._responsiveStore);
+        if (index < orderedStores.length - 1) {
+          runInAction(() => (this._responsiveStore = orderedStores[index + 1]));
+        } else {
+          console.warn(
+            "FallbackStore ran out of fallback stores. Last store error:",
+            this._responsiveStore.error
+          );
+        }
+      }
+    });
+
+    makeObservable(this);
+  }
+
+  get responsiveStore(): TStore {
+    return this._responsiveStore;
+  }
+}

--- a/packages/stores/src/queries/fallback-query-store.ts
+++ b/packages/stores/src/queries/fallback-query-store.ts
@@ -7,6 +7,10 @@ export class FallbackStore<TStore extends ObservableQuery> {
   protected _responsiveStore: TStore;
 
   constructor(readonly orderedStores: TStore[]) {
+    if (orderedStores.length === 0) {
+      throw new Error("Must provide at least one store.");
+    }
+
     this._responsiveStore = orderedStores[0];
 
     // Runs any time error changes in current store.

--- a/packages/stores/src/queries/pools/pools.ts
+++ b/packages/stores/src/queries/pools/pools.ts
@@ -11,6 +11,7 @@ import { ObservableQueryPool } from "./pool";
 import { Pools, PoolGetter } from "./types";
 import { GET_POOLS_PAGINATION_LIMIT } from ".";
 
+/** Fetches all pools directly from node in order of pool creation. */
 export class ObservableQueryPools
   extends ObservableChainQuery<Pools>
   implements PoolGetter
@@ -98,4 +99,13 @@ export class ObservableQueryPools
       return this.getPool(raw.id)!;
     });
   });
+
+  /** TODO: implement pagination when we hit the limit of pools, for now, the url will be set to the max number of pools in the autorun above */
+  paginate() {
+    /** do nothing */
+  }
+
+  fetchRemainingPools() {
+    /** do nothing since all pools get fetched. */
+  }
 }

--- a/packages/stores/src/queries/pools/types.ts
+++ b/packages/stores/src/queries/pools/types.ts
@@ -6,6 +6,8 @@ export interface PoolGetter extends ObservableQuery {
   getPool(id: string): ObservableQueryPool | undefined;
   poolExists(id: string): boolean | undefined;
   getAllPools(): ObservableQueryPool[];
+  paginate(): void;
+  fetchRemainingPools(): void;
 }
 
 export type Pools = {

--- a/packages/stores/src/queries/store.ts
+++ b/packages/stores/src/queries/store.ts
@@ -1,4 +1,4 @@
-import { autorun, makeObservable, observable } from "mobx";
+import { autorun } from "mobx";
 import { ChainGetter, QueriesSetBase } from "@keplr-wallet/stores";
 import { KVStore } from "@keplr-wallet/common";
 import { DeepReadonly } from "utility-types";
@@ -74,8 +74,7 @@ export const OsmosisQueries = {
 
 /** Root queries store for all Osmosis queries. */
 export class OsmosisQueriesImpl {
-  @observable.ref
-  public queryGammPools: PoolGetter;
+  protected _queryGammPools: DeepReadonly<PoolGetter>;
   public readonly queryGammNumPools: DeepReadonly<ObservableQueryNumPools>;
   public readonly queryGammPoolShare: DeepReadonly<ObservableQueryGammPoolShare>;
 
@@ -103,6 +102,10 @@ export class OsmosisQueriesImpl {
   public readonly querySuperfluidParams: DeepReadonly<ObservableQuerySuperfluidParams>;
   public readonly querySuperfluidAssetMultiplier: DeepReadonly<ObservableQuerySuperfluidAssetMultiplier>;
   public readonly querySuperfluidOsmoEquivalent: DeepReadonly<ObservableQuerySuperfluidOsmoEquivalent>;
+
+  get queryGammPools(): PoolGetter {
+    return this._queryGammPools;
+  }
 
   constructor(
     queries: QueriesSetBase,
@@ -152,14 +155,14 @@ export class OsmosisQueriesImpl {
         this.queryGammNumPools
       ),
     ]);
-    this.queryGammPools = poolsQueryFallbacks.responsiveStore;
-    // update the pools query store any time the fallback store changes
+    this._queryGammPools = poolsQueryFallbacks.responsiveStore;
+    // hot swap the pools query store any time the fallback store changes
     autorun(() => {
-      this.queryGammPools = poolsQueryFallbacks.responsiveStore;
+      this._queryGammPools = poolsQueryFallbacks.responsiveStore;
     });
 
     this.queryGammPoolShare = new ObservableQueryGammPoolShare(
-      this.queryGammPools,
+      this._queryGammPools,
       queries.queryBalances,
       this.queryAccountLocked,
       this.queryLockedCoins,
@@ -197,7 +200,7 @@ export class OsmosisQueriesImpl {
       chainGetter,
       this.queryLockableDurations,
       this.queryDistrInfo,
-      this.queryGammPools,
+      this._queryGammPools,
       this.queryMintParams,
       this.queryEpochProvisions,
       this.queryEpochs,
@@ -244,9 +247,7 @@ export class OsmosisQueriesImpl {
         chainGetter,
         this.querySuperfluidParams,
         this.querySuperfluidAssetMultiplier,
-        this.queryGammPools
+        this._queryGammPools
       );
-
-    makeObservable(this);
   }
 }

--- a/packages/web/stores/root.ts
+++ b/packages/web/stores/root.ts
@@ -111,7 +111,7 @@ export class RootStore {
       this.chainStore,
       CosmosQueries.use(),
       CosmwasmQueries.use(),
-      OsmosisQueries.use(this.chainStore.osmosis.chainId)
+      OsmosisQueries.use(this.chainStore.osmosis.chainId, IS_TESTNET)
     );
 
     this.accountStore = new AccountStore(

--- a/yarn.lock
+++ b/yarn.lock
@@ -4208,15 +4208,10 @@ camelcase@^6.2.0:
   resolved "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
-caniuse-lite@^1.0.30001283:
-  version "1.0.30001442"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001442.tgz#40337f1cf3be7c637b061e2f78582dc1daec0614"
-  integrity sha512-239m03Pqy0hwxYPYR5JwOIxRJfLTWtle9FV8zosfV5pHg+/51uD4nxcUlM8+mWWGfwKtt8lJNHnD3cWw9VZ6ow==
-
-caniuse-lite@^1.0.30001286, caniuse-lite@^1.0.30001297:
-  version "1.0.30001367"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001367.tgz"
-  integrity sha512-XDgbeOHfifWV3GEES2B8rtsrADx4Jf+juKX2SICJcaUhjYBO3bR96kvEIHa15VU6ohtOhBZuPGGYGbXMRn0NCw==
+caniuse-lite@^1.0.30001283, caniuse-lite@^1.0.30001286, caniuse-lite@^1.0.30001297:
+  version "1.0.30001451"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001451.tgz"
+  integrity sha512-XY7UbUpGRatZzoRft//5xOa69/1iGJRBlrieH6QYrkKLIFn3m7OVEJ81dSrKoy2BnKsdbX5cLrOispZNYo9v2w==
 
 caseless@~0.12.0:
   version "0.12.0"


### PR DESCRIPTION
This is an automated approach to switching to the slower pools query when the optimized query object fails to fetch. This should allow our frontend to still be usable without imperator (or other) data services. This only recently became a concern once a core and important query, the pools query, was moved to data services instead of directly from the node due to performance issues.