### PR TITLE
(Draft) Support swap exact amount out progress

### DIFF
--- a/packages/web/config/user-analytics-v2.ts
+++ b/packages/web/config/user-analytics-v2.ts
@@ -62,6 +62,7 @@ export const EventName = {
     maxClicked: "Swap: Max clicked",
     halfClicked: "Swap: Half clicked",
     inputEntered: "Swap: Input entered",
+    toInputEntered: "Swap: To input entered",
     slippageToleranceSet: "Swap: Slippage tolerance set",
     switchClicked: "Swap: Switch clicked",
     swapStarted: "Swap: Swap started",


### PR DESCRIPTION
This PR contains progress on https://github.com/osmosis-labs/osmosis-frontend/issues/657

I spent a lot of time trying to find documentation on the `@keplr-wallet` code without much luck. In the end, I read the code directly. This took quite a bit of time in addition to reading the files associated with this change. Having so many inline callbacks and objects in addition to being an antipattern also makes the code difficult to read. Moreover, there are parts of the code here that are good candidates for more modularization - the trade-clipboard component is much too long. I started to attempt some of this for this change but reverted those changes as it seemed pulling on that thread was going to be more work than it would be worth. 

In this change, I'm attempting to reuse the `useTradeTokenInConfig` to make another instance of the `ObservableTradeTokenInConfig` to map updates to the to field into the from field. This sort of works but doesn't preserve the exact input the user types in the `to` field (because typing in `to` triggers an update to `from`). So that obviously isn't the right user experience. Perhaps there is some existing code that helps with this but I didn't find it. As is, the code is not production ready and is in an interim state but I'm time bounding it. 