### PR TITLE
(CL) Migrate to increase liquidity message

### DIFF
--- a/packages/math/src/pool/concentrated/math.ts
+++ b/packages/math/src/pool/concentrated/math.ts
@@ -309,6 +309,10 @@ export function calcAmount0(
   let sqrtPriceA = currentSqrtPrice;
   let sqrtPriceB = lowerTickSqrt;
 
+  if (sqrtPriceA.equals(sqrtPriceB)) {
+    return new Int(0);
+  }
+
   if (sqrtPriceA.gt(sqrtPriceB)) {
     sqrtPriceA = lowerTickSqrt;
     sqrtPriceB = currentSqrtPrice;
@@ -342,6 +346,10 @@ export function calcAmount1(
 
   let sqrtPriceA = currentSqrtPrice;
   let sqrtPriceB = upperTickSqrt;
+
+  if (sqrtPriceA.equals(sqrtPriceB)) {
+    return new Int(0);
+  }
 
   if (sqrtPriceA.gt(sqrtPriceB)) {
     sqrtPriceA = upperTickSqrt;

--- a/packages/math/src/pool/concentrated/tick.ts
+++ b/packages/math/src/pool/concentrated/tick.ts
@@ -256,7 +256,14 @@ export function roundPriceToNearestTick(
   }
 
   const sqrtPrice = tickToSqrtPrice(tick);
-  return sqrtPrice.mul(sqrtPrice);
+  const ret = sqrtPrice.mul(sqrtPrice).roundDec();
+
+  if (ret.gt(maxSpotPrice)) {
+    return maxSpotPrice;
+  } else if (ret.lt(minSpotPrice)) {
+    return minSpotPrice;
+  }
+  return ret;
 }
 
 // TODO: consider moving

--- a/packages/math/src/pool/concentrated/tick.ts
+++ b/packages/math/src/pool/concentrated/tick.ts
@@ -256,14 +256,7 @@ export function roundPriceToNearestTick(
   }
 
   const sqrtPrice = tickToSqrtPrice(tick);
-  const ret = sqrtPrice.mul(sqrtPrice).roundDec();
-
-  if (ret.gt(maxSpotPrice)) {
-    return maxSpotPrice;
-  } else if (ret.lt(minSpotPrice)) {
-    return minSpotPrice;
-  }
-  return ret;
+  return sqrtPrice.mul(sqrtPrice);
 }
 
 // TODO: consider moving

--- a/packages/stores/README.md
+++ b/packages/stores/README.md
@@ -33,13 +33,14 @@ Components:
 ### Troubleshooting
 
 - Account sequence mismatch errors: go to the sendTx function passed to `MockKeplrWithFee` in `test-env.ts` and increase the timeout to allow for more time for the transaction to be processed (depends on the Docker VM and the host machine). If that doesn't fix it, you likely have a promise somewhere around a send function that is not resolving and is causing a test case to timeout.
+- If data from query stores are not returning as expected, don't forget to add explicit `waitFreshResponse()` calls since we're outside of a reactive context.
 
 ### Tips
 
 Say you want to create add a new message to the frontend; the fastest approach is to:
 
 1. Write the message in the account layer
-2. Add any needed queries in the query layer
+2. Add any needed queries in the query layer.
 3. Add test cases, in a file that makes sense to categorize it in
 4. To avoid waiting for all of the tests to run you can:
    - Isolate just the test file. Example: `yarn test:e2e positions`

--- a/packages/stores/README.md
+++ b/packages/stores/README.md
@@ -33,3 +33,16 @@ Components:
 ### Troubleshooting
 
 - Account sequence mismatch errors: go to the sendTx function passed to `MockKeplrWithFee` in `test-env.ts` and increase the timeout to allow for more time for the transaction to be processed (depends on the Docker VM and the host machine). If that doesn't fix it, you likely have a promise somewhere around a send function that is not resolving and is causing a test case to timeout.
+
+### Tips
+
+Say you want to create add a new message to the frontend; the fastest approach is to:
+
+1. Write the message in the account layer
+2. Add any needed queries in the query layer
+3. Add test cases, in a file that makes sense to categorize it in
+4. To avoid waiting for all of the tests to run you can:
+   - Isolate just the test file. Example: `yarn test:e2e positions`
+   - Isolate further to just the test case, with a fuzzy search param: `yarn test:e2e positions -t "should fail"`
+
+Writing e2e tests help identify gas amount errors and message encoding issues.

--- a/packages/stores/src/account/__tests_e2e__/collect-rewards.spec.ts
+++ b/packages/stores/src/account/__tests_e2e__/collect-rewards.spec.ts
@@ -14,7 +14,7 @@ describe("Collect Cl Fees Txs", () => {
 
   beforeAll(async () => {
     const account = accountStore.getAccount(chainId);
-    account.cosmos.broadcastMode = "block";
+    account.cosmos.broadcastMode = "sync";
     await waitAccountLoaded(account);
   });
 
@@ -142,10 +142,11 @@ describe("Collect Cl Fees Txs", () => {
     const account = accountStore.getAccount(chainId);
     const osmosisQueries = queriesStore.get(chainId).osmosis!;
 
-    const positions =
-      osmosisQueries.queryAccountsPositions.get(account.bech32Address)
-        .positionIds ?? [];
+    const positions = osmosisQueries.queryAccountsPositions.get(
+      account.bech32Address
+    );
+    await positions.waitResponse();
 
-    return positions;
+    return positions.positionIds;
   }
 });

--- a/packages/stores/src/account/__tests_e2e__/positions.spec.ts
+++ b/packages/stores/src/account/__tests_e2e__/positions.spec.ts
@@ -83,6 +83,7 @@ describe("Create CL Positions Txs", () => {
     ).resolves.toBeDefined();
 
     // old position is replaced
+    // we can't rely on position IDs as other positions may have been globally created first in future tests
     await expect(
       getUserPositionsIdsForPool(queryPool!.id)
     ).resolves.toHaveLength(2);

--- a/packages/stores/src/account/__tests_e2e__/positions.spec.ts
+++ b/packages/stores/src/account/__tests_e2e__/positions.spec.ts
@@ -1,0 +1,171 @@
+/* eslint-disable */
+import { ObservableQueryPool } from "src/queries";
+import {
+  chainId,
+  getLatestQueryPool,
+  RootStore,
+  waitAccountLoaded,
+} from "../../__tests_e2e__/test-env";
+import { maxTick, minTick } from "@osmosis-labs/math";
+// import { Int } from "@keplr-wallet/unit";
+
+describe("Create CL Positions Txs", () => {
+  const { accountStore, queriesStore, chainStore } = new RootStore();
+  let queryPool: ObservableQueryPool | undefined;
+
+  beforeAll(async () => {
+    const account = accountStore.getAccount(chainId);
+    account.cosmos.broadcastMode = "sync";
+    await waitAccountLoaded(account);
+  });
+
+  beforeEach(async () => {
+    const account = accountStore.getAccount(chainId);
+
+    // prepare CL pool
+    await new Promise((resolve, reject) =>
+      account.osmosis.sendCreateConcentratedPoolMsg(
+        "uion",
+        "uosmo",
+        1,
+        0.001, // must have spread factor to generate fees
+        undefined,
+        (tx) => {
+          if (tx.code) reject(tx.log);
+          else resolve(tx);
+        }
+      )
+    );
+
+    queryPool = await getLatestQueryPool(chainId, queriesStore);
+  });
+
+  it("should be able to be created", async () => {
+    await expect(createFullRangePosition(queryPool!.id)).resolves.toBeDefined();
+    await expect(
+      getUserPositionsIdsForPool(queryPool!.id)
+    ).resolves.toHaveLength(1);
+    await expect(createFullRangePosition(queryPool!.id)).resolves.toBeDefined();
+    await expect(
+      getUserPositionsIdsForPool(queryPool!.id)
+    ).resolves.toHaveLength(2);
+  });
+
+  it("can have liquidity be added to it", async () => {
+    const account = accountStore.getAccount(chainId);
+
+    // create 2 positions, since there need to be at least 2 to be able to add liquidity
+    await createFullRangePosition(queryPool!.id);
+    await createFullRangePosition(queryPool!.id);
+    const userPositionIds = await getUserPositionsIdsForPool(queryPool!.id);
+    const lastPositionId = userPositionIds[userPositionIds.length - 1];
+
+    // add liquidity to position
+    const specifiedAmount0 = "1000";
+    const calculatedAmount1 = "1000";
+
+    await expect(
+      new Promise((resolve, reject) =>
+        account.osmosis
+          .sendAddToConcentratedLiquidityPositionMsg(
+            lastPositionId,
+            specifiedAmount0,
+            calculatedAmount1,
+            undefined,
+            undefined,
+            (tx) => {
+              if (tx.code) reject(tx.log);
+              else resolve(tx);
+            }
+          )
+          .catch(reject)
+      )
+    ).resolves.toBeDefined();
+
+    // old position is replaced
+    await expect(
+      getUserPositionsIdsForPool(queryPool!.id)
+    ).resolves.toHaveLength(2);
+  });
+
+  it("rejects adding liquidity to position if last position in pool", async () => {
+    const account = accountStore.getAccount(chainId);
+
+    // create initial position
+    await createFullRangePosition(queryPool!.id);
+    const userPositionIds = await getUserPositionsIdsForPool(queryPool!.id);
+    const lastPositionId = userPositionIds[userPositionIds.length - 1];
+
+    // add liquidity to position
+    const specifiedAmount0 = "1000";
+    const calculatedAmount1 = "1000";
+
+    await expect(
+      new Promise((resolve, reject) =>
+        account.osmosis
+          .sendAddToConcentratedLiquidityPositionMsg(
+            lastPositionId,
+            specifiedAmount0,
+            calculatedAmount1,
+            undefined,
+            undefined,
+            (tx) => {
+              if (tx.code) reject(tx.log);
+              else resolve(tx);
+            }
+          )
+          .catch(reject)
+      )
+    ).rejects.toBeDefined();
+  });
+
+  /** Leave `poolId` undefined to get all position IDs. */
+  async function getUserPositionsIdsForPool(poolId?: string) {
+    const account = accountStore.getAccount(chainId);
+    const osmosisQueries = queriesStore.get(chainId).osmosis!;
+
+    const positions = osmosisQueries.queryAccountsPositions.get(
+      account.bech32Address
+    );
+    await positions.waitFreshResponse();
+
+    return positions.positions
+      .filter((position) => !poolId || position.poolId === poolId)
+      .map((position) => position.id);
+  }
+
+  function createFullRangePosition(poolId: string) {
+    const account = accountStore.getAccount(chainId);
+
+    const osmoCurrency = chainStore
+      .getChain(chainId)
+      .forceFindCurrency("uosmo");
+    const osmoSwapAmount = "10";
+
+    const ionCurrency = chainStore.getChain(chainId).forceFindCurrency("uion");
+    const ionSwapAmount = "10";
+
+    // prepare CL position
+    return new Promise<any>((resolve, reject) => {
+      account.osmosis.sendCreateConcentratedLiquidityPositionMsg(
+        poolId,
+        minTick,
+        maxTick,
+        {
+          currency: osmoCurrency,
+          amount: osmoSwapAmount,
+        },
+        {
+          currency: ionCurrency,
+          amount: ionSwapAmount,
+        },
+        undefined,
+        undefined,
+        (tx) => {
+          if (tx.code) reject(tx.log);
+          else resolve(tx);
+        }
+      );
+    });
+  }
+});

--- a/packages/stores/src/account/index.ts
+++ b/packages/stores/src/account/index.ts
@@ -815,6 +815,16 @@ export class OsmosisAccountImpl {
     );
   }
 
+  /**
+   * Adds to a concentrated liquidity position, if successful replacing the old position with a new position and ID.
+   *
+   * @param positionId Position ID.
+   * @param amount0 Integer amount of token0 to add to the position.
+   * @param amount1 Integer amount of token1 to add to the position.
+   * @param maxSlippage Max token amounts slippage as whole %. Default `2.5`, meaning 2.5%.
+   * @param memo Optional memo to add to the transaction.
+   * @param onFulfill Optional callback to be called when tx is fulfilled.
+   */
   async sendAddToConcentratedLiquidityPositionMsg(
     positionId: string,
     amount0: string,

--- a/packages/stores/src/account/index.ts
+++ b/packages/stores/src/account/index.ts
@@ -17,7 +17,7 @@ import { DeepPartial } from "utility-types";
 import { OsmosisQueries } from "../queries";
 import * as Msgs from "./msg/amino";
 import { osmosis } from "./msg/proto";
-import { defaultMsgOpts, OsmosisMsgOpts } from "./msg-opts";
+import { DEFAULT_SLIPPAGE, defaultMsgOpts, OsmosisMsgOpts } from "./msg-opts";
 
 export interface OsmosisAccount {
   osmosis: OsmosisAccountImpl;
@@ -422,7 +422,7 @@ export class OsmosisAccountImpl {
   async sendJoinPoolMsg(
     poolId: string,
     shareOutAmount: string,
-    maxSlippage: string = "2.5",
+    maxSlippage: string = DEFAULT_SLIPPAGE,
     memo: string = "",
     onFulfill?: (tx: any) => void
   ) {
@@ -547,7 +547,7 @@ export class OsmosisAccountImpl {
   async sendJoinSwapExternAmountInMsg(
     poolId: string,
     tokenIn: { currency: Currency; amount: string },
-    maxSlippage: string = "2.5",
+    maxSlippage: string = DEFAULT_SLIPPAGE,
     memo: string = "",
     onFulfill?: (tx: any) => void
   ) {
@@ -682,7 +682,7 @@ export class OsmosisAccountImpl {
     upperTick: Int,
     baseDeposit?: { currency: Currency; amount: string },
     quoteDeposit?: { currency: Currency; amount: string },
-    maxSlippage = "2.5",
+    maxSlippage = DEFAULT_SLIPPAGE,
     memo: string = "",
     onFulfill?: (tx: any) => void
   ) {
@@ -829,7 +829,7 @@ export class OsmosisAccountImpl {
     positionId: string,
     amount0: string,
     amount1: string,
-    maxSlippage = "2.5",
+    maxSlippage = DEFAULT_SLIPPAGE,
     memo: string = "",
     onFulfill?: (tx: any) => void
   ) {
@@ -1384,7 +1384,7 @@ export class OsmosisAccountImpl {
   async sendExitPoolMsg(
     poolId: string,
     shareInAmount: string,
-    maxSlippage: string = "2.5",
+    maxSlippage: string = DEFAULT_SLIPPAGE,
     memo: string = "",
     onFulfill?: (tx: any) => void
   ) {

--- a/packages/stores/src/account/index.ts
+++ b/packages/stores/src/account/index.ts
@@ -889,8 +889,10 @@ export class OsmosisAccountImpl {
                 bal.waitFreshResponse();
             });
 
-          // refresh position
-          queryPosition.waitFreshResponse();
+          // refresh all user positions since IDs shift after adding to a position
+          queries.osmosis?.queryAccountsPositions
+            .get(this.base.bech32Address)
+            .waitFreshResponse();
         }
 
         onFulfill?.(tx);

--- a/packages/stores/src/account/msg-opts.ts
+++ b/packages/stores/src/account/msg-opts.ts
@@ -124,3 +124,5 @@ export const defaultMsgOpts: OsmosisMsgOpts = {
     gas: 900_000,
   },
 };
+
+export const DEFAULT_SLIPPAGE = "2.5";

--- a/packages/stores/src/account/msg-opts.ts
+++ b/packages/stores/src/account/msg-opts.ts
@@ -29,6 +29,7 @@ export interface OsmosisMsgOpts {
   readonly clCollectPositionsIncentivesRewards: (
     numPositions: number
   ) => MsgOpt;
+  readonly clAddToConcentratedPosition: MsgOpt;
 }
 
 export const defaultMsgOpts: OsmosisMsgOpts = {
@@ -108,7 +109,7 @@ export const defaultMsgOpts: OsmosisMsgOpts = {
   },
   clCreatePosition: {
     type: "osmosis/cl-create-position",
-    gas: 3000000,
+    gas: 3_000_000,
   },
   clCollectPositionsSpreadRewards: (numPositions: number) => ({
     type: "osmosis/cl-col-sp-rewards",
@@ -118,4 +119,8 @@ export const defaultMsgOpts: OsmosisMsgOpts = {
     type: "osmosis/cl-collect-incentives",
     gas: 300_000 * numPositions,
   }),
+  clAddToConcentratedPosition: {
+    type: "osmosis/cl-add-to-position",
+    gas: 900_000,
+  },
 };

--- a/packages/stores/src/ui-config/manage-liquidity/add-concentrated-liquidity.ts
+++ b/packages/stores/src/ui-config/manage-liquidity/add-concentrated-liquidity.ts
@@ -426,6 +426,6 @@ export class ObservableAddConcentratedLiquidityConfig extends TxChainSetter {
       return this._baseDepositAmountIn.error;
     }
 
-    // return this._baseDepositAmountIn.error || this._quoteDepositAmountIn.error;
+    return this._baseDepositAmountIn.error || this._quoteDepositAmountIn.error;
   }
 }

--- a/packages/web/components/complex/my-positions-section.tsx
+++ b/packages/web/components/complex/my-positions-section.tsx
@@ -23,6 +23,12 @@ export const MyPositionsSection: FunctionComponent<{ forPoolId?: string }> =
           return false;
         }
         return true;
+      })
+      .sort((a, b) => {
+        if (b.joinTime && a.joinTime) {
+          return b.joinTime.getTime() - a.joinTime.getTime();
+        }
+        return 0;
       });
 
     const visiblePositions = positions.slice(

--- a/packages/web/hooks/ui-config/use-add-concentrated-liquidity-config.ts
+++ b/packages/web/hooks/ui-config/use-add-concentrated-liquidity-config.ts
@@ -15,6 +15,8 @@ import { useStore } from "~/stores";
 
 /** Maintains a single instance of `ObservableAddConcentratedLiquidityConfig` for React view lifecycle.
  *  Updates `osmosisChainId`, `poolId`, `bech32Address` on render.
+ *
+ *  Provides memoized callbacks for sending common messages associated with adding concentrated liquidity.
  */
 export function useAddConcentratedLiquidityConfig(
   chainGetter: ChainGetter,
@@ -24,6 +26,7 @@ export function useAddConcentratedLiquidityConfig(
 ): {
   config: ObservableAddConcentratedLiquidityConfig;
   addLiquidity: () => Promise<void>;
+  increaseLiquidity: (positionId: string) => Promise<void>;
 } {
   const { accountStore, derivedDataStore } = useStore();
 
@@ -46,7 +49,7 @@ export function useAddConcentratedLiquidityConfig(
       )
   );
 
-  const addLiquidity = useCallback(async () => {
+  const addLiquidity = useCallback(() => {
     return new Promise<void>(async (resolve, reject) => {
       try {
         const quoteCoin = {
@@ -77,7 +80,7 @@ export function useAddConcentratedLiquidityConfig(
           undefined,
           undefined,
           (tx) => {
-            if (tx.code) reject();
+            if (tx.code) reject(tx.log);
             resolve();
           }
         );
@@ -98,5 +101,33 @@ export function useAddConcentratedLiquidityConfig(
     config.poolId,
   ]);
 
-  return { config, addLiquidity };
+  const increaseLiquidity = useCallback(
+    (positionId: string) => {
+      return new Promise<void>(async (resolve, reject) => {
+        const amount0 = config.baseDepositAmountIn.getAmountPrimitive().amount;
+        const amount1 = config.quoteDepositAmountIn.getAmountPrimitive().amount;
+
+        await account.osmosis.sendAddToConcentratedLiquidityPositionMsg(
+          positionId,
+          amount0,
+          amount1,
+          undefined,
+          undefined,
+          (tx) => {
+            if (tx.code) reject(tx.log);
+            resolve();
+          }
+        );
+
+        try {
+        } catch (e: any) {
+          console.error(e);
+          reject(e.message);
+        }
+      });
+    },
+    [config.baseDepositAmountIn, config.quoteDepositAmountIn, account.osmosis]
+  );
+
+  return { config, addLiquidity, increaseLiquidity };
 }

--- a/packages/web/hooks/ui-config/use-add-concentrated-liquidity-config.ts
+++ b/packages/web/hooks/ui-config/use-add-concentrated-liquidity-config.ts
@@ -81,7 +81,7 @@ export function useAddConcentratedLiquidityConfig(
           undefined,
           (tx) => {
             if (tx.code) reject(tx.log);
-            resolve();
+            else resolve();
           }
         );
       } catch (e: any) {
@@ -107,19 +107,18 @@ export function useAddConcentratedLiquidityConfig(
         const amount0 = config.baseDepositAmountIn.getAmountPrimitive().amount;
         const amount1 = config.quoteDepositAmountIn.getAmountPrimitive().amount;
 
-        await account.osmosis.sendAddToConcentratedLiquidityPositionMsg(
-          positionId,
-          amount0,
-          amount1,
-          undefined,
-          undefined,
-          (tx) => {
-            if (tx.code) reject(tx.log);
-            resolve();
-          }
-        );
-
         try {
+          await account.osmosis.sendAddToConcentratedLiquidityPositionMsg(
+            positionId,
+            amount0,
+            amount1,
+            undefined,
+            undefined,
+            (tx) => {
+              if (tx.code) reject(tx.log);
+              else resolve();
+            }
+          );
         } catch (e: any) {
           console.error(e);
           reject(e.message);

--- a/packages/web/modals/increase-concentrated-liquidity.tsx
+++ b/packages/web/modals/increase-concentrated-liquidity.tsx
@@ -54,8 +54,6 @@ export const IncreaseConcentratedLiquidityModal: FunctionComponent<
   const isSendingMsg = account.txTypeInProgress !== "";
 
   const {
-    quoteCurrency,
-    baseCurrency,
     historicalChartData,
     historicalRange,
     xRange,
@@ -73,7 +71,7 @@ export const IncreaseConcentratedLiquidityModal: FunctionComponent<
     setPriceRange,
   } = useHistoricalAndLiquidityData(chainId, poolId);
 
-  const { config, addLiquidity } = useAddConcentratedLiquidityConfig(
+  const { config, increaseLiquidity } = useAddConcentratedLiquidityConfig(
     chainStore,
     chainId,
     poolId,
@@ -94,7 +92,9 @@ export const IncreaseConcentratedLiquidityModal: FunctionComponent<
     {
       disabled: config.error !== undefined || isSendingMsg,
       onClick: () => {
-        addLiquidity().finally(() => props.onRequestClose());
+        increaseLiquidity(props.position.id).finally(() =>
+          props.onRequestClose()
+        );
       },
       children: config.error
         ? t(...tError(config.error))
@@ -172,8 +172,8 @@ export const IncreaseConcentratedLiquidityModal: FunctionComponent<
             </div>
             <div className="text-subtitle1 font-subtitle1 text-osmoverse-300">
               {t("addConcentratedLiquidity.basePerQuote", {
-                base: baseCurrency?.coinDenom || "",
-                quote: quoteCurrency?.coinDenom || "",
+                base: config.baseDepositAmountIn.sendCurrency.coinDenom,
+                quote: config.quoteDepositAmountIn.sendCurrency.coinDenom,
               })}
             </div>
           </div>
@@ -185,8 +185,8 @@ export const IncreaseConcentratedLiquidityModal: FunctionComponent<
                 }}
                 historicalRange={historicalRange}
                 setHistoricalRange={setHistoricalRange}
-                baseDenom={baseCurrency?.coinDenom || ""}
-                quoteDenom={quoteCurrency?.coinDenom || ""}
+                baseDenom={config.baseDepositAmountIn.sendCurrency.coinDenom}
+                quoteDenom={config.quoteDepositAmountIn.sendCurrency.coinDenom}
                 hoverPrice={hoverPrice}
                 decimal={priceDecimal}
                 hideButtons
@@ -230,7 +230,7 @@ export const IncreaseConcentratedLiquidityModal: FunctionComponent<
                       depth: xRange[1],
                     },
                   ]}
-                  offset={{ top: 0, right: 32, bottom: 24 + 28, left: 0 }}
+                  offset={{ top: 0, right: 32, bottom: 24 + 24, left: 0 }}
                   horizontal
                   fullRange={isFullRange}
                 />
@@ -297,7 +297,7 @@ export const IncreaseConcentratedLiquidityModal: FunctionComponent<
               },
               [config]
             )}
-            currentValue={config.quoteDepositAmountIn.amount}
+            currentValue={config.baseDepositAmountIn.amount}
             outOfRange={config.quoteDepositOnly}
             percentage={config.depositPercentages[0]}
           />

--- a/packages/web/modals/increase-concentrated-liquidity.tsx
+++ b/packages/web/modals/increase-concentrated-liquidity.tsx
@@ -116,8 +116,6 @@ export const IncreaseConcentratedLiquidityModal: FunctionComponent<
     }
   }, [config, setPriceRange, lowerPrices, upperPrices]);
 
-  console.log({ baseAsset, quoteAsset });
-
   return (
     <ModalBase
       {...props}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

Since we're no longer aggregating positions by price range and don't have charging periods, we should use the AddToPosition message instead of creating a new position with the same range. This is the functionality behind the increase liquidity modal.

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/863gxjgk4)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

- Adds the `MsgAddToPosition` message
  - e2e tests
- Wires the message up to the increase liquidity modal
- Fixes for rounding to nearest tick
- Sorts position card list by join time

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

- E2e tests work
- Add to position increases the liquidity of a position

