### PR TITLE
Update nUSDC symbol

### DIFF
--- a/packages/web/config/chain-infos.ts
+++ b/packages/web/config/chain-infos.ts
@@ -2973,11 +2973,11 @@ const chainInfos = (
           isStakeCurrency: true,
         },
         {
-          coinDenom: "USDC",
+          coinDenom: "nUSDC",
           coinMinimalDenom: "uusdc",
           coinDecimals: 6,
           coinImageUrl: "/tokens/usdc.svg",
-          coinGeckoId: "pool:nusdc",
+          coinGeckoId: "usd-coin",
           isFeeCurrency: true,
           gasPriceStep: {
             low: 0.01,


### PR DESCRIPTION
to correct USDC.axl fromdisplaying Noble as the source chain. It must do a search for the symbol (assuming each symbol is unique)

Before:
<img width="145" alt="image" src="https://user-images.githubusercontent.com/95667791/229936594-0f566c16-b30b-485a-ab99-b47d616e3219.png">

After:
<img width="158" alt="image" src="https://user-images.githubusercontent.com/95667791/229936548-6d4903ae-c112-4d21-8282-daa390010fde.png">
