### PR TITLE
fix: Account Sequencing and Accurate IBC Transfer Amount

### DIFF
--- a/packages/stores/src/account/amino-converters.ts
+++ b/packages/stores/src/account/amino-converters.ts
@@ -124,7 +124,7 @@ const ibcAminoConverters: Record<
       source_channel: sourceChannel,
       token: {
         denom: token?.denom,
-        amount: token?.amount ? Long.fromValue(token.amount).toString() : "0",
+        amount: token?.amount ?? "0",
       },
       sender,
       receiver,

--- a/packages/stores/src/account/base.ts
+++ b/packages/stores/src/account/base.ts
@@ -31,6 +31,7 @@ import {
   WalletManager,
   WalletStatus,
 } from "@cosmos-kit/core";
+import { BaseAccount } from "@keplr-wallet/cosmos";
 import {
   ChainedFunctionifyTuple,
   ChainGetter,
@@ -684,19 +685,18 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
         throw new Error("Endpoint is not provided");
       }
 
-      const res = await axios.get<{
-        account: {
-          "@type": string;
-          address: string;
-          pub_key: { "@type": string; key: string };
-          account_number: string;
-          sequence: string;
-        };
-      }>(
-        `${removeLastSlash(endpoint)}/cosmos/auth/v1beta1/accounts/${address}`
+      const account = await BaseAccount.fetchFromRest(
+        axios.create({
+          baseURL: removeLastSlash(endpoint),
+        }),
+        address,
+        true
       );
 
-      return res.data.account;
+      return {
+        accountNumber: account.getAccountNumber(),
+        sequence: account.getSequence(),
+      };
     } catch (error: any) {
       throw error;
     }
@@ -713,8 +713,8 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
     }
 
     return {
-      accountNumber: Number(account.account_number),
-      sequence: Number(account.sequence),
+      accountNumber: Number(account.accountNumber.toString()),
+      sequence: Number(account.sequence.toString()),
     };
   }
 }


### PR DESCRIPTION
## What is the purpose of the change

Fix the following bugs: 

- [x] Get 404 when depositing CW tokens
- [x] Transfer status not updated until the page is refreshed for ETH tokens
- [x] Deposit status of native ETH(Axelar) tokens get stuck at  pending

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/866ad98b0)
