### PR TITLE
Max/banner styles

### DIFF
--- a/packages/web/components/cards/hero-card.tsx
+++ b/packages/web/components/cards/hero-card.tsx
@@ -45,7 +45,7 @@ export const HeroCard: React.FunctionComponent<{
       </div>
       <div
         onClick={handleAppClicked}
-        className="heroImage relative flex h-[400px]  cursor-pointer items-end overflow-hidden rounded-lg sm:h-[300px]"
+        className="heroImage relative flex h-[400px]  cursor-pointer items-end overflow-hidden rounded-2xl sm:h-[300px]"
       >
         <div
           className="absolute top-0 left-0 z-10 h-full w-full  bg-cover bg-center bg-no-repeat"
@@ -55,7 +55,7 @@ export const HeroCard: React.FunctionComponent<{
         ></div>
 
         <div className="gradient absolute top-0 left-0 z-20 h-full w-full bg-gradient-hero-card"></div>
-        <div className="content text-white relative z-30 m-9 max-w-35 sm:max-w-full">
+        <div className="content text-white relative z-30 m-9 max-w-[45%] sm:max-w-full">
           <div className="flex items-center space-x-6">
             <h4 className="pb-2 text-h4 font-h4">{title}</h4>
             {!!twitterUrl && (

--- a/packages/web/components/navbar/index.tsx
+++ b/packages/web/components/navbar/index.tsx
@@ -291,7 +291,7 @@ const AnnouncementBanner: FunctionComponent<
   return (
     <div
       className={classNames(
-        "fixed top-[72px] z-[51] float-right my-auto ml-sidebar flex w-[calc(100vw_-_12.875rem)] items-center px-8 py-[14px] md:ml-0 md:w-full sm:gap-3 sm:px-2",
+        "fixed top-[71px] z-[51] float-right my-auto ml-sidebar flex w-[calc(100vw_-_12.875rem)] items-center px-8 py-[14px] md:top-[57px] md:ml-0 md:w-full sm:gap-3 sm:px-2",
         {
           "bg-gradient-negative": isWarning,
           "bg-gradient-neutral": !isWarning,

--- a/packages/web/components/navbar/index.tsx
+++ b/packages/web/components/navbar/index.tsx
@@ -299,8 +299,8 @@ const AnnouncementBanner: FunctionComponent<
         bg
       )}
     >
-      <div className="flex w-full place-content-center items-center gap-1.5 text-center text-subtitle1 lg:flex-col lg:gap-1 md:text-left sm:items-start">
-        {t(enTextOrLocalizationPath)}{" "}
+      <div className="flex w-full place-content-center items-center gap-1.5 text-center text-subtitle1 lg:gap-1 lg:text-xs lg:tracking-normal md:text-left md:text-xxs sm:items-start">
+        <span>{t(enTextOrLocalizationPath)}</span>
         {Boolean(link) && (
           <div className="flex cursor-pointer items-center gap-2">
             {link?.isExternal ? (


### PR DESCRIPTION
UPDATE: updated so that there wont be a gap between the banner and the top navbar on mobile. Also small tweaks to hero card. 


Updated the banner styles so that on mobile, it won't overlay the content of the page. First image is what it looked like, and the next four images are with the change
<img width="345" alt="Screen Shot 2023-05-26 at 10 56 53 AM" src="https://github.com/osmosis-labs/osmosis-frontend/assets/11064595/52773f6e-57cc-460f-9bda-8fe639f485f3">


<img width="289" alt="Screen Shot 2023-05-26 at 10 53 37 AM" src="https://github.com/osmosis-labs/osmosis-frontend/assets/11064595/582420d0-367c-49b2-8f7f-d30c2180d7cc">
<img width="472" alt="Screen Shot 2023-05-26 at 10 54 33 AM" src="https://github.com/osmosis-labs/osmosis-frontend/assets/11064595/1e1a6eed-752d-4ab7-87fc-239c9477af01">
<img width="855" alt="Screen Shot 2023-05-26 at 10 54 47 AM" src="https://github.com/osmosis-labs/osmosis-frontend/assets/11064595/d5c0c435-c51c-4313-81b3-cb3607f715a1">
<img width="1210" alt="Screen Shot 2023-05-26 at 10 54 55 AM" src="https://github.com/osmosis-labs/osmosis-frontend/assets/11064595/4eac780b-2574-459d-bf8b-a6db4e8b7a78">
