### PR TITLE
fix: connecting wallet redirect in trade tool on pool detail page

### DIFF
--- a/packages/web/components/trade-clipboard/index.tsx
+++ b/packages/web/components/trade-clipboard/index.tsx
@@ -45,8 +45,15 @@ export const TradeClipboard: FunctionComponent<{
   containerClassName?: string;
   isInModal?: boolean;
   onRequestModalClose?: () => void;
+  swapButton?: React.ReactElement;
 }> = observer(
-  ({ containerClassName, pools, isInModal, onRequestModalClose }) => {
+  ({
+    containerClassName,
+    pools,
+    isInModal,
+    onRequestModalClose,
+    swapButton,
+  }) => {
     const {
       chainStore,
       accountStore,
@@ -1097,41 +1104,43 @@ export const TradeClipboard: FunctionComponent<{
             </div>
           </div>
         </div>
-        <Button
-          mode={
-            showPriceImpactWarning &&
-            account.walletStatus === WalletStatus.Loaded
-              ? "primary-warning"
-              : "primary"
-          }
-          disabled={
-            account.walletStatus === WalletStatus.Loaded &&
-            (tradeTokenInConfig.error !== undefined ||
-              tradeTokenInConfig.optimizedRoutePaths.length === 0 ||
-              account.txTypeInProgress !== "")
-          }
-          onClick={swap}
-        >
-          {account.walletStatus === WalletStatus.Loaded ? (
-            tradeTokenInConfig.error ? (
-              t(...tError(tradeTokenInConfig.error))
-            ) : showPriceImpactWarning ? (
-              t("swap.buttonError")
+        {swapButton ?? (
+          <Button
+            mode={
+              showPriceImpactWarning &&
+              account.walletStatus === WalletStatus.Loaded
+                ? "primary-warning"
+                : "primary"
+            }
+            disabled={
+              account.walletStatus === WalletStatus.Loaded &&
+              (tradeTokenInConfig.error !== undefined ||
+                tradeTokenInConfig.optimizedRoutePaths.length === 0 ||
+                account.txTypeInProgress !== "")
+            }
+            onClick={swap}
+          >
+            {account.walletStatus === WalletStatus.Loaded ? (
+              tradeTokenInConfig.error ? (
+                t(...tError(tradeTokenInConfig.error))
+              ) : showPriceImpactWarning ? (
+                t("swap.buttonError")
+              ) : (
+                t("swap.button")
+              )
             ) : (
-              t("swap.button")
-            )
-          ) : (
-            <h6 className="flex items-center gap-3">
-              <Image
-                alt="wallet"
-                src="/icons/wallet.svg"
-                height={24}
-                width={24}
-              />
-              {t("connectWallet")}
-            </h6>
-          )}
-        </Button>
+              <h6 className="flex items-center gap-3">
+                <Image
+                  alt="wallet"
+                  src="/icons/wallet.svg"
+                  height={24}
+                  width={24}
+                />
+                {t("connectWallet")}
+              </h6>
+            )}
+          </Button>
+        )}
       </div>
     );
   }

--- a/packages/web/modals/trade-tokens.tsx
+++ b/packages/web/modals/trade-tokens.tsx
@@ -1,19 +1,31 @@
-import { FunctionComponent } from "react";
-import { ModalBase, ModalBaseProps } from "./base";
-import { TradeClipboard } from "../components/trade-clipboard";
 import { Pool } from "@osmosis-labs/pools";
+import { FunctionComponent } from "react";
+
+import { useConnectWalletModalRedirect } from "~/hooks";
+
+import { TradeClipboard } from "../components/trade-clipboard";
+import { ModalBase, ModalBaseProps } from "./base";
 
 interface Props extends ModalBaseProps {
   pools: Pool[];
 }
 
 export const TradeTokens: FunctionComponent<Props> = (props) => {
+  const { showModalBase, accountActionButton, walletConnected } =
+    useConnectWalletModalRedirect({}, props.onRequestClose);
+
   return (
-    <ModalBase {...props} hideCloseButton className="!w-fit !p-0">
+    <ModalBase
+      {...props}
+      isOpen={showModalBase && props.isOpen}
+      hideCloseButton
+      className="!w-fit !p-0"
+    >
       <TradeClipboard
         pools={props.pools}
         isInModal
         onRequestModalClose={props.onRequestClose}
+        swapButton={!walletConnected ? accountActionButton : undefined}
       />
     </ModalBase>
   );


### PR DESCRIPTION
When opening the trade tokens modal on any pool detail page without wallet connected, the modal now properly redirects to connect wallet modal. Previously, the connect wallets modal appeared behind the swap tool, and was not accessible.