### PR TITLE
fix popup bug and height bug

### DIFF
--- a/packages/web/components/cards/hero-card.tsx
+++ b/packages/web/components/cards/hero-card.tsx
@@ -60,7 +60,7 @@ export const HeroCard: React.FunctionComponent<{
         target="_blank"
         rel="noopener noreferrer"
         onClick={handleAppClicked}
-        className="heroImage height-[400px] relative flex items-end overflow-hidden rounded-lg"
+        className="heroImage relative flex h-[400px] items-end overflow-hidden rounded-lg"
       >
         <div
           className="backgroundImage absolute top-0 left-0 z-10 h-full w-full bg-cover bg-center bg-no-repeat"

--- a/packages/web/components/cards/icon-link.tsx
+++ b/packages/web/components/cards/icon-link.tsx
@@ -1,21 +1,20 @@
-import { HTMLProps } from "react";
-interface IconLinkProps extends HTMLProps<HTMLAnchorElement> {
-  url: string;
-  ariaLabel?: string;
-}
+import { FC, HTMLProps } from "react";
 
-export const IconLink: React.FC<IconLinkProps> = (props) => {
+export const IconLink: FC<
+  HTMLProps<HTMLAnchorElement> & {
+    url: string;
+    ariaLabel?: string;
+  }
+> = ({ url, ariaLabel, children, className }) => {
   return (
     <a
-      href={props.url}
+      href={url}
       target="_blank"
       rel="noopener noreferrer"
-      className={props.className}
-      aria-label={props.ariaLabel}
+      className={className}
+      aria-label={ariaLabel}
     >
-      {props.children}
+      {children}
     </a>
   );
 };
-
-export default IconLink;

--- a/packages/web/pages/apps/index.tsx
+++ b/packages/web/pages/apps/index.tsx
@@ -64,8 +64,6 @@ export const AppStore: React.FC<AppStoreProps> = ({ apps }) => {
 
   const handleApplyClick = () => {
     logEvent([EventName.AppStore.applyClicked]);
-    const url = "https://cosmos-ecosystem.webflow.io/submit";
-    window.open(url, "_blank");
   };
 
   const handleSearchInput = (value: string) => {


### PR DESCRIPTION
Fixing the bugs I pushed 🙃 

The popup blocker was being triggered because we were essentially opening the cosmos eco form in two places, once via the link, and once via `window.open`. I had forgotten to remove `window.open` when a reviewer asked to have the button wrapped in an `<a>` tag. 

@jonator also removed the default export per your request