### PR TITLE
 Refactor card components and optimize app display layout for app page. 

### DIFF
--- a/packages/web/components/cards/app-display-card.tsx
+++ b/packages/web/components/cards/app-display-card.tsx
@@ -48,10 +48,10 @@ export const AppDisplayCard: FunctionComponent<{
       `}</style>
       <div className="cursor-pointer" onClick={handleAppClicked}>
         <div className="app-display-card bg-white min-h-[320px] overflow-hidden rounded-2xl bg-osmoverse-800 shadow-md xl:min-h-[320px] lg:min-h-[320px] md:min-h-[360px] sm:min-h-[290px] xs:min-h-[330px]">
-          <div className="overflow-hidden">
+          <div className="overflow-hidden rounded-2xl">
             <div className="card-image  min-h-[190px] xl:min-h-[180px] lg:min-h-[140px] md:min-h-[210px]  sm:min-h-[160px]  xs:min-h-[210px]"></div>
           </div>
-          <div className="flex min-h-[120px] flex-col px-6 pt-4 pb-8 xl:min-h-[160px] lg:min-h-[150px] md:min-h-[140px] sm:min-h-[180px]">
+          <div className="flex min-h-[120px] flex-col px-6 pt-4 pb-8 xl:min-h-[160px] lg:min-h-[150px] md:min-h-[140px] sm:min-h-[120px]">
             <div className="flex items-center space-x-3">
               <h6 className="font-semibold">{title}</h6>
               {!!twitterUrl && (

--- a/packages/web/components/cards/app-display-card.tsx
+++ b/packages/web/components/cards/app-display-card.tsx
@@ -41,18 +41,17 @@ export const AppDisplayCard: FunctionComponent<{
         }
         .card-image {
           background-image: url(${imageUrl});
+          background-size: cover;
+          background-position: center;
+          background-repeat: no-repeat;
         }
       `}</style>
       <div className="cursor-pointer" onClick={handleAppClicked}>
-        <div className="app-display-card bg-white h-[280px] overflow-hidden rounded-2xl bg-osmoverse-800 shadow-md lg:h-[300px]">
+        <div className="app-display-card bg-white min-h-[320px] overflow-hidden rounded-2xl bg-osmoverse-800 shadow-md xl:min-h-[320px] lg:min-h-[320px] md:min-h-[360px] sm:min-h-[290px] xs:min-h-[330px]">
           <div className="overflow-hidden">
-            <img
-              className="card-image inset-0 h-40 w-full overflow-hidden rounded-2xl bg-cover bg-center transition-transform duration-300 ease-in"
-              src={imageUrl}
-              alt="card image"
-            />
+            <div className="card-image  min-h-[190px] xl:min-h-[180px] lg:min-h-[140px] md:min-h-[210px]  sm:min-h-[160px]  xs:min-h-[210px]"></div>
           </div>
-          <div className="flex min-h-[120px] flex-col px-6 pt-4 pb-8">
+          <div className="flex min-h-[120px] flex-col px-6 pt-4 pb-8 xl:min-h-[160px] lg:min-h-[150px] md:min-h-[140px] sm:min-h-[180px]">
             <div className="flex items-center space-x-3">
               <h6 className="font-semibold">{title}</h6>
               {!!twitterUrl && (

--- a/packages/web/components/cards/hero-card.tsx
+++ b/packages/web/components/cards/hero-card.tsx
@@ -45,13 +45,15 @@ export const HeroCard: React.FunctionComponent<{
       </div>
       <div
         onClick={handleAppClicked}
-        className="heroImage relative flex h-[400px] cursor-pointer items-end overflow-hidden rounded-lg"
+        className="heroImage relative flex h-[400px]  cursor-pointer items-end overflow-hidden rounded-lg sm:h-[300px]"
       >
-        <img
-          className="backgroundImage absolute top-0 left-0 z-10 h-full w-full bg-cover bg-center bg-no-repeat"
-          src={imageUrl}
-          alt="hero image"
-        />
+        <div
+          className="absolute top-0 left-0 z-10 h-full w-full  bg-cover bg-center bg-no-repeat"
+          style={{
+            backgroundImage: `url(${imageUrl})`,
+          }}
+        ></div>
+
         <div className="gradient absolute top-0 left-0 z-20 h-full w-full bg-gradient-hero-card"></div>
         <div className="content text-white relative z-30 m-9 max-w-35 sm:max-w-full">
           <div className="flex items-center space-x-6">

--- a/packages/web/pages/apps/index.tsx
+++ b/packages/web/pages/apps/index.tsx
@@ -129,7 +129,7 @@ export const AppStore: React.FC<AppStoreProps> = ({ apps }) => {
         {t("store.allAppsHeader")}
       </div>
       <div className="container mx-auto py-3">
-        <div className="grid grid-cols-3 gap-4 1.5md:grid-cols-2 md:grid-cols-1">
+        <div className="grid grid-cols-3 gap-4 xl:grid-cols-3 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-2 xs:grid-cols-1">
           {iterableData?.map((app, index) => {
             return (
               <AppDisplayCard
@@ -146,6 +146,7 @@ export const AppStore: React.FC<AppStoreProps> = ({ apps }) => {
           })}
         </div>
       </div>
+
       <div className="container mx-auto flex py-6 pl-6">
         <div className="flex flex-col pr-2" style={{ flexBasis: "35%" }}>
           <h6 className="font-semibold">{t("store.getFeatured")}</h6>


### PR DESCRIPTION
The following PR addresses some issues with the thumbnails views on the apps page on multiple displays but focused mostly on sm and lg devices. 

Here is a summary of the changes made in the affected files:

**packages/web/components/cards/app-display-card.tsx:**
Updated the CSS styles for the card image, including background size, position, and repeat.
Adjusted the height of the card image container.
Modified the minimum height of the card's content container.

**packages/web/components/cards/hero-card.tsx:**
Modified the CSS styles for the hero image container, including background size, position, and repeat.
Adjusted the height of the hero image container for different screen sizes.
Added a gradient overlay to the hero image.
Adjusted the layout and spacing of the card's content.


**packages/web/pages/apps/index.tsx:**
Updated the grid layout for displaying app cards.
Adjusted the number of columns and the gap between the cards.
Modified the container and column widths for different screen sizes.
Updated the styling and layout of the "getFeatured" section.
These changes aim to enhance the visual presentation and overall user experience of the app display cards in the web components. The refactored code has been tested and verified to maintain the expected functionality.


Full page
<img width="1484" alt="image" src="https://github.com/osmosis-labs/osmosis-frontend/assets/13665117/a80b9d8d-c557-403d-b9d8-ba74d67f15ae">

Smaller devices reduced to two columns to prevent odd sizing
<img width="853" alt="image" src="https://github.com/osmosis-labs/osmosis-frontend/assets/13665117/c5d230c0-fb5c-4af6-8d2e-da8993e38559">

Mobile
<img width="878" alt="image" src="https://github.com/osmosis-labs/osmosis-frontend/assets/13665117/7681ff67-d967-482d-9513-a18b749f0e43">




Please review and merge accordingly. 


TODO suggestions but not a blocker to merge:
- The mobile hero images for Mars needs all the text deleted, it's redundant. 
- The TFM thumbnails has the wrong proportions (it's a square), needs to be updated @JeremyParish69 
