### PR TITLE
Swap tool fixes

### DIFF
--- a/packages/web/components/drawers/token-select-drawer.tsx
+++ b/packages/web/components/drawers/token-select-drawer.tsx
@@ -299,7 +299,11 @@ export const TokenSelectDrawer: FunctionComponent<{
 
                 const tokenAmount =
                   t.token instanceof CoinPretty
-                    ? t.token.hideDenom(true).trim(true).toString()
+                    ? t.token
+                        .hideDenom(true)
+                        .maxDecimals(8)
+                        .trim(true)
+                        .toString()
                     : undefined;
                 const tokenPrice =
                   t.token instanceof CoinPretty

--- a/packages/web/components/trade-clipboard/index.tsx
+++ b/packages/web/components/trade-clipboard/index.tsx
@@ -121,7 +121,7 @@ export const TradeClipboard: FunctionComponent<{
     const setShowEstimateDetails = useCallback(
       (value: boolean) => {
         // refresh current route's pools
-        if (value === true) {
+        if (value) {
           tradeTokenInConfig.optimizedRoutePaths.forEach((route) => {
             route.pools.forEach((pool) => {
               console.log("refresh pool", pool.id);

--- a/packages/web/components/trade-clipboard/index.tsx
+++ b/packages/web/components/trade-clipboard/index.tsx
@@ -1100,20 +1100,21 @@ export const TradeClipboard: FunctionComponent<{
                   </span>
                 </div>
               </div>
-              {tradeTokenInConfig.optimizedRoutePaths
-                .slice(0, 1)
-                .map((route, index) => (
-                  <TradeRoute
-                    key={index}
-                    sendCurrency={tradeTokenInConfig.sendCurrency}
-                    outCurrency={tradeTokenInConfig.outCurrency}
-                    route={route}
-                    isMultihopOsmoFeeDiscount={
-                      tradeTokenInConfig.expectedSwapResult
-                        .isMultihopOsmoFeeDiscount
-                    }
-                  />
-                ))}
+              {!isInModal &&
+                tradeTokenInConfig.optimizedRoutePaths
+                  .slice(0, 1)
+                  .map((route, index) => (
+                    <TradeRoute
+                      key={index}
+                      sendCurrency={tradeTokenInConfig.sendCurrency}
+                      outCurrency={tradeTokenInConfig.outCurrency}
+                      route={route}
+                      isMultihopOsmoFeeDiscount={
+                        tradeTokenInConfig.expectedSwapResult
+                          .isMultihopOsmoFeeDiscount
+                      }
+                    />
+                  ))}
             </div>
           </div>
         </div>

--- a/packages/web/components/trade-clipboard/index.tsx
+++ b/packages/web/components/trade-clipboard/index.tsx
@@ -209,7 +209,7 @@ export const TradeClipboard: FunctionComponent<{
       () =>
         tradeTokenInConfig.beforeSpotPriceWithoutSwapFeeOutOverIn
           .trim(true)
-          .maxDecimals(tradeTokenInConfig.outCurrency.coinDecimals),
+          .maxDecimals(8),
       [
         tradeTokenInConfig.beforeSpotPriceWithoutSwapFeeOutOverIn,
         tradeTokenInConfig.outCurrency,
@@ -672,7 +672,7 @@ export const TradeClipboard: FunctionComponent<{
                     .getBalanceFromCurrency(tradeTokenInConfig.sendCurrency)
                     .trim(true)
                     .hideDenom(true)
-                    .maxDecimals(tradeTokenInConfig.sendCurrency.coinDecimals)
+                    .maxDecimals(8)
                     .toString()}{" "}
                   {tradeTokenInConfig.sendCurrency.coinDenom.toLowerCase() ===
                   "unknown"

--- a/packages/web/components/trade-clipboard/index.tsx
+++ b/packages/web/components/trade-clipboard/index.tsx
@@ -114,9 +114,27 @@ export const TradeClipboard: FunctionComponent<{
     tradeTokenInConfig.setFeeConfig(feeConfig);
 
     // show details
-    const [showEstimateDetails, setShowEstimateDetails] = useState(false);
+    const [showEstimateDetails, _setShowEstimateDetails] = useState(false);
     const isEstimateDetailRelevant = !(
       tradeTokenInConfig.amount === "" || tradeTokenInConfig.amount === "0"
+    );
+    const setShowEstimateDetails = useCallback(
+      (value: boolean) => {
+        // refresh current route's pools
+        if (value === true) {
+          tradeTokenInConfig.optimizedRoutePaths.forEach((route) => {
+            route.pools.forEach((pool) => {
+              console.log("refresh pool", pool.id);
+              queries.osmosis?.queryGammPools
+                .getPool(pool.id)
+                ?.waitFreshResponse();
+            });
+          });
+        }
+
+        _setShowEstimateDetails(value);
+      },
+      [tradeTokenInConfig, queries.osmosis?.queryGammPools]
     );
     useEffect(() => {
       // auto collapse on input clear
@@ -146,7 +164,7 @@ export const TradeClipboard: FunctionComponent<{
         fetchedRemainingPoolsRef.current = true;
         queries.osmosis?.queryGammPools.fetchRemainingPools();
       }
-    }, []);
+    }, [queries.osmosis?.queryGammPools]);
     const [showFromTokenSelectDropdown, _setFromTokenSelectDropdownLocal] =
       useState(false);
     const setFromTokenSelectDropdownLocal = useCallback(

--- a/packages/web/components/trade-clipboard/index.tsx
+++ b/packages/web/components/trade-clipboard/index.tsx
@@ -314,7 +314,7 @@ export const TradeClipboard: FunctionComponent<{
         return account.init();
       }
       if (tradeTokenInConfig.optimizedRoutePaths.length > 0) {
-        const routes: {
+        const routePools: {
           poolId: string;
           tokenOutCurrency: Currency;
         }[] = [];
@@ -343,7 +343,7 @@ export const TradeClipboard: FunctionComponent<{
             return;
           }
 
-          routes.push({
+          routePools.push({
             poolId: pool.id,
             tokenOutCurrency,
           });
@@ -381,14 +381,14 @@ export const TradeClipboard: FunctionComponent<{
               tokenAmount: Number(tokenIn.amount),
               toToken: tradeTokenInConfig.outCurrency.coinDenom,
               isOnHome: !isInModal,
-              isMultiHop: routes.length !== 1,
+              isMultiHop: routePools.length !== 1,
             },
           ]);
-          if (routes.length === 1) {
+          if (routePools.length === 1) {
             await account.osmosis.sendSwapExactAmountInMsg(
-              routes[0].poolId,
+              routePools[0].poolId,
               tokenIn,
-              routes[0].tokenOutCurrency,
+              routePools[0].tokenOutCurrency,
               maxSlippage,
               "",
               {
@@ -418,7 +418,7 @@ export const TradeClipboard: FunctionComponent<{
             );
           } else {
             await account.osmosis.sendMultihopSwapExactAmountInMsg(
-              routes,
+              routePools,
               tokenIn,
               maxSlippage,
               "",

--- a/packages/web/modals/token-select.tsx
+++ b/packages/web/modals/token-select.tsx
@@ -1,14 +1,15 @@
-import Image from "next/image";
-import { observer } from "mobx-react-lite";
-import { FunctionComponent } from "react";
-import { CoinPretty } from "@keplr-wallet/unit";
 import { AppCurrency, IBCCurrency } from "@keplr-wallet/types";
-import { InputProps } from "../components/types";
-import { SearchBox } from "../components/input";
+import { CoinPretty } from "@keplr-wallet/unit";
+import classNames from "classnames";
+import { observer } from "mobx-react-lite";
+import Image from "next/image";
+import { FunctionComponent } from "react";
 import { t } from "react-multi-lang";
+
+import { SearchBox } from "../components/input";
+import { InputProps } from "../components/types";
 import { useStore } from "../stores";
 import { ModalBase, ModalBaseProps } from "./base";
-import classNames from "classnames";
 
 /** Intended for mobile use only - full screen alternative to token select dropdown.
  *
@@ -61,7 +62,7 @@ export const TokenSelectModal: FunctionComponent<
 
           const tokenAmount =
             t.token instanceof CoinPretty
-              ? t.token.hideDenom(true).trim(true).toString()
+              ? t.token.hideDenom(true).maxDecimals(8).trim(true).toString()
               : undefined;
           const tokenPrice =
             t.token instanceof CoinPretty


### PR DESCRIPTION
* Re-query pools in route when details are expanded (helps address #1274)
* Limit available balance to 8 decimals. Closes #1346 
* Only show swap route vis in home page, not in pool detail page


TODO
- [x] Max 8 decimals on token select