### PR TITLE
v15: Hotfix: Use shares instead of value

### DIFF
--- a/packages/stores/src/derived-data/pool/bonding.ts
+++ b/packages/stores/src/derived-data/pool/bonding.ts
@@ -74,13 +74,19 @@ export class ObservablePoolBonding {
    */
   readonly calculateBondLevel = computedFn(
     (bondDurations: BondDuration[]): 1 | 2 | undefined => {
+      const userAvailableShares =
+        this.queries.queryGammPoolShare.getAvailableGammShare(
+          this.bech32Address,
+          this.poolId
+        );
+
       if (
-        this.poolDetail.userAvailableValue.toDec().gt(new Dec(0)) &&
+        userAvailableShares.toDec().gt(new Dec(0)) &&
         bondDurations.some((duration) => duration.bondable)
       )
         return 2;
 
-      if (this.poolDetail?.userAvailableValue.toDec().isZero()) return 1;
+      if (userAvailableShares.toDec().isZero()) return 1;
     }
   );
 

--- a/packages/stores/src/derived-data/pool/bonding.ts
+++ b/packages/stores/src/derived-data/pool/bonding.ts
@@ -74,19 +74,13 @@ export class ObservablePoolBonding {
    */
   readonly calculateBondLevel = computedFn(
     (bondDurations: BondDuration[]): 1 | 2 | undefined => {
-      const userAvailableShares =
-        this.queries.queryGammPoolShare.getAvailableGammShare(
-          this.bech32Address,
-          this.poolId
-        );
-
       if (
-        userAvailableShares.toDec().gt(new Dec(0)) &&
+        this.poolDetail.userAvailableShares.toDec().gt(new Dec(0)) &&
         bondDurations.some((duration) => duration.bondable)
       )
         return 2;
 
-      if (userAvailableShares.toDec().isZero()) return 1;
+      if (this.poolDetail.userAvailableShares.toDec().isZero()) return 1;
     }
   );
 

--- a/packages/stores/src/derived-data/pool/details.ts
+++ b/packages/stores/src/derived-data/pool/details.ts
@@ -157,6 +157,14 @@ export class ObservablePoolDetail {
   }
 
   @computed
+  get userAvailableShares(): CoinPretty {
+    return this.queries.queryGammPoolShare.getAvailableGammShare(
+      this.bech32Address,
+      this.poolId
+    );
+  }
+
+  @computed
   get userPoolAssets() {
     const queryPool = this.pool;
     if (!queryPool) return [];


### PR DESCRIPTION
* Check amount of shares instead of $ value of shares, since prices may not be available in some environments