### PR TITLE
add translation badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,5 @@ Release tags are for the published [npm packages](https://www.npmjs.com/org/osmo
 Have a change you want to make with our translations? We have a frontend for updating localizations in our app easily, all you need is a GitHub account. Coming soon: creating new language profiles from this frontend.
 
 https://inlang.com/editor/github.com/osmosis-labs/osmosis-frontend
+
+[![translation badge](https://inlang.com/badge?url=github.com/osmosis-labs/osmosis-frontend)](https://inlang.com/editor/github.com/osmosis-labs/osmosis-frontend?ref=badge)


### PR DESCRIPTION
Hey there, we want to get you more contributors to your repository!
Therefore, I added a badge which lets users contribute to your translations.

The badge endpoint allows you to create a dynamic badge that display real-time data on your project. For instance, you can use it to showcase your project's localization progress or the number of errors/warnings on your Github repository. This means that whenever someone views the badge, they will see the most up-to-date information about your project.

We would be really happy if you decide to place this into your README to let people contribute to your translations 🥰

– Thank you,
Felix