### PR TITLE
Update Kado ramp modal settings

### DIFF
--- a/packages/web/integrations/kado/index.tsx
+++ b/packages/web/integrations/kado/index.tsx
@@ -1,4 +1,5 @@
 import { WalletStatus } from "@keplr-wallet/stores";
+import { observer } from "mobx-react-lite";
 import { FunctionComponent } from "react";
 
 import { ModalBaseProps } from "../../modals";
@@ -7,7 +8,7 @@ import { useStore } from "../../stores";
 /** Assumed wallet connected */
 export const Kado: FunctionComponent<
   { assetKey: string } & Pick<ModalBaseProps, "isOpen" | "onRequestClose">
-> = ({ assetKey }) => {
+> = observer(({ assetKey }) => {
   const { chainStore, accountStore } = useStore();
 
   const account = accountStore.getAccount(chainStore.osmosis.chainId);
@@ -21,4 +22,4 @@ export const Kado: FunctionComponent<
       height="700"
     />
   );
-};
+});

--- a/packages/web/integrations/layerswap/index.tsx
+++ b/packages/web/integrations/layerswap/index.tsx
@@ -1,12 +1,14 @@
-import { FunctionComponent } from "react";
 import { WalletStatus } from "@keplr-wallet/stores";
-import { useStore } from "../../stores";
+import { observer } from "mobx-react-lite";
+import { FunctionComponent } from "react";
+
 import { ModalBaseProps } from "../../modals";
+import { useStore } from "../../stores";
 
 /** Assumed wallet connected */
 export const Layerswap: FunctionComponent<
-  {} & Pick<ModalBaseProps, "isOpen" | "onRequestClose">
-> = ({}) => {
+  Pick<ModalBaseProps, "isOpen" | "onRequestClose">
+> = observer(() => {
   const { chainStore, accountStore } = useStore();
 
   const account = accountStore.getAccount(chainStore.osmosis.chainId);
@@ -20,4 +22,4 @@ export const Layerswap: FunctionComponent<
       height="700"
     />
   );
-};
+});


### PR DESCRIPTION
Kado recently added OSMO as a buy option. Was prev just USDC.

* OSMO is pre-selected, with option to select USDC
* If you change your account in your wallet extension, the ramp iframes will be refreshed to use the new account address