### PR TITLE
feat: Remove Zero Fee for Swaps

### DIFF
--- a/packages/web/components/trade-clipboard/index.tsx
+++ b/packages/web/components/trade-clipboard/index.tsx
@@ -81,19 +81,7 @@ export const TradeClipboard: FunctionComponent<{
       queriesStore,
       pools
     );
-    // Some validators allow 0 fee tx.
-    // Therefore, users can send tx at 0 fee even though they have no OSMO,
-    // Users who have OSMO pay a fee by default so that tx is processed faster.
-    let preferZeroFee = true;
-    const queryOsmo = queries.queryBalances.getQueryBech32Address(
-      account.bech32Address
-    ).stakable;
-    if (
-      // If user has an OSMO 0.001 or higher, he pay the fee by default.
-      queryOsmo.balance.toDec().gt(DecUtils.getTenExponentN(-3))
-    ) {
-      preferZeroFee = false;
-    }
+
     const gasForecasted = (() => {
       if (
         tradeTokenInConfig.optimizedRoutePaths.length === 0 ||
@@ -108,8 +96,7 @@ export const TradeClipboard: FunctionComponent<{
     const feeConfig = useFakeFeeConfig(
       chainStore,
       chainStore.osmosis.chainId,
-      gasForecasted,
-      preferZeroFee
+      gasForecasted
     );
     tradeTokenInConfig.setFeeConfig(feeConfig);
 
@@ -413,9 +400,7 @@ export const TradeClipboard: FunctionComponent<{
                   },
                 ],
               },
-              {
-                preferNoSetFee: preferZeroFee,
-              },
+              undefined,
               () => {
                 logEvent([
                   EventName.Swap.swapCompleted,
@@ -444,9 +429,7 @@ export const TradeClipboard: FunctionComponent<{
                   },
                 ],
               },
-              {
-                preferNoSetFee: preferZeroFee,
-              },
+              undefined,
               () => {
                 logEvent([
                   EventName.Swap.swapCompleted,

--- a/packages/web/hooks/ui-config/use-fake-fee-config.ts
+++ b/packages/web/hooks/ui-config/use-fake-fee-config.ts
@@ -1,6 +1,6 @@
-import { useState } from "react";
 import { ChainGetter } from "@keplr-wallet/stores";
 import { FakeFeeConfig } from "@osmosis-labs/stores";
+import { useState } from "react";
 
 /** Maintains a single instance of `FakeFeeConfig` for React view lifecycle.
  *  Updates `chainId` and `feeType` on render.


### PR DESCRIPTION
## Description

Previously, zero fee swaps were possible whenever the user had less than `0.001 osmo` on their wallet.  This pull request makes fees always required for swaps. 