### PR TITLE
fix: asset0/asset1 calculation

### DIFF
--- a/packages/math/src/pool/concentrated/math.ts
+++ b/packages/math/src/pool/concentrated/math.ts
@@ -296,43 +296,84 @@ export function convertTokenInGivenOutToTokenOutGivenIn(
 // add liquidity
 // docs ref: https://github.com/osmosis-labs/osmosis/blob/b764323ce7702185d2089b9e76a0115c7058f37e/x/concentrated-liquidity/README.md#L573
 
+// calcAmount0
 export function calculateDepositAmountForQuote(
-  curSqrtPrice: Dec,
-  lowerTick: Int,
   upperTick: Int,
-  baseDeposit: Int
-): Int {
-  const sqrtPu = tickToSqrtPrice(upperTick);
-  const sqrtPl = tickToSqrtPrice(lowerTick);
-  const sqrtPc = curSqrtPrice;
+  currentSqrtPrice: Dec,
+  baseDeposit: Dec
+): Dec {
+  const upperTickSqrt = tickToSqrtPrice(upperTick);
 
-  // calculate liquidity needed for token0
-  const L = new Dec(baseDeposit)
-    .mul(sqrtPu)
-    .mul(sqrtPl)
-    .quo(sqrtPu.sub(sqrtPl));
+  let sqrtPriceA = currentSqrtPrice;
+  let sqrtPriceB = upperTickSqrt;
 
-  // calculate delta y
-  const deltaY = L.mul(sqrtPc.sub(sqrtPl));
+  if (sqrtPriceA.gt(sqrtPriceB)) {
+    sqrtPriceA = upperTickSqrt;
+    sqrtPriceB = currentSqrtPrice;
+  }
 
-  return deltaY.truncate();
+  const numerator = baseDeposit.mul(sqrtPriceB.sub(sqrtPriceA));
+  const denominator = sqrtPriceB.mul(sqrtPriceA);
+
+  return numerator.quo(denominator);
 }
 
+// calcAmount1
 export function calculateDepositAmountForBase(
-  curSqrtPrice: Dec,
   lowerTick: Int,
-  upperTick: Int,
-  quoteDeposit: Int
-): Int {
-  const sqrtPu = tickToSqrtPrice(upperTick);
-  const sqrtPl = tickToSqrtPrice(lowerTick);
-  const sqrtPc = curSqrtPrice;
+  currentSqrtPrice: Dec,
+  quoteDeposit: Dec
+): Dec {
+  const lowerTickSqrt = tickToSqrtPrice(lowerTick);
 
-  // calculate liquidity needed for token1
-  const L = new Dec(quoteDeposit).quo(sqrtPu.sub(sqrtPl));
+  let sqrtPriceA = currentSqrtPrice;
+  let sqrtPriceB = lowerTickSqrt;
 
-  // calculate delta x
-  const deltaX = L.mul(sqrtPu.sub(sqrtPc)).quo(sqrtPu.mul(sqrtPc));
+  if (sqrtPriceA.gt(sqrtPriceB)) {
+    sqrtPriceA = lowerTickSqrt;
+    sqrtPriceB = currentSqrtPrice;
+  }
 
-  return deltaX.truncate();
+  return quoteDeposit.mul(sqrtPriceB.sub(sqrtPriceA));
 }
+
+// export function calculateDepositAmountForQuote(
+//   curSqrtPrice: Dec,
+//   lowerTick: Int,
+//   upperTick: Int,
+//   baseDeposit: Int
+// ): Int {
+//   const sqrtPu = tickToSqrtPrice(upperTick);
+//   const sqrtPl = tickToSqrtPrice(lowerTick);
+//   const sqrtPc = curSqrtPrice;
+
+//   // calculate liquidity needed for token0
+//   const L = new Dec(baseDeposit)
+//     .mul(sqrtPu)
+//     .mul(sqrtPl)
+//     .quo(sqrtPu.sub(sqrtPl));
+
+//   // calculate delta y
+//   const deltaY = L.mul(sqrtPc.sub(sqrtPl));
+
+//   return deltaY.truncate();
+// }
+
+// export function calculateDepositAmountForBase(
+//   curSqrtPrice: Dec,
+//   lowerTick: Int,
+//   upperTick: Int,
+//   quoteDeposit: Int
+// ): Int {
+//   const sqrtPu = tickToSqrtPrice(upperTick);
+//   const sqrtPl = tickToSqrtPrice(lowerTick);
+//   const sqrtPc = curSqrtPrice;
+
+//   // calculate liquidity needed for token1
+//   const L = new Dec(quoteDeposit).quo(sqrtPu.sub(sqrtPl));
+
+//   // calculate delta x
+//   const deltaX = L.mul(sqrtPu.sub(sqrtPc)).quo(sqrtPu.mul(sqrtPc));
+
+//   return deltaX.truncate();
+// }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Fixes:
- Inputting asset0 properly calculates asset1
- Percent values for asset0 and asset1

Still broken:
- Off by 1 when inputting asset1
 - still looking into this but pushing what I have so far
