### PR TITLE
Update useDepositAddress to use fromPromise for caching Axelar calls

### DIFF
--- a/packages/web/config/price.ts
+++ b/packages/web/config/price.ts
@@ -1345,8 +1345,8 @@ export const PoolPriceRoutes: IntermediateRoute[] = [
     alternativeCoinId: "pool:fox",
     poolId: "949",
     spotPriceSourceDenom: DenomHelper.ibcDenom(
-        [{ portId: "transfer", channelId: "channel-169" }],
-        "cw20:juno1u8cr3hcjvfkzxcaacv9q75uw9hwjmn8pucc93pmy6yvkzz79kh3qncca8x"
+      [{ portId: "transfer", channelId: "channel-169" }],
+      "cw20:juno1u8cr3hcjvfkzxcaacv9q75uw9hwjmn8pucc93pmy6yvkzz79kh3qncca8x"
     ),
     spotPriceDestDenom: "uosmo",
     destCoinId: "pool:uosmo",

--- a/packages/web/integrations/axelar/axelar-deposit-address-ui-config.ts
+++ b/packages/web/integrations/axelar/axelar-deposit-address-ui-config.ts
@@ -1,0 +1,68 @@
+import { AxelarAssetTransfer, Environment } from "@axelar-network/axelarjs-sdk";
+import { action, makeObservable, observable } from "mobx";
+import { fromPromise, IPromiseBasedObservable } from "mobx-utils";
+
+/** Manages a cache of Axelar requests for deposit addresses */
+export class ObservableAxelarUIConfig {
+  private readonly className = "ObservableAxelarUIConfig";
+
+  private readonly _AxelarAssetTransfer: AxelarAssetTransfer;
+
+  @observable
+  private observablePromiseCache = new Map<
+    string,
+    IPromiseBasedObservable<string | undefined>
+  >();
+
+  constructor(environment = Environment.MAINNET) {
+    makeObservable(this);
+    this._AxelarAssetTransfer = new AxelarAssetTransfer({ environment });
+  }
+
+  getGeneratedAddress(
+    sourceChain: string,
+    destChain: string,
+    destinationAddress: string,
+    coinMinimalDenom: string,
+    shouldUnwrapIntoNative: boolean | undefined
+  ) {
+    const cacheKey = `${sourceChain}/${destChain}/${destinationAddress}/${coinMinimalDenom}/${Boolean(
+      shouldUnwrapIntoNative
+    )}`;
+    if (!this.observablePromiseCache.has(cacheKey)) {
+      const requestGeneratedAddress = async () => {
+        try {
+          return await this._AxelarAssetTransfer.getDepositAddress({
+            fromChain: sourceChain,
+            toChain: destChain,
+            destinationAddress: destinationAddress,
+            asset: coinMinimalDenom,
+            options: { shouldUnwrapIntoNative },
+          });
+        } catch (e: unknown) {
+          if (e instanceof Error) {
+            console.error(`${this.className}: ${e.message}`);
+          } else {
+            console.error(
+              `${this.className}: Unknown error in getGeneratedAddress`
+            );
+          }
+          throw e;
+        }
+      };
+
+      this.setCacheRecord(cacheKey, requestGeneratedAddress());
+    }
+    return this.observablePromiseCache.get(cacheKey);
+  }
+
+  // Move the set into an action to avoid having a lookup in the action
+  @action
+  private setCacheRecord(
+    cacheKey: string,
+    promiseToObserver: Promise<string | undefined>
+  ) {
+    const observablePromise = fromPromise(promiseToObserver);
+    this.observablePromiseCache.set(cacheKey, observablePromise);
+  }
+}

--- a/packages/web/integrations/axelar/hooks/use-axelar-config.ts
+++ b/packages/web/integrations/axelar/hooks/use-axelar-config.ts
@@ -1,0 +1,9 @@
+import { Environment } from "@axelar-network/axelarjs-sdk";
+import { useState } from "react";
+
+import { ObservableAxelarUIConfig } from "../axelar-deposit-address-ui-config";
+
+export function useAxelarConfig(environment = Environment.MAINNET) {
+  const [config] = useState(() => new ObservableAxelarUIConfig(environment));
+  return config;
+}

--- a/packages/web/integrations/axelar/hooks/use-deposit-address.ts
+++ b/packages/web/integrations/axelar/hooks/use-deposit-address.ts
@@ -14,7 +14,7 @@ function useCache<T>() {
 }
 
 /**
- * Generate deposit addresses reactively. Will hold onto the last generated address for each sourceChain/destChain/address/coinMinimalDenom combination until unmount.
+ * Generate deposit addresses reactively, saving each promise in an observable and caching the results.
  * @param sourceChain Source chain.
  * @param destChain Destination chain.
  * @param destinationAddress User's destination address to generate deposit address for (on counterparty).


### PR DESCRIPTION
Issue: https://github.com/osmosis-labs/osmosis-frontend/issues/1391

I considered a couple possible solutions to this. First, I followed the suggestion from the issue of making a new observable class instance that was saved in a `useState`. This approach worked for the most part, however, there were issues with computedFn not correctly memoizing based on the input args. Based on other warnings in my console, this issue appears to be happening elsewhere, though I did not have time to verify.  While the class instance could be made to work it didn't, in opinion, return better ergonomics or expanded functionality so long as it wasn't in the root store. While I could have put it in the root store there didn't seem to be a benefit of doing so since it is currently only used in one place in the app. In fact, adding it to the store would add extra complexity regarding data lifespan, as noted in the issue above. In the end, I opted for a simpler solution that simplifies the existing hook, removes dead code, and lets mobx handle the async state by wrapping each deposit address request promise in an observable and caching each observable. 