### PR TITLE
(CL) simplify: remove exponentAtPriceOne param, rounding changes

### DIFF
--- a/packages/math/src/big-dec.ts
+++ b/packages/math/src/big-dec.ts
@@ -224,6 +224,13 @@ export class BigDec {
     );
   }
 
+  public mulRoundUp(d2: BigDec): BigDec {
+    return new BigDec(
+      this.mulRaw(d2).chopPrecisionAndRoundUp(),
+      BigDec.precision
+    );
+  }
+
   public mulTruncate(d2: BigDec): BigDec {
     return new BigDec(
       this.mulRaw(d2).chopPrecisionAndTruncate(),

--- a/packages/math/src/pool/__tests__/stable.spec.ts
+++ b/packages/math/src/pool/__tests__/stable.spec.ts
@@ -1,10 +1,10 @@
 import { Coin, Dec, DecUtils, Int } from "@keplr-wallet/unit";
 
 import { BigDec } from "../../big-dec";
+import { compareDec_checkMultErrorTolerance } from "../../rounding";
 import {
   calcWSumSquares,
   cfmmConstantMultiNoV,
-  compareDec_checkMultErrorTolerance,
   solveCfmm,
   StableSwapMath,
   StableSwapToken,

--- a/packages/math/src/pool/__tests__/stable.spec.ts
+++ b/packages/math/src/pool/__tests__/stable.spec.ts
@@ -1,7 +1,7 @@
 import { Coin, Dec, DecUtils, Int } from "@keplr-wallet/unit";
 
 import { BigDec } from "../../big-dec";
-import { compareDec_checkMultErrorTolerance } from "../../rounding";
+import { checkMultiplicativeErrorTolerance } from "../../rounding";
 import {
   calcWSumSquares,
   cfmmConstantMultiNoV,
@@ -227,7 +227,7 @@ describe("Test stableswap math", () => {
       const tolerance = new Dec(1).quo(
         DecUtils.getTenExponentNInPrecisionRange(3)
       );
-      const comparison = compareDec_checkMultErrorTolerance(
+      const comparison = checkMultiplicativeErrorTolerance(
         expectedSpotPrice,
         actualSpotPrice,
         tolerance,
@@ -270,7 +270,7 @@ describe("Test stableswap math", () => {
       const tolerance = new Dec(1).quo(
         DecUtils.getTenExponentNInPrecisionRange(3)
       );
-      const comparison = compareDec_checkMultErrorTolerance(
+      const comparison = checkMultiplicativeErrorTolerance(
         expectedSpotPrice,
         actualSpotPrice,
         tolerance,

--- a/packages/math/src/pool/concentrated/__tests__/math.spec.ts
+++ b/packages/math/src/pool/concentrated/__tests__/math.spec.ts
@@ -1,6 +1,6 @@
 import { Dec } from "@keplr-wallet/unit";
 
-import { compareDec_checkMultErrorTolerance } from "../../../rounding";
+import { checkMultiplicativeErrorTolerance } from "../../../rounding";
 import { smallestDec } from "../const";
 import {
   approxRoot,
@@ -39,7 +39,7 @@ describe("calcAmount0Delta: matches chain code tests", () => {
       "6098022989717817431593106314408.888128101590393209"
     ).truncateDec();
 
-    const tolerance = compareDec_checkMultErrorTolerance(
+    const tolerance = checkMultiplicativeErrorTolerance(
       expected,
       res,
       smallestDec,
@@ -62,7 +62,7 @@ describe("calcAmount0Delta: matches chain code tests", () => {
       "6098022989717817431593106314408.888128101590393209"
     ).roundUpDec();
 
-    const tolerance = compareDec_checkMultErrorTolerance(
+    const tolerance = checkMultiplicativeErrorTolerance(
       expected,
       res,
       smallestDec,
@@ -95,7 +95,6 @@ describe("calcAmount1Delta: matches chain code test", () => {
 
     const res = calcAmount1Delta(liquidity, sqrtPriceA, sqrtPriceB, roundUp);
 
-    // with tolerance
     const expected = new Dec(
       "28742157707995443393876876754535992.801567623738751734"
     );
@@ -111,7 +110,6 @@ describe("calcAmount1Delta: matches chain code test", () => {
 
     const res = calcAmount1Delta(liquidity, sqrtPriceA, sqrtPriceB, roundUp);
 
-    // with tolerance
     const expected = new Dec(
       "28742157707995443393876876754535992.801567623738751734"
     ).roundUpDec();

--- a/packages/math/src/pool/concentrated/__tests__/math.spec.ts
+++ b/packages/math/src/pool/concentrated/__tests__/math.spec.ts
@@ -1,5 +1,6 @@
 import { Dec } from "@keplr-wallet/unit";
 
+import { compareDec_checkMultErrorTolerance } from "../../../rounding";
 import { smallestDec } from "../const";
 import {
   approxRoot,
@@ -12,29 +13,110 @@ import {
   getNextSqrtPriceFromAmount1OutRoundingDown,
 } from "../math";
 
-describe("calcAmount0Delta", () => {
-  // https://github.com/osmosis-labs/osmosis/blob/fffe3a2ad32a8c51d654212e70dfa1e8eff5f323/x/concentrated-liquidity/internal/math/math_test.go#L156
-  it("matches chain code test", () => {
+describe("calcAmount0Delta: matches chain code tests", () => {
+  // https://github.com/osmosis-labs/osmosis/blob/0f9eb3c1259078035445b3e3269659469b95fd9f/x/concentrated-liquidity/math/math_test.go#L160
+  it("normal case", () => {
     const sqrtPriceA = new Dec("70.710678118654752440");
     const sqrtPriceB = new Dec("74.161984870956629487");
     const liquidity = new Dec("1517882343.751510418088349649");
+    const roundUp = false;
 
-    const res = calcAmount0Delta(liquidity, sqrtPriceA, sqrtPriceB, false);
+    const res = calcAmount0Delta(liquidity, sqrtPriceA, sqrtPriceB, roundUp);
 
-    expect(res.toString()).toBe("998976.618347426388356620");
+    expect(res.toString()).toBe("998976.618347426388356619");
+  });
+  // https://github.com/osmosis-labs/osmosis/blob/0f9eb3c1259078035445b3e3269659469b95fd9f/x/concentrated-liquidity/math/math_test.go#L169
+  it("round down: large liquidity amount in wide price range", () => {
+    const sqrtPriceA = new Dec("0.000000152731791058");
+    const sqrtPriceB = new Dec("30860351331.852813530648276680");
+    const liquidity = new Dec("931361973132462178951297");
+    const roundUp = false;
+
+    const res = calcAmount0Delta(liquidity, sqrtPriceA, sqrtPriceB, roundUp);
+
+    // with tolerance
+    const expected = new Dec(
+      "6098022989717817431593106314408.888128101590393209"
+    ).truncateDec();
+
+    const tolerance = compareDec_checkMultErrorTolerance(
+      expected,
+      res,
+      smallestDec,
+      "roundDown"
+    );
+
+    expect(tolerance).toBe(0);
+  });
+  // https://github.com/osmosis-labs/osmosis/blob/0f9eb3c1259078035445b3e3269659469b95fd9f/x/concentrated-liquidity/math/math_test.go#L189
+  it("round up: large liquidity amount in wide price range", () => {
+    const sqrtPriceA = new Dec("0.000000152731791058");
+    const sqrtPriceB = new Dec("30860351331.852813530648276680");
+    const liquidity = new Dec("931361973132462178951297");
+    const roundUp = true;
+
+    const res = calcAmount0Delta(liquidity, sqrtPriceA, sqrtPriceB, roundUp);
+
+    // with tolerance
+    const expected = new Dec(
+      "6098022989717817431593106314408.888128101590393209"
+    ).roundUpDec();
+
+    const tolerance = compareDec_checkMultErrorTolerance(
+      expected,
+      res,
+      smallestDec,
+      "roundUp"
+    );
+
+    expect(tolerance).toBe(0);
   });
 });
 
-describe("calcAmount1Delta", () => {
-  // https://github.com/osmosis-labs/osmosis/blob/fffe3a2ad32a8c51d654212e70dfa1e8eff5f323/x/concentrated-liquidity/internal/math/math_test.go#L186
-  it("matches chain code test", () => {
+describe("calcAmount1Delta: matches chain code test", () => {
+  // https://github.com/osmosis-labs/osmosis/blob/0f9eb3c1259078035445b3e3269659469b95fd9f/x/concentrated-liquidity/math/math_test.go#L252
+  it("normal case", () => {
     const sqrtPriceA = new Dec("70.710678118654752440");
     const sqrtPriceB = new Dec("67.416615162732695594");
     const liquidity = new Dec("1517882343.751510418088349649");
 
     const res = calcAmount1Delta(liquidity, sqrtPriceA, sqrtPriceB, false);
 
-    expect(res.toString()).toBe("5000000000.000000000000000000");
+    expect(res.toString()).toBe(
+      new Dec("5000000000.000000000000000000").sub(smallestDec).toString()
+    );
+  });
+  // https://github.com/osmosis-labs/osmosis/blob/0f9eb3c1259078035445b3e3269659469b95fd9f/x/concentrated-liquidity/math/math_test.go#L260
+  it("round down: large liquidity amount in wide price range", () => {
+    const sqrtPriceA = new Dec("0.000000152731791058");
+    const sqrtPriceB = new Dec("30860351331.852813530648276680");
+    const liquidity = new Dec("931361973132462178951297");
+    const roundUp = false;
+
+    const res = calcAmount1Delta(liquidity, sqrtPriceA, sqrtPriceB, roundUp);
+
+    // with tolerance
+    const expected = new Dec(
+      "28742157707995443393876876754535992.801567623738751734"
+    );
+
+    expect(res.toString()).toBe(expected.toString());
+  });
+  // https://github.com/osmosis-labs/osmosis/blob/77c0aa5a5572dc09d6d43ddf75f3bf47683f53d7/x/concentrated-liquidity/math/math_test.go#L278
+  it("round up: large liquidity amount in wide price range", () => {
+    const sqrtPriceA = new Dec("0.000000152731791058");
+    const sqrtPriceB = new Dec("30860351331.852813530648276680");
+    const liquidity = new Dec("931361973132462178951297");
+    const roundUp = true;
+
+    const res = calcAmount1Delta(liquidity, sqrtPriceA, sqrtPriceB, roundUp);
+
+    // with tolerance
+    const expected = new Dec(
+      "28742157707995443393876876754535992.801567623738751734"
+    ).roundUpDec();
+
+    expect(res.toString()).toBe(expected.toString());
   });
 });
 

--- a/packages/math/src/pool/concentrated/__tests__/quotes.spec.ts
+++ b/packages/math/src/pool/concentrated/__tests__/quotes.spec.ts
@@ -28,7 +28,6 @@ describe("calcOutGivenIn matches chain code", () => {
         },
       ];
       const curSqrtPrice = new Dec("70.710678118654752440");
-      const exponentAtPriceOne = -4;
       const swapFee = new Dec("0");
       const result = calcOutGivenIn({
         tokenIn,
@@ -36,7 +35,6 @@ describe("calcOutGivenIn matches chain code", () => {
         poolLiquidity,
         inittedTicks,
         curSqrtPrice,
-        exponentAtPriceOne,
         swapFee,
       });
       if (result === "no-more-ticks") throw new Error("no more ticks");
@@ -65,7 +63,6 @@ describe("calcOutGivenIn matches chain code", () => {
         },
       ];
       const curSqrtPrice = new Dec("70.710678118654752440");
-      const exponentAtPriceOne = -4;
       const swapFee = new Dec("0");
       const result = calcOutGivenIn({
         tokenIn,
@@ -73,7 +70,6 @@ describe("calcOutGivenIn matches chain code", () => {
         poolLiquidity,
         inittedTicks,
         curSqrtPrice,
-        exponentAtPriceOne,
         swapFee,
       });
       if (result === "no-more-ticks") throw new Error("no more ticks");
@@ -103,7 +99,6 @@ describe("calcOutGivenIn matches chain code", () => {
         },
       ];
       const curSqrtPrice = new Dec("70.710678118654752440");
-      const exponentAtPriceOne = -4;
       const swapFee = new Dec("0");
       const result = calcOutGivenIn({
         tokenIn,
@@ -111,7 +106,6 @@ describe("calcOutGivenIn matches chain code", () => {
         poolLiquidity,
         inittedTicks,
         curSqrtPrice,
-        exponentAtPriceOne,
         swapFee,
       });
       if (result === "no-more-ticks") throw new Error("no more ticks");
@@ -141,7 +135,6 @@ describe("calcOutGivenIn matches chain code", () => {
         },
       ];
       const curSqrtPrice = new Dec("70.710678118654752440");
-      const exponentAtPriceOne = -4;
       const swapFee = new Dec("0");
       const result = calcOutGivenIn({
         tokenIn,
@@ -149,7 +142,6 @@ describe("calcOutGivenIn matches chain code", () => {
         poolLiquidity,
         inittedTicks,
         curSqrtPrice,
-        exponentAtPriceOne,
         swapFee,
       });
       if (result === "no-more-ticks") throw new Error("no more ticks");
@@ -178,7 +170,6 @@ describe("calcOutGivenIn matches chain code", () => {
         },
       ];
       const curSqrtPrice = new Dec("70.710678118654752440");
-      const exponentAtPriceOne = -4;
       const swapFee = new Dec("0");
       const result = calcOutGivenIn({
         tokenIn,
@@ -186,7 +177,6 @@ describe("calcOutGivenIn matches chain code", () => {
         poolLiquidity,
         inittedTicks,
         curSqrtPrice,
-        exponentAtPriceOne,
         swapFee,
       });
       if (result === "no-more-ticks") throw new Error("no more ticks");
@@ -215,7 +205,6 @@ describe("calcOutGivenIn matches chain code", () => {
         },
       ];
       const curSqrtPrice = new Dec("70.710678118654752440");
-      const exponentAtPriceOne = -4;
       const swapFee = new Dec("0");
       const result = calcOutGivenIn({
         tokenIn,
@@ -223,7 +212,6 @@ describe("calcOutGivenIn matches chain code", () => {
         poolLiquidity,
         inittedTicks,
         curSqrtPrice,
-        exponentAtPriceOne,
         swapFee,
       });
       if (result === "no-more-ticks") throw new Error("no more ticks");
@@ -256,7 +244,6 @@ describe("calcOutGivenIn matches chain code", () => {
         },
       ];
       const curSqrtPrice = new Dec("70.710678118654752440");
-      const exponentAtPriceOne = -4;
       const swapFee = new Dec("0");
       const result = calcOutGivenIn({
         tokenIn,
@@ -264,7 +251,6 @@ describe("calcOutGivenIn matches chain code", () => {
         poolLiquidity,
         inittedTicks,
         curSqrtPrice,
-        exponentAtPriceOne,
         swapFee,
       });
       if (result === "no-more-ticks") throw new Error("no more ticks");
@@ -293,7 +279,6 @@ describe("calcOutGivenIn matches chain code", () => {
         },
       ];
       const curSqrtPrice = new Dec("70.710678118654752440");
-      const exponentAtPriceOne = -4;
       const swapFee = new Dec("0");
       const result = calcOutGivenIn({
         tokenIn,
@@ -301,7 +286,6 @@ describe("calcOutGivenIn matches chain code", () => {
         poolLiquidity,
         inittedTicks,
         curSqrtPrice,
-        exponentAtPriceOne,
         swapFee,
       });
       if (result === "no-more-ticks") throw new Error("no more ticks");
@@ -334,7 +318,6 @@ describe("calcOutGivenIn matches chain code", () => {
         },
       ];
       const curSqrtPrice = new Dec("70.710678118654752440");
-      const exponentAtPriceOne = -4;
       const swapFee = new Dec("0");
       const result = calcOutGivenIn({
         tokenIn,
@@ -342,7 +325,6 @@ describe("calcOutGivenIn matches chain code", () => {
         poolLiquidity,
         inittedTicks,
         curSqrtPrice,
-        exponentAtPriceOne,
         swapFee,
       });
       if (result === "no-more-ticks") throw new Error("no more ticks");
@@ -374,7 +356,6 @@ describe("calcOutGivenIn matches chain code", () => {
         },
       ];
       const curSqrtPrice = new Dec("70.710678118654752440");
-      const exponentAtPriceOne = -4;
       const swapFee = new Dec("0");
       const result = calcOutGivenIn({
         tokenIn,
@@ -382,7 +363,6 @@ describe("calcOutGivenIn matches chain code", () => {
         poolLiquidity,
         inittedTicks,
         curSqrtPrice,
-        exponentAtPriceOne,
         swapFee,
       });
       if (result === "no-more-ticks") throw new Error("no more ticks");
@@ -414,7 +394,6 @@ describe("calcOutGivenIn matches chain code", () => {
         },
       ];
       const curSqrtPrice = new Dec("70.710678118654752440");
-      const exponentAtPriceOne = -4;
       const swapFee = new Dec("0");
       const result = calcOutGivenIn({
         tokenIn,
@@ -422,7 +401,6 @@ describe("calcOutGivenIn matches chain code", () => {
         poolLiquidity,
         inittedTicks,
         curSqrtPrice,
-        exponentAtPriceOne,
         swapFee,
       });
       if (result === "no-more-ticks") throw new Error("no more ticks");
@@ -453,7 +431,6 @@ describe("calcOutGivenIn matches chain code", () => {
         },
       ];
       const curSqrtPrice = new Dec("70.710678118654752440");
-      const exponentAtPriceOne = -4;
       const swapFee = new Dec("0.01");
       const result = calcOutGivenIn({
         tokenIn,
@@ -461,7 +438,6 @@ describe("calcOutGivenIn matches chain code", () => {
         poolLiquidity,
         inittedTicks,
         curSqrtPrice,
-        exponentAtPriceOne,
         swapFee,
       });
       if (result === "no-more-ticks") throw new Error("no more ticks");
@@ -491,7 +467,6 @@ describe("calcOutGivenIn matches chain code", () => {
         },
       ];
       const curSqrtPrice = new Dec("70.710678118654752440");
-      const exponentAtPriceOne = -4;
       const swapFee = new Dec("0.03");
       const result = calcOutGivenIn({
         tokenIn,
@@ -499,7 +474,6 @@ describe("calcOutGivenIn matches chain code", () => {
         poolLiquidity,
         inittedTicks,
         curSqrtPrice,
-        exponentAtPriceOne,
         swapFee,
       });
       if (result === "no-more-ticks") throw new Error("no more ticks");
@@ -527,7 +501,6 @@ describe("calcOutGivenIn matches chain code", () => {
         },
       ];
       const curSqrtPrice = new Dec("70.710678118654752440");
-      const exponentAtPriceOne = -4;
       const swapFee = new Dec("0.05");
       const result = calcOutGivenIn({
         tokenIn,
@@ -535,7 +508,6 @@ describe("calcOutGivenIn matches chain code", () => {
         poolLiquidity,
         inittedTicks,
         curSqrtPrice,
-        exponentAtPriceOne,
         swapFee,
       });
       if (result === "no-more-ticks") throw new Error("no more ticks");
@@ -567,7 +539,6 @@ describe("calcOutGivenIn matches chain code", () => {
         },
       ];
       const curSqrtPrice = new Dec("70.710678118654752440");
-      const exponentAtPriceOne = -4;
       const swapFee = new Dec("0.1");
       const result = calcOutGivenIn({
         tokenIn,
@@ -575,7 +546,6 @@ describe("calcOutGivenIn matches chain code", () => {
         poolLiquidity,
         inittedTicks,
         curSqrtPrice,
-        exponentAtPriceOne,
         swapFee,
       });
       if (result === "no-more-ticks") throw new Error("no more ticks");
@@ -608,7 +578,6 @@ describe("calcOutGivenIn matches chain code", () => {
         },
       ];
       const curSqrtPrice = new Dec("70.710678118654752440");
-      const exponentAtPriceOne = -4;
       const swapFee = new Dec("0.005");
       const result = calcOutGivenIn({
         tokenIn,
@@ -616,7 +585,6 @@ describe("calcOutGivenIn matches chain code", () => {
         poolLiquidity,
         inittedTicks,
         curSqrtPrice,
-        exponentAtPriceOne,
         swapFee,
       });
       if (result === "no-more-ticks") throw new Error("no more ticks");
@@ -648,7 +616,6 @@ describe("calcOutGivenIn matches chain code", () => {
         },
       ];
       const curSqrtPrice = new Dec("70.710678118654752440");
-      const exponentAtPriceOne = -4;
       const swapFee = new Dec("0.03");
       const result = calcOutGivenIn({
         tokenIn,
@@ -656,7 +623,6 @@ describe("calcOutGivenIn matches chain code", () => {
         poolLiquidity,
         inittedTicks,
         curSqrtPrice,
-        exponentAtPriceOne,
         swapFee,
       });
       if (result === "no-more-ticks") throw new Error("no more ticks");
@@ -680,7 +646,6 @@ describe("calcOutGivenIn matches chain code", () => {
         },
       ];
       const curSqrtPrice = new Dec("70.710678118654752440");
-      const exponentAtPriceOne = -4;
       const swapFee = new Dec("0");
       expect(
         calcOutGivenIn({
@@ -689,7 +654,6 @@ describe("calcOutGivenIn matches chain code", () => {
           poolLiquidity,
           inittedTicks,
           curSqrtPrice,
-          exponentAtPriceOne,
           swapFee,
         })
       ).toEqual("no-more-ticks");
@@ -707,7 +671,6 @@ describe("calcOutGivenIn matches chain code", () => {
         },
       ];
       const curSqrtPrice = new Dec("70.710678118654752440");
-      const exponentAtPriceOne = -4;
       const swapFee = new Dec("0");
       expect(
         calcOutGivenIn({
@@ -716,7 +679,6 @@ describe("calcOutGivenIn matches chain code", () => {
           poolLiquidity,
           inittedTicks,
           curSqrtPrice,
-          exponentAtPriceOne,
           swapFee,
         })
       ).toEqual("no-more-ticks");
@@ -748,7 +710,6 @@ describe("calcInGivenOut matches chain code", () => {
         },
       ];
       const curSqrtPrice = new Dec("70.710678118654752440");
-      const exponentAtPriceOne = -4;
       const swapFee = new Dec("0");
       const result = calcInGivenOut({
         tokenOut,
@@ -756,7 +717,6 @@ describe("calcInGivenOut matches chain code", () => {
         poolLiquidity,
         inittedTicks,
         curSqrtPrice,
-        exponentAtPriceOne,
         swapFee,
       });
       if (result === "no-more-ticks") throw new Error("no more ticks");
@@ -781,7 +741,6 @@ describe("calcInGivenOut matches chain code", () => {
         },
       ];
       const curSqrtPrice = new Dec("70.710678118654752440");
-      const exponentAtPriceOne = -4;
       const swapFee = new Dec("0");
       const result = calcInGivenOut({
         tokenOut,
@@ -789,7 +748,6 @@ describe("calcInGivenOut matches chain code", () => {
         poolLiquidity,
         inittedTicks,
         curSqrtPrice,
-        exponentAtPriceOne,
         swapFee,
       });
       if (result === "no-more-ticks") throw new Error("no more ticks");
@@ -819,7 +777,6 @@ describe("calcInGivenOut matches chain code", () => {
         },
       ];
       const curSqrtPrice = new Dec("70.710678118654752440");
-      const exponentAtPriceOne = -4;
       const swapFee = new Dec("0");
       const result = calcInGivenOut({
         tokenOut,
@@ -827,7 +784,6 @@ describe("calcInGivenOut matches chain code", () => {
         poolLiquidity,
         inittedTicks,
         curSqrtPrice,
-        exponentAtPriceOne,
         swapFee,
       });
       if (result === "no-more-ticks") throw new Error("no more ticks");
@@ -857,7 +813,6 @@ describe("calcInGivenOut matches chain code", () => {
         },
       ];
       const curSqrtPrice = new Dec("70.710678118654752440");
-      const exponentAtPriceOne = -4;
       const swapFee = new Dec("0");
       const result = calcInGivenOut({
         tokenOut,
@@ -865,7 +820,6 @@ describe("calcInGivenOut matches chain code", () => {
         poolLiquidity,
         inittedTicks,
         curSqrtPrice,
-        exponentAtPriceOne,
         swapFee,
       });
       if (result === "no-more-ticks") throw new Error("no more ticks");
@@ -899,7 +853,6 @@ describe("calcInGivenOut matches chain code", () => {
         },
       ];
       const curSqrtPrice = new Dec("70.710678118654752440");
-      const exponentAtPriceOne = -4;
       const swapFee = new Dec("0");
       const result = calcInGivenOut({
         tokenOut,
@@ -907,7 +860,6 @@ describe("calcInGivenOut matches chain code", () => {
         poolLiquidity,
         inittedTicks,
         curSqrtPrice,
-        exponentAtPriceOne,
         swapFee,
       });
       if (result === "no-more-ticks") throw new Error("no more ticks");
@@ -940,7 +892,6 @@ describe("calcInGivenOut matches chain code", () => {
         },
       ];
       const curSqrtPrice = new Dec("70.710678118654752440");
-      const exponentAtPriceOne = -4;
       const swapFee = new Dec("0");
       const result = calcInGivenOut({
         tokenOut,
@@ -948,7 +899,6 @@ describe("calcInGivenOut matches chain code", () => {
         poolLiquidity,
         inittedTicks,
         curSqrtPrice,
-        exponentAtPriceOne,
         swapFee,
       });
       if (result === "no-more-ticks") throw new Error("no more ticks");
@@ -981,7 +931,6 @@ describe("calcInGivenOut matches chain code", () => {
         },
       ];
       const curSqrtPrice = new Dec("70.710678118654752440");
-      const exponentAtPriceOne = -4;
       const swapFee = new Dec("0");
       const result = calcInGivenOut({
         tokenOut,
@@ -989,7 +938,6 @@ describe("calcInGivenOut matches chain code", () => {
         poolLiquidity,
         inittedTicks,
         curSqrtPrice,
-        exponentAtPriceOne,
         swapFee,
       });
       if (result === "no-more-ticks") throw new Error("no more ticks");
@@ -1022,7 +970,6 @@ describe("calcInGivenOut matches chain code", () => {
         },
       ];
       const curSqrtPrice = new Dec("70.710678118654752440");
-      const exponentAtPriceOne = -4;
       const swapFee = new Dec("0");
       const result = calcInGivenOut({
         tokenOut,
@@ -1030,7 +977,6 @@ describe("calcInGivenOut matches chain code", () => {
         poolLiquidity,
         inittedTicks,
         curSqrtPrice,
-        exponentAtPriceOne,
         swapFee,
       });
       if (result === "no-more-ticks") throw new Error("no more ticks");
@@ -1063,7 +1009,6 @@ describe("calcInGivenOut matches chain code", () => {
         },
       ];
       const curSqrtPrice = new Dec("70.710678118654752440");
-      const exponentAtPriceOne = -4;
       const swapFee = new Dec("0");
       const result = calcInGivenOut({
         tokenOut,
@@ -1071,7 +1016,6 @@ describe("calcInGivenOut matches chain code", () => {
         poolLiquidity,
         inittedTicks,
         curSqrtPrice,
-        exponentAtPriceOne,
         swapFee,
       });
       if (result === "no-more-ticks") throw new Error("no more ticks");
@@ -1104,7 +1048,6 @@ describe("calcInGivenOut matches chain code", () => {
         },
       ];
       const curSqrtPrice = new Dec("70.710678118654752440");
-      const exponentAtPriceOne = -4;
       const swapFee = new Dec("0");
       const result = calcInGivenOut({
         tokenOut,
@@ -1112,7 +1055,6 @@ describe("calcInGivenOut matches chain code", () => {
         poolLiquidity,
         inittedTicks,
         curSqrtPrice,
-        exponentAtPriceOne,
         swapFee,
       });
       if (result === "no-more-ticks") throw new Error("no more ticks");
@@ -1145,7 +1087,6 @@ describe("calcInGivenOut matches chain code", () => {
         },
       ];
       const curSqrtPrice = new Dec("70.710678118654752440");
-      const exponentAtPriceOne = -4;
       const swapFee = new Dec("0");
       const result = calcInGivenOut({
         tokenOut,
@@ -1153,7 +1094,6 @@ describe("calcInGivenOut matches chain code", () => {
         poolLiquidity,
         inittedTicks,
         curSqrtPrice,
-        exponentAtPriceOne,
         swapFee,
       });
       if (result === "no-more-ticks") throw new Error("no more ticks");
@@ -1183,7 +1123,6 @@ describe("calcInGivenOut matches chain code", () => {
         },
       ];
       const curSqrtPrice = new Dec("70.710678118654752440");
-      const exponentAtPriceOne = -4;
       const swapFee = new Dec("0.01");
       const result = calcInGivenOut({
         tokenOut,
@@ -1191,7 +1130,6 @@ describe("calcInGivenOut matches chain code", () => {
         poolLiquidity,
         inittedTicks,
         curSqrtPrice,
-        exponentAtPriceOne,
         swapFee,
       });
       if (result === "no-more-ticks") throw new Error("no more ticks");
@@ -1216,7 +1154,6 @@ describe("calcInGivenOut matches chain code", () => {
         },
       ];
       const curSqrtPrice = new Dec("70.710678118654752440");
-      const exponentAtPriceOne = -4;
       const swapFee = new Dec("0.03");
       const result = calcInGivenOut({
         tokenOut,
@@ -1224,7 +1161,6 @@ describe("calcInGivenOut matches chain code", () => {
         poolLiquidity,
         inittedTicks,
         curSqrtPrice,
-        exponentAtPriceOne,
         swapFee,
       });
       if (result === "no-more-ticks") throw new Error("no more ticks");
@@ -1253,7 +1189,6 @@ describe("calcInGivenOut matches chain code", () => {
         },
       ];
       const curSqrtPrice = new Dec("70.710678118654752440");
-      const exponentAtPriceOne = -4;
       const swapFee = new Dec("0.001");
       const result = calcInGivenOut({
         tokenOut,
@@ -1261,7 +1196,6 @@ describe("calcInGivenOut matches chain code", () => {
         poolLiquidity,
         inittedTicks,
         curSqrtPrice,
-        exponentAtPriceOne,
         swapFee,
       });
       if (result === "no-more-ticks") throw new Error("no more ticks");
@@ -1290,7 +1224,6 @@ describe("calcInGivenOut matches chain code", () => {
         },
       ];
       const curSqrtPrice = new Dec("70.710678118654752440");
-      const exponentAtPriceOne = -4;
       const swapFee = new Dec("0.1");
       const result = calcInGivenOut({
         tokenOut,
@@ -1298,7 +1231,6 @@ describe("calcInGivenOut matches chain code", () => {
         poolLiquidity,
         inittedTicks,
         curSqrtPrice,
-        exponentAtPriceOne,
         swapFee,
       });
       if (result === "no-more-ticks") throw new Error("no more ticks");
@@ -1327,7 +1259,6 @@ describe("calcInGivenOut matches chain code", () => {
         },
       ];
       const curSqrtPrice = new Dec("70.710678118654752440");
-      const exponentAtPriceOne = -4;
       const swapFee = new Dec("0.05");
       const result = calcInGivenOut({
         tokenOut,
@@ -1335,7 +1266,6 @@ describe("calcInGivenOut matches chain code", () => {
         poolLiquidity,
         inittedTicks,
         curSqrtPrice,
-        exponentAtPriceOne,
         swapFee,
       });
       if (result === "no-more-ticks") throw new Error("no more ticks");
@@ -1364,7 +1294,6 @@ describe("calcInGivenOut matches chain code", () => {
         },
       ];
       const curSqrtPrice = new Dec("70.710678118654752440");
-      const exponentAtPriceOne = -4;
       const swapFee = new Dec("0.0003");
       const result = calcInGivenOut({
         tokenOut,
@@ -1372,7 +1301,6 @@ describe("calcInGivenOut matches chain code", () => {
         poolLiquidity,
         inittedTicks,
         curSqrtPrice,
-        exponentAtPriceOne,
         swapFee,
       });
       if (result === "no-more-ticks") throw new Error("no more ticks");
@@ -1397,7 +1325,6 @@ describe("calcInGivenOut matches chain code", () => {
         },
       ];
       const curSqrtPrice = new Dec("70.710678118654752440");
-      const exponentAtPriceOne = -4;
       const swapFee = new Dec("0");
       expect(
         calcInGivenOut({
@@ -1406,7 +1333,6 @@ describe("calcInGivenOut matches chain code", () => {
           poolLiquidity,
           inittedTicks,
           curSqrtPrice,
-          exponentAtPriceOne,
           swapFee,
         })
       ).toEqual("no-more-ticks");
@@ -1423,7 +1349,6 @@ describe("calcInGivenOut matches chain code", () => {
         },
       ];
       const curSqrtPrice = new Dec("70.710678118654752440");
-      const exponentAtPriceOne = -4;
       const swapFee = new Dec("0");
       expect(
         calcInGivenOut({
@@ -1432,7 +1357,6 @@ describe("calcInGivenOut matches chain code", () => {
           poolLiquidity,
           inittedTicks,
           curSqrtPrice,
-          exponentAtPriceOne,
           swapFee,
         })
       ).toEqual("no-more-ticks");

--- a/packages/math/src/pool/concentrated/__tests__/quotes.spec.ts
+++ b/packages/math/src/pool/concentrated/__tests__/quotes.spec.ts
@@ -90,12 +90,8 @@ describe("calcOutGivenIn matches chain code", () => {
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
-          tickIndex: new Int(305450),
-          netLiquidity: new Dec("1517882343.751510418088349649"),
-        },
-        {
           tickIndex: new Int(315000),
-          netLiquidity: new Dec("-1517882343.751510418088349649"),
+          netLiquidity: new Dec("-3035764687.503020836176699298"),
         },
       ];
       const curSqrtPrice = new Dec("70.710678118654752440");
@@ -161,11 +157,11 @@ describe("calcOutGivenIn matches chain code", () => {
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
-          tickIndex: new Int(315000),
+          tickIndex: new Int(31500000),
           netLiquidity: new Dec("-320114898.796002294865348513"),
         },
         {
-          tickIndex: new Int(322500),
+          tickIndex: new Int(32250000),
           netLiquidity: new Dec("-1197767444.955508123223001136"),
         },
       ];
@@ -196,11 +192,11 @@ describe("calcOutGivenIn matches chain code", () => {
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
-          tickIndex: new Int(305450),
-          netLiquidity: new Dec("319146854.1542601224183902529"),
+          tickIndex: new Int(30545000),
+          netLiquidity: new Dec("319146854.154260122418390252"),
         },
         {
-          tickIndex: new Int(300000),
+          tickIndex: new Int(30000000),
           netLiquidity: new Dec("1198735489.597250295669959397"),
         },
       ];
@@ -231,15 +227,15 @@ describe("calcOutGivenIn matches chain code", () => {
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
-          tickIndex: new Int(310010),
+          tickIndex: new Int(31001000),
           netLiquidity: new Dec("670416088.605668727039240782"),
         },
         {
-          tickIndex: new Int(315000),
+          tickIndex: new Int(31500000),
           netLiquidity: new Dec("-1517882343.751510418088349649"),
         },
         {
-          tickIndex: new Int(322500),
+          tickIndex: new Int(32250000),
           netLiquidity: new Dec("-670416088.605668727039240782"),
         },
       ];
@@ -266,15 +262,15 @@ describe("calcOutGivenIn matches chain code", () => {
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
-          tickIndex: new Int(310010),
+          tickIndex: new Int(31001000),
           netLiquidity: new Dec("670416088.605668727039240782"),
         },
         {
-          tickIndex: new Int(315000),
+          tickIndex: new Int(31500000),
           netLiquidity: new Dec("-1517882343.751510418088349649"),
         },
         {
-          tickIndex: new Int(322500),
+          tickIndex: new Int(32250000),
           netLiquidity: new Dec("-670416088.605668727039240782"),
         },
       ];
@@ -305,15 +301,15 @@ describe("calcOutGivenIn matches chain code", () => {
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
-          tickIndex: new Int(309990),
+          tickIndex: new Int(30999000),
           netLiquidity: new Dec("-670416215.718827443660400593"),
         },
         {
-          tickIndex: new Int(305450),
+          tickIndex: new Int(30545000),
           netLiquidity: new Dec("1517882343.751510418088349649"),
         },
         {
-          tickIndex: new Int(300000),
+          tickIndex: new Int(30000000),
           netLiquidity: new Dec("670416215.718827443660400593"),
         },
       ];
@@ -343,15 +339,15 @@ describe("calcOutGivenIn matches chain code", () => {
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
-          tickIndex: new Int(309990),
+          tickIndex: new Int(30999000),
           netLiquidity: new Dec("-670416215.718827443660400593"),
         },
         {
-          tickIndex: new Int(305450),
+          tickIndex: new Int(30545000),
           netLiquidity: new Dec("1517882343.751510418088349649"),
         },
         {
-          tickIndex: new Int(300000),
+          tickIndex: new Int(30000000),
           netLiquidity: new Dec("670416215.718827443660400593"),
         },
       ];
@@ -381,15 +377,15 @@ describe("calcOutGivenIn matches chain code", () => {
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
-          tickIndex: new Int(315000),
+          tickIndex: new Int(31500000),
           netLiquidity: new Dec("-1517882343.751510418088349649"),
         },
         {
-          tickIndex: new Int(315010),
+          tickIndex: new Int(31501000),
           netLiquidity: new Dec("1199528406.187413669220031452"),
         },
         {
-          tickIndex: new Int(322500),
+          tickIndex: new Int(32250000),
           netLiquidity: new Dec("670416215.718827443660400593"),
         },
       ];
@@ -422,11 +418,11 @@ describe("calcOutGivenIn matches chain code", () => {
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
-          tickIndex: new Int(305450),
+          tickIndex: new Int(30545000),
           netLiquidity: new Dec("1517882343.751510418088349649"),
         },
         {
-          tickIndex: new Int(315000),
+          tickIndex: new Int(31500000),
           netLiquidity: new Dec("-1517882343.751510418088349649"),
         },
       ];
@@ -458,11 +454,11 @@ describe("calcOutGivenIn matches chain code", () => {
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
-          tickIndex: new Int(305450),
+          tickIndex: new Int(30545000),
           netLiquidity: new Dec("1517882343.751510418088349649"),
         },
         {
-          tickIndex: new Int(315000),
+          tickIndex: new Int(31500000),
           netLiquidity: new Dec("-1517882343.751510418088349649"),
         },
       ];
@@ -492,11 +488,11 @@ describe("calcOutGivenIn matches chain code", () => {
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
-          tickIndex: new Int(305450),
+          tickIndex: new Int(30545000),
           netLiquidity: new Dec("319146854.1542601224183902529"),
         },
         {
-          tickIndex: new Int(300000),
+          tickIndex: new Int(30000000),
           netLiquidity: new Dec("1198735489.597250295669959397"),
         },
       ];
@@ -526,15 +522,15 @@ describe("calcOutGivenIn matches chain code", () => {
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
-          tickIndex: new Int(310010),
+          tickIndex: new Int(31001000),
           netLiquidity: new Dec("670416088.605668727039240782"),
         },
         {
-          tickIndex: new Int(315000),
+          tickIndex: new Int(31500000),
           netLiquidity: new Dec("-1517882343.751510418088349649"),
         },
         {
-          tickIndex: new Int(322500),
+          tickIndex: new Int(32250000),
           netLiquidity: new Dec("-670416088.605668727039240782"),
         },
       ];
@@ -565,15 +561,15 @@ describe("calcOutGivenIn matches chain code", () => {
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
-          tickIndex: new Int(309990),
+          tickIndex: new Int(30999000),
           netLiquidity: new Dec("-670416215.718827443660400593"),
         },
         {
-          tickIndex: new Int(305450),
+          tickIndex: new Int(30545000),
           netLiquidity: new Dec("1517882343.751510418088349649"),
         },
         {
-          tickIndex: new Int(300000),
+          tickIndex: new Int(30000000),
           netLiquidity: new Dec("670416215.718827443660400593"),
         },
       ];
@@ -603,15 +599,15 @@ describe("calcOutGivenIn matches chain code", () => {
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
-          tickIndex: new Int(315000),
+          tickIndex: new Int(31500000),
           netLiquidity: new Dec("-1517882343.751510418088349649"),
         },
         {
-          tickIndex: new Int(315010),
+          tickIndex: new Int(31501000),
           netLiquidity: new Dec("1199528406.187413669220031452"),
         },
         {
-          tickIndex: new Int(322500),
+          tickIndex: new Int(32250000),
           netLiquidity: new Dec("670416215.718827443660400593"),
         },
       ];
@@ -641,7 +637,7 @@ describe("calcOutGivenIn matches chain code", () => {
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
-          tickIndex: new Int(315000),
+          tickIndex: new Int(31500000),
           netLiquidity: new Dec("-1517882343.751510418088349649"),
         },
       ];
@@ -666,7 +662,7 @@ describe("calcOutGivenIn matches chain code", () => {
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
-          tickIndex: new Int(315000),
+          tickIndex: new Int(31500000),
           netLiquidity: new Dec("-1517882343.751510418088349649"),
         },
       ];
@@ -701,11 +697,11 @@ describe("calcInGivenOut matches chain code", () => {
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
-          tickIndex: new Int(305450),
+          tickIndex: new Int(30545000),
           netLiquidity: new Dec("1517882343.751510418088349649"),
         },
         {
-          tickIndex: new Int(315000),
+          tickIndex: new Int(31500000),
           netLiquidity: new Dec("-1517882343.751510418088349649"),
         },
       ];
@@ -732,11 +728,11 @@ describe("calcInGivenOut matches chain code", () => {
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
-          tickIndex: new Int(305450),
+          tickIndex: new Int(30545000),
           netLiquidity: new Dec("1517882343.751510418088349649"),
         },
         {
-          tickIndex: new Int(315000),
+          tickIndex: new Int(31500000),
           netLiquidity: new Dec("-1517882343.751510418088349649"),
         },
       ];
@@ -768,11 +764,11 @@ describe("calcInGivenOut matches chain code", () => {
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
-          tickIndex: new Int(305450),
+          tickIndex: new Int(30545000),
           netLiquidity: new Dec("3035764687.503020836176699298"),
         },
         {
-          tickIndex: new Int(315000),
+          tickIndex: new Int(31500000),
           netLiquidity: new Dec("-3035764687.503020836176699298"),
         },
       ];
@@ -804,11 +800,11 @@ describe("calcInGivenOut matches chain code", () => {
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
-          tickIndex: new Int(305450),
+          tickIndex: new Int(30545000),
           netLiquidity: new Dec("3035764687.503020836176699298"),
         },
         {
-          tickIndex: new Int(315000),
+          tickIndex: new Int(31500000),
           netLiquidity: new Dec("-3035764687.503020836176699298"),
         },
       ];
@@ -840,15 +836,15 @@ describe("calcInGivenOut matches chain code", () => {
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
-          tickIndex: new Int(305450),
+          tickIndex: new Int(30545000),
           netLiquidity: new Dec("319146854.154260122418390252"),
         },
         {
-          tickIndex: new Int(300000),
+          tickIndex: new Int(30000000),
           netLiquidity: new Dec("1198735489.597250295669959397"),
         },
         {
-          tickIndex: new Int(315000),
+          tickIndex: new Int(31500000),
           netLiquidity: new Dec("-1517882343.751510418088349649"),
         },
       ];
@@ -879,15 +875,15 @@ describe("calcInGivenOut matches chain code", () => {
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
-          tickIndex: new Int(315000),
+          tickIndex: new Int(31500000),
           netLiquidity: new Dec("-320114898.796002294865348513"),
         },
         {
-          tickIndex: new Int(322500),
+          tickIndex: new Int(32250000),
           netLiquidity: new Dec("-1197767444.955508123223001136"),
         },
         {
-          tickIndex: new Int(315010),
+          tickIndex: new Int(31501000),
           netLiquidity: new Dec("1199528406.187413669220031452"),
         },
       ];
@@ -918,15 +914,15 @@ describe("calcInGivenOut matches chain code", () => {
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
-          tickIndex: new Int(309990),
+          tickIndex: new Int(30999000),
           netLiquidity: new Dec("-670416215.718827443660400593"),
         },
         {
-          tickIndex: new Int(305450),
+          tickIndex: new Int(30545000),
           netLiquidity: new Dec("1517882343.751510418088349649"),
         },
         {
-          tickIndex: new Int(300000),
+          tickIndex: new Int(30000000),
           netLiquidity: new Dec("670416215.718827443660400593"),
         },
       ];
@@ -957,15 +953,15 @@ describe("calcInGivenOut matches chain code", () => {
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
-          tickIndex: new Int(309990),
+          tickIndex: new Int(30999000),
           netLiquidity: new Dec("-670416215.718827443660400593"),
         },
         {
-          tickIndex: new Int(305450),
+          tickIndex: new Int(30545000),
           netLiquidity: new Dec("1517882343.751510418088349649"),
         },
         {
-          tickIndex: new Int(300000),
+          tickIndex: new Int(30000000),
           netLiquidity: new Dec("670416215.718827443660400593"),
         },
       ];
@@ -996,15 +992,15 @@ describe("calcInGivenOut matches chain code", () => {
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
-          tickIndex: new Int(310010),
+          tickIndex: new Int(31001000),
           netLiquidity: new Dec("670416088.605668727039240782"),
         },
         {
-          tickIndex: new Int(315000),
+          tickIndex: new Int(31500000),
           netLiquidity: new Dec("-1517882343.751510418088349649"),
         },
         {
-          tickIndex: new Int(322500),
+          tickIndex: new Int(32250000),
           netLiquidity: new Dec("-670416088.605668727039240782"),
         },
       ];
@@ -1035,15 +1031,15 @@ describe("calcInGivenOut matches chain code", () => {
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
-          tickIndex: new Int(310010),
+          tickIndex: new Int(31001000),
           netLiquidity: new Dec("670416088.605668727039240782"),
         },
         {
-          tickIndex: new Int(315000),
+          tickIndex: new Int(31500000),
           netLiquidity: new Dec("-1517882343.751510418088349649"),
         },
         {
-          tickIndex: new Int(322500),
+          tickIndex: new Int(32250000),
           netLiquidity: new Dec("-670416088.605668727039240782"),
         },
       ];
@@ -1074,15 +1070,15 @@ describe("calcInGivenOut matches chain code", () => {
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
-          tickIndex: new Int(315000),
+          tickIndex: new Int(31500000),
           netLiquidity: new Dec("-1517882343.751510418088349649"),
         },
         {
-          tickIndex: new Int(315010),
+          tickIndex: new Int(31501000),
           netLiquidity: new Dec("1199528406.187413669220031452"),
         },
         {
-          tickIndex: new Int(322500),
+          tickIndex: new Int(32250000),
           netLiquidity: new Dec("670416215.718827443660400593"),
         },
       ];
@@ -1114,11 +1110,11 @@ describe("calcInGivenOut matches chain code", () => {
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
-          tickIndex: new Int(305450),
+          tickIndex: new Int(30545000),
           netLiquidity: new Dec("1517882343.751510418088349649"),
         },
         {
-          tickIndex: new Int(315000),
+          tickIndex: new Int(31500000),
           netLiquidity: new Dec("-1517882343.751510418088349649"),
         },
       ];
@@ -1145,11 +1141,11 @@ describe("calcInGivenOut matches chain code", () => {
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
-          tickIndex: new Int(305450),
+          tickIndex: new Int(30545000),
           netLiquidity: new Dec("3035764687.503020836176699298"),
         },
         {
-          tickIndex: new Int(315000),
+          tickIndex: new Int(31500000),
           netLiquidity: new Dec("-3035764687.503020836176699298"),
         },
       ];
@@ -1176,15 +1172,15 @@ describe("calcInGivenOut matches chain code", () => {
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
-          tickIndex: new Int(315000),
+          tickIndex: new Int(31500000),
           netLiquidity: new Dec("-320114898.796002294865348513"),
         },
         {
-          tickIndex: new Int(322500),
+          tickIndex: new Int(32250000),
           netLiquidity: new Dec("-1197767444.955508123223001136"),
         },
         {
-          tickIndex: new Int(315010),
+          tickIndex: new Int(31501000),
           netLiquidity: new Dec("1199528406.187413669220031452"),
         },
       ];
@@ -1211,15 +1207,15 @@ describe("calcInGivenOut matches chain code", () => {
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
-          tickIndex: new Int(309990),
+          tickIndex: new Int(30999000),
           netLiquidity: new Dec("-670416215.718827443660400593"),
         },
         {
-          tickIndex: new Int(305450),
+          tickIndex: new Int(30545000),
           netLiquidity: new Dec("1517882343.751510418088349649"),
         },
         {
-          tickIndex: new Int(300000),
+          tickIndex: new Int(30000000),
           netLiquidity: new Dec("670416215.718827443660400593"),
         },
       ];
@@ -1246,15 +1242,15 @@ describe("calcInGivenOut matches chain code", () => {
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
-          tickIndex: new Int(310010),
+          tickIndex: new Int(31001000),
           netLiquidity: new Dec("670416088.605668727039240782"),
         },
         {
-          tickIndex: new Int(315000),
+          tickIndex: new Int(31500000),
           netLiquidity: new Dec("-1517882343.751510418088349649"),
         },
         {
-          tickIndex: new Int(322500),
+          tickIndex: new Int(32250000),
           netLiquidity: new Dec("-670416088.605668727039240782"),
         },
       ];
@@ -1281,15 +1277,15 @@ describe("calcInGivenOut matches chain code", () => {
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
-          tickIndex: new Int(315000),
+          tickIndex: new Int(31500000),
           netLiquidity: new Dec("-1517882343.751510418088349649"),
         },
         {
-          tickIndex: new Int(315010),
+          tickIndex: new Int(31501000),
           netLiquidity: new Dec("1199528406.187413669220031452"),
         },
         {
-          tickIndex: new Int(322500),
+          tickIndex: new Int(32250000),
           netLiquidity: new Dec("670416215.718827443660400593"),
         },
       ];
@@ -1310,6 +1306,23 @@ describe("calcInGivenOut matches chain code", () => {
     });
     // https://github.com/osmosis-labs/osmosis/blob/e7b5c4a6f88004fe8a6976fd7e4cb5e90339d629/x/concentrated-liquidity/swaps_test.go#L1383
     // won't do slippage protection test since we are generating estimates to protect against slippage on chain from frontends
+
+    it("returns not-enough-ticks if there's not enough ticks to calculate", () => {
+      const tokenOut = new Coin("eth", "1820545");
+      const tokenDenom0 = "eth";
+      const poolLiquidity = new Dec("1517882343.751510418088349649");
+      const curSqrtPrice = new Dec("70.710678118654752440");
+      const swapFee = new Dec("0.0003");
+      const result = calcInGivenOut({
+        tokenOut,
+        tokenDenom0,
+        poolLiquidity,
+        inittedTicks: [],
+        curSqrtPrice,
+        swapFee,
+      });
+      expect(result).toEqual("no-more-ticks");
+    });
   });
 
   describe("failure cases", () => {
@@ -1320,7 +1333,7 @@ describe("calcInGivenOut matches chain code", () => {
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
-          tickIndex: new Int(315000),
+          tickIndex: new Int(31500000),
           netLiquidity: new Dec("-1517882343.751510418088349649"),
         },
       ];
@@ -1344,7 +1357,7 @@ describe("calcInGivenOut matches chain code", () => {
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
-          tickIndex: new Int(315000),
+          tickIndex: new Int(31500000),
           netLiquidity: new Dec("-1517882343.751510418088349649"),
         },
       ];

--- a/packages/math/src/pool/concentrated/const.ts
+++ b/packages/math/src/pool/concentrated/const.ts
@@ -6,5 +6,10 @@ export const smallestDec = new Dec("1", Dec.precision);
 // https://github.com/osmosis-labs/osmosis/blob/1c5f166d180ca6ffdd0a4068b97422c5c169240c/x/concentrated-liquidity/types/constants.go#L24
 export const minSpotPrice = new Dec("0.000000000000000001");
 export const maxSpotPrice = new Dec("100000000000000000000000000000000000000");
-export const exponentAtPriceOneMax = new Int(-1);
-export const exponentAtPriceOneMin = new Int(-12);
+
+// https://github.com/osmosis-labs/osmosis/blob/0f9eb3c1259078035445b3e3269659469b95fd9f/x/concentrated-liquidity/types/constants.go#L22
+export const exponentAtPriceOne = -6;
+
+// https://github.com/osmosis-labs/osmosis/blob/0f9eb3c1259078035445b3e3269659469b95fd9f/x/concentrated-liquidity/types/constants.go#L11
+export const minTick = new Int(-162000000);
+export const maxTick = new Int(342000000);

--- a/packages/math/src/pool/concentrated/math.ts
+++ b/packages/math/src/pool/concentrated/math.ts
@@ -5,7 +5,7 @@ import { smallestDec } from "./const";
 /** The `@keplr-wallet/unit` `Dec` object doesn't have the `mulRoundUp()` function
  *  as seen in Cosmos SDK `Dec` object. To adapt, we extend Dec and add the function.
  *
- *  Create a custom Dec object if it's needed in more places than `calcAmount0Delta`.
+ *  Create a custom Dec object if it's needed in more places than below.
  *  TODO:  If we manage to update `@keplr-wallet/unit` to have `mulRoundUp()` function, we can remove this.
  *  Proposed in PR: https://github.com/chainapsis/keplr-wallet/pull/721
  */

--- a/packages/math/src/pool/concentrated/quotes.ts
+++ b/packages/math/src/pool/concentrated/quotes.ts
@@ -34,7 +34,6 @@ function calcOutGivenIn({
   poolLiquidity,
   inittedTicks,
   curSqrtPrice,
-  exponentAtPriceOne,
   swapFee,
 }: QuoteOutGivenInParams):
   | { amountOut: Int; afterSqrtPrice: Dec }
@@ -71,10 +70,7 @@ function calcOutGivenIn({
       return "no-more-ticks";
     }
 
-    const nextTickSqrtPrice = tickToSqrtPrice(
-      nextTick.tickIndex,
-      exponentAtPriceOne
-    );
+    const nextTickSqrtPrice = tickToSqrtPrice(nextTick.tickIndex);
 
     const sqrtPriceTarget = swapStrategy.getSqrtTargetPrice(nextTickSqrtPrice);
 
@@ -126,7 +122,6 @@ export function calcInGivenOut({
   poolLiquidity,
   inittedTicks,
   curSqrtPrice,
-  exponentAtPriceOne,
   swapFee,
 }: QuoteInGivenOutParams):
   | { amountIn: Int; afterSqrtPrice: Dec }
@@ -163,10 +158,7 @@ export function calcInGivenOut({
       return "no-more-ticks";
     }
 
-    const nextTickSqrtPrice = tickToSqrtPrice(
-      nextTick.tickIndex,
-      exponentAtPriceOne
-    );
+    const nextTickSqrtPrice = tickToSqrtPrice(nextTick.tickIndex);
 
     const sqrtPriceTarget = swapStrategy.getSqrtTargetPrice(nextTickSqrtPrice);
 

--- a/packages/math/src/pool/concentrated/tick.ts
+++ b/packages/math/src/pool/concentrated/tick.ts
@@ -2,45 +2,31 @@ import { Dec, DecUtils, Int } from "@keplr-wallet/unit";
 
 import { BigDec } from "../../big-dec";
 import {
-  exponentAtPriceOneMax,
-  exponentAtPriceOneMin,
+  exponentAtPriceOne,
   maxSpotPrice,
+  maxTick,
   minSpotPrice,
+  minTick,
 } from "./const";
 import { approxSqrt, convertTokenInGivenOutToTokenOutGivenIn } from "./math";
 const nine = new Dec(9);
 
 // Ref: https://github.com/osmosis-labs/osmosis/blob/main/x/concentrated-liquidity/README.md#tick-spacing-example-tick-to-price
-// chain: https://github.com/osmosis-labs/osmosis/blob/e7b5c4a6f88004fe8a6976fd7e4cb5e90339d629/x/concentrated-liquidity/internal/math/tick.go#L39
+// chain: https://github.com/osmosis-labs/osmosis/blob/0f9eb3c1259078035445b3e3269659469b95fd9f/x/concentrated-liquidity/math/tick.go#L35
 /** TickToSqrtPrice returns the sqrtPrice given the following two arguments:
     - tickIndex: the tick index to calculate the price for
-    - exponentAtPriceOne: the value of the exponent (and therefore the precision) at which the starting price of 1 is set
 
     If tickIndex is zero, the function returns new Dec(1).
  */
-export function tickToSqrtPrice(
-  tickIndex: Int,
-  exponentAtPriceOne: number
-): Dec {
+export function tickToSqrtPrice(tickIndex: Int): Dec {
   if (tickIndex.isZero()) {
     return new Dec(1);
-  }
-
-  if (
-    new Int(exponentAtPriceOne).gt(exponentAtPriceOneMax) ||
-    new Int(exponentAtPriceOne).lt(exponentAtPriceOneMin)
-  ) {
-    throw new Error(
-      `exponentAtPriceOne is out of range: ${exponentAtPriceOne.toString()}`
-    );
   }
 
   const geometricExponentIncrementDistanceInTicks = nine.mul(
     powTenBigDec(new Int(exponentAtPriceOne).neg()).toDec()
   );
 
-  const { minTick, maxTick } =
-    computeMinMaxTicksFromExponentAtPriceOne(exponentAtPriceOne);
   if (tickIndex.lt(minTick) || tickIndex.gt(maxTick)) {
     throw new Error(
       `tickIndex is out of range: ${tickIndex.toString()}, min: ${minTick.toString()}, max: ${maxTick.toString()}`
@@ -79,71 +65,18 @@ export function tickToSqrtPrice(
   return approxSqrt(price);
 }
 
-/** PriceToTick takes a price and returns the corresponding tick index */
-export function priceToTick(price: Dec, exponentAtPriceOne: number): Int {
+/** PriceToTick takes a price and returns the corresponding tick index
+ *  This function does not take into consideration tick spacing.
+ */
+// https://github.com/osmosis-labs/osmosis/blob/0f9eb3c1259078035445b3e3269659469b95fd9f/x/concentrated-liquidity/math/tick.go#L98
+export function priceToTick(price: Dec): Int {
   if (price.equals(new Dec(1))) {
     return new Int(0);
   }
   if (price.isNegative()) throw new Error("Price is negative");
   if (price.gt(maxSpotPrice) || price.lt(minSpotPrice))
     throw new Error("Price not within bounds: " + price.toString());
-  if (
-    new Int(exponentAtPriceOne).gt(exponentAtPriceOneMax) ||
-    new Int(exponentAtPriceOne).lt(exponentAtPriceOneMin)
-  )
-    throw new Error("Exponent at price one not within bounds");
 
-  const { currentPrice, ticksPassed, currentAdditiveIncrementInTicks } =
-    calculatePriceAndTicksPassed(price, exponentAtPriceOne);
-
-  const ticksToBeFilledByExponentAtCurrentTick = new BigDec(
-    price.sub(currentPrice)
-  ).quo(currentAdditiveIncrementInTicks);
-
-  const tickIndex = ticksPassed.add(
-    ticksToBeFilledByExponentAtCurrentTick.toDec().truncate()
-  );
-
-  const { minTick, maxTick } =
-    computeMinMaxTicksFromExponentAtPriceOne(exponentAtPriceOne);
-  if (tickIndex.lt(minTick) || tickIndex.gt(maxTick))
-    throw new Error("Tick index not within bounds");
-
-  return tickIndex;
-}
-
-export function computeMinMaxTicksFromExponentAtPriceOne(
-  exponentAtPriceOne: number
-): {
-  minTick: Int;
-  maxTick: Int;
-} {
-  const geometricExponentIncrementDistanceInTicks = new Dec(9).mul(
-    new Dec(10).pow(new Int(exponentAtPriceOne).neg())
-  );
-  return {
-    minTick: new Dec(18)
-      .mul(geometricExponentIncrementDistanceInTicks)
-      .neg()
-      .round(),
-    maxTick: new Dec(38)
-      .mul(geometricExponentIncrementDistanceInTicks)
-      .truncate(),
-  };
-}
-
-/** The function uses the geometricExponentIncrementDistanceInTicks formula to determine the number of ticks passed and the current additive increment in ticks.
-    If the price is greater than 1, the function increments the exponentAtCurrentTick until the currentPrice is greater than the input price.
-    If the price is less than 1, the function decrements the exponentAtCurrentTick until the currentPrice is less than the input price.
- */
-export function calculatePriceAndTicksPassed(
-  price: Dec,
-  exponentAtPriceOne: number
-): {
-  currentPrice: Dec;
-  ticksPassed: Int;
-  currentAdditiveIncrementInTicks: BigDec;
-} {
   const geometricExponentIncrementDistanceInTicks = nine.mul(
     DecUtils.getTenExponentN(-exponentAtPriceOne)
   );
@@ -186,7 +119,14 @@ export function calculatePriceAndTicksPassed(
       );
     }
   }
-  return { currentPrice, ticksPassed, currentAdditiveIncrementInTicks };
+
+  const ticksToBeFilledByExponentAtCurrentTick = new BigDec(
+    price.sub(currentPrice)
+  ).quo(currentAdditiveIncrementInTicks);
+
+  return ticksPassed.add(
+    ticksToBeFilledByExponentAtCurrentTick.toDec().truncate()
+  );
 }
 
 /** Estimates the initial first tick index bound for querying ticks efficiently (not requesting too many ticks).
@@ -201,7 +141,6 @@ export function estimateInitialTickBound({
   token1Denom,
   currentSqrtPrice,
   currentTickLiquidity,
-  exponentAtPriceOne,
 }: {
   /** May be specified amount of token out, or token in. */
   specifiedToken: {
@@ -213,7 +152,6 @@ export function estimateInitialTickBound({
   token1Denom: string;
   currentSqrtPrice: Dec;
   currentTickLiquidity: Dec;
-  exponentAtPriceOne: number;
 }): { boundTickIndex: Int } {
   // modify the input amount based on out given in vs in given out and swap direction
   const currentPrice = currentSqrtPrice.pow(new Int(2));
@@ -282,7 +220,7 @@ export function estimateInitialTickBound({
   const price = sqrtPriceTarget.pow(new Int(2));
 
   return {
-    boundTickIndex: priceToTick(price, exponentAtPriceOne),
+    boundTickIndex: priceToTick(price),
   };
 }
 

--- a/packages/math/src/pool/concentrated/types.ts
+++ b/packages/math/src/pool/concentrated/types.ts
@@ -11,8 +11,6 @@ export interface QuoteParams {
   inittedTicks: LiquidityDepth[];
   /** Current tick as price. */
   curSqrtPrice: Dec;
-  /** Exponent factor of pool. */
-  exponentAtPriceOne: number;
   /** Swap fee. i.e. `0.01` */
   swapFee: Dec;
 }

--- a/packages/math/src/pool/stable.ts
+++ b/packages/math/src/pool/stable.ts
@@ -1,6 +1,7 @@
 import { Coin, Dec, DecUtils, Int } from "@keplr-wallet/unit";
 
 import { BigDec } from "../big-dec";
+import { compareBigDec_checkMultErrorTolerance } from "../rounding";
 
 export const StableSwapMath = {
   calcOutGivenIn,
@@ -331,90 +332,6 @@ export function binarySearch(
   }
 
   throw Error("binary search did not converge");
-}
-
-export function compareBigDec_checkMultErrorTolerance(
-  expected: BigDec,
-  actual: BigDec,
-  tolerance: BigDec,
-  roundingMode: string
-) {
-  let comparison = 0;
-  if (expected.gt(actual)) {
-    comparison = 1;
-  } else {
-    comparison = -1;
-  }
-
-  // roundBankers case is handled by default quo function so we
-  // fall back to that for all other roundingMode inputs
-  if (roundingMode == "roundDown") {
-    if (expected.lt(actual)) return -1;
-  } else if (roundingMode == "roundUp") {
-    if (expected.gt(actual)) return 1;
-  }
-
-  // multiplicative tolerance
-
-  if (tolerance.isZero()) return 0;
-
-  // get min dec
-  let min = actual;
-  if (expected.lt(min)) {
-    min = expected;
-  }
-
-  // check mult tolerance
-  const diff = expected.sub(actual);
-  const diffAbs = diff.abs();
-  const errorTerm = diffAbs.quo(min.abs());
-  if (errorTerm.gt(tolerance)) {
-    return comparison;
-  }
-
-  return 0;
-}
-
-export function compareDec_checkMultErrorTolerance(
-  expected: Dec,
-  actual: Dec,
-  tolerance: Dec,
-  roundingMode: string
-) {
-  let comparison = 0;
-  if (expected.gt(actual)) {
-    comparison = 1;
-  } else {
-    comparison = -1;
-  }
-
-  // roundBankers case is handled by default quo function so we
-  // fall back to that for all other roundingMode inputs
-  if (roundingMode == "roundDown") {
-    if (expected.lt(actual)) return -1;
-  } else if (roundingMode == "roundUp") {
-    if (expected.gt(actual)) return 1;
-  }
-
-  // multiplicative tolerance
-
-  if (tolerance.isZero()) return 0;
-
-  // get min dec
-  let min = actual;
-  if (expected.lt(min)) {
-    min = expected;
-  }
-
-  // check mult tolerance
-  const diff = expected.sub(actual);
-  const diffAbs = diff.abs();
-  const errorTerm = diffAbs.quo(min.abs());
-  if (errorTerm.gt(tolerance)) {
-    return comparison;
-  }
-
-  return 0;
 }
 
 export function calcWSumSquares(remReserves: BigDec[]): BigDec {

--- a/packages/math/src/pool/stable.ts
+++ b/packages/math/src/pool/stable.ts
@@ -1,7 +1,7 @@
 import { Coin, Dec, DecUtils, Int } from "@keplr-wallet/unit";
 
 import { BigDec } from "../big-dec";
-import { compareBigDec_checkMultErrorTolerance } from "../rounding";
+import { checkMultiplicativeErrorTolerance } from "../rounding";
 
 export const StableSwapMath = {
   calcOutGivenIn,
@@ -312,7 +312,7 @@ export function binarySearch(
   // only need multiplicative error tolerance
 
   for (let curIteration = 0; curIteration < maxIterations; curIteration++) {
-    const compare = compareBigDec_checkMultErrorTolerance(
+    const compare = checkMultiplicativeErrorTolerance(
       targetOutput,
       curOutput,
       errorTolerance,

--- a/packages/math/src/rounding.ts
+++ b/packages/math/src/rounding.ts
@@ -1,53 +1,16 @@
-import { Dec } from "@keplr-wallet/unit";
-
-import { BigDec } from "./big-dec";
-
-export function compareBigDec_checkMultErrorTolerance(
-  expected: BigDec,
-  actual: BigDec,
-  tolerance: BigDec,
-  roundingMode: string
-) {
-  let comparison = 0;
-  if (expected.gt(actual)) {
-    comparison = 1;
-  } else {
-    comparison = -1;
+export function checkMultiplicativeErrorTolerance<
+  Decimal extends {
+    gt(other: Decimal): boolean;
+    lt(other: Decimal): boolean;
+    abs(): Decimal;
+    quo(other: Decimal): Decimal;
+    sub(other: Decimal): Decimal;
+    isZero(): boolean;
   }
-
-  // roundBankers case is handled by default quo function so we
-  // fall back to that for all other roundingMode inputs
-  if (roundingMode == "roundDown") {
-    if (expected.lt(actual)) return -1;
-  } else if (roundingMode == "roundUp") {
-    if (expected.gt(actual)) return 1;
-  }
-
-  // multiplicative tolerance
-
-  if (tolerance.isZero()) return 0;
-
-  // get min dec
-  let min = actual;
-  if (expected.lt(min)) {
-    min = expected;
-  }
-
-  // check mult tolerance
-  const diff = expected.sub(actual);
-  const diffAbs = diff.abs();
-  const errorTerm = diffAbs.quo(min.abs());
-  if (errorTerm.gt(tolerance)) {
-    return comparison;
-  }
-
-  return 0;
-}
-
-export function compareDec_checkMultErrorTolerance(
-  expected: Dec,
-  actual: Dec,
-  tolerance: Dec,
+>(
+  expected: Decimal,
+  actual: Decimal,
+  tolerance: Decimal,
   roundingMode: string
 ) {
   let comparison = 0;

--- a/packages/math/src/rounding.ts
+++ b/packages/math/src/rounding.ts
@@ -1,0 +1,87 @@
+import { Dec } from "@keplr-wallet/unit";
+
+import { BigDec } from "./big-dec";
+
+export function compareBigDec_checkMultErrorTolerance(
+  expected: BigDec,
+  actual: BigDec,
+  tolerance: BigDec,
+  roundingMode: string
+) {
+  let comparison = 0;
+  if (expected.gt(actual)) {
+    comparison = 1;
+  } else {
+    comparison = -1;
+  }
+
+  // roundBankers case is handled by default quo function so we
+  // fall back to that for all other roundingMode inputs
+  if (roundingMode == "roundDown") {
+    if (expected.lt(actual)) return -1;
+  } else if (roundingMode == "roundUp") {
+    if (expected.gt(actual)) return 1;
+  }
+
+  // multiplicative tolerance
+
+  if (tolerance.isZero()) return 0;
+
+  // get min dec
+  let min = actual;
+  if (expected.lt(min)) {
+    min = expected;
+  }
+
+  // check mult tolerance
+  const diff = expected.sub(actual);
+  const diffAbs = diff.abs();
+  const errorTerm = diffAbs.quo(min.abs());
+  if (errorTerm.gt(tolerance)) {
+    return comparison;
+  }
+
+  return 0;
+}
+
+export function compareDec_checkMultErrorTolerance(
+  expected: Dec,
+  actual: Dec,
+  tolerance: Dec,
+  roundingMode: string
+) {
+  let comparison = 0;
+  if (expected.gt(actual)) {
+    comparison = 1;
+  } else {
+    comparison = -1;
+  }
+
+  // roundBankers case is handled by default quo function so we
+  // fall back to that for all other roundingMode inputs
+  if (roundingMode == "roundDown") {
+    if (expected.lt(actual)) return -1;
+  } else if (roundingMode == "roundUp") {
+    if (expected.gt(actual)) return 1;
+  }
+
+  // multiplicative tolerance
+
+  if (tolerance.isZero()) return 0;
+
+  // get min dec
+  let min = actual;
+  if (expected.lt(min)) {
+    min = expected;
+  }
+
+  // check mult tolerance
+  const diff = expected.sub(actual);
+  const diffAbs = diff.abs();
+  const errorTerm = diffAbs.quo(min.abs());
+  if (errorTerm.gt(tolerance)) {
+    return comparison;
+  }
+
+  return 0;
+}

--- a/packages/pools/src/concentrated.ts
+++ b/packages/pools/src/concentrated.ts
@@ -193,7 +193,6 @@ export class ConcentratedLiquidityPool implements BasePool, RoutablePool {
         poolLiquidity: this.currentTickLiquidity,
         inittedTicks: allTicks,
         curSqrtPrice: this.currentSqrtPrice,
-        exponentAtPriceOne: this.exponentAtPriceOne,
         swapFee,
       });
 
@@ -289,7 +288,6 @@ export class ConcentratedLiquidityPool implements BasePool, RoutablePool {
         poolLiquidity: this.currentTickLiquidity,
         inittedTicks,
         curSqrtPrice: this.currentSqrtPrice,
-        exponentAtPriceOne: this.exponentAtPriceOne,
         swapFee,
       });
 

--- a/packages/stores/src/queries/concentrated-liquidity/liquidity-net-in-direction.ts
+++ b/packages/stores/src/queries/concentrated-liquidity/liquidity-net-in-direction.ts
@@ -1,10 +1,7 @@
 import { KVStore } from "@keplr-wallet/common";
 import { ChainGetter, ObservableChainQuery } from "@keplr-wallet/stores";
 import { Dec, Int } from "@keplr-wallet/unit";
-import {
-  computeMinMaxTicksFromExponentAtPriceOne,
-  LiquidityDepth,
-} from "@osmosis-labs/math";
+import { LiquidityDepth, maxTick, minTick } from "@osmosis-labs/math";
 import { computed, makeObservable, observable } from "mobx";
 
 import { LiquidityNetInDirection } from "./types";
@@ -161,7 +158,6 @@ export class ObservableQueryLiquiditiesNetInDirection {
     token0Denom: string,
     token1Denom: string,
     zeroForOne: boolean,
-    exponentAtPriceOne: number,
     initialBoundTick?: Int
   ) {
     // endpoint is on a per-pool and direction basis, so we need to store a query per pool
@@ -172,9 +168,6 @@ export class ObservableQueryLiquiditiesNetInDirection {
     });
 
     if (!this._poolNetInDirQueries.has(codedKey)) {
-      const { minTick, maxTick } =
-        computeMinMaxTicksFromExponentAtPriceOne(exponentAtPriceOne);
-
       const newQuery = new ObservableQueryLiquidityNetInDirection(
         this.kvStore,
         this.chainId,

--- a/packages/stores/src/queries/concentrated-liquidity/tick-data-provider.ts
+++ b/packages/stores/src/queries/concentrated-liquidity/tick-data-provider.ts
@@ -43,7 +43,6 @@ export class ConcentratedLiquidityPoolTickDataProvider
       token1Denom: pool.token1,
       currentSqrtPrice: pool.currentSqrtPrice,
       currentTickLiquidity: pool.currentTickLiquidity,
-      exponentAtPriceOne: pool.exponentAtPriceOne,
     });
 
     if (
@@ -83,7 +82,6 @@ export class ConcentratedLiquidityPoolTickDataProvider
       token1Denom: pool.token1,
       currentSqrtPrice: pool.currentSqrtPrice,
       currentTickLiquidity: pool.currentTickLiquidity,
-      exponentAtPriceOne: pool.exponentAtPriceOne,
     });
 
     if (
@@ -118,7 +116,6 @@ export class ConcentratedLiquidityPoolTickDataProvider
       pool.token0,
       pool.token1,
       zeroForOne,
-      pool.exponentAtPriceOne,
       initialBoundTick // this is the initial bound tick index
     );
 


### PR DESCRIPTION
Inspired by the changes in these chain PRs, in order:
* https://github.com/osmosis-labs/osmosis/pull/4957 (first commit)
* https://github.com/osmosis-labs/osmosis/pull/5022 (second commit)
* https://github.com/osmosis-labs/osmosis/pull/5019 (no changes on frontend)

TODO:
- [x] quotes.spec.ts: update the `inittedTicks` members of the test cases to the new net tick values (as would be returned from chain query) derived from the new go test pools with a different `exponentAtPriceOne` values