### PR TITLE
Fix: APR overflow

### DIFF
--- a/packages/web/components/cards/bond-card.tsx
+++ b/packages/web/components/cards/bond-card.tsx
@@ -208,8 +208,6 @@ const Drawer: FunctionComponent<{
   }, [incentivesBreakdown]);
   const t = useTranslation();
 
-  aggregateApr = new RatePretty("23000");
-
   return (
     <div
       className={classNames(
@@ -231,10 +229,10 @@ const Drawer: FunctionComponent<{
           <span className="subtitle1 text-osmoverse-200">
             {t("pool.incentives")}
           </span>
-          <div className="flex items-center gap-2 md:gap-1.5">
+          <div className="flex items-center gap-1.5">
             <h5
               className={classNames(
-                "max-w-1/3 text-ellipsis",
+                "whitespace-nowrap",
                 superfluid ? "text-superfluid-gradient" : "text-bullish-400"
               )}
             >

--- a/packages/web/components/cards/bond-card.tsx
+++ b/packages/web/components/cards/bond-card.tsx
@@ -15,7 +15,7 @@ import { useMeasure } from "react-use";
 
 import { EventName } from "../../config";
 import { useAmplitudeAnalytics } from "../../hooks";
-import { coinFormatter, priceFormatter } from "../../utils/formatter";
+import { formatPretty } from "../../utils/formatter";
 import { FallbackImg, Icon } from "../assets";
 import { RightArrowIcon } from "../assets/right-arrow-icon";
 import { UnlockIcon } from "../assets/unlock-icon";
@@ -208,6 +208,8 @@ const Drawer: FunctionComponent<{
   }, [incentivesBreakdown]);
   const t = useTranslation();
 
+  aggregateApr = new RatePretty("23000");
+
   return (
     <div
       className={classNames(
@@ -232,10 +234,11 @@ const Drawer: FunctionComponent<{
           <div className="flex items-center gap-2 md:gap-1.5">
             <h5
               className={classNames(
+                "max-w-1/3 text-ellipsis",
                 superfluid ? "text-superfluid-gradient" : "text-bullish-400"
               )}
             >
-              {aggregateApr.maxDecimals(0).toString()} {t("pool.APR")}
+              {formatPretty(aggregateApr.maxDecimals(0))} {t("pool.APR")}
             </h5>
             <div
               className={classNames(
@@ -400,7 +403,7 @@ const IncentiveBreakdownRow: FunctionComponent<
       <div className="flex flex-col text-right">
         <span className="text-osmoverse-100">
           {t("pool.dailyEarnAmount", {
-            amount: coinFormatter(dailyPoolReward),
+            amount: formatPretty(dailyPoolReward),
           })}
         </span>
         {numDaysRemaining && (
@@ -431,7 +434,7 @@ const SwapFeeBreakdownRow: FunctionComponent<{
       <div className="flex flex-col text-right">
         <span className="text-osmoverse-100">
           {t("pool.dailyEarnAmount", {
-            amount: priceFormatter(swapFeeDailyReward),
+            amount: formatPretty(swapFeeDailyReward),
           })}
         </span>
         <span className="caption text-osmoverse-400">

--- a/packages/web/modals/profile.tsx
+++ b/packages/web/modals/profile.tsx
@@ -1,3 +1,10 @@
+import { Dec, PricePretty } from "@keplr-wallet/unit";
+import classNames from "classnames";
+import { observer } from "mobx-react-lite";
+import dynamic from "next/dynamic";
+import Image from "next/image";
+import Link from "next/link";
+import { useRouter } from "next/router";
 import {
   AnchorHTMLAttributes,
   ButtonHTMLAttributes,
@@ -9,30 +16,18 @@ import {
   useEffect,
   useState,
 } from "react";
-import dynamic from "next/dynamic";
-import { observer } from "mobx-react-lite";
-import { ModalBase, ModalBaseProps } from "./base";
 import { useTranslation } from "react-multi-lang";
-import Image from "next/image";
-import { CreditCardIcon } from "../components/assets/credit-card-icon";
-import { useStore } from "../stores";
-import { FiatRampsModal } from "./fiat-ramps";
-import {
-  useAmplitudeAnalytics,
-  useDisclosure,
-  useTransferConfig,
-  useWindowSize,
-} from "../hooks";
-import { EventName } from "../config";
 import { useCopyToClipboard, useTimeoutFn } from "react-use";
+
 import {
+  CheckMarkIcon,
   CopyIcon,
+  ExternalLinkIcon,
   LogOutIcon,
   QRIcon,
-  ExternalLinkIcon,
-  CheckMarkIcon,
 } from "../components/assets";
-import classNames from "classnames";
+import { CreditCardIcon } from "../components/assets/credit-card-icon";
+import { ArrowButton } from "../components/buttons";
 import {
   Drawer,
   DrawerButton,
@@ -40,12 +35,18 @@ import {
   DrawerOverlay,
   DrawerPanel,
 } from "../components/drawers";
-import { ArrowButton } from "../components/buttons";
-import Link from "next/link";
-import { useRouter } from "next/router";
+import { EventName } from "../config";
+import {
+  useAmplitudeAnalytics,
+  useDisclosure,
+  useTransferConfig,
+  useWindowSize,
+} from "../hooks";
+import { useStore } from "../stores";
+import { formatPretty } from "../utils/formatter";
 import { formatICNSName, getShortAddress } from "../utils/string";
-import { coinFormatter, priceFormatter } from "../utils/formatter";
-import { Dec, PricePretty } from "@keplr-wallet/unit";
+import { ModalBase, ModalBaseProps } from "./base";
+import { FiatRampsModal } from "./fiat-ramps";
 
 const QRCode = dynamic(() => import("qrcode.react"));
 
@@ -202,7 +203,7 @@ export const ProfileModal: FunctionComponent<
 
             <div>
               <h6 className="mb-[4px] tracking-wide text-osmoverse-100">
-                {priceFormatter(
+                {formatPretty(
                   priceStore.calculatePrice(
                     navBarStore.walletInfo.balance,
                     priceStore.defaultVsCurrency
@@ -219,7 +220,7 @@ export const ProfileModal: FunctionComponent<
                 )}
               </h6>
               <p className="text-h5 font-h5">
-                {coinFormatter(navBarStore.walletInfo.balance, {
+                {formatPretty(navBarStore.walletInfo.balance, {
                   minimumFractionDigits: 2,
                   maximumSignificantDigits: undefined,
                   notation: "standard",

--- a/packages/web/pages/pools/index.tsx
+++ b/packages/web/pages/pools/index.tsx
@@ -46,7 +46,7 @@ import {
   SuperfluidValidatorModal,
 } from "../../modals";
 import { useStore } from "../../stores";
-import { priceFormatter } from "../../utils/formatter";
+import { formatPretty } from "../../utils/formatter";
 
 const TVL_FILTER_THRESHOLD = 1000;
 
@@ -397,7 +397,7 @@ const Pools: NextPage = observer(function () {
                       <MetricLoader isLoading={poolLiquidity.toDec().isZero()}>
                         <h6>
                           {isMobile
-                            ? priceFormatter(myLiquidity)
+                            ? formatPretty(myLiquidity)
                             : myLiquidity.maxDecimals(2).toString()}
                         </h6>
                       </MetricLoader>
@@ -409,7 +409,7 @@ const Pools: NextPage = observer(function () {
                       myBonded.toString()
                     ) : (
                       <MetricLoader isLoading={poolLiquidity.toDec().isZero()}>
-                        <h6>{priceFormatter(myBonded)}</h6>
+                        <h6>{formatPretty(myBonded)}</h6>
                       </MetricLoader>
                     ),
                   },
@@ -644,7 +644,7 @@ const Pools: NextPage = observer(function () {
                               <MetricLoader
                                 isLoading={poolLiquidity.toDec().isZero()}
                               >
-                                <h6>{priceFormatter(poolLiquidity)}</h6>
+                                <h6>{formatPretty(poolLiquidity)}</h6>
                               </MetricLoader>
                             ),
                           },

--- a/packages/web/utils/formatter.ts
+++ b/packages/web/utils/formatter.ts
@@ -1,7 +1,28 @@
-import { PricePretty, IntPretty, CoinPretty } from "@keplr-wallet/unit";
+import {
+  CoinPretty,
+  IntPretty,
+  PricePretty,
+  RatePretty,
+} from "@keplr-wallet/unit";
+
+/** Formats a pretty object as compact by default. i.e. $7.53M or $265K, or 2K%. Validate handled by pretty object. */
+export function formatPretty(
+  prettyValue: PricePretty | CoinPretty | RatePretty,
+  opts?: Partial<Intl.NumberFormatOptions>
+) {
+  if (prettyValue instanceof PricePretty) {
+    return priceFormatter(prettyValue, opts);
+  } else if (prettyValue instanceof CoinPretty) {
+    return coinFormatter(prettyValue, opts);
+  } else if (prettyValue instanceof RatePretty) {
+    return rateFormatter(prettyValue, opts);
+  } else {
+    throw new Error("Unknown pretty value");
+  }
+}
 
 /** Formats a price as compact by default. i.e. $7.53M or $265K. Validate handled by `PricePretty`. */
-export function priceFormatter(
+function priceFormatter(
   price: PricePretty,
   opts?: Partial<Intl.NumberFormatOptions>
 ): string {
@@ -15,12 +36,12 @@ export function priceFormatter(
   };
   const formatter = new Intl.NumberFormat(price.fiatCurrency.locale, options);
   return formatter.format(
-    Number(new IntPretty(price).maxDecimals(2).toString().split(",").join(""))
+    Number(new IntPretty(price).maxDecimals(2).locale(false).toString())
   );
 }
 
 /** Formats a coin as compact by default. i.e. $7.53 ATOM or $265 OSMO. Validate handled by `CoinPretty`. */
-export function coinFormatter(
+function coinFormatter(
   coin: CoinPretty,
   opts?: Partial<Intl.NumberFormatOptions>
 ): string {
@@ -33,6 +54,26 @@ export function coinFormatter(
   };
   const formatter = new Intl.NumberFormat("en-US", options);
   return `${formatter.format(
-    Number(new IntPretty(coin).maxDecimals(2).toString().split(",").join(""))
+    Number(new IntPretty(coin).maxDecimals(2).locale(false).toString())
   )} ${coin.currency.coinDenom.toUpperCase()}`;
+}
+
+/** Formats a coin as compact by default. i.e. $7.53 ATOM or $265 OSMO. Validate handled by `CoinPretty`. */
+function rateFormatter(
+  rate: RatePretty,
+  opts?: Partial<Intl.NumberFormatOptions>
+): string {
+  const options: Intl.NumberFormatOptions = {
+    maximumSignificantDigits: 3,
+    notation: "compact",
+    compactDisplay: "short",
+    style: "decimal",
+    ...opts,
+  };
+  const formatter = new Intl.NumberFormat("en-US", options);
+  return `${formatter.format(
+    Number(
+      new RatePretty(rate).maxDecimals(2).locale(false).symbol("").toString()
+    )
+  )}${rate.options.symbol}`;
 }


### PR DESCRIPTION
Closes #1330 

Prevents text wrap, only allowing the following possibilities:

<img width="337" alt="Screen Shot 2023-02-15 at 1 29 59 PM" src="https://user-images.githubusercontent.com/4606373/219133290-7dcf9a1d-b5e2-478c-9b82-68f1d66e48f1.png">
<img width="344" alt="Screen Shot 2023-02-15 at 1 29 45 PM" src="https://user-images.githubusercontent.com/4606373/219133312-41831372-791f-435f-8880-6c64217dfcab.png">
<img width="336" alt="Screen Shot 2023-02-15 at 1 22 06 PM" src="https://user-images.githubusercontent.com/4606373/219133330-78f9dea1-269e-4ed6-b04b-26e3501f4f1a.png">
<img width="319" alt="Screen Shot 2023-02-15 at 1 32 45 PM" src="https://user-images.githubusercontent.com/4606373/219133556-7a766fcf-4bac-43ac-af2e-1fde7efa3ce1.png">