### PR TITLE
fix: Transaction Not Popping Out and Correct Types for `prettifyTxError`

### DIFF
--- a/packages/web/components/alert/tx-event-toast.ts
+++ b/packages/web/components/alert/tx-event-toast.ts
@@ -1,6 +1,7 @@
 import { ChainInfoInner } from "@keplr-wallet/stores";
 import {
   ChainInfoWithExplorer,
+  DeliverTxResponse,
   isSlippageError,
   prettifyTxError,
 } from "@osmosis-labs/stores";
@@ -45,7 +46,7 @@ export function toastOnBroadcast() {
 export function toastOnFulfill(
   getChain: (chainId: string) => ChainInfoInner<ChainInfoWithExplorer>
 ) {
-  return (chainId: string, tx: any) => {
+  return (chainId: string, tx: DeliverTxResponse) => {
     const chainInfo = getChain(chainId);
     if (tx.code) {
       displayToast(
@@ -53,7 +54,8 @@ export function toastOnFulfill(
           message: "transactionFailed",
           caption: isSlippageError(tx)
             ? "swapFailed"
-            : prettifyTxError(tx.log, chainInfo.currencies) ?? tx.log,
+            : prettifyTxError(tx.rawLog ?? "", chainInfo.currencies) ??
+              tx.rawLog,
         },
         ToastType.ERROR
       );

--- a/packages/web/hooks/ui-config/use-lock-token-config.ts
+++ b/packages/web/hooks/ui-config/use-lock-token-config.ts
@@ -115,6 +115,7 @@ export function useLockTokenConfig(sendCurrency?: AppCurrency | undefined): {
       queryOsmosis,
       queryOsmosis.querySyntheticLockupsByLockId,
       queryOsmosis.queryLockableDurations.response,
+      account?.osmosis,
     ]
   );
 

--- a/packages/web/hooks/ui-config/use-remove-liquidity-config.ts
+++ b/packages/web/hooks/ui-config/use-remove-liquidity-config.ts
@@ -66,7 +66,7 @@ export function useRemoveLiquidityConfig(
         reject();
       }
     });
-  }, []);
+  }, [account?.osmosis]);
 
   return { config, removeLiquidity };
 }

--- a/packages/web/hooks/ui-config/use-superfluid-pool.ts
+++ b/packages/web/hooks/ui-config/use-superfluid-pool.ts
@@ -65,7 +65,7 @@ export function useSuperfluidPool(): {
         }
       );
     },
-    []
+    [account?.osmosis]
   );
 
   return {


### PR DESCRIPTION
## What is the purpose of the change

- Fix the transaction window not opening after refreshing the page. This was caused by outdated callbacks given account was not included as a dep. 
- Use correct types for `prettifyTxError`

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/866ad98b0)