### PR TITLE
Hotfix: swap tool / tx differences

### DIFF
--- a/packages/stores/src/account/index.ts
+++ b/packages/stores/src/account/index.ts
@@ -613,7 +613,6 @@ export class OsmosisAccountImpl {
       "swapExactAmountIn",
       async () => {
         // refresh data and get pools
-        await queries.queryIncentivizedPools.waitFreshResponse();
         const pools: Pool[] = [];
         for (const route of routes) {
           const queryPool = queries.queryGammPools.getPool(route.poolId);
@@ -624,14 +623,7 @@ export class OsmosisAccountImpl {
             );
           }
 
-          await queryPool.waitFreshResponse();
-
-          const pool = queryPool.pool;
-          if (!pool) {
-            throw new Error("Unknown pool");
-          }
-
-          pools.push(pool);
+          pools.push(queryPool.pool);
         }
 
         // make message with estimated min out amounts
@@ -794,11 +786,7 @@ export class OsmosisAccountImpl {
         if (!queryPool) {
           throw new Error(`Pool #${poolId} not found`);
         }
-        await queryPool.waitFreshResponse();
         const pool = queryPool.pool;
-        if (!pool) {
-          throw new Error("Unknown pool");
-        }
 
         // reconcile weighted and stable pool asset data
         const inPoolAsset = queryPool.getPoolAsset(
@@ -926,8 +914,6 @@ export class OsmosisAccountImpl {
         if (!queryPool) {
           throw new Error(`Pool #${poolId} not found`);
         }
-
-        await queryPool.waitFreshResponse();
 
         const pool = queryPool.pool;
         if (!pool) {

--- a/packages/web/components/trade-clipboard/index.tsx
+++ b/packages/web/components/trade-clipboard/index.tsx
@@ -196,7 +196,10 @@ export const TradeClipboard: FunctionComponent<{
         new Dec(1).sub(slippageConfig.slippage.toDec())
       );
       return coinLessSlippage.maxDecimals(
-        coinLessSlippage.toDec().gt(new Dec(1)) ? 8 : 12
+        Math.min(
+          coinLessSlippage.toDec().gt(new Dec(1)) ? 8 : 12,
+          coinLessSlippage.currency.coinDecimals
+        )
       );
     }, [tradeTokenInConfig.expectedSwapResult.amount, slippageConfig.slippage]);
     const spotPrice = useMemo(


### PR DESCRIPTION
* When the user clicks "swap" all the pools involved are refreshed, and we re-calculate the swap with updated pool values. However, this can be misleading as, especially with multihop swaps, large pool activity could occur between inputting into the swap tool and clicking swap. Some users have clicked swap, and signed transactions that were, in some more rare cases, quite a bit less favorable. Instead of refreshing, we should maintain the values the users see and let the tx fail on chain instead.