### PR TITLE
Update README.md with Asset Listings section

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,7 @@ Have a change you want to make with our translations? We have a frontend for upd
 Inlang editor & status:
 
 [![translation badge](https://inlang.com/badge?url=github.com/osmosis-labs/osmosis-frontend)](https://inlang.com/editor/github.com/osmosis-labs/osmosis-frontend?ref=badge)
+
+## Asset Listings
+
+Please see the asset [listing requirements](https://github.com/osmosis-labs/assetlists/blob/main/LISTING.md) to display assets on Osmosis Zone web app.


### PR DESCRIPTION
I feel like an Asset Listings section should just link the user to the proper location and full docs on asset listings, but for now at least the reference is there now in the root level README