### PR TITLE
(CL) My pos cleanup

### DIFF
--- a/packages/stores/src/account/__tests_e2e__/collect-rewards.spec.ts
+++ b/packages/stores/src/account/__tests_e2e__/collect-rewards.spec.ts
@@ -143,9 +143,8 @@ describe("Collect Cl Fees Txs", () => {
     const osmosisQueries = queriesStore.get(chainId).osmosis!;
 
     const positions =
-      osmosisQueries.queryLiquidityPositionsByAddress.getForAddress(
-        account.bech32Address
-      ).positionIds ?? [];
+      osmosisQueries.queryAccountsPositions.get(account.bech32Address)
+        .positionIds ?? [];
 
     return positions;
   }

--- a/packages/stores/src/account/index.ts
+++ b/packages/stores/src/account/index.ts
@@ -797,7 +797,7 @@ export class OsmosisAccountImpl {
       },
       undefined,
       (tx) => {
-        console.log({ tx });
+        this.sendBeginUnlockingMsg;
         if (tx.code == null || tx.code === 0) {
           const queries = this.queriesStore.get(this.chainId);
           queries.queryBalances

--- a/packages/stores/src/account/index.ts
+++ b/packages/stores/src/account/index.ts
@@ -958,8 +958,8 @@ export class OsmosisAccountImpl {
             .balances.forEach((bal) => {
               bal.waitFreshResponse();
             });
-          this.queries.queryLiquidityPositionsByAddress
-            .getForAddress(this.base.bech32Address)
+          this.queries.queryAccountsPositions
+            .get(this.base.bech32Address)
             ?.waitFreshResponse();
 
           positionIds.forEach((id) => {
@@ -1073,8 +1073,8 @@ export class OsmosisAccountImpl {
                 ?.waitFreshResponse();
             });
 
-          queries.osmosis?.queryLiquidityPositionsByAddress
-            .getForAddress(this.base.bech32Address)
+          queries.osmosis?.queryAccountsPositions
+            .get(this.base.bech32Address)
             .waitFreshResponse();
         }
 
@@ -1172,8 +1172,8 @@ export class OsmosisAccountImpl {
               ?.waitFreshResponse();
           });
 
-          queries.osmosis?.queryLiquidityPositionsByAddress
-            .getForAddress(this.base.bech32Address)
+          queries.osmosis?.queryAccountsPositions
+            .get(this.base.bech32Address)
             .waitFreshResponse();
         }
 
@@ -1268,8 +1268,8 @@ export class OsmosisAccountImpl {
             this.queries.queryGammPools.getPool(id)?.waitFreshResponse()
           );
 
-          queries.osmosis?.queryLiquidityPositionsByAddress
-            .getForAddress(this.base.bech32Address)
+          queries.osmosis?.queryAccountsPositions
+            .get(this.base.bech32Address)
             .waitFreshResponse();
         }
 

--- a/packages/stores/src/queries-external/README.md
+++ b/packages/stores/src/queries-external/README.md
@@ -1,0 +1,16 @@
+## External Queries
+
+This folder contains what we call "queries-external" -- or any queries that do not originate from the Osmosis node.
+
+Our ethos is that the frontend should operate gracefully without any of these supplemental queries. These should mainly
+be queries that are not essential and improve the UX in some way; APRs, performance-optimized queries/proxy queries, historical data user account, historical price data, etc.
+
+### Creating an External Query
+
+1. Create a new folder in this directory with the concise name of your query.
+2. Define the query either in the index file if it's the only one, or a more specifically named file if there are multiple.
+3. Add the query to the `index.ts` file in this directory.
+4. Add a types file for the data shape, as well as any externally exportable types.
+5. Create a query that extends the `ObservableQueryExternalBase` class. This class simply creates the Axios instance passed to Keplr team's base query class that is used to handle the request. Includes caching, activation, invalidation, etc.
+   > 💡 If your query is a "Map" query, as in it has varying parameters (example: query a pool by ID), create an additional parent class that extends the HasMapStore that will automatically create a new store for each requested parameter(s). You may need to de/serialize a string key if there's more than one parameter.
+6. Add your query or map query to the store.ts file to be used by the depending package.

--- a/packages/stores/src/queries-external/concentrated-liquidity/index.ts
+++ b/packages/stores/src/queries-external/concentrated-liquidity/index.ts
@@ -1,0 +1,1 @@
+export * from "./position-range";

--- a/packages/stores/src/queries-external/concentrated-liquidity/position-range.ts
+++ b/packages/stores/src/queries-external/concentrated-liquidity/position-range.ts
@@ -1,0 +1,79 @@
+import { KVStore } from "@keplr-wallet/common";
+import { HasMapStore } from "@keplr-wallet/stores";
+import { RatePretty } from "@keplr-wallet/unit";
+import { maxTick, minTick } from "@osmosis-labs/math";
+import { computed, makeObservable } from "mobx";
+
+import { IMPERATOR_TX_REWARD_BASEURL } from "..";
+import { ObservableQueryExternalBase } from "../base";
+
+/** Queries Imperator for extrapolated APR of a given position's tick range. */
+export class ObservableQueryPositionRangeApr extends ObservableQueryExternalBase<{
+  spreadFactorApr: string;
+  incentivesApr: string;
+}> {
+  constructor(
+    kvStore: KVStore,
+    baseURL: string,
+    protected readonly poolId: string,
+    protected readonly lowerTickIndex: number,
+    protected readonly upperTickIndex: number
+  ) {
+    // TODO: add endpoint
+    super(kvStore, baseURL, `/lp/v1/rewards/estimation/`);
+
+    makeObservable(this);
+  }
+
+  @computed
+  get apr(): RatePretty | undefined {
+    // TODO: don't use mock data
+
+    return new RatePretty(23);
+  }
+}
+
+export class ObservableQueryPositionsRangeApr extends HasMapStore<ObservableQueryPositionRangeApr> {
+  constructor(
+    kvStore: KVStore,
+    poolRewardsBaseUrl = IMPERATOR_TX_REWARD_BASEURL
+  ) {
+    super((key) => {
+      const { poolId, lowerTickIndex, upperTickIndex } = parseKey(key);
+      return new ObservableQueryPositionRangeApr(
+        kvStore,
+        poolRewardsBaseUrl,
+        poolId,
+        lowerTickIndex,
+        upperTickIndex
+      );
+    });
+  }
+
+  get(poolId: string, lowerTickIndex?: number, upperTickIndex?: number) {
+    const key = makeKey(
+      poolId,
+      lowerTickIndex ?? Number(minTick.toString()),
+      upperTickIndex ?? Number(maxTick.toString())
+    );
+    return super.get(key) as ObservableQueryPositionRangeApr;
+  }
+}
+
+function makeKey(
+  poolId: string,
+  lowerTickIndex: number,
+  upperTickIndex: number
+) {
+  return `${poolId}:${lowerTickIndex}:${upperTickIndex}`;
+}
+
+function parseKey(key: string) {
+  const [poolId, lowerTickIndex, upperTickIndex] = key.split(":");
+
+  return {
+    poolId,
+    lowerTickIndex: parseInt(lowerTickIndex),
+    upperTickIndex: parseInt(upperTickIndex),
+  };
+}

--- a/packages/stores/src/queries-external/concentrated-liquidity/position-range.ts
+++ b/packages/stores/src/queries-external/concentrated-liquidity/position-range.ts
@@ -71,9 +71,19 @@ function makeKey(
 function parseKey(key: string) {
   const [poolId, lowerTickIndex, upperTickIndex] = key.split(":");
 
+  const lowerTickIndexNum = parseInt(lowerTickIndex);
+  const upperTickIndexNum = parseInt(upperTickIndex);
+
+  if (isNaN(lowerTickIndexNum)) {
+    throw new Error(`Invalid lower tick index: ${lowerTickIndex}`);
+  }
+  if (isNaN(upperTickIndexNum)) {
+    throw new Error(`Invalid upper tick index: ${upperTickIndex}`);
+  }
+
   return {
     poolId,
-    lowerTickIndex: parseInt(lowerTickIndex),
-    upperTickIndex: parseInt(upperTickIndex),
+    lowerTickIndex: lowerTickIndexNum,
+    upperTickIndex: upperTickIndexNum,
   };
 }

--- a/packages/stores/src/queries-external/store.ts
+++ b/packages/stores/src/queries-external/store.ts
@@ -10,6 +10,7 @@ import {
   IMPERATOR_TX_REWARD_BASEURL,
 } from ".";
 import { ObservableQueryActiveGauges } from "./active-gauges";
+import { ObservableQueryPositionsRangeApr } from "./concentrated-liquidity";
 import { ObservableQueryIbcChainsStatus } from "./ibc";
 import { ObservableQueryICNSNames } from "./icns";
 import { ObservableQueryPoolFeesMetrics } from "./pool-fees";
@@ -25,6 +26,7 @@ export class QueriesExternalStore {
   public readonly queryChainStatus: DeepReadonly<ObservableQueryIbcChainsStatus>;
   public readonly queryTokenHistoricalChart: DeepReadonly<ObservableQueryTokensHistoricalChart>;
   public readonly queryTokenPairHistoricalChart: DeepReadonly<ObservableQueryTokensPairHistoricalChart>;
+  public readonly queryPositionsRangeApr: DeepReadonly<ObservableQueryPositionsRangeApr>;
   public readonly queryTokenData: DeepReadonly<ObservableQueryTokensData>;
   public readonly queryActiveGauges: DeepReadonly<ObservableQueryActiveGauges>;
   public readonly queryICNSNames: DeepReadonly<ObservableQueryICNSNames>;
@@ -67,6 +69,10 @@ export class QueriesExternalStore {
         feeMetricsBaseURL,
         isTestnet
       );
+    this.queryPositionsRangeApr = new ObservableQueryPositionsRangeApr(
+      kvStore,
+      poolRewardsBaseUrl
+    );
     this.queryTokenData = new ObservableQueryTokensData(
       kvStore,
       feeMetricsBaseURL

--- a/packages/stores/src/queries/concentrated-liquidity/position-by-id.ts
+++ b/packages/stores/src/queries/concentrated-liquidity/position-by-id.ts
@@ -122,6 +122,7 @@ export class ObservableQueryLiquidityPositionById extends ObservableChainQuery<{
     );
   }
 
+  @computed
   get claimableSpreadRewards(): CoinPretty[] {
     if (!this._raw?.claimable_spread_rewards) return [];
     return this._raw?.claimable_spread_rewards.map(
@@ -133,14 +134,33 @@ export class ObservableQueryLiquidityPositionById extends ObservableChainQuery<{
     );
   }
 
+  @computed
   get claimableIncentiveRewards(): CoinPretty[] {
     if (!this._raw?.claimable_incentives) return [];
-    return this._raw?.claimable_fees.map(
+    return this._raw?.claimable_incentives?.map(
       ({ denom, amount }) =>
         new CoinPretty(
           this.chainGetter.getChain(this.chainId).forceFindCurrency(denom),
           amount
         )
+    );
+  }
+
+  /** Aggregation of claimable rewards by coin denom. */
+  @computed
+  get totalClaimableRewards(): CoinPretty[] {
+    return Array.from(
+      [...this.claimableSpreadRewards, ...this.claimableIncentiveRewards]
+        .reduce<Map<string, CoinPretty>>((sumByDenoms, coin) => {
+          const current = sumByDenoms.get(coin.currency.coinMinimalDenom);
+          if (current) {
+            sumByDenoms.set(coin.currency.coinMinimalDenom, current.add(coin));
+          } else {
+            sumByDenoms.set(coin.currency.coinMinimalDenom, coin);
+          }
+          return sumByDenoms;
+        }, new Map())
+        .values()
     );
   }
 

--- a/packages/stores/src/queries/concentrated-liquidity/types.ts
+++ b/packages/stores/src/queries/concentrated-liquidity/types.ts
@@ -21,22 +21,26 @@ export type PositionAsset = {
 };
 
 export type LiquidityPosition = {
-  asset0: PositionAsset;
-  asset1: PositionAsset;
   position: {
+    position_id: string;
     address: string;
     join_time: string;
     liquidity: string;
     lower_tick: string;
     pool_id: string;
-    position_id: string;
     upper_tick: string;
   };
-  claimable_fees: {
+  asset0: PositionAsset;
+  asset1: PositionAsset;
+  claimable_spread_rewards: {
     denom: string;
     amount: string;
   }[];
   claimable_incentives: {
+    denom: string;
+    amount: string;
+  }[];
+  forfeited_incentives: {
     denom: string;
     amount: string;
   }[];

--- a/packages/web/components/assets/icon.tsx
+++ b/packages/web/components/assets/icon.tsx
@@ -32,6 +32,7 @@ export type SpriteIconId =
   | "medium"
   | "alert-triangle"
   | "lightning"
+  | "lightning-small"
   | "left-right-arrow";
 
 /**

--- a/packages/web/components/assets/icon.tsx
+++ b/packages/web/components/assets/icon.tsx
@@ -31,7 +31,8 @@ export type SpriteIconId =
   | "twitter"
   | "medium"
   | "alert-triangle"
-  | "lightning";
+  | "lightning"
+  | "left-right-arrow";
 
 /**
  * It takes an icon id and returns an svg element with the corresponding icon defined in /public/icons/sprite.svg.

--- a/packages/web/components/buttons/chart-button.tsx
+++ b/packages/web/components/buttons/chart-button.tsx
@@ -15,7 +15,7 @@ export const ChartButton: FunctionComponent<{
   return (
     <button
       className={classNames(
-        "flex h-6 cursor-pointer flex-row items-center justify-center",
+        "flex h-6 cursor-pointer items-center justify-center",
         "rounded-lg bg-osmoverse-800 px-2 text-caption hover:bg-osmoverse-900",
         "whitespace-nowrap",
         {

--- a/packages/web/components/cards/my-position/expanded.tsx
+++ b/packages/web/components/cards/my-position/expanded.tsx
@@ -19,6 +19,7 @@ import { PriceChartHeader } from "~/components/chart/token-pair-historical";
 import { CustomClasses } from "~/components/types";
 import { IncreaseConcentratedLiquidityModal } from "~/modals/increase-concentrated-liquidity";
 import { RemoveConcentratedLiquidityModal } from "~/modals/remove-concentrated-liquidity";
+import { useStore } from "~/stores";
 import { ObservableHistoricalAndLiquidityData } from "~/stores/derived-data/concentrated-liquidity/historical-and-liquidity-data";
 
 const ConcentratedLiquidityDepthChart = dynamic(
@@ -294,7 +295,7 @@ const AssetsInfo: FunctionComponent<
                   width={24}
                 />
               )}
-              <span>{asset.toString()}</span>
+              <span>{asset.trim(true).toString()}</span>
             </div>
           ))
         ) : (

--- a/packages/web/components/cards/my-position/expanded.tsx
+++ b/packages/web/components/cards/my-position/expanded.tsx
@@ -93,7 +93,7 @@ export const MyPositionCardExpandedSection: FunctionComponent<{
           onRequestClose={() => setActiveModal(null)}
         />
       )}
-      <div className="flex flex-row gap-1">
+      <div className="flex gap-1">
         <div className="flex-shrink-1 flex h-[20.1875rem] w-0 flex-1 flex-col gap-[20px] rounded-l-2xl bg-osmoverse-700 py-7 pl-6">
           <PriceChartHeader
             historicalRange={historicalRange}
@@ -122,7 +122,7 @@ export const MyPositionCardExpandedSection: FunctionComponent<{
             }
           />
         </div>
-        <div className="flex-shrink-1 flex h-[20.1875rem] w-0 flex-1 flex-row rounded-r-2xl bg-osmoverse-700">
+        <div className="flex-shrink-1 flex h-[20.1875rem] w-0 flex-1 rounded-r-2xl bg-osmoverse-700">
           <div className="mt-[84px] flex flex-1 flex-col">
             <ConcentratedLiquidityDepthChart
               yRange={yRange}
@@ -148,7 +148,7 @@ export const MyPositionCardExpandedSection: FunctionComponent<{
             />
           </div>
           <div className="mb-8 flex flex-col pr-8">
-            <div className="mt-7 mr-6 flex h-6 flex-row gap-1">
+            <div className="mt-7 mr-6 flex h-6 gap-1">
               <ChartButton
                 alt="refresh"
                 src="/icons/refresh-ccw.svg"
@@ -188,7 +188,7 @@ export const MyPositionCardExpandedSection: FunctionComponent<{
       </div>
       <div className="flex flex-row">
         <div className="flex w-full flex-col gap-4">
-          <div className="flex flex-row justify-between">
+          <div className="flex justify-between">
             <AssetsInfo
               className="w-0 flex-shrink flex-grow"
               title={t("clPositions.currentAssets")}
@@ -205,7 +205,7 @@ export const MyPositionCardExpandedSection: FunctionComponent<{
               title={t("clPositions.totalFeesEarned")}
             />
           </div>
-          <div className="flex flex-row justify-between">
+          <div className="flex justify-between">
             <AssetsInfo
               className="w-0 flex-shrink flex-grow"
               title={t("clPositions.principleAssets")}
@@ -219,7 +219,7 @@ export const MyPositionCardExpandedSection: FunctionComponent<{
           </div>
         </div>
       </div>
-      <div className="mt-4 flex flex-row justify-end gap-5">
+      <div className="mt-4 flex justify-end gap-5">
         <PositionButton onClick={() => null}>
           {t("clPositions.collectRewards")}
         </PositionButton>
@@ -263,10 +263,10 @@ const AssetsInfo: FunctionComponent<
       )}
     >
       <div className="text-subtitle1">{title}</div>
-      <div className="flex flex-row items-center gap-5">
+      <div className="flex items-center gap-5">
         {assets.length > 0 ? (
           assets.map((asset) => (
-            <div key={asset.denom} className="flex flex-row items-center gap-2">
+            <div key={asset.denom} className="flex items-center gap-2">
               {asset.currency.coinImageUrl && (
                 <Image
                   alt="base currency"
@@ -296,7 +296,7 @@ const PriceBox: FunctionComponent<{
   <div className="flex w-full max-w-[9.75rem] flex-col gap-1">
     <span className="pt-2 text-caption text-osmoverse-400">{label}</span>
     {infinity ? (
-      <div className="flex h-[41px] flex-row items-center">
+      <div className="flex h-[41px] items-center">
         <Image
           alt="infinity"
           src="/icons/infinity.svg"

--- a/packages/web/components/cards/my-position/index.tsx
+++ b/packages/web/components/cards/my-position/index.tsx
@@ -46,6 +46,8 @@ export const MyPositionCard: FunctionComponent<{
     ? useHistoricalAndLiquidityData(chainId, poolId)
     : undefined;
 
+  const roi = undefined; // TODO: calculate APR (stretch)
+
   const baseAssetValue = baseAsset && priceStore.calculatePrice(baseAsset);
   const quoteAssetValue = quoteAsset && priceStore.calculatePrice(quoteAsset);
   const fiatCurrency =
@@ -62,16 +64,16 @@ export const MyPositionCard: FunctionComponent<{
           poolId,
           Number(lowerTick.toString()),
           Number(upperTick.toString())
-        )
+        )?.apr
       : undefined;
 
   return (
     <div className="flex flex-col gap-8 overflow-hidden rounded-[20px] bg-osmoverse-800 p-8">
       <div
-        className="flex cursor-pointer items-center gap-[52px]"
+        className="flex cursor-pointer place-content-between items-center gap-[52px]"
         onClick={() => setCollapsed(!collapsed)}
       >
-        <div>
+        <div className="flex items-center gap-9">
           <PoolAssetsIcon
             className="!w-[78px]"
             assets={queryPool?.poolAssets.map((poolAsset) => ({
@@ -79,8 +81,6 @@ export const MyPositionCard: FunctionComponent<{
               coinDenom: poolAsset.amount.denom,
             }))}
           />
-        </div>
-        <div className="flex flex-shrink-0 flex-grow flex-col gap-[6px]">
           <div className="flex flex-shrink-0 flex-grow flex-col gap-[6px]">
             <div className="flex items-center gap-[6px]">
               <PoolAssetsName
@@ -107,21 +107,27 @@ export const MyPositionCard: FunctionComponent<{
           </div>
         </div>
         <div className="flex gap-[52px] self-start">
-          <PositionDataGroup label={t("clPositions.roi")} value="-" />
+          {roi && (
+            <PositionDataGroup label={t("clPositions.roi")} value={roi} />
+          )}
           {lowerPrices && upperPrices && (
             <RangeDataGroup
               lowerPrice={lowerPrices.price}
               upperPrice={upperPrices.price}
             />
           )}
-          <PositionDataGroup
-            label={t("clPositions.myLiquidity")}
-            value={liquidityValue ? formatPretty(liquidityValue) : "-"}
-          />
-          <PositionDataGroup
-            label={t("clPositions.incentives")}
-            value={incentivesApr?.apr?.maxDecimals(0).toString() ?? "-"}
-          />
+          {liquidityValue && (
+            <PositionDataGroup
+              label={t("clPositions.myLiquidity")}
+              value={formatPretty(liquidityValue)}
+            />
+          )}
+          {incentivesApr && (
+            <PositionDataGroup
+              label={t("clPositions.incentives")}
+              value={incentivesApr.maxDecimals(0).toString()}
+            />
+          )}
         </div>
       </div>
       {!collapsed && poolId && config && (

--- a/packages/web/components/cards/my-position/index.tsx
+++ b/packages/web/components/cards/my-position/index.tsx
@@ -53,7 +53,7 @@ export const MyPositionCard: FunctionComponent<{
   return (
     <div className="flex flex-col gap-8 overflow-hidden rounded-[20px] bg-osmoverse-800 p-8">
       <div
-        className="flex cursor-pointer flex-row items-center gap-[52px]"
+        className="flex cursor-pointer items-center gap-[52px]"
         onClick={() => setCollapsed(!collapsed)}
       >
         <div>
@@ -67,7 +67,7 @@ export const MyPositionCard: FunctionComponent<{
         </div>
         <div className="flex flex-shrink-0 flex-grow flex-col gap-[6px]">
           <div className="flex flex-shrink-0 flex-grow flex-col gap-[6px]">
-            <div className="flex flex-row items-center gap-[6px]">
+            <div className="flex items-center gap-[6px]">
               <PoolAssetsName
                 size="md"
                 assetDenoms={queryPool?.poolAssets.map(
@@ -91,7 +91,7 @@ export const MyPositionCard: FunctionComponent<{
               )}
           </div>
         </div>
-        <div className="flex flex-row gap-[52px] self-start">
+        <div className="flex gap-[52px] self-start">
           <PositionDataGroup label={t("clPositions.roi")} value="-" />
           {lowerPrices && upperPrices && (
             <RangeDataGroup
@@ -140,7 +140,7 @@ const RangeDataGroup: FunctionComponent<{
     <PositionDataGroup
       label={t("clPositions.selectedRange")}
       value={
-        <div className="flex w-full flex-row justify-end gap-1 overflow-hidden">
+        <div className="flex w-full justify-end gap-1 overflow-hidden">
           <h6>{lowerPrice.toString()}</h6>
           <img alt="" src="/icons/left-right-arrow.svg" className="h-6 w-6" />
           <h6>{upperPrice.toString()}</h6>

--- a/packages/web/components/cards/my-position/status.tsx
+++ b/packages/web/components/cards/my-position/status.tsx
@@ -46,7 +46,7 @@ export const MyPositionStatus: FunctionComponent<{
   return (
     <div
       className={classNames(
-        "flex w-fit flex-row items-center gap-[10px] rounded-[12px] px-3 py-1",
+        "flex w-fit items-center gap-[10px] rounded-[12px] px-3 py-1",
         {
           "bg-bullish-600/30": !negative && status === PositionStatus.InRange,
           "bg-ammelia-600/30":

--- a/packages/web/components/chart/concentrated-liquidity-depth.tsx
+++ b/packages/web/components/chart/concentrated-liquidity-depth.tsx
@@ -198,50 +198,49 @@ const ConcentratedLiquidityDepthChart: FunctionComponent<{
   );
 };
 
-function DragContainer(props: {
+const DragContainer: FunctionComponent<{
   defaultValue?: number;
   length?: number;
   scale: any;
   onMove?: (value: number) => void;
   onSubmit?: (value: number) => void;
   stroke: string;
-}) {
-  return (
-    <Annotation
-      dataKey="depth"
-      xAccessor={(d: any) => d?.depth}
-      yAccessor={(d: any) => d?.tick}
-      datum={{ tick: props.defaultValue, depth: props.length }}
-      canEditSubject
-      canEditLabel={false}
-      onDragMove={({ event, ...nextPos }) => {
-        if (props.onMove) {
-          const val = props.scale.invert(nextPos.y);
-          props.onMove(+Math.max(0, val));
-        }
-      }}
-      onDragEnd={({ event, ...nextPos }) => {
-        if (props.onSubmit) {
-          const val = props.scale.invert(nextPos.y);
-          props.onSubmit(+Math.max(0, val));
-        }
-      }}
-      editable
-    >
-      <AnnotationConnector />
-      <AnnotationCircleSubject
-        stroke={props.stroke}
-        // @ts-ignore
-        strokeWidth={8}
-        radius={2}
-      />
-      <AnnotationLineSubject
-        orientation="horizontal"
-        stroke={props.stroke}
-        strokeWidth={3}
-      />
-    </Annotation>
-  );
-}
+}> = (props) => (
+  <Annotation
+    dataKey="depth"
+    xAccessor={(d: any) => d?.depth}
+    yAccessor={(d: any) => d?.tick}
+    datum={{ tick: props.defaultValue, depth: props.length }}
+    canEditSubject
+    canEditLabel={false}
+    onDragMove={({ event, ...nextPos }) => {
+      if (props.onMove) {
+        const val = props.scale.invert(nextPos.y);
+        props.onMove(+Math.max(0, val));
+      }
+    }}
+    onDragEnd={({ event, ...nextPos }) => {
+      if (props.onSubmit) {
+        const val = props.scale.invert(nextPos.y);
+        props.onSubmit(+Math.max(0, val));
+      }
+    }}
+    editable
+  >
+    <AnnotationConnector />
+    <AnnotationCircleSubject
+      stroke={props.stroke}
+      // @ts-ignore
+      strokeWidth={8}
+      radius={2}
+    />
+    <AnnotationLineSubject
+      orientation="horizontal"
+      stroke={props.stroke}
+      strokeWidth={3}
+    />
+  </Annotation>
+);
 
+// needed for next/dynamic to avoid including visx in main bundle
 export default ConcentratedLiquidityDepthChart;

--- a/packages/web/components/chart/token-pair-historical.tsx
+++ b/packages/web/components/chart/token-pair-historical.tsx
@@ -190,7 +190,7 @@ export const PriceChartHeader: FunctionComponent<{
           </div>
         </div>
         {!hideButtons && (
-          <div className="flex flex-1 flex-row justify-end gap-1 pr-2">
+          <div className="flex flex-1 justify-end gap-1 pr-2">
             <ChartButton
               label="7 day"
               onClick={() => setHistoricalRange("7d")}

--- a/packages/web/components/cl-deposit-input-group/index.tsx
+++ b/packages/web/components/cl-deposit-input-group/index.tsx
@@ -58,7 +58,7 @@ export const DepositAmountGroup: FunctionComponent<{
       return (
         <div
           className={classNames(
-            "flex flex-1 flex-shrink-0 flex-row items-center gap-3 rounded-[20px] bg-osmoverse-700 px-6 py-7",
+            "flex flex-1 flex-shrink-0 items-center gap-3 rounded-[20px] bg-osmoverse-700 px-6 py-7",
             outOfRangeClassName
           )}
         >
@@ -79,11 +79,11 @@ export const DepositAmountGroup: FunctionComponent<{
     return (
       <div
         className={classNames(
-          "flex flex-1 flex-shrink-0 flex-row items-center rounded-[20px] bg-osmoverse-700 p-6",
+          "flex flex-1 flex-shrink-0 items-center rounded-[20px] bg-osmoverse-700 p-6",
           className
         )}
       >
-        <div className="flex w-full flex-row items-center">
+        <div className="flex w-full items-center">
           <div
             className={classNames(
               "flex overflow-clip rounded-full border-4 p-1",

--- a/packages/web/components/complex/add-conc-liquidity.tsx
+++ b/packages/web/components/complex/add-conc-liquidity.tsx
@@ -150,9 +150,9 @@ const Overview: FunctionComponent<
             />
           </div>
         </div>
-        <div className="flex flex-row rounded-[1rem] bg-osmoverse-700/[.3] px-[28px] py-4">
+        <div className="flex rounded-[1rem] bg-osmoverse-700/[.3] px-[28px] py-4">
           <div className="flex flex-1 flex-col gap-1">
-            <div className="flex flex-row flex-nowrap items-center gap-2">
+            <div className="flex flex-nowrap items-center gap-2">
               {pool && (
                 <>
                   <PoolAssetsIcon
@@ -208,7 +208,7 @@ const Overview: FunctionComponent<
           </div>
         </div>
         <div className="flex flex-col">
-          <div className="flex flex-row justify-center gap-[12px]">
+          <div className="flex justify-center gap-[12px]">
             <StrategySelector
               title={t("addConcentratedLiquidity.managed")}
               description={t("addConcentratedLiquidity.managedDescription")}
@@ -378,7 +378,7 @@ const AddConcLiqView: FunctionComponent<
         <span className="subtitle1 px-4 pb-3">
           {t("addConcentratedLiquidity.priceRange")}
         </span>
-        <div className="flex flex-row gap-1">
+        <div className="flex gap-1">
           <div className="flex-shrink-1 flex h-[20.1875rem] w-0 flex-1 flex-col gap-[20px] rounded-l-2xl bg-osmoverse-700 py-7 pl-6">
             <PriceChartHeader
               historicalRange={historicalRange}
@@ -404,9 +404,9 @@ const AddConcLiqView: FunctionComponent<
               }
             />
           </div>
-          <div className="flex-shrink-1 flex h-[20.1875rem] w-0 flex-1 flex-row rounded-r-2xl bg-osmoverse-700">
+          <div className="flex-shrink-1 flex h-[20.1875rem] w-0 flex-1 rounded-r-2xl bg-osmoverse-700">
             <div className="flex flex-1 flex-col">
-              <div className="mt-7 mr-6 mb-8 flex h-6 flex-row justify-end gap-1">
+              <div className="mt-7 mr-6 mb-8 flex h-6 justify-end gap-1">
                 <ChartButton
                   alt="refresh"
                   src="/icons/refresh-ccw.svg"
@@ -504,7 +504,7 @@ const AddConcLiqView: FunctionComponent<
         <div className="subtitle1 px-4 pb-3">
           {t("addConcentratedLiquidity.amountToDeposit")}
         </div>
-        <div className="flex flex-row justify-center gap-3">
+        <div className="flex justify-center gap-3">
           <DepositAmountGroup
             getFiatValue={getFiatValue}
             coin={pool?.poolAssets[0]?.amount}
@@ -578,7 +578,7 @@ const StrategySelectorGroup: FunctionComponent<
         <span className="caption text-osmoverse-200">
           {descriptionText}
           <a
-            className="caption mx-1 inline-flex flex-row items-center text-wosmongton-300 underline"
+            className="caption mx-1 inline-flex items-center text-wosmongton-300 underline"
             href="#"
             target="_blank"
             rel="noopener noreferrer"
@@ -587,7 +587,7 @@ const StrategySelectorGroup: FunctionComponent<
           </a>
         </span>
       </div>
-      <div className="flex flex-1 flex-row justify-end gap-2">
+      <div className="flex flex-1 justify-end gap-2">
         <PresetStrategyCard
           type={null}
           src="/images/small-vial.svg"
@@ -675,7 +675,7 @@ const PresetStrategyCard: FunctionComponent<
     return (
       <div
         className={classNames(
-          "flex w-[114px] flex-row items-center justify-center gap-2 rounded-2xl p-[2px]",
+          "flex w-[114px] items-center justify-center gap-2 rounded-2xl p-[2px]",
           {
             "bg-supercharged": isSelected,
             "cursor-pointer hover:bg-supercharged": type !== null,
@@ -719,7 +719,7 @@ const PriceInputBox: FunctionComponent<{
   <div className="flex w-full max-w-[9.75rem] flex-col items-end rounded-xl bg-osmoverse-800 px-2">
     <span className="caption px-2 pt-2 text-osmoverse-400">{label}</span>
     {infinity ? (
-      <div className="flex h-[41px] flex-row items-center px-2">
+      <div className="flex h-[41px] items-center px-2">
         <Image
           alt="infinity"
           src="/icons/infinity.svg"

--- a/packages/web/components/main-menu.tsx
+++ b/packages/web/components/main-menu.tsx
@@ -105,7 +105,7 @@ export const MainMenu: FunctionComponent<{
                     )}
                   >
                     {isNew ? (
-                      <div className="flex flex-row items-center justify-between">
+                      <div className="flex items-center justify-between">
                         {label}
                         <Pill>
                           <span className="button px-[8px] py-[2px]">

--- a/packages/web/components/pixels/pallete.tsx
+++ b/packages/web/components/pixels/pallete.tsx
@@ -100,7 +100,7 @@ const Palette = ({
         {maxColors < 5 ? (
           <div className="relative">
             <a
-              className="absolute bottom-[6px] flex w-full flex-row items-center justify-center rounded-lg py-[8px] text-center text-subtitle1 text-xs tracking-tighter"
+              className="absolute bottom-[6px] flex w-full items-center justify-center rounded-lg py-[8px] text-center text-subtitle1 text-xs tracking-tighter"
               href="https://wallet.keplr.app/chains/osmosis"
               target="_blank"
               rel="noopener noreferrer"

--- a/packages/web/components/pool-detail/concentrated.tsx
+++ b/packages/web/components/pool-detail/concentrated.tsx
@@ -1,3 +1,4 @@
+import { Dec } from "@keplr-wallet/unit";
 import { observer } from "mobx-react-lite";
 import dynamic from "next/dynamic";
 import Head from "next/head";
@@ -57,6 +58,12 @@ export const ConcentratedLiquidityPool: FunctionComponent<{ poolId: string }> =
         priceStore
       ).volume24h;
     const poolLiquidity = pool?.computeTotalValueLocked(priceStore);
+
+    const currentPrice = pool?.concentratedLiquidityPoolInfo
+      ? pool.concentratedLiquidityPoolInfo.currentSqrtPrice.mul(
+          pool.concentratedLiquidityPoolInfo.currentSqrtPrice
+        )
+      : undefined;
 
     return (
       <main className="m-auto flex min-h-screen max-w-container flex-col gap-8 bg-osmoverse-900 px-8 py-4 md:gap-4 md:p-4">
@@ -136,28 +143,26 @@ export const ConcentratedLiquidityPool: FunctionComponent<{ poolId: string }> =
                   }
                 />
               </div>
-              <div className="flex-shrink-1 flex w-[229px] flex-col">
-                <div className="flex flex-col pr-8">
-                  <div className="mt-7 flex h-6 justify-end gap-1">
-                    <ChartButton
-                      alt="refresh"
-                      src="/icons/refresh-ccw.svg"
-                      selected={false}
-                      onClick={() => setZoom(1)}
-                    />
-                    <ChartButton
-                      alt="zoom in"
-                      src="/icons/zoom-in.svg"
-                      selected={false}
-                      onClick={zoomIn}
-                    />
-                    <ChartButton
-                      alt="zoom out"
-                      src="/icons/zoom-out.svg"
-                      selected={false}
-                      onClick={zoomOut}
-                    />
-                  </div>
+              <div className="flex-shrink-1 relative flex w-[229px] flex-col">
+                <div className="mt-7 flex h-6 justify-end gap-1 pr-8">
+                  <ChartButton
+                    alt="refresh"
+                    src="/icons/refresh-ccw.svg"
+                    selected={false}
+                    onClick={() => setZoom(1)}
+                  />
+                  <ChartButton
+                    alt="zoom in"
+                    src="/icons/zoom-in.svg"
+                    selected={false}
+                    onClick={zoomIn}
+                  />
+                  <ChartButton
+                    alt="zoom out"
+                    src="/icons/zoom-out.svg"
+                    selected={false}
+                    onClick={zoomOut}
+                  />
                 </div>
                 <div className="mt-[32px] flex flex-1 flex-col">
                   <ConcentratedLiquidityDepthChart
@@ -168,10 +173,26 @@ export const ConcentratedLiquidityPool: FunctionComponent<{ poolId: string }> =
                       price: lastChartData?.close || 0,
                       depth: xRange[1],
                     }}
-                    offset={{ top: 0, right: 36, bottom: 24 + 28, left: 0 }}
+                    offset={{
+                      top: 0,
+                      right: currentPrice
+                        ? currentPrice.gt(new Dec(100))
+                          ? 120
+                          : 56
+                        : 36,
+                      bottom: 24 + 28,
+                      left: 0,
+                    }}
                     horizontal
                   />
                 </div>
+                {currentPrice && (
+                  <h6 className="absolute right-0 top-[51%]">
+                    {currentPrice.toString(
+                      currentPrice.gt(new Dec(100)) ? 0 : 2
+                    )}
+                  </h6>
+                )}
               </div>
             </div>
           </div>

--- a/packages/web/components/pool-detail/concentrated.tsx
+++ b/packages/web/components/pool-detail/concentrated.tsx
@@ -69,7 +69,7 @@ export const ConcentratedLiquidityPool: FunctionComponent<{ poolId: string }> =
           <div className="flex flex-col rounded-[28px] bg-osmoverse-1000 p-8">
             <div className="flex flex-row">
               <div className="flex flex-col gap-3">
-                <div className="flex flex-row items-center gap-2">
+                <div className="flex items-center gap-2">
                   <PoolAssetsIcon
                     className="!w-[78px]"
                     assets={pool?.poolAssets.map((poolAsset) => ({
@@ -91,7 +91,7 @@ export const ConcentratedLiquidityPool: FunctionComponent<{ poolId: string }> =
                   </span>
                 </div>
               </div>
-              <div className="flex flex-grow flex-row justify-end gap-10">
+              <div className="flex flex-grow justify-end gap-10">
                 <PoolDataGroup label={t("pool.liquidity")} value="$0.00" />
                 <PoolDataGroup
                   label={t("pool.24hrTradingVolume")}
@@ -127,7 +127,7 @@ export const ConcentratedLiquidityPool: FunctionComponent<{ poolId: string }> =
               </div>
               <div className="flex-shrink-1 flex w-[229px] flex-col">
                 <div className="flex flex-col pr-8">
-                  <div className="mt-7 flex h-6 flex-row justify-end gap-1">
+                  <div className="mt-7 flex h-6 justify-end gap-1">
                     <ChartButton
                       alt="refresh"
                       src="/icons/refresh-ccw.svg"
@@ -168,13 +168,13 @@ export const ConcentratedLiquidityPool: FunctionComponent<{ poolId: string }> =
             <div className="flex flex-row">
               <div className="flex flex-grow flex-col gap-3">
                 <h6>{t("clPositions.yourPositions")}</h6>
-                <div className="flex flex-row items-center text-body2 font-body2">
+                <div className="flex items-center text-body2 font-body2">
                   <span className="text-wosmongton-200">
                     {t("clPositions.yourPositionsDesc")}
                   </span>
                   <span className="flex flex-row">
                     <a
-                      className="mx-1 inline-flex flex-row items-center text-wosmongton-300 underline"
+                      className="mx-1 inline-flex items-center text-wosmongton-300 underline"
                       href="#"
                       target="_blank"
                       rel="noopener noreferrer"

--- a/packages/web/localizations/en.json
+++ b/packages/web/localizations/en.json
@@ -49,7 +49,7 @@
     "currentAssets": "Current Assets",
     "principleAssets": "Principle Assets",
     "totalFeesEarned": "Total Fees Earned",
-    "unclaimedFees": "Unclaimed Fees",
+    "unclaimedRewards": "Unclaimed Rewards",
     "roi": "ROI",
     "selectedRange": "Selected Range",
     "myLiquidity": "My Liquidity",
@@ -58,6 +58,7 @@
     "maxPrice": "Max price",
     "minPrice": "Min price",
     "collectRewards": "Collect Rewards",
+    "noRewards": "No rewards to collect",
     "removeLiquidity": "Remove Liquidity",
     "increaseLiquidity": "Increase Liquidity",
     "yourPositions": "Your Positions",
@@ -278,7 +279,8 @@
     "percentageSum": "Sum of percentages is not 100",
     "scalingFactorTooLow": "Scaling factor too low",
     "zeroAmount": "Amount is zero",
-    "invalidRange": "Invalid price range"
+    "invalidRange": "Invalid price range",
+    "notAvailable": "Not available"
   },
   "keplr": {
     "extension": "Keplr Browser Extension",

--- a/packages/web/modals/increase-concentrated-liquidity.tsx
+++ b/packages/web/modals/increase-concentrated-liquidity.tsx
@@ -124,7 +124,7 @@ export const IncreaseConcentratedLiquidityModal: FunctionComponent<
       className="!max-w-[500px]"
     >
       <div className="flex flex-col gap-3">
-        <div className="flex flex-row items-center justify-between">
+        <div className="flex items-center justify-between">
           <div className="pl-4 text-subtitle1 font-subtitle1">
             {t("clPositions.yourPosition")}
           </div>
@@ -137,9 +137,9 @@ export const IncreaseConcentratedLiquidityModal: FunctionComponent<
             />
           )}
         </div>
-        <div className="mb-2 flex flex-row justify-between rounded-[12px] bg-osmoverse-700 py-3 px-5 text-osmoverse-100">
+        <div className="mb-2 flex justify-between rounded-[12px] bg-osmoverse-700 py-3 px-5 text-osmoverse-100">
           {baseAsset && (
-            <div className="flex flex-row items-center gap-2 text-subtitle1 font-subtitle1">
+            <div className="flex items-center gap-2 text-subtitle1 font-subtitle1">
               {baseAsset.currency.coinImageUrl && (
                 <Image
                   alt="base currency"
@@ -152,7 +152,7 @@ export const IncreaseConcentratedLiquidityModal: FunctionComponent<
             </div>
           )}
           {quoteAsset && (
-            <div className="flex flex-row items-center gap-2 text-subtitle1 font-subtitle1">
+            <div className="flex items-center gap-2 text-subtitle1 font-subtitle1">
               {quoteAsset.currency.coinImageUrl && (
                 <Image
                   alt="base currency"
@@ -166,7 +166,7 @@ export const IncreaseConcentratedLiquidityModal: FunctionComponent<
           )}
         </div>
         <div className="flex flex-col gap-3">
-          <div className="flex flex-row gap-2 pl-4">
+          <div className="flex gap-2 pl-4">
             <div className="text-subtitle1 font-subtitle1">
               {t("clPositions.selectedRange")}
             </div>
@@ -177,7 +177,7 @@ export const IncreaseConcentratedLiquidityModal: FunctionComponent<
               })}
             </div>
           </div>
-          <div className="flex flex-row gap-1">
+          <div className="flex gap-1">
             <div className="flex-shrink-1 flex h-[20.1875rem] w-0 flex-1 flex-col gap-[20px] rounded-l-2xl bg-osmoverse-700 py-6 pl-6">
               <PriceChartHeader
                 priceHeaderClass="text-h5 font-h5 text-osmoverse-200"
@@ -208,7 +208,7 @@ export const IncreaseConcentratedLiquidityModal: FunctionComponent<
                 }
               />
             </div>
-            <div className="flex-shrink-1 relative flex h-[20.1875rem] w-0 flex-1 flex-row rounded-r-2xl bg-osmoverse-700">
+            <div className="flex-shrink-1 relative flex h-[20.1875rem] w-0 flex-1 rounded-r-2xl bg-osmoverse-700">
               <div className="mt-[84px] flex flex-1 flex-col">
                 <ConcentratedLiquidityDepthChart
                   yRange={yRange}
@@ -234,7 +234,7 @@ export const IncreaseConcentratedLiquidityModal: FunctionComponent<
                 />
               </div>
               <div className="flex h-full flex-col">
-                <div className="mt-[25px] mr-[22px] flex h-6 flex-row gap-1">
+                <div className="mt-[25px] mr-[22px] flex h-6 gap-1">
                   <ChartButton
                     alt="refresh"
                     src="/icons/refresh-ccw.svg"
@@ -334,7 +334,7 @@ const PriceBox: FunctionComponent<{
       {label}
     </span>
     {infinity ? (
-      <div className="flex h-5 flex-row items-center">
+      <div className="flex h-5 items-center">
         <Image
           alt="infinity"
           src="/icons/infinity.svg"

--- a/packages/web/modals/increase-concentrated-liquidity.tsx
+++ b/packages/web/modals/increase-concentrated-liquidity.tsx
@@ -116,8 +116,6 @@ export const IncreaseConcentratedLiquidityModal: FunctionComponent<
     }
   }, [config, setPriceRange, lowerPrices, upperPrices]);
 
-  console.log({ baseAsset, quoteAsset });
-
   return (
     <ModalBase
       {...props}

--- a/packages/web/modals/remove-concentrated-liquidity.tsx
+++ b/packages/web/modals/remove-concentrated-liquidity.tsx
@@ -116,7 +116,7 @@ export const RemoveConcentratedLiquidityModal: FunctionComponent<
         </div>
       </div>
       <div className="flex flex-col gap-3">
-        <div className="flex flex-row items-center justify-between">
+        <div className="flex items-center justify-between">
           <div className="pl-4 text-subtitle1 font-subtitle1">
             {t("clPositions.yourPosition")}
           </div>
@@ -129,7 +129,7 @@ export const RemoveConcentratedLiquidityModal: FunctionComponent<
             />
           )}
         </div>
-        <div className="mb-8 flex flex-row justify-between rounded-[12px] bg-osmoverse-700 py-3 px-5 text-osmoverse-100">
+        <div className="mb-8 flex justify-between rounded-[12px] bg-osmoverse-700 py-3 px-5 text-osmoverse-100">
           {baseAsset && <AssetAmount amount={baseAsset} />}
           {quoteAsset && <AssetAmount amount={quoteAsset} />}
         </div>
@@ -152,7 +152,7 @@ export const RemoveConcentratedLiquidityModal: FunctionComponent<
             step={1}
             useSuperchargedGradient
           />
-          <div className="flex w-full flex-row gap-2 px-5">
+          <div className="flex w-full gap-2 px-5">
             <PresetPercentageButton onClick={() => config.setPercentage(0.25)}>
               25%
             </PresetPercentageButton>
@@ -172,7 +172,7 @@ export const RemoveConcentratedLiquidityModal: FunctionComponent<
         <div className="pl-4 text-subtitle1 font-subtitle1">
           {t("clPositions.pendingRewards")}
         </div>
-        <div className="flex flex-row justify-between gap-3 rounded-[12px] border-[1.5px]  border-osmoverse-700 px-5 py-3">
+        <div className="flex justify-between gap-3 rounded-[12px] border-[1.5px]  border-osmoverse-700 px-5 py-3">
           {baseAsset && (
             <AssetAmount
               className="!text-body2 !font-body2"
@@ -200,7 +200,7 @@ const PresetPercentageButton: FunctionComponent<{
   return (
     <button
       className={classNames(
-        "flex flex-1 cursor-pointer flex-row items-center justify-center",
+        "flex flex-1 cursor-pointer items-center justify-center",
         "rounded-[8px] bg-osmoverse-700 px-5 py-2 text-h6 font-h6 hover:bg-osmoverse-600",
         "whitespace-nowrap",
         {
@@ -220,7 +220,7 @@ export const AssetAmount: FunctionComponent<{
 }> = (props) => (
   <div
     className={classNames(
-      "flex flex-row items-center gap-2 text-subtitle1 font-subtitle1",
+      "flex items-center gap-2 text-subtitle1 font-subtitle1",
       props.className
     )}
   >

--- a/packages/web/pages/apps/index.tsx
+++ b/packages/web/pages/apps/index.tsx
@@ -96,7 +96,7 @@ export const AppStore: React.FC<AppStoreProps> = ({ apps }) => {
 
   return (
     <main className="mx-auto flex max-w-container flex-col bg-osmoverse-900 p-8 pt-4 md:gap-8 md:p-4">
-      <div className="flex flex-row justify-between pl-6 md:flex-col">
+      <div className="flex justify-between pl-6 md:flex-col">
         <div className="mb-0 basis-1/2 lg:mr-4 md:mb-4 md:mr-0">
           <h4 className="pb-2 text-wosmongton-100">{t("store.headerTitle")}</h4>
           <span className="body2 text-osmoverse-200">

--- a/packages/web/pages/bootstrap/index.tsx
+++ b/packages/web/pages/bootstrap/index.tsx
@@ -150,7 +150,7 @@ const SynthesisItem: FunctionComponent<{
             width={80}
           />
         </div>
-        <div className="flex flex-col justify-between md:w-full md:flex-row md:items-center">
+        <div className="flex flex-col justify-between md:w-full md:md:items-center">
           <div className="mr-2 mb-3 flex flex-col md:mb-0">
             <p className="mb-2 text-sm font-semibold text-white-mid">
               {pool.smoothWeightChange.initialPoolWeights

--- a/packages/web/public/icons/left-right-arrow.svg
+++ b/packages/web/public/icons/left-right-arrow.svg
@@ -1,6 +1,0 @@
-<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M15.9854 7.75781L20.228 12.0005L15.9854 16.2431" stroke="#E4E1FB" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M9.01465 16.2431L4.77201 12.0005L9.01465 7.75781" stroke="#E4E1FB" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M20.2281 11.9996H12.3286" stroke="#E4E1FB" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M6.77193 11.9996H13.6714" stroke="#E4E1FB" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-</svg>

--- a/packages/web/public/icons/sprite.svg
+++ b/packages/web/public/icons/sprite.svg
@@ -369,5 +369,14 @@
         <path d="M7.21334 1.95066C7.26031 1.57498 6.74735 1.41966 6.57803 1.7583L1.26328 12.3878C1.0767 12.7609 1.34805 13.2 1.76526 13.2H6.35718L5.50101 20.0493C5.45405 20.425 5.96701 20.5803 6.13633 20.2417L11.4511 9.61221C11.6377 9.23905 11.3663 8.8 10.9491 8.8H6.35718L7.21334 1.95066Z" stroke="#EE65E9" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
       </svg>
     </symbol>
+
+    <symbol id="left-right-arrow" viewBox="0 0 24 24">
+      <svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M15.9854 7.75781L20.228 12.0005L15.9854 16.2431" stroke="#E4E1FB" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M9.01465 16.2431L4.77201 12.0005L9.01465 7.75781" stroke="#E4E1FB" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M20.2281 11.9996H12.3286" stroke="#E4E1FB" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+        <path d="M6.77193 11.9996H13.6714" stroke="#E4E1FB" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+    </symbol>
   </defs>
 </svg>

--- a/packages/web/public/icons/sprite.svg
+++ b/packages/web/public/icons/sprite.svg
@@ -370,6 +370,12 @@
       </svg>
     </symbol>
 
+    <symbol id="lightning-small" viewBox="0 0 16 16">
+      <svg width="9" height="16" viewBox="0 0 9 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M5.15617 0.950664C5.20313 0.574976 4.69017 0.419663 4.52085 0.758303L0.406106 8.98779C0.219526 9.36095 0.490876 9.8 0.90808 9.8H4.5L3.84383 15.0493C3.79687 15.425 4.30983 15.5803 4.47915 15.2417L8.59389 7.01221C8.78047 6.63905 8.50912 6.2 8.09192 6.2H4.5L5.15617 0.950664Z" fill="#EC66E9"/>
+      </svg>
+    </symbol>
+
     <symbol id="left-right-arrow" viewBox="0 0 24 24">
       <svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
         <path d="M15.9854 7.75781L20.228 12.0005L15.9854 16.2431" stroke="#E4E1FB" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- Add a description of the overall background and high level changes that this PR introduces -->

Improve and polish the my position card.
<img width="1082" alt="Screenshot 2023-06-08 at 10 53 28 AM" src="https://github.com/osmosis-labs/osmosis-frontend/assets/4606373/4af9a9e3-d06d-4d24-ae20-dd37f6e21d5a">

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/863gxjv4v)

## Brief Changelog

- Improves position component header, more closely matching Figma
- For assets in the expanded position view, if there's more than 2 they will be organized in a uniform 2x2 table, with the USD value in the 3rd column
- Add placeholder text if there are no assets, like no rewards
- Show current price in depth chart of pool overview

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

Visual testing
