### PR TITLE
Hotfix: Axelar Transfer: Fix insufficient fee bug

### DIFF
--- a/packages/web/integrations/axelar/transfer.tsx
+++ b/packages/web/integrations/axelar/transfer.tsx
@@ -415,7 +415,6 @@ const AxelarTransfer: FunctionComponent<
           DecUtils.getTenExponentNInPrecisionRange(originCurrency.coinDecimals)
         )
       )
-        .moveDecimalPointRight(originCurrency.coinDecimals)
         .toDec()
         .lt(transferFee.toDec());
     const isInsufficientBal =


### PR DESCRIPTION
When we started querying for the transfer fee, it broke the comparison of the input amount and the transfer fee that would block users from transferring if the amount wasn't greater then the fee that would be subtracted.