### PR TITLE
Hotfix: currency used in calc

### DIFF
--- a/packages/web/components/trade-clipboard/index.tsx
+++ b/packages/web/components/trade-clipboard/index.tsx
@@ -199,17 +199,18 @@ export const TradeClipboard: FunctionComponent<{
           tradeTokenInConfig.expectedSwapResult.beforeSpotPriceInOverOut.toDec();
         const inAmount =
           tradeTokenInConfig.amount === ""
-            ? new Int(1)
+            ? new Int(0)
             : new Int(
                 new Dec(tradeTokenInConfig.amount)
                   .mul(
-                    DecUtils.getTenExponentN(
-                      tradeTokenInConfig.sendCurrency.coinDecimals
+                    DecUtils.getTenExponentNInPrecisionRange(
+                      tradeTokenInConfig.outCurrency.coinDecimals
                     )
                   )
                   .truncate()
                   .toString()
               );
+
         amountLessSlippage = calcPriceImpactWithAmount(
           beforeSpotPrice.gt(new Dec(0)) ? beforeSpotPrice : new Dec(1),
           inAmount,
@@ -217,7 +218,7 @@ export const TradeClipboard: FunctionComponent<{
         );
       } catch {
         // address any /0 errors
-        amountLessSlippage = new Dec(0);
+        amountLessSlippage = new Int(0);
       }
 
       const coinLessSlippage = new CoinPretty(
@@ -232,7 +233,6 @@ export const TradeClipboard: FunctionComponent<{
       );
     }, [
       tradeTokenInConfig.outCurrency,
-      tradeTokenInConfig.sendCurrency.coinDecimals,
       tradeTokenInConfig.expectedSwapResult.beforeSpotPriceInOverOut,
       tradeTokenInConfig.amount,
       slippageConfig.slippage,


### PR DESCRIPTION
Use the swapping out currency instead of the in currency for calculating min out amount. Was displaying fine when the out currency had the same decimals as in currency, but was displaying improperly for out currencies with 18 decimals (ETH, EVMOS, etc.)