### PR TITLE
Hotfix: axelar native wrap deposit address

### DIFF
--- a/packages/web/integrations/axelar/transfer.tsx
+++ b/packages/web/integrations/axelar/transfer.tsx
@@ -314,7 +314,7 @@ const AxelarTransfer: FunctionComponent<
       originCurrency.coinMinimalDenom,
       false,
       axelarApiEnv,
-      shouldGenAddress
+      !useNativeToken && shouldGenAddress
     );
     const baseDenom = isWithdraw
       ? originCurrency.coinMinimalDenom // withdraw uses wrapped denom

--- a/packages/web/integrations/axelar/transfer.tsx
+++ b/packages/web/integrations/axelar/transfer.tsx
@@ -296,21 +296,52 @@ const AxelarTransfer: FunctionComponent<
       (AxelarChainIds_SourceChainMap[selectedSourceChainAxelarKey] ??
         selectedSourceChainAxelarKey);
 
-    const { depositAddress, isLoading: isDepositAddressLoading } =
-      useDepositAddress(
-        sourceChain,
-        destChain,
-        isWithdraw || correctChainSelected ? accountAddress : undefined,
-        !isWithdraw && useNativeToken
-          ? sourceChainConfig!.nativeWrapEquivalent!.tokenMinDenom
-          : originCurrency.coinMinimalDenom, // evm -> osmosis uses the native denom if native (autowrap) selected
-        isWithdraw ? useNativeToken : undefined,
-        isTestNet ? Environment.TESTNET : Environment.MAINNET,
-        isWithdraw ? balanceOnOsmosis.balance.toDec().gt(new Dec(0)) : true
-      );
+    // get deposit address
+    const destinationAddress =
+      isWithdraw || correctChainSelected ? accountAddress : undefined;
+    const axelarApiEnv = isTestNet ? Environment.TESTNET : Environment.MAINNET;
+    const shouldGenAddress = isWithdraw
+      ? balanceOnOsmosis.balance.toDec().gt(new Dec(0)) // if there's nothing to withdraw from, don't generate an address
+      : true;
+    // normal case, address with wrapped source token (WETH)
+    const {
+      depositAddress: wrapDepositAddress,
+      isLoading: isWrapDepositAddressLoading,
+    } = useDepositAddress(
+      sourceChain,
+      destChain,
+      destinationAddress,
+      originCurrency.coinMinimalDenom,
+      false,
+      axelarApiEnv,
+      shouldGenAddress
+    );
+    const baseDenom = isWithdraw
+      ? originCurrency.coinMinimalDenom // withdraw uses wrapped denom
+      : sourceChainConfig?.nativeWrapEquivalent?.tokenMinDenom ?? // deposit uses native/gas token denom
+        originCurrency.coinMinimalDenom;
+    // address that auto un/wraps our wrapped representation (ETH)
+    const {
+      depositAddress: autowrapDepositAddress,
+      isLoading: isAutowrapAddressLoading,
+    } = useDepositAddress(
+      sourceChain,
+      destChain,
+      destinationAddress,
+      baseDenom,
+      true,
+      axelarApiEnv,
+      useNativeToken && shouldGenAddress // should generate
+    );
+    const isDepositAddressLoading = useNativeToken
+      ? isAutowrapAddressLoading
+      : isWrapDepositAddressLoading;
+    const depositAddress = useNativeToken
+      ? autowrapDepositAddress
+      : wrapDepositAddress;
 
     // notify user they are withdrawing into a different account then they last deposited to
-    const [lastDepositAccountAddress, setLastDepositAccountAddress] =
+    const [lastDepositAccountEvmAddress, setLastDepositAccountEvmAddress] =
       useLocalStorageState<string | null>(
         isWithdraw
           ? ""
@@ -320,14 +351,14 @@ const AxelarTransfer: FunctionComponent<
     const warnOfDifferentDepositAddress =
       isWithdraw &&
       ethWalletClient.isConnected &&
-      lastDepositAccountAddress &&
+      lastDepositAccountEvmAddress &&
       ethWalletClient.accountAddress
-        ? ethWalletClient.accountAddress !== lastDepositAccountAddress
+        ? ethWalletClient.accountAddress !== lastDepositAccountEvmAddress
         : false;
 
     // start transfer
     const [transferInitiated, setTransferInitiated] = useState(false);
-    const doAxelarTransfer = useCallback(async () => {
+    const doAxelarTransfer = async () => {
       if (depositAddress) {
         logEvent([
           isWithdraw
@@ -383,7 +414,7 @@ const AxelarTransfer: FunctionComponent<
                 depositAddress
               );
               trackTransferStatus(txHash as string);
-              setLastDepositAccountAddress(ethWalletClient.accountAddress!);
+              setLastDepositAccountEvmAddress(ethWalletClient.accountAddress!);
               logEvent([
                 EventName.Assets.depositAssetCompleted,
                 {
@@ -419,7 +450,7 @@ const AxelarTransfer: FunctionComponent<
                 depositAddress
               );
               trackTransferStatus(txHash as string);
-              setLastDepositAccountAddress(ethWalletClient.accountAddress!);
+              setLastDepositAccountEvmAddress(ethWalletClient.accountAddress!);
               logEvent([
                 EventName.Assets.depositAssetCompleted,
                 {
@@ -457,26 +488,8 @@ const AxelarTransfer: FunctionComponent<
         }
         setTransferInitiated(true);
       }
-    }, [
-      axelarChainId,
-      chainId,
-      balanceOnOsmosis.sourceChannelId,
-      balanceOnOsmosis.destChannelId,
-      depositAddress,
-      erc20ContractAddress,
-      ethWalletClient,
-      isWithdraw,
-      useNativeToken,
-      originCurrency,
-      osmosisAccount,
-      trackTransferStatus,
-      withdrawAmountConfig,
-      inputAmount,
-      inputAmountRaw,
-      logEvent,
-      setLastDepositAccountAddress,
-      setDepositAmount,
-    ]);
+    };
+
     // close modal when initial eth transaction is committed
     const isSendTxPending = isWithdraw
       ? osmosisAccount.txTypeInProgress !== ""
@@ -582,7 +595,6 @@ const AxelarTransfer: FunctionComponent<
                   nativeDenom:
                     balanceOnOsmosis.balance.currency.originCurrency.coinDenom,
                   wrapDenom: sourceChainConfig.nativeWrapEquivalent.wrapDenom,
-                  disabled: isDepositAddressLoading,
                 }
               : undefined
           }


### PR DESCRIPTION
We had one more user report getting the wrong address. I'm using a different approach to get around the race condition in the Promise.then callback. I think if a user switched between un/wrapped at the right moment, that .then callback would contain the wrong data, and the wrong address would get set in state.

In this case, we use another `useDepositAddress` hook to manage the generation of the autowrap address with completely different state. Since it's separate state entirely, it should be more reliable.

Also, since it's separate state I re-enabled the toggle at the top for slightly better UX. They can't click transfer until the relevant deposit address is loaded.

### Testing
@arispech please repeat the same tests for last weeks hotfix for transfers

For both deposit and withdraw:
* Test transferring wrapped version (WETH), then the native (ETH)
* Test an asset that only offers wrapped/ERC20 (USDC)