### PR TITLE
Change osmo-test-4 to osmo-test-5

### DIFF
--- a/packages/web/config/chain-infos.ts
+++ b/packages/web/config/chain-infos.ts
@@ -26,7 +26,7 @@ const chainInfos = (
           : "https://lcd-osmosis.keplr.app/"),
       chainId:
         OSMOSIS_CHAIN_ID_OVERWRITE ??
-        (IS_TESTNET ? "osmo-test-4" : "osmosis-1"),
+        (IS_TESTNET ? "osmo-test-5" : "osmosis-1"),
       chainName: OSMOSIS_CHAIN_NAME_OVERWRITE ?? "Osmosis",
       bip44: {
         coinType: 118,

--- a/packages/web/stores/root.ts
+++ b/packages/web/stores/root.ts
@@ -86,7 +86,7 @@ export class RootStore {
     this.chainStore = new ChainStore(
       ChainInfos,
       process.env.NEXT_PUBLIC_OSMOSIS_CHAIN_ID_OVERWRITE ??
-        (IS_TESTNET ? "osmo-test-4" : "osmosis")
+        (IS_TESTNET ? "osmo-test-5" : "osmosis")
     );
 
     const eventListener = (() => {


### PR DESCRIPTION
This pull request updates the Osmosis frontend from osmo-test-4 to osmo-test-5. The following changes were made:

Replaced references to osmo-test-4 with osmo-test-5 in the codebase.

These changes were necessary to ensure compatibility with the latest version of the Osmosis protocol. We are testing this changes on a new environment on vercel that will show up on this PR. 