### PR TITLE
Remove Autonomy Banner

### DIFF
--- a/packages/web/config/feature-flag.ts
+++ b/packages/web/config/feature-flag.ts
@@ -36,14 +36,7 @@ export const Announcement:
         "Chain is halted, transactions are temporarily disabled",
       isWarning: true,
     }
-  : {
-      enTextOrLocalizationPath: "autonomy.description",
-      link: {
-        enTextOrLocalizationKey: "autonomy.link",
-        url: "https://osmosis.autoswap.trade/",
-        isExternal: true,
-      },
-    };
+  : undefined;
 
 // Past localstorage keys:
 // * "feedback_wQ1KR7": "Help us shape the future of Osmosis." Give us feedback -> https://tally.so/r/wQ1KR7

--- a/packages/web/localizations/en.json
+++ b/packages/web/localizations/en.json
@@ -462,9 +462,5 @@
   "unknownError": "Unknown error",
   "viewExplorer": "View explorer",
   "waitingForTransaction": "Waiting for transaction to be included in the block",
-  "highPoolInflationWarning": "High APRs may result from inflationary rewards. Proceed with caution.",
-  "autonomy": {
-    "description": "Explore Limit and Stop Orders brought to you by Autonomy: ",
-    "link": "osmosis.autoswap.trade"
-  }
+  "highPoolInflationWarning": "High APRs may result from inflationary rewards. Proceed with caution."
 }

--- a/packages/web/localizations/es.json
+++ b/packages/web/localizations/es.json
@@ -462,9 +462,5 @@
   "unknownError": "Error desconocido",
   "viewExplorer": "Ver Explorador",
   "waitingForTransaction": "Esperando que la transacción se incluya en el bloque",
-  "highPoolInflationWarning": "Los APRs altos pueden ser resultado de recompensas inflacionarias. Proceda con precaución.",
-  "autonomy": {
-    "description": "Explora Órdenes de Límite y Stop presentadas por Autonomy: ",
-    "link": "osmosis.autoswap.trade"
-  }
+  "highPoolInflationWarning": "Los APRs altos pueden ser resultado de recompensas inflacionarias. Proceda con precaución."
 }

--- a/packages/web/localizations/fa.json
+++ b/packages/web/localizations/fa.json
@@ -462,9 +462,5 @@
   "unknownError": "خطای نا شناس",
   "viewExplorer": "مشاهده جزئیات تراکنش",
   "waitingForTransaction": "صبر کنید تا یک تراکنش در بلاک قرار بگیرد",
-  "highPoolInflationWarning": "نرخ سود سالانه بالا ممکن است ناشی از پاداش‌های تورمی باشد. با احتیاط ادامه دهید.",
-  "autonomy": {
-    "description": "تحقیق در حد و سفارش‌های توقفی که توسط Autonomy ارائه شده‌اند: ",
-    "link": "osmosis.autoswap.trade"
-  }
+  "highPoolInflationWarning": "نرخ سود سالانه بالا ممکن است ناشی از پاداش‌های تورمی باشد. با احتیاط ادامه دهید."
 }

--- a/packages/web/localizations/fr.json
+++ b/packages/web/localizations/fr.json
@@ -462,9 +462,5 @@
   "unknownError": "Erreur inconnue",
   "viewExplorer": "Voir dans l'exploreur",
   "waitingForTransaction": "Attente de l'inclusion de la transaction dans le bloc",
-  "highPoolInflationWarning": "Des APR élevés peuvent être le résultat de récompenses inflationnistes. Procédez avec prudence.",
-  "autonomy": {
-    "description": "Découvrez les ordres à cours limité et les ordres stop proposés par Autonomy: ",
-    "link": "osmosis.autoswap.trade"
-  }
+  "highPoolInflationWarning": "Des APR élevés peuvent être le résultat de récompenses inflationnistes. Procédez avec prudence."
 }

--- a/packages/web/localizations/ko.json
+++ b/packages/web/localizations/ko.json
@@ -462,9 +462,5 @@
   "unknownError": "알 수 없는 에러",
   "viewExplorer": "블록 익스플로러 보기",
   "waitingForTransaction": "트랜잭션이 블록에 담기는 중입니다",
-  "highPoolInflationWarning": "높은 APR은 인플레이션 보상에서 비롯될 수 있습니다. 주의해서 진행하십시오.",
-  "autonomy": {
-    "description": "Autonomy가 제공하는 한정 및 중지 주문을 살펴보세요: ",
-    "link": "osmosis.autoswap.trade"
-  }
+  "highPoolInflationWarning": "높은 APR은 인플레이션 보상에서 비롯될 수 있습니다. 주의해서 진행하십시오."
 }

--- a/packages/web/localizations/pl.json
+++ b/packages/web/localizations/pl.json
@@ -462,9 +462,5 @@
   "unknownError": "Nieznany błąd",
   "viewExplorer": "zobacz eksplorer",
   "waitingForTransaction": "Oczekiwanie na dołączenie transakcji do bloku",
