### PR TITLE
(CL) Depth chart data fixes

### DIFF
--- a/packages/web/modals/add-liquidity.tsx
+++ b/packages/web/modals/add-liquidity.tsx
@@ -48,12 +48,7 @@ export const AddLiquidityModal: FunctionComponent<
   );
 
   const { config: addConliqConfig, addLiquidity: addConLiquidity } =
-    useAddConcentratedLiquidityConfig(
-      chainStore,
-      chainId,
-      poolId,
-      queriesStore
-    );
+    useAddConcentratedLiquidityConfig(chainStore, chainId, poolId);
 
   // initialize pool data stores once root pool store is loaded
   const { poolDetail } = derivedDataStore.getForPool(poolId as string);

--- a/packages/web/modals/increase-concentrated-liquidity.tsx
+++ b/packages/web/modals/increase-concentrated-liquidity.tsx
@@ -40,13 +40,7 @@ export const IncreaseConcentratedLiquidityModal: FunctionComponent<
     poolId,
     position: { lowerPrices, upperPrices, baseAsset, quoteAsset, isFullRange },
   } = props;
-  const {
-    chainStore,
-    accountStore,
-    derivedDataStore,
-    priceStore,
-    queriesStore,
-  } = useStore();
+  const { chainStore, accountStore, derivedDataStore, priceStore } = useStore();
   const t = useTranslation();
 
   const { chainId } = chainStore.osmosis;
@@ -74,8 +68,7 @@ export const IncreaseConcentratedLiquidityModal: FunctionComponent<
   const { config, increaseLiquidity } = useAddConcentratedLiquidityConfig(
     chainStore,
     chainId,
-    poolId,
-    queriesStore
+    poolId
   );
 
   // initialize pool data stores once root pool store is loaded


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

It seems **not** refreshing the depth chart after creating or increasing a position caused the charts to break in the expanded view for the new/changed position. 

### ClickUp Task

https://app.clickup.com/t/86780cqt2?comment=90060018069050
https://app.clickup.com/t/86780cqt2?comment=90060018070654

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

- Refreshing depths when creating or adding to a position seemed to fix the charts. Note: I added the refresh logic in the "view" layer since we don't pass the poolId to the account layer since it's not needed there. It seems to make sense to add it in the view layer since our view happens to use the depth data. It's good the account layer doesn't make that assumption.
- For remove liquidity, I added the fix to the `jonator/remove-liquidity` branch since it's WIP
- Since we `useStore` in the `useUIConfig` hook, it makes sense to import the queriesStore there instead of passing it as a param. More flexible.

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

- Creating or adding to a position updates the charts everywhere