-  "highPoolInflationWarning": "Wysokie APR-y mogą wynikać z nagród inflacyjnych. Postępuj ostrożnie.",
-  "autonomy": {
-    "description": "Poznaj Limity i Zlecenia Stop oferowane przez Autonomy: ",
-    "link": "osmosis.autoswap.trade"
-  }
+  "highPoolInflationWarning": "Wysokie APR-y mogą wynikać z nagród inflacyjnych. Postępuj ostrożnie."
 }

--- a/packages/web/localizations/pt-br.json
+++ b/packages/web/localizations/pt-br.json
@@ -462,9 +462,5 @@
   "unknownError": "Erro desconhecido",
   "viewExplorer": "Visualizar explorer",
   "waitingForTransaction": "Aguardando para que a transação seja incluida no bloco",
-  "highPoolInflationWarning": "APRs altos podem ser resultado de recompensas inflacionárias. Proceda com cautela.",
-  "autonomy": {
-    "description": "Explore Ordens de Limite e Stop oferecidas pela Autonomy: ",
-    "link": "osmosis.autoswap.trade"
-  }
+  "highPoolInflationWarning": "APRs altos podem ser resultado de recompensas inflacionárias. Proceda com cautela."
 }

--- a/packages/web/localizations/ro.json
+++ b/packages/web/localizations/ro.json
@@ -463,9 +463,5 @@
   "unknownError": "Eroare necunoscuta",
   "viewExplorer": "vezi explorer",
   "waitingForTransaction": "Se asteapta includerea tranzactiei intr-un bloc.",
-  "highPoolInflationWarning": "APR-uri ridicate pot fi rezultatul recompenselor inflaționiste. Procedează cu prudență.",
-  "autonomy": {
-    "description": "Explorează Ordinele Limită și Ordinele de Oprire aduse de Autonomy: ",
-    "link": "osmosis.autoswap.trade"
-  }
+  "highPoolInflationWarning": "APR-uri ridicate pot fi rezultatul recompenselor inflaționiste. Procedează cu prudență."
 }

--- a/packages/web/localizations/tr.json
+++ b/packages/web/localizations/tr.json
@@ -462,9 +462,5 @@
   "unknownError": "Bilinmeyen hata",
   "viewExplorer": "gezginde görüntüle",
   "waitingForTransaction": "İşlemin bloğa eklenmesi bekleniyor",
-  "highPoolInflationWarning": "Yüksek APR'ler enflasyonist ödüllerden kaynaklanabilir. Dikkatli ilerleyin.",
-  "autonomy": {
-    "description": "Autonomy tarafından sunulan Sınırlama ve Durdurma Emirlerini Keşfedin: ",
-    "link": "osmosis.autoswap.trade"
-  }
+  "highPoolInflationWarning": "Yüksek APR'ler enflasyonist ödüllerden kaynaklanabilir. Dikkatli ilerleyin."
 }

--- a/packages/web/localizations/zh-cn.json
+++ b/packages/web/localizations/zh-cn.json
@@ -462,9 +462,5 @@
   "unknownError": "未知错误",
   "viewExplorer": "浏览器查看",
   "waitingForTransaction": "等待交易打包进区块",
-  "highPoolInflationWarning": "高APR可能源自通胀性奖励。请谨慎操作。",
-  "autonomy": {
-    "description": "通过 Autonomy 探索限价和止损订单: ",
-    "link": "osmosis.autoswap.trade"
-  }
+  "highPoolInflationWarning": "高APR可能源自通胀性奖励。请谨慎操作。"
 }

--- a/packages/web/localizations/zh-hk.json
+++ b/packages/web/localizations/zh-hk.json
@@ -462,9 +462,5 @@
   "unknownError": "未知錯誤",
   "viewExplorer": "使用區塊瀏覽器查看",
   "waitingForTransaction": "正等待交易被加入到區塊中",
-  "highPoolInflationWarning": "高APR可能源自通脹性獎勵。請謹慎操作。",
-  "autonomy": {
-    "description": "探索由 Autonomy 提供的限價和止損訂單: ",
-    "link": "osmosis.autoswap.trade"
-  }
+  "highPoolInflationWarning": "高APR可能源自通脹性獎勵。請謹慎操作。"
 }

--- a/packages/web/localizations/zh-tw.json
+++ b/packages/web/localizations/zh-tw.json
@@ -462,9 +462,5 @@
   "unknownError": "未知錯誤",
   "viewExplorer": "使用區塊瀏覽器查看",
   "waitingForTransaction": "正等待交易被加入到區塊中",
-  "highPoolInflationWarning": "高APR可能源自通脹性獎勵。請謹慎操作。",
-  "autonomy": {
-    "description": "探索由 Autonomy 提供的限價和停損訂單: ",
-    "link": "osmosis.autoswap.trade"
-  }
+  "highPoolInflationWarning": "高APR可能源自通脹性獎勵。請謹慎操作。"
 }


### PR DESCRIPTION
## What is the purpose of the change

Removes Autonomy Banner which has been up for 4 days

## Testing and Verifying

This change has been tested locally by rebuilding the website and verified content and links are expected

