### PR TITLE
(CL) Add CL pool detail store, update naming

### DIFF
--- a/packages/stores/src/__tests_e2e__/test-env.ts
+++ b/packages/stores/src/__tests_e2e__/test-env.ts
@@ -296,14 +296,14 @@ export async function getLatestQueryPool(
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const osmosisQueries = queryStore.get(chainId).osmosis!;
   const queryNumPools = osmosisQueries.queryGammNumPools;
-  const queryGammPools = osmosisQueries.queryGammPools;
+  const queryPools = osmosisQueries.queryPools;
 
   await queryNumPools.waitFreshResponse();
-  await queryGammPools.waitFreshResponse();
+  await queryPools.waitFreshResponse();
 
   // wait for desired observable state
   await when(
-    () => Boolean(queryNumPools.response) && Boolean(queryGammPools.response)
+    () => Boolean(queryNumPools.response) && Boolean(queryPools.response)
   );
 
   if (queryNumPools.numPools === 0) {
@@ -317,5 +317,5 @@ export async function getLatestQueryPool(
   // get query pool
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  return osmosisQueries.queryGammPools.getPool(poolId)!;
+  return osmosisQueries.queryPools.getPool(poolId)!;
 }

--- a/packages/stores/src/account/__tests_e2e__/positions.spec.ts
+++ b/packages/stores/src/account/__tests_e2e__/positions.spec.ts
@@ -67,9 +67,7 @@ describe("Create CL Positions Txs", () => {
 
     // get current tick, subtract to be below current price
     const currentTick = priceToTick(
-      queryPool!.concentratedLiquidityPoolInfo!.currentSqrtPrice.mul(
-        queryPool!.concentratedLiquidityPoolInfo!.currentSqrtPrice
-      )
+      queryPool!.concentratedLiquidityPoolInfo!.currentPrice
     ).sub(new Int(1));
 
     // create CL position
@@ -110,9 +108,7 @@ describe("Create CL Positions Txs", () => {
 
     // get current tick, add to be below above price
     const currentTick = priceToTick(
-      queryPool!.concentratedLiquidityPoolInfo!.currentSqrtPrice.mul(
-        queryPool!.concentratedLiquidityPoolInfo!.currentSqrtPrice
-      )
+      queryPool!.concentratedLiquidityPoolInfo!.currentPrice
     ).add(new Int(1));
 
     // create CL position

--- a/packages/stores/src/account/index.ts
+++ b/packages/stores/src/account/index.ts
@@ -166,7 +166,7 @@ export class OsmosisAccountImpl {
         if (tx.code == null || tx.code === 0) {
           // Refresh the balances
           const queries = this.queriesStore.get(this.chainId);
-          this.queries.queryGammPools.waitFreshResponse();
+          this.queries.queryPools.waitFreshResponse();
           queries.queryBalances
             .getQueryBech32Address(this.base.bech32Address)
             .balances.forEach((bal) => {
@@ -249,7 +249,7 @@ export class OsmosisAccountImpl {
         if (tx.code == null || tx.code === 0) {
           // Refresh the balances
           const queries = this.queriesStore.get(this.chainId);
-          this.queries.queryGammPools.waitFreshResponse();
+          this.queries.queryPools.waitFreshResponse();
           queries.queryBalances
             .getQueryBech32Address(this.base.bech32Address)
             .balances.forEach((bal) => {
@@ -388,7 +388,7 @@ export class OsmosisAccountImpl {
         if (tx.code == null || tx.code === 0) {
           // Refresh the balances
           const queries = this.queriesStore.get(this.chainId);
-          this.queries.queryGammPools.waitFreshResponse();
+          this.queries.queryPools.waitFreshResponse();
           queries.queryBalances
             .getQueryBech32Address(this.base.bech32Address)
             .balances.forEach((bal) => {
@@ -432,7 +432,7 @@ export class OsmosisAccountImpl {
     await this.base.cosmos.sendMsgs(
       "joinPool",
       async () => {
-        const queryPool = queries.queryGammPools.getPool(poolId);
+        const queryPool = queries.queryPools.getPool(poolId);
 
         if (!queryPool) {
           throw new Error(`Pool #${poolId} not found`);
@@ -526,7 +526,7 @@ export class OsmosisAccountImpl {
               bal.waitFreshResponse();
             });
 
-          this.queries.queryGammPools.getPool(poolId)?.waitFreshResponse();
+          this.queries.queryPools.getPool(poolId)?.waitFreshResponse();
         }
 
         onFulfill?.(tx);
@@ -556,7 +556,7 @@ export class OsmosisAccountImpl {
     await this.base.cosmos.sendMsgs(
       "joinPool",
       async () => {
-        const queryPool = queries.queryGammPools.getPool(poolId);
+        const queryPool = queries.queryPools.getPool(poolId);
 
         if (!queryPool) {
           throw new Error(`Pool #${poolId} not found`);
@@ -657,7 +657,7 @@ export class OsmosisAccountImpl {
             .balances.forEach((bal) => {
               bal.waitFreshResponse();
             });
-          this.queries.queryGammPools.getPool(poolId)?.waitFreshResponse();
+          this.queries.queryPools.getPool(poolId)?.waitFreshResponse();
         }
 
         onFulfill?.(tx);
@@ -691,7 +691,7 @@ export class OsmosisAccountImpl {
     await this.base.cosmos.sendMsgs(
       "clCreatePosition",
       () => {
-        const queryPool = queries.queryGammPools.getPool(poolId);
+        const queryPool = queries.queryPools.getPool(poolId);
 
         if (!queryPool) {
           throw new Error(`Pool #${poolId} not found`);
@@ -804,7 +804,7 @@ export class OsmosisAccountImpl {
             .balances.forEach((bal) => {
               bal.waitFreshResponse();
             });
-          this.queries.queryGammPools.getPool(poolId)?.waitFreshResponse();
+          this.queries.queryPools.getPool(poolId)?.waitFreshResponse();
           this.queries.queryAccountsPositions
             .get(this.base.bech32Address)
             ?.waitFreshResponse();
@@ -1243,9 +1243,7 @@ export class OsmosisAccountImpl {
           routes
             .flatMap(({ pools }) => pools)
             .forEach(({ id: poolId }) => {
-              queries.osmosis?.queryGammPools
-                .getPool(poolId)
-                ?.waitFreshResponse();
+              queries.osmosis?.queryPools.getPool(poolId)?.waitFreshResponse();
             });
 
           queries.osmosis?.queryAccountsPositions
@@ -1342,9 +1340,7 @@ export class OsmosisAccountImpl {
             });
 
           pools.forEach(({ id: poolId }) => {
-            queries.osmosis?.queryGammPools
-              .getPool(poolId)
-              ?.waitFreshResponse();
+            queries.osmosis?.queryPools.getPool(poolId)?.waitFreshResponse();
           });
 
           queries.osmosis?.queryAccountsPositions
@@ -1440,7 +1436,7 @@ export class OsmosisAccountImpl {
             });
 
           pools.forEach(({ id }) =>
-            this.queries.queryGammPools.getPool(id)?.waitFreshResponse()
+            this.queries.queryPools.getPool(id)?.waitFreshResponse()
           );
 
           queries.osmosis?.queryAccountsPositions
@@ -1474,7 +1470,7 @@ export class OsmosisAccountImpl {
     await this.base.cosmos.sendMsgs(
       "exitPool",
       async () => {
-        const queryPool = queries.queryGammPools.getPool(poolId);
+        const queryPool = queries.queryPools.getPool(poolId);
 
         if (!queryPool) {
           throw new Error(`Pool #${poolId} not found`);
@@ -1561,7 +1557,7 @@ export class OsmosisAccountImpl {
             .getQueryBech32Address(this.base.bech32Address)
             .balances.forEach((balance) => balance.waitFreshResponse());
 
-          this.queries.queryGammPools.getPool(poolId)?.waitFreshResponse();
+          this.queries.queryPools.getPool(poolId)?.waitFreshResponse();
         }
 
         onFulfill?.(tx);

--- a/packages/stores/src/derived-data/pool/bonding.ts
+++ b/packages/stores/src/derived-data/pool/bonding.ts
@@ -17,16 +17,16 @@ import {
   ObservableQueryActiveGauges,
   ObservableQueryPoolFeesMetrics,
 } from "../../queries-external";
-import { ObservablePoolDetails } from "./details";
+import { ObservableSharePoolDetails } from "./share-pool-details";
 import { ObservableSuperfluidPoolDetails } from "./superfluid";
 import { BondDuration } from "./types";
 
 /** Provides info for the current account's bonding status in a pool. */
-export class ObservablePoolBonding {
+export class ObservableSharePoolBonding {
   constructor(
     protected readonly poolId: string,
     protected readonly osmosisChainId: string,
-    protected readonly poolDetails: ObservablePoolDetails,
+    protected readonly sharePoolDetails: ObservableSharePoolDetails,
     protected readonly superfluidPoolDetails: ObservableSuperfluidPoolDetails,
     protected readonly chainGetter: ChainGetter,
     protected readonly priceStore: IPriceStore,
@@ -51,12 +51,16 @@ export class ObservablePoolBonding {
     return osmosisQueries;
   }
 
-  protected get queryPool() {
-    return this.queries.queryGammPools.getPool(this.poolId);
+  @computed
+  protected get querySharePool() {
+    const pool = this.queries.queryGammPools.getPool(this.poolId);
+
+    if (Boolean(pool?.sharePool)) return pool;
   }
 
-  protected get poolDetail() {
-    return this.poolDetails.get(this.poolId);
+  /** Information about share pools. */
+  protected get sharePoolDetail() {
+    return this.sharePoolDetails.get(this.poolId);
   }
 
   protected get superfluidPoolDetail() {
@@ -71,12 +75,12 @@ export class ObservablePoolBonding {
   readonly calculateBondLevel = computedFn(
     (bondDurations: BondDuration[]): 1 | 2 | undefined => {
       if (
-        this.poolDetail.userAvailableShares.toDec().gt(new Dec(0)) &&
+        this.sharePoolDetail.userAvailableShares.toDec().gt(new Dec(0)) &&
         bondDurations.some((duration) => duration.bondable)
       )
         return 2;
 
-      if (this.poolDetail.userAvailableShares.toDec().isZero()) return 1;
+      if (this.sharePoolDetail.userAvailableShares.toDec().isZero()) return 1;
     }
   );
 
@@ -85,6 +89,8 @@ export class ObservablePoolBonding {
    *  Internal OSMO incentives & swap fees included in breakdown. */
   @computed
   get bondDurations(): BondDuration[] {
+    if (!this.querySharePool) return [];
+
     const internalGauges = this.superfluidPoolDetail.gaugesWithSuperfluidApr;
 
     const queryLockedCoin = this.queries.queryAccountLocked.get(
@@ -110,7 +116,7 @@ export class ObservablePoolBonding {
       .forEach((coin) => {
         if (
           coin.amount.currency.coinMinimalDenom ===
-          this.poolDetail.poolShareCurrency.coinMinimalDenom
+          this.sharePoolDetail.poolShareCurrency.coinMinimalDenom
         ) {
           durationsMsSet.add(coin.duration.asMilliseconds());
         }
@@ -137,10 +143,10 @@ export class ObservablePoolBonding {
 
   /** Highest APR that can be earned in this share pool. */
   get highestBondDuration(): BondDuration | undefined {
-    if (!this.poolDetail.longestDuration) return;
+    if (!this.sharePoolDetail.longestDuration) return;
 
     return this.getBondDuration(
-      this.poolDetail.longestDuration.asMilliseconds()
+      this.sharePoolDetail.longestDuration.asMilliseconds()
     );
   }
 
@@ -157,7 +163,7 @@ export class ObservablePoolBonding {
         this.bech32Address
       );
 
-      const _queryPool = this.queryPool;
+      const _queryPool = this.querySharePool;
       if (!_queryPool) return;
 
       const curDuration = dayjs.duration({
@@ -165,11 +171,11 @@ export class ObservablePoolBonding {
       });
 
       const lockedUserShares = queryLockedCoin.getLockedCoinWithDuration(
-        this.poolDetail.poolShareCurrency,
+        this.sharePoolDetail.poolShareCurrency,
         curDuration
       ).amount;
 
-      const userLockedShareValue = this.poolDetail.totalValueLocked.mul(
+      const userLockedShareValue = this.sharePoolDetail.totalValueLocked.mul(
         new IntPretty(lockedUserShares.quo(_queryPool.totalShare))
       );
 
@@ -187,7 +193,7 @@ export class ObservablePoolBonding {
       }, []);
 
       const unlockingUserShares = queryLockedCoin.getUnlockingCoinWithDuration(
-        this.poolDetail.poolShareCurrency,
+        this.sharePoolDetail.poolShareCurrency,
         curDuration
       );
       const userUnlockingShares =
@@ -196,7 +202,7 @@ export class ObservablePoolBonding {
               // only return soonest unlocking shares
               shares:
                 unlockingUserShares[0].amount ??
-                new CoinPretty(this.poolDetail.poolShareCurrency, 0),
+                new CoinPretty(this.sharePoolDetail.poolShareCurrency, 0),
               endTime: unlockingUserShares[0].endTime,
             }
           : undefined;
@@ -262,7 +268,7 @@ export class ObservablePoolBonding {
       });
 
       // add superfluid data if highest duration
-      const sfsDuration = this.poolDetail.longestDuration;
+      const sfsDuration = this.sharePoolDetail.longestDuration;
       let superfluid: BondDuration["superfluid"] | undefined;
       if (
         this.superfluidPoolDetail.isSuperfluid &&
@@ -299,7 +305,7 @@ export class ObservablePoolBonding {
         (sum, { apr }) => sum.add(apr),
         new RatePretty(0)
       );
-      aggregateApr = aggregateApr.add(this.poolDetail.swapFeeApr);
+      aggregateApr = aggregateApr.add(this.sharePoolDetail.swapFeeApr);
       if (superfluid) aggregateApr = aggregateApr.add(superfluid.apr);
 
       return {
@@ -311,7 +317,7 @@ export class ObservablePoolBonding {
         userLockedShareValue,
         userUnlockingShares,
         aggregateApr,
-        swapFeeApr: this.poolDetail.swapFeeApr,
+        swapFeeApr: this.sharePoolDetail.swapFeeApr,
         swapFeeDailyReward: this.externalQueries.queryGammPoolFeeMetrics
           .getPoolFeesMetrics(this.poolId, this.priceStore)
           .feesSpent7d.quo(new Dec(7)),
@@ -323,10 +329,10 @@ export class ObservablePoolBonding {
 }
 
 /** Map of current accounts bonding info for all pools by pool ID. */
-export class ObservablePoolsBonding extends HasMapStore<ObservablePoolBonding> {
+export class ObservablePoolsBonding extends HasMapStore<ObservableSharePoolBonding> {
   constructor(
     protected readonly osmosisChainId: string,
-    protected readonly poolDetails: ObservablePoolDetails,
+    protected readonly poolDetails: ObservableSharePoolDetails,
     protected readonly superfluidPoolDetails: ObservableSuperfluidPoolDetails,
     protected readonly priceStore: IPriceStore,
     protected readonly chainGetter: ChainGetter,
@@ -339,7 +345,7 @@ export class ObservablePoolsBonding extends HasMapStore<ObservablePoolBonding> {
   ) {
     super(
       (poolId) =>
-        new ObservablePoolBonding(
+        new ObservableSharePoolBonding(
           poolId,
           this.osmosisChainId,
           this.poolDetails,
@@ -353,7 +359,7 @@ export class ObservablePoolsBonding extends HasMapStore<ObservablePoolBonding> {
     );
   }
 
-  get(poolId: string): ObservablePoolBonding {
+  get(poolId: string): ObservableSharePoolBonding {
     return super.get(poolId);
   }
 }

--- a/packages/stores/src/derived-data/pool/bonding.ts
+++ b/packages/stores/src/derived-data/pool/bonding.ts
@@ -53,7 +53,7 @@ export class ObservableSharePoolBonding {
 
   @computed
   protected get querySharePool() {
-    const pool = this.queries.queryGammPools.getPool(this.poolId);
+    const pool = this.queries.queryPools.getPool(this.poolId);
 
     if (Boolean(pool?.sharePool)) return pool;
   }

--- a/packages/stores/src/derived-data/pool/concentrated.ts
+++ b/packages/stores/src/derived-data/pool/concentrated.ts
@@ -127,16 +127,19 @@ export class ObservableConcentratedPoolDetail {
   }
 
   @computed
+  get userPositions() {
+    return this.osmosisQueries.queryAccountsPositions
+      .get(this.bech32Address)
+      .positions.filter((position) => position.poolId === this.poolId);
+  }
+
+  @computed
   get userPoolAssets(): { asset: CoinPretty }[] {
     const queryPool = this.queryConcentratedPool;
-    const userPositions = this.osmosisQueries.queryAccountsPositions
-      .get(this.bech32Address)
-      .positions.filter((position) => position.poolId === queryPool?.id);
-
     if (!queryPool) return [];
 
     // reduce to a summed map of coins by coin denom
-    const coinSumsMap = userPositions.reduce<Map<string, CoinPretty>>(
+    const coinSumsMap = this.userPositions.reduce<Map<string, CoinPretty>>(
       (coins, position) => {
         [position.baseAsset, position.quoteAsset]
           .filter((coin): coin is CoinPretty => Boolean(coin))

--- a/packages/stores/src/derived-data/pool/concentrated.ts
+++ b/packages/stores/src/derived-data/pool/concentrated.ts
@@ -1,0 +1,191 @@
+import {
+  HasMapStore,
+  IAccountStore,
+  IQueriesStore,
+} from "@keplr-wallet/stores";
+import { FiatCurrency } from "@keplr-wallet/types";
+import { CoinPretty, PricePretty, RatePretty } from "@keplr-wallet/unit";
+import { Duration } from "dayjs/plugin/duration";
+import { computed, makeObservable } from "mobx";
+
+import { IPriceStore } from "../../price";
+import { OsmosisQueries } from "../../queries/store";
+import {
+  ObservableQueryActiveGauges,
+  ObservableQueryPoolFeesMetrics,
+} from "../../queries-external";
+
+/** Convenience store for getting common details of a share pool (balancer or stable) via many other lower-level query stores. */
+export class ObservableConcentratedPoolDetail {
+  protected readonly _fiatCurrency: FiatCurrency;
+
+  constructor(
+    protected readonly poolId: string,
+    protected readonly osmosisChainId: string,
+    protected readonly queriesStore: IQueriesStore<OsmosisQueries>,
+    protected readonly externalQueries: {
+      queryGammPoolFeeMetrics: ObservableQueryPoolFeesMetrics;
+      queryActiveGauges: ObservableQueryActiveGauges;
+    },
+    protected readonly accountStore: IAccountStore,
+    protected readonly priceStore: IPriceStore
+  ) {
+    const fiat = this.priceStore.getFiatCurrency(
+      this.priceStore.defaultVsCurrency
+    );
+
+    if (!fiat)
+      throw new Error("Could not find fiat currency from price store.");
+
+    this._fiatCurrency = fiat;
+
+    makeObservable(this);
+  }
+
+  @computed
+  get queryConcentratedPool() {
+    const pool = this.osmosisQueries.queryPools.getPool(this.poolId);
+
+    if (Boolean(pool?.concentratedLiquidityPoolInfo)) return pool;
+  }
+
+  protected get bech32Address() {
+    return this.accountStore.getAccount(this.osmosisChainId).bech32Address;
+  }
+
+  @computed
+  protected get osmosisQueries() {
+    const osmosisQueries = this.queriesStore.get(this.osmosisChainId).osmosis;
+    if (!osmosisQueries) throw Error("Did not supply Osmosis chain ID");
+    return osmosisQueries;
+  }
+
+  get isIncentivized() {
+    return this.osmosisQueries.queryIncentivizedPools.isIncentivized(
+      this.poolId
+    );
+  }
+
+  @computed
+  get totalValueLocked(): PricePretty {
+    return (
+      this.queryConcentratedPool?.computeTotalValueLocked(this.priceStore) ??
+      new PricePretty(this._fiatCurrency, 0)
+    );
+  }
+
+  @computed
+  get swapFeeApr(): RatePretty {
+    const queryPool = this.osmosisQueries.queryPools.getPool(this.poolId);
+    if (!queryPool) return new RatePretty(0);
+
+    return this.externalQueries.queryGammPoolFeeMetrics.get7dPoolFeeApr(
+      queryPool,
+      this.priceStore
+    );
+  }
+
+  // TODO: figure out how we can integrate with concentrated pool here
+  @computed
+  get internalGauges() {
+    return this.osmosisQueries.queryLockableDurations.lockableDurations
+      .map((duration) => {
+        const gaugeId =
+          this.osmosisQueries.queryIncentivizedPools.getIncentivizedGaugeId(
+            this.poolId,
+            duration
+          );
+
+        const gauge = this.externalQueries.queryActiveGauges.get(
+          gaugeId ?? "1"
+        );
+
+        const apr = this.osmosisQueries.queryIncentivizedPools.computeApr(
+          this.poolId,
+          duration,
+          this.priceStore,
+          this._fiatCurrency
+        );
+
+        return {
+          id: gaugeId,
+          duration,
+          apr,
+          isLoading: gauge?.isFetching ?? true,
+        };
+      })
+      .filter(
+        (
+          gauge
+        ): gauge is {
+          id: string;
+          duration: Duration;
+          apr: RatePretty;
+          isLoading: boolean;
+        } => gauge !== undefined
+      );
+  }
+
+  @computed
+  get userPoolAssets(): { asset: CoinPretty }[] {
+    const queryPool = this.queryConcentratedPool;
+    const userPositions = this.osmosisQueries.queryAccountsPositions
+      .get(this.bech32Address)
+      .positions.filter((position) => position.poolId === queryPool?.id);
+
+    if (!queryPool) return [];
+
+    // reduce to a summed map of coins by coin denom
+    const coinSumsMap = userPositions.reduce<Map<string, CoinPretty>>(
+      (coins, position) => {
+        [position.baseAsset, position.quoteAsset]
+          .filter((coin): coin is CoinPretty => Boolean(coin))
+          .forEach((asset) => {
+            const existingCoin = coins.get(asset.currency.coinMinimalDenom);
+            if (existingCoin) {
+              coins.set(
+                asset.currency.coinMinimalDenom,
+                existingCoin.add(asset)
+              );
+            } else {
+              coins.set(asset.currency.coinMinimalDenom, asset);
+            }
+          });
+        return coins;
+      },
+      new Map()
+    );
+
+    return Array.from(coinSumsMap.values()).map((asset) => ({ asset }));
+  }
+}
+
+/** Stores a map of additional details for each share pool (balancer or stable) ID. */
+export class ObservableConcentratedPoolDetails extends HasMapStore<ObservableConcentratedPoolDetail> {
+  constructor(
+    protected readonly osmosisChainId: string,
+    protected readonly queriesStore: IQueriesStore<OsmosisQueries>,
+    protected readonly externalQueries: {
+      queryGammPoolFeeMetrics: ObservableQueryPoolFeesMetrics;
+      queryActiveGauges: ObservableQueryActiveGauges;
+    },
+    protected readonly accountStore: IAccountStore,
+    protected readonly priceStore: IPriceStore
+  ) {
+    super(
+      (poolId: string) =>
+        new ObservableConcentratedPoolDetail(
+          poolId,
+          this.osmosisChainId,
+          this.queriesStore,
+          this.externalQueries,
+          this.accountStore,
+          this.priceStore
+        )
+    );
+  }
+
+  get(poolId: string): ObservableConcentratedPoolDetail {
+    return super.get(poolId);
+  }
+}

--- a/packages/stores/src/derived-data/pool/index.ts
+++ b/packages/stores/src/derived-data/pool/index.ts
@@ -1,4 +1,4 @@
 export * from "./bonding";
-export * from "./details";
+export * from "./share-pool-details";
 export * from "./superfluid";
 export * from "./types";

--- a/packages/stores/src/derived-data/pool/index.ts
+++ b/packages/stores/src/derived-data/pool/index.ts
@@ -1,4 +1,5 @@
 export * from "./bonding";
+export * from "./concentrated";
 export * from "./share-pool-details";
 export * from "./superfluid";
 export * from "./types";

--- a/packages/stores/src/derived-data/pool/share-pool-details.ts
+++ b/packages/stores/src/derived-data/pool/share-pool-details.ts
@@ -46,7 +46,7 @@ export class ObservableSharePoolDetail {
 
   @computed
   get querySharePool() {
-    const pool = this.queries.queryGammPools.getPool(this.poolId);
+    const pool = this.queries.queryPools.getPool(this.poolId);
 
     if (Boolean(pool?.sharePool)) return pool;
   }
@@ -88,7 +88,7 @@ export class ObservableSharePoolDetail {
 
   @computed
   get swapFeeApr(): RatePretty {
-    const queryPool = this.queries.queryGammPools.getPool(this.poolId);
+    const queryPool = this.queries.queryPools.getPool(this.poolId);
     if (!queryPool) return new RatePretty(0);
 
     return this.externalQueries.queryGammPoolFeeMetrics.get7dPoolFeeApr(

--- a/packages/stores/src/derived-data/pool/superfluid.ts
+++ b/packages/stores/src/derived-data/pool/superfluid.ts
@@ -11,7 +11,7 @@ import { computed, makeObservable } from "mobx";
 
 import { IPriceStore } from "../../price";
 import { OsmosisQueries } from "../../queries/store";
-import { ObservablePoolDetails } from "./details";
+import { ObservableSharePoolDetails } from "./share-pool-details";
 
 /** Convenience store getting common superfluid data for a pool via superfluid stores. */
 export class ObservableSuperfluidPoolDetail {
@@ -24,7 +24,7 @@ export class ObservableSuperfluidPoolDetail {
       CosmosQueries & OsmosisQueries
     >,
     protected readonly accountStore: IAccountStore,
-    protected readonly poolDetails: ObservablePoolDetails,
+    protected readonly sharePoolDetails: ObservableSharePoolDetails,
     protected readonly priceStore: IPriceStore
   ) {
     const fiat = this.priceStore.getFiatCurrency(
@@ -43,8 +43,8 @@ export class ObservableSuperfluidPoolDetail {
     return this.accountStore.getAccount(this.osmosisChainId).bech32Address;
   }
 
-  protected get queryPoolDetails() {
-    return this.poolDetails.get(this.poolId);
+  protected get querySharePoolDetails() {
+    return this.sharePoolDetails.get(this.poolId);
   }
 
   protected get cosmosQueries() {
@@ -67,8 +67,8 @@ export class ObservableSuperfluidPoolDetail {
   /** Wraps `gauges` member of pool detail store with potential superfluid APR info. */
   @computed
   get gaugesWithSuperfluidApr() {
-    return this.queryPoolDetails.internalGauges.map((gaugeInfo) => {
-      const lastDuration = this.queryPoolDetails.longestDuration;
+    return this.querySharePoolDetails.internalGauges.map((gaugeInfo) => {
+      const lastDuration = this.querySharePoolDetails.longestDuration;
       return {
         ...gaugeInfo,
         superfluidApr:
@@ -105,136 +105,145 @@ export class ObservableSuperfluidPoolDetail {
 
   @computed
   get superfluid() {
-    if (!this.isSuperfluid || !this.queryPoolDetails.longestDuration) return;
+    // share pool superfluid info
+    if (this.isSuperfluid && this.querySharePoolDetails.longestDuration) {
+      let upgradeableLpLockIds:
+        | {
+            amount: CoinPretty;
+            lockIds: string[];
+          }
+        | undefined;
+      if (this.querySharePoolDetails.lockableDurations.length > 0) {
+        upgradeableLpLockIds = this.osmosisQueries.queryAccountLocked
+          .get(this.bech32Address)
+          .getLockedCoinWithDuration(
+            this.querySharePoolDetails.poolShareCurrency,
+            this.querySharePoolDetails.longestDuration
+          );
+      }
 
-    let upgradeableLpLockIds:
-      | {
-          amount: CoinPretty;
-          lockIds: string[];
-        }
-      | undefined;
-    if (this.queryPoolDetails.lockableDurations.length > 0) {
-      upgradeableLpLockIds = this.osmosisQueries.queryAccountLocked
-        .get(this.bech32Address)
-        .getLockedCoinWithDuration(
-          this.queryPoolDetails.poolShareCurrency,
-          this.queryPoolDetails.longestDuration
-        );
-    }
+      const undelegatedLockedLpShares =
+        (this.osmosisQueries.querySuperfluidDelegations
+          .getQuerySuperfluidDelegations(this.bech32Address)
+          .getDelegations(this.querySharePoolDetails.poolShareCurrency)
+          ?.length === 0 &&
+          upgradeableLpLockIds &&
+          upgradeableLpLockIds.lockIds.length > 0) ??
+        false;
 
-    const undelegatedLockedLpShares =
-      (this.osmosisQueries.querySuperfluidDelegations
-        .getQuerySuperfluidDelegations(this.bech32Address)
-        .getDelegations(this.queryPoolDetails.poolShareCurrency)?.length ===
-        0 &&
-        upgradeableLpLockIds &&
-        upgradeableLpLockIds.lockIds.length > 0) ??
-      false;
-
-    return undelegatedLockedLpShares
-      ? { upgradeableLpLockIds }
-      : {
-          delegations: this.osmosisQueries.querySuperfluidDelegations
-            .getQuerySuperfluidDelegations(this.bech32Address)
-            .getDelegations(this.queryPoolDetails.poolShareCurrency)
-            ?.map(({ validator_address, amount }) => {
-              let jailed = false;
-              let inactive = false;
-              let validator = this.cosmosQueries.queryValidators
-                .getQueryStatus(Staking.BondStatus.Bonded)
-                .getValidator(validator_address);
-
-              if (!validator) {
-                validator = this.cosmosQueries.queryValidators
-                  .getQueryStatus(Staking.BondStatus.Unbonded)
+      return undelegatedLockedLpShares
+        ? { upgradeableLpLockIds }
+        : {
+            delegations: this.osmosisQueries.querySuperfluidDelegations
+              .getQuerySuperfluidDelegations(this.bech32Address)
+              .getDelegations(this.querySharePoolDetails.poolShareCurrency)
+              ?.map(({ validator_address, amount }) => {
+                let jailed = false;
+                let inactive = false;
+                let validator = this.cosmosQueries.queryValidators
+                  .getQueryStatus(Staking.BondStatus.Bonded)
                   .getValidator(validator_address);
-                inactive = true;
-                if (validator?.jailed) jailed = true;
-              }
 
-              let thumbnail: string | undefined;
-              if (validator) {
-                thumbnail = this.cosmosQueries.queryValidators
-                  .getQueryStatus(
-                    inactive
-                      ? Staking.BondStatus.Unbonded
-                      : Staking.BondStatus.Bonded
-                  )
-                  .getValidatorThumbnail(validator_address);
-              }
+                if (!validator) {
+                  validator = this.cosmosQueries.queryValidators
+                    .getQueryStatus(Staking.BondStatus.Unbonded)
+                    .getValidator(validator_address);
+                  inactive = true;
+                  if (validator?.jailed) jailed = true;
+                }
 
-              let superfluidApr =
-                this.cosmosQueries.queryInflation.inflation.mul(
-                  this.osmosisQueries.querySuperfluidOsmoEquivalent.estimatePoolAPROsmoEquivalentMultiplier(
-                    this.poolId
-                  )
-                );
+                let thumbnail: string | undefined;
+                if (validator) {
+                  thumbnail = this.cosmosQueries.queryValidators
+                    .getQueryStatus(
+                      inactive
+                        ? Staking.BondStatus.Unbonded
+                        : Staking.BondStatus.Bonded
+                    )
+                    .getValidatorThumbnail(validator_address);
+                }
 
-              if (
-                this.queryPoolDetails.lockableDurations.length > 0 &&
-                this.queryPoolDetails.longestDuration
-              ) {
-                const poolApr =
-                  this.osmosisQueries.queryIncentivizedPools.computeApr(
-                    this.poolId,
-                    this.queryPoolDetails.longestDuration,
-                    this.priceStore,
-                    this._fiatCurrency
+                let superfluidApr =
+                  this.cosmosQueries.queryInflation.inflation.mul(
+                    this.osmosisQueries.querySuperfluidOsmoEquivalent.estimatePoolAPROsmoEquivalentMultiplier(
+                      this.poolId
+                    )
                   );
-                superfluidApr = superfluidApr.add(
-                  poolApr.moveDecimalPointRight(2).toDec()
-                );
-              }
 
-              const commissionRateRaw =
-                validator?.commission.commission_rates.rate;
+                if (
+                  this.querySharePoolDetails.lockableDurations.length > 0 &&
+                  this.querySharePoolDetails.longestDuration
+                ) {
+                  const poolApr =
+                    this.osmosisQueries.queryIncentivizedPools.computeApr(
+                      this.poolId,
+                      this.querySharePoolDetails.longestDuration,
+                      this.priceStore,
+                      this._fiatCurrency
+                    );
+                  superfluidApr = superfluidApr.add(
+                    poolApr.moveDecimalPointRight(2).toDec()
+                  );
+                }
 
-              return {
-                validatorName: validator?.description.moniker,
-                validatorCommission: commissionRateRaw
-                  ? new RatePretty(new Dec(commissionRateRaw))
-                  : undefined,
-                validatorImgSrc: thumbnail,
-                inactive: jailed ? "jailed" : inactive ? "inactive" : undefined,
-                apr: new RatePretty(superfluidApr.moveDecimalPointLeft(2)),
-                amount:
-                  this.osmosisQueries.querySuperfluidOsmoEquivalent.calculateOsmoEquivalent(
-                    amount
-                  ),
-              };
-            }),
-          undelegations: this.osmosisQueries.querySuperfluidUndelegations
-            .getQuerySuperfluidDelegations(this.bech32Address)
-            .getUndelegations(this.queryPoolDetails.poolShareCurrency)
-            ?.map(({ validator_address, amount, end_time }) => {
-              let jailed = false;
-              let inactive = false;
-              let validator = this.cosmosQueries.queryValidators
-                .getQueryStatus(Staking.BondStatus.Bonded)
-                .getValidator(validator_address);
+                const commissionRateRaw =
+                  validator?.commission.commission_rates.rate;
 
-              if (!validator) {
-                validator = this.cosmosQueries.queryValidators
-                  .getQueryStatus(Staking.BondStatus.Unbonded)
+                return {
+                  validatorName: validator?.description.moniker,
+                  validatorCommission: commissionRateRaw
+                    ? new RatePretty(new Dec(commissionRateRaw))
+                    : undefined,
+                  validatorImgSrc: thumbnail,
+                  inactive: jailed
+                    ? "jailed"
+                    : inactive
+                    ? "inactive"
+                    : undefined,
+                  apr: new RatePretty(superfluidApr.moveDecimalPointLeft(2)),
+                  amount:
+                    this.osmosisQueries.querySuperfluidOsmoEquivalent.calculateOsmoEquivalent(
+                      amount
+                    ),
+                };
+              }),
+            undelegations: this.osmosisQueries.querySuperfluidUndelegations
+              .getQuerySuperfluidDelegations(this.bech32Address)
+              .getUndelegations(this.querySharePoolDetails.poolShareCurrency)
+              ?.map(({ validator_address, amount, end_time }) => {
+                let jailed = false;
+                let inactive = false;
+                let validator = this.cosmosQueries.queryValidators
+                  .getQueryStatus(Staking.BondStatus.Bonded)
                   .getValidator(validator_address);
-                inactive = true;
-                if (validator?.jailed) jailed = true;
-              }
 
-              return {
-                validatorName: validator?.description.moniker,
-                inactive: jailed ? "jailed" : inactive ? "inactive" : undefined,
-                amount,
-                endTime: end_time,
-              };
-            }),
-          superfluidLpShares: this.osmosisQueries.queryAccountLocked
-            .get(this.bech32Address)
-            .getLockedCoinWithDuration(
-              this.queryPoolDetails.poolShareCurrency,
-              this.queryPoolDetails.longestDuration
-            ),
-        };
+                if (!validator) {
+                  validator = this.cosmosQueries.queryValidators
+                    .getQueryStatus(Staking.BondStatus.Unbonded)
+                    .getValidator(validator_address);
+                  inactive = true;
+                  if (validator?.jailed) jailed = true;
+                }
+
+                return {
+                  validatorName: validator?.description.moniker,
+                  inactive: jailed
+                    ? "jailed"
+                    : inactive
+                    ? "inactive"
+                    : undefined,
+                  amount,
+                  endTime: end_time,
+                };
+              }),
+            superfluidLpShares: this.osmosisQueries.queryAccountLocked
+              .get(this.bech32Address)
+              .getLockedCoinWithDuration(
+                this.querySharePoolDetails.poolShareCurrency,
+                this.querySharePoolDetails.longestDuration
+              ),
+          };
+    }
   }
 }
 
@@ -245,7 +254,7 @@ export class ObservableSuperfluidPoolDetails extends HasMapStore<ObservableSuper
       CosmosQueries & OsmosisQueries
     >,
     protected readonly accountStore: IAccountStore,
-    protected readonly poolDetails: ObservablePoolDetails,
+    protected readonly poolDetails: ObservableSharePoolDetails,
     protected readonly priceStore: IPriceStore
   ) {
     super(

--- a/packages/stores/src/derived-data/pool/superfluid.ts
+++ b/packages/stores/src/derived-data/pool/superfluid.ts
@@ -254,7 +254,7 @@ export class ObservableSuperfluidPoolDetails extends HasMapStore<ObservableSuper
       CosmosQueries & OsmosisQueries
     >,
     protected readonly accountStore: IAccountStore,
-    protected readonly poolDetails: ObservableSharePoolDetails,
+    protected readonly sharePoolDetails: ObservableSharePoolDetails,
     protected readonly priceStore: IPriceStore
   ) {
     super(
@@ -264,7 +264,7 @@ export class ObservableSuperfluidPoolDetails extends HasMapStore<ObservableSuper
           this.osmosisChainId,
           this.queriesStore,
           this.accountStore,
-          this.poolDetails,
+          this.sharePoolDetails,
           this.priceStore
         )
     );

--- a/packages/stores/src/derived-data/pool/types.ts
+++ b/packages/stores/src/derived-data/pool/types.ts
@@ -2,13 +2,14 @@ import { CoinPretty, PricePretty, RatePretty } from "@keplr-wallet/unit";
 import { Duration } from "dayjs/plugin/duration";
 
 /** Non OSMO gauge. */
-export type ExternalGauge = {
+export type ExternalSharesGauge = {
   id: string;
   duration: Duration;
   rewardAmount?: CoinPretty;
   remainingEpochs: number;
 };
 
+/** Bond duration that corresponds to locked pool shares. */
 export type BondDuration = {
   duration: Duration;
   /** Bondable if there's any active gauges for this duration. */

--- a/packages/stores/src/derived-data/store.ts
+++ b/packages/stores/src/derived-data/store.ts
@@ -13,14 +13,14 @@ import {
   ObservableQueryPoolFeesMetrics,
 } from "../queries-external";
 import {
-  ObservablePoolDetails,
   ObservablePoolsBonding,
+  ObservableSharePoolDetails,
   ObservableSuperfluidPoolDetails,
 } from "./pool";
 
 /** Contains stores that compute on the lower level stores. */
 export class DerivedDataStore {
-  public readonly poolDetails: DeepReadonly<ObservablePoolDetails>;
+  public readonly sharePoolDetails: DeepReadonly<ObservableSharePoolDetails>;
   public readonly superfluidPoolDetails: DeepReadonly<ObservableSuperfluidPoolDetails>;
   public readonly poolsBonding: DeepReadonly<ObservablePoolsBonding>;
 
@@ -37,7 +37,7 @@ export class DerivedDataStore {
     protected readonly priceStore: IPriceStore,
     protected readonly chainGetter: ChainStore
   ) {
-    this.poolDetails = new ObservablePoolDetails(
+    this.sharePoolDetails = new ObservableSharePoolDetails(
       this.osmosisChainId,
       this.queriesStore,
       this.externalQueries,
@@ -48,12 +48,12 @@ export class DerivedDataStore {
       this.osmosisChainId,
       this.queriesStore,
       this.accountStore,
-      this.poolDetails,
+      this.sharePoolDetails,
       this.priceStore
     );
     this.poolsBonding = new ObservablePoolsBonding(
       this.osmosisChainId,
-      this.poolDetails,
+      this.sharePoolDetails,
       this.superfluidPoolDetails,
       this.priceStore,
       this.chainGetter,
@@ -65,7 +65,7 @@ export class DerivedDataStore {
 
   getForPool(poolId: string) {
     return {
-      poolDetail: this.poolDetails.get(poolId),
+      poolDetail: this.sharePoolDetails.get(poolId),
       superfluidPoolDetail: this.superfluidPoolDetails.get(poolId),
       poolBonding: this.poolsBonding.get(poolId),
     };

--- a/packages/stores/src/derived-data/store.ts
+++ b/packages/stores/src/derived-data/store.ts
@@ -13,6 +13,7 @@ import {
   ObservableQueryPoolFeesMetrics,
 } from "../queries-external";
 import {
+  ObservableConcentratedPoolDetails,
   ObservablePoolsBonding,
   ObservableSharePoolDetails,
   ObservableSuperfluidPoolDetails,
@@ -21,6 +22,7 @@ import {
 /** Contains stores that compute on the lower level stores. */
 export class DerivedDataStore {
   public readonly sharePoolDetails: DeepReadonly<ObservableSharePoolDetails>;
+  public readonly concentratedPoolDetails: DeepReadonly<ObservableConcentratedPoolDetails>;
   public readonly superfluidPoolDetails: DeepReadonly<ObservableSuperfluidPoolDetails>;
   public readonly poolsBonding: DeepReadonly<ObservablePoolsBonding>;
 
@@ -38,6 +40,13 @@ export class DerivedDataStore {
     protected readonly chainGetter: ChainStore
   ) {
     this.sharePoolDetails = new ObservableSharePoolDetails(
+      this.osmosisChainId,
+      this.queriesStore,
+      this.externalQueries,
+      this.accountStore,
+      this.priceStore
+    );
+    this.concentratedPoolDetails = new ObservableConcentratedPoolDetails(
       this.osmosisChainId,
       this.queriesStore,
       this.externalQueries,
@@ -65,7 +74,8 @@ export class DerivedDataStore {
 
   getForPool(poolId: string) {
     return {
-      poolDetail: this.sharePoolDetails.get(poolId),
+      sharePoolDetail: this.sharePoolDetails.get(poolId),
+      concentratedPoolDetail: this.concentratedPoolDetails.get(poolId),
       superfluidPoolDetail: this.superfluidPoolDetails.get(poolId),
       poolBonding: this.poolsBonding.get(poolId),
     };

--- a/packages/stores/src/queries/pool-share/index.ts
+++ b/packages/stores/src/queries/pool-share/index.ts
@@ -61,14 +61,14 @@ export class ObservableQueryGammPoolShare {
     return result;
   });
 
-  readonly getShareCurrency = computedFn((poolId: string): Currency => {
+  readonly makeShareCurrency = computedFn((poolId: string): Currency => {
     return ObservableQueryGammPoolShare.getShareCurrency(poolId);
   });
 
   /** Gets coin balance of user's locked gamm shares in pool. */
   readonly getLockedGammShare = computedFn(
     (bech32Address: string, poolId: string): CoinPretty => {
-      const currency = this.getShareCurrency(poolId);
+      const currency = this.makeShareCurrency(poolId);
 
       const locked = this.queryLockedCoins
         .get(bech32Address)
@@ -133,7 +133,7 @@ export class ObservableQueryGammPoolShare {
   /** Gets coin balance of user's shares currently unlocking in pool. */
   readonly getUnlockingGammShare = computedFn(
     (bech32Address: string, poolId: string): CoinPretty => {
-      const currency = this.getShareCurrency(poolId);
+      const currency = this.makeShareCurrency(poolId);
 
       const locked = this.queryUnlockingCoins
         .get(bech32Address)
@@ -150,7 +150,7 @@ export class ObservableQueryGammPoolShare {
   /** Gets coin balance of user's unlocked gamm shares in a pool.  */
   readonly getAvailableGammShare = computedFn(
     (bech32Address: string, poolId: string): CoinPretty => {
-      const currency = this.getShareCurrency(poolId);
+      const currency = this.makeShareCurrency(poolId);
 
       return this.queryBalances
         .getQueryBech32Address(bech32Address)
@@ -216,7 +216,7 @@ export class ObservableQueryGammPoolShare {
       amount: CoinPretty;
       lockIds: string[];
     }[] => {
-      const poolShareCurrency = this.getShareCurrency(poolId);
+      const poolShareCurrency = this.makeShareCurrency(poolId);
       return lockableDurations.map((duration) => {
         const lockedCoin = this.queryAccountLocked
           .get(bech32Address)

--- a/packages/stores/src/queries/pools/pool.ts
+++ b/packages/stores/src/queries/pools/pool.ts
@@ -134,6 +134,9 @@ export class ObservableQueryPool extends ObservableChainQuery<{
     if (this.pool instanceof ConcentratedLiquidityPool) {
       return {
         currentSqrtPrice: this.pool.currentSqrtPrice,
+        currentPrice: this.pool.currentSqrtPrice.mul(
+          this.pool.currentSqrtPrice
+        ),
         currentTickLiquidity: this.pool.currentTickLiquidity,
         tickSpacing: this.pool.tickSpacing,
         exponentAtPriceOne: this.pool.exponentAtPriceOne,

--- a/packages/stores/src/queries/store.ts
+++ b/packages/stores/src/queries/store.ts
@@ -89,7 +89,7 @@ export class OsmosisQueriesImpl {
   public readonly queryLiquidityPositionsById: DeepReadonly<ObservableQueryLiquidityPositionsById>;
   public readonly queryAccountsPositions: DeepReadonly<ObservableQueryAccountsPositions>;
 
-  protected _queryGammPools: DeepReadonly<ObservableQueryPoolGetter>;
+  protected _queryPools: DeepReadonly<ObservableQueryPoolGetter>;
   public readonly queryGammNumPools: DeepReadonly<ObservableQueryNumPools>;
   public readonly queryGammPoolShare: DeepReadonly<ObservableQueryGammPoolShare>;
 
@@ -119,7 +119,7 @@ export class OsmosisQueriesImpl {
   public readonly querySuperfluidOsmoEquivalent: DeepReadonly<ObservableQuerySuperfluidOsmoEquivalent>;
 
   get queryPools(): ObservableQueryPoolGetter {
-    return this._queryGammPools;
+    return this._queryPools;
   }
 
   constructor(
@@ -206,14 +206,14 @@ export class OsmosisQueriesImpl {
             ),
           ]
     );
-    this._queryGammPools = poolsQueryFallbacks.responsiveStore;
+    this._queryPools = poolsQueryFallbacks.responsiveStore;
     // hot swap the pools query store any time the fallback store changes
     autorun(() => {
-      this._queryGammPools = poolsQueryFallbacks.responsiveStore;
+      this._queryPools = poolsQueryFallbacks.responsiveStore;
     });
 
     this.queryGammPoolShare = new ObservableQueryGammPoolShare(
-      this._queryGammPools,
+      this._queryPools,
       queries.queryBalances,
       this.queryAccountLocked,
       this.queryLockedCoins,
@@ -251,7 +251,7 @@ export class OsmosisQueriesImpl {
       chainGetter,
       this.queryLockableDurations,
       this.queryDistrInfo,
-      this._queryGammPools,
+      this._queryPools,
       this.queryMintParams,
       this.queryEpochProvisions,
       this.queryEpochs,
@@ -298,7 +298,7 @@ export class OsmosisQueriesImpl {
         chainGetter,
         this.querySuperfluidParams,
         this.querySuperfluidAssetMultiplier,
-        this._queryGammPools
+        this._queryPools
       );
   }
 }

--- a/packages/stores/src/queries/store.ts
+++ b/packages/stores/src/queries/store.ts
@@ -89,7 +89,7 @@ export class OsmosisQueriesImpl {
   public readonly queryLiquidityPositionsById: DeepReadonly<ObservableQueryLiquidityPositionsById>;
   public readonly queryAccountsPositions: DeepReadonly<ObservableQueryAccountsPositions>;
 
-  protected _queryPools: DeepReadonly<ObservableQueryPoolGetter>;
+  protected _queryGammPools: DeepReadonly<ObservableQueryPoolGetter>;
   public readonly queryGammNumPools: DeepReadonly<ObservableQueryNumPools>;
   public readonly queryGammPoolShare: DeepReadonly<ObservableQueryGammPoolShare>;
 
@@ -118,8 +118,8 @@ export class OsmosisQueriesImpl {
   public readonly querySuperfluidAssetMultiplier: DeepReadonly<ObservableQuerySuperfluidAssetMultiplier>;
   public readonly querySuperfluidOsmoEquivalent: DeepReadonly<ObservableQuerySuperfluidOsmoEquivalent>;
 
-  get queryGammPools(): ObservableQueryPoolGetter {
-    return this._queryPools;
+  get queryPools(): ObservableQueryPoolGetter {
+    return this._queryGammPools;
   }
 
   constructor(
@@ -206,14 +206,14 @@ export class OsmosisQueriesImpl {
             ),
           ]
     );
-    this._queryPools = poolsQueryFallbacks.responsiveStore;
+    this._queryGammPools = poolsQueryFallbacks.responsiveStore;
     // hot swap the pools query store any time the fallback store changes
     autorun(() => {
-      this._queryPools = poolsQueryFallbacks.responsiveStore;
+      this._queryGammPools = poolsQueryFallbacks.responsiveStore;
     });
 
     this.queryGammPoolShare = new ObservableQueryGammPoolShare(
-      this._queryPools,
+      this._queryGammPools,
       queries.queryBalances,
       this.queryAccountLocked,
       this.queryLockedCoins,
@@ -251,7 +251,7 @@ export class OsmosisQueriesImpl {
       chainGetter,
       this.queryLockableDurations,
       this.queryDistrInfo,
-      this._queryPools,
+      this._queryGammPools,
       this.queryMintParams,
       this.queryEpochProvisions,
       this.queryEpochs,
@@ -298,7 +298,7 @@ export class OsmosisQueriesImpl {
         chainGetter,
         this.querySuperfluidParams,
         this.querySuperfluidAssetMultiplier,
-        this._queryPools
+        this._queryGammPools
       );
   }
 }

--- a/packages/stores/src/queries/store.ts
+++ b/packages/stores/src/queries/store.ts
@@ -89,7 +89,7 @@ export class OsmosisQueriesImpl {
   public readonly queryLiquidityPositionsById: DeepReadonly<ObservableQueryLiquidityPositionsById>;
   public readonly queryAccountsPositions: DeepReadonly<ObservableQueryAccountsPositions>;
 
-  protected _queryGammPools: DeepReadonly<ObservableQueryPoolGetter>;
+  protected _queryPools: DeepReadonly<ObservableQueryPoolGetter>;
   public readonly queryGammNumPools: DeepReadonly<ObservableQueryNumPools>;
   public readonly queryGammPoolShare: DeepReadonly<ObservableQueryGammPoolShare>;
 
@@ -119,7 +119,7 @@ export class OsmosisQueriesImpl {
   public readonly querySuperfluidOsmoEquivalent: DeepReadonly<ObservableQuerySuperfluidOsmoEquivalent>;
 
   get queryGammPools(): ObservableQueryPoolGetter {
-    return this._queryGammPools;
+    return this._queryPools;
   }
 
   constructor(
@@ -206,14 +206,14 @@ export class OsmosisQueriesImpl {
             ),
           ]
     );
-    this._queryGammPools = poolsQueryFallbacks.responsiveStore;
+    this._queryPools = poolsQueryFallbacks.responsiveStore;
     // hot swap the pools query store any time the fallback store changes
     autorun(() => {
-      this._queryGammPools = poolsQueryFallbacks.responsiveStore;
+      this._queryPools = poolsQueryFallbacks.responsiveStore;
     });
 
     this.queryGammPoolShare = new ObservableQueryGammPoolShare(
-      this._queryGammPools,
+      this._queryPools,
       queries.queryBalances,
       this.queryAccountLocked,
       this.queryLockedCoins,
@@ -251,7 +251,7 @@ export class OsmosisQueriesImpl {
       chainGetter,
       this.queryLockableDurations,
       this.queryDistrInfo,
-      this._queryGammPools,
+      this._queryPools,
       this.queryMintParams,
       this.queryEpochProvisions,
       this.queryEpochs,
@@ -298,7 +298,7 @@ export class OsmosisQueriesImpl {
         chainGetter,
         this.querySuperfluidParams,
         this.querySuperfluidAssetMultiplier,
-        this._queryGammPools
+        this._queryPools
       );
   }
 }

--- a/packages/stores/src/ui-config/manage-liquidity/add-concentrated-liquidity.ts
+++ b/packages/stores/src/ui-config/manage-liquidity/add-concentrated-liquidity.ts
@@ -203,7 +203,7 @@ export class ObservableAddConcentratedLiquidityConfig extends TxChainSetter {
 
   @computed
   get moderatePriceRange(): [Dec, Dec] {
-    if (!this.pool) return [new Dec(0), new Dec(100)];
+    if (!this.pool) return [new Dec(0.1), new Dec(100)];
 
     return [
       roundPriceToNearestTick(
@@ -229,7 +229,7 @@ export class ObservableAddConcentratedLiquidityConfig extends TxChainSetter {
 
   @computed
   get aggressivePriceRange(): [Dec, Dec] {
-    if (!this.pool) return [new Dec(0), new Dec(100)];
+    if (!this.pool) return [new Dec(0.1), new Dec(100)];
 
     return [
       roundPriceToNearestTick(

--- a/packages/web/components/cards/my-position/expanded.tsx
+++ b/packages/web/components/cards/my-position/expanded.tsx
@@ -41,9 +41,14 @@ export const MyPositionCardExpandedSection: FunctionComponent<{
       osmosis: { chainId },
     },
     accountStore,
+    queriesStore,
   } = useStore();
 
   const account = accountStore.getAccount(chainId);
+  const osmosisQueries = queriesStore.get(chainId).osmosis!;
+  const queryPool = osmosisQueries.queryPools.getPool(poolId);
+
+  const currentPrice = queryPool?.concentratedLiquidityPoolInfo?.currentPrice;
 
   const {
     historicalChartData,
@@ -139,7 +144,9 @@ export const MyPositionCardExpandedSection: FunctionComponent<{
               xRange={xRange}
               data={depthChartData}
               annotationDatum={{
-                price: lastChartData?.close || 0,
+                price: currentPrice
+                  ? Number(currentPrice.toString())
+                  : lastChartData?.close || 0,
                 depth: xRange[1],
               }}
               rangeAnnotation={[

--- a/packages/web/components/cards/my-position/index.tsx
+++ b/packages/web/components/cards/my-position/index.tsx
@@ -99,9 +99,9 @@ export const MyPositionCard: FunctionComponent<{
               lowerPrices &&
               upperPrices && (
                 <MyPositionStatus
-                  currentPrice={queryPool.concentratedLiquidityPoolInfo.currentSqrtPrice.mul(
-                    queryPool.concentratedLiquidityPoolInfo.currentSqrtPrice
-                  )}
+                  currentPrice={
+                    queryPool.concentratedLiquidityPoolInfo.currentPrice
+                  }
                   lowerPrice={lowerPrices.price}
                   upperPrice={upperPrices.price}
                 />

--- a/packages/web/components/cards/my-position/index.tsx
+++ b/packages/web/components/cards/my-position/index.tsx
@@ -40,7 +40,7 @@ export const MyPositionCard: FunctionComponent<{
   const [collapsed, setCollapsed] = useState(true);
 
   const queryPool = poolId
-    ? queriesStore.get(chainId).osmosis!.queryGammPools.getPool(poolId)
+    ? queriesStore.get(chainId).osmosis!.queryPools.getPool(poolId)
     : undefined;
 
   const config = poolId

--- a/packages/web/components/complex/add-conc-liquidity.tsx
+++ b/packages/web/components/complex/add-conc-liquidity.tsx
@@ -64,9 +64,7 @@ export const AddConcLiquidity: FunctionComponent<
     } = useStore();
 
     // initialize pool data stores once root pool store is loaded
-    const pool = queriesStore
-      .get(chainId)
-      .osmosis!.queryGammPools.getPool(poolId);
+    const pool = queriesStore.get(chainId).osmosis!.queryPools.getPool(poolId);
 
     return (
       <div className={classNames("flex flex-col gap-8", className)}>

--- a/packages/web/components/complex/add-conc-liquidity.tsx
+++ b/packages/web/components/complex/add-conc-liquidity.tsx
@@ -1,9 +1,7 @@
 import { CoinPretty, Dec, PricePretty } from "@keplr-wallet/unit";
 import {
   ObservableAddConcentratedLiquidityConfig,
-  ObservablePoolDetail,
   ObservableQueryPool,
-  ObservableSuperfluidPoolDetail,
 } from "@osmosis-labs/stores";
 import classNames from "classnames";
 import debounce from "debounce";
@@ -58,17 +56,17 @@ export const AddConcLiquidity: FunctionComponent<
     onRequestClose,
   }) => {
     const { poolId } = addLiquidityConfig;
-    const { derivedDataStore } = useStore();
+    const {
+      queriesStore,
+      chainStore: {
+        osmosis: { chainId },
+      },
+    } = useStore();
 
     // initialize pool data stores once root pool store is loaded
-    const { poolDetail, superfluidPoolDetail } =
-      typeof poolId === "string"
-        ? derivedDataStore.getForPool(poolId as string)
-        : {
-            poolDetail: undefined,
-            superfluidPoolDetail: undefined,
-          };
-    const pool = poolDetail?.pool;
+    const pool = queriesStore
+      .get(chainId)
+      .osmosis!.queryGammPools.getPool(poolId);
 
     return (
       <div className={classNames("flex flex-col gap-8", className)}>
@@ -78,8 +76,6 @@ export const AddConcLiquidity: FunctionComponent<
               return (
                 <Overview
                   pool={pool}
-                  poolDetail={poolDetail}
-                  superfluidPoolDetail={superfluidPoolDetail}
                   addLiquidityConfig={addLiquidityConfig}
                   onRequestClose={onRequestClose}
                 />
@@ -105,138 +101,130 @@ export const AddConcLiquidity: FunctionComponent<
 const Overview: FunctionComponent<
   {
     pool?: ObservableQueryPool;
-    poolDetail?: ObservablePoolDetail;
-    superfluidPoolDetail?: ObservableSuperfluidPoolDetail;
     addLiquidityConfig: ObservableAddConcentratedLiquidityConfig;
     onRequestClose: () => void;
   } & CustomClasses
-> = observer(
-  ({
-    addLiquidityConfig,
-    pool,
-    superfluidPoolDetail,
-    poolDetail,
-    onRequestClose,
-  }) => {
-    const { priceStore, queriesExternalStore } = useStore();
-    const { poolId } = addLiquidityConfig;
-    const t = useTranslation();
-    const [selected, selectView] =
-      useState<typeof addLiquidityConfig.modalView>("add_manual");
-    const queryGammPoolFeeMetrics =
-      queriesExternalStore.queryGammPoolFeeMetrics;
+> = observer(({ addLiquidityConfig, pool, onRequestClose }) => {
+  const { priceStore, queriesExternalStore, derivedDataStore } = useStore();
+  const t = useTranslation();
+  const [selected, selectView] =
+    useState<typeof addLiquidityConfig.modalView>("add_manual");
+  const queryGammPoolFeeMetrics = queriesExternalStore.queryGammPoolFeeMetrics;
 
-    return (
-      <>
-        <div className="align-center relative flex flex-row">
-          <div className="absolute left-0 flex h-full items-center text-sm" />
-          <h6 className="flex-1 text-center">
-            {t("addConcentratedLiquidity.step1Title")}
-          </h6>
-          <div className="absolute right-0">
-            <IconButton
-              aria-label="Close"
-              mode="unstyled"
-              size="unstyled"
-              className="!p-0"
-              icon={
-                <Icon
-                  id="close-thin"
-                  className="text-wosmongton-400 hover:text-wosmongton-100"
-                  height={24}
-                  width={24}
-                />
-              }
-              onClick={onRequestClose}
-            />
-          </div>
+  const superfluidPoolDetail = derivedDataStore.superfluidPoolDetails.get(
+    addLiquidityConfig.poolId
+  );
+
+  return (
+    <>
+      <div className="align-center relative flex flex-row">
+        <div className="absolute left-0 flex h-full items-center text-sm" />
+        <h6 className="flex-1 text-center">
+          {t("addConcentratedLiquidity.step1Title")}
+        </h6>
+        <div className="absolute right-0">
+          <IconButton
+            aria-label="Close"
+            mode="unstyled"
+            size="unstyled"
+            className="!p-0"
+            icon={
+              <Icon
+                id="close-thin"
+                className="text-wosmongton-400 hover:text-wosmongton-100"
+                height={24}
+                width={24}
+              />
+            }
+            onClick={onRequestClose}
+          />
         </div>
-        <div className="flex rounded-[1rem] bg-osmoverse-700/[.3] px-[28px] py-4">
-          <div className="flex flex-1 flex-col gap-1">
-            <div className="flex flex-nowrap items-center gap-2">
-              {pool && (
-                <>
-                  <PoolAssetsIcon
-                    assets={pool.poolAssets.map(
-                      (asset: { amount: CoinPretty }) => ({
-                        coinDenom: asset.amount.denom,
-                        coinImageUrl: asset.amount.currency.coinImageUrl,
-                      })
-                    )}
-                    size="sm"
-                  />
-                  <PoolAssetsName
-                    size="md"
-                    className="max-w-xs truncate"
-                    assetDenoms={pool.poolAssets.map(
-                      (asset: { amount: CoinPretty }) => asset.amount.denom
-                    )}
-                  />
-                </>
-              )}
-            </div>
-            {!superfluidPoolDetail?.isSuperfluid && (
-              <span className="body2 text-superfluid-gradient">
-                {t("pool.superfluidEnabled")}
-              </span>
+      </div>
+      <div className="flex rounded-[1rem] bg-osmoverse-700/[.3] px-[28px] py-4">
+        <div className="flex flex-1 flex-col gap-1">
+          <div className="flex flex-nowrap items-center gap-2">
+            {pool && (
+              <>
+                <PoolAssetsIcon
+                  assets={pool.poolAssets.map(
+                    (asset: { amount: CoinPretty }) => ({
+                      coinDenom: asset.amount.denom,
+                      coinImageUrl: asset.amount.currency.coinImageUrl,
+                    })
+                  )}
+                  size="sm"
+                />
+                <PoolAssetsName
+                  size="md"
+                  className="max-w-xs truncate"
+                  assetDenoms={pool.poolAssets.map(
+                    (asset: { amount: CoinPretty }) => asset.amount.denom
+                  )}
+                />
+              </>
             )}
           </div>
-          <div className="flex items-center gap-10">
-            <div className="gap-[3px]">
-              <span className="body2 text-osmoverse-400">
-                {t("pool.liquidity")}
-              </span>
-              <h6 className="text-osmoverse-100">
-                {poolDetail?.totalValueLocked.toString()}
-              </h6>
-            </div>
-            <div className="gap-[3px]">
-              <span className="body2 text-osmoverse-400">
-                {t("pool.24hrTradingVolume")}
-              </span>
-              <h6 className="text-osmoverse-100">
-                {queryGammPoolFeeMetrics
-                  .getPoolFeesMetrics(poolId, priceStore)
-                  .volume24h.toString()}
-              </h6>
-            </div>
-            <div className="gap-[3px]">
-              <span className="body2 text-osmoverse-400">
-                {t("pool.swapFee")}
-              </span>
-              <h6 className="text-osmoverse-100">{pool?.swapFee.toString()}</h6>
-            </div>
+          {!superfluidPoolDetail?.isSuperfluid && (
+            <span className="body2 text-superfluid-gradient">
+              {t("pool.superfluidEnabled")}
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-10">
+          <div className="gap-[3px]">
+            <span className="body2 text-osmoverse-400">
+              {t("pool.liquidity")}
+            </span>
+            <h6 className="text-osmoverse-100">
+              {pool?.computeTotalValueLocked(priceStore).toString()}
+            </h6>
+          </div>
+          <div className="gap-[3px]">
+            <span className="body2 text-osmoverse-400">
+              {t("pool.24hrTradingVolume")}
+            </span>
+            <h6 className="text-osmoverse-100">
+              {queryGammPoolFeeMetrics
+                .getPoolFeesMetrics(addLiquidityConfig.poolId, priceStore)
+                .volume24h.toString()}
+            </h6>
+          </div>
+          <div className="gap-[3px]">
+            <span className="body2 text-osmoverse-400">
+              {t("pool.swapFee")}
+            </span>
+            <h6 className="text-osmoverse-100">{pool?.swapFee.toString()}</h6>
           </div>
         </div>
-        <div className="flex flex-col">
-          <div className="flex justify-center gap-[12px]">
-            <StrategySelector
-              title={t("addConcentratedLiquidity.managed")}
-              description={t("addConcentratedLiquidity.managedDescription")}
-              selected={selected === "add_managed"}
-              imgSrc="/images/managed_liquidity_mock.png"
-            />
-            <StrategySelector
-              title={t("addConcentratedLiquidity.manual")}
-              description={t("addConcentratedLiquidity.manualDescription")}
-              selected={selected === "add_manual"}
-              onClick={() => selectView("add_manual")}
-              imgSrc="/images/conliq_mock_range.png"
-            />
-          </div>
+      </div>
+      <div className="flex flex-col">
+        <div className="flex justify-center gap-[12px]">
+          <StrategySelector
+            title={t("addConcentratedLiquidity.managed")}
+            description={t("addConcentratedLiquidity.managedDescription")}
+            selected={selected === "add_managed"}
+            imgSrc="/images/managed_liquidity_mock.png"
+          />
+          <StrategySelector
+            title={t("addConcentratedLiquidity.manual")}
+            description={t("addConcentratedLiquidity.manualDescription")}
+            selected={selected === "add_manual"}
+            onClick={() => selectView("add_manual")}
+            imgSrc="/images/conliq_mock_range.png"
+          />
         </div>
-        <div className="flex w-full items-center justify-center">
-          <Button
-            className="w-[25rem]"
-            onClick={() => addLiquidityConfig.setModalView(selected)}
-          >
-            {t("pools.createPool.buttonNext")}
-          </Button>
-        </div>
-      </>
-    );
-  }
-);
+      </div>
+      <div className="flex w-full items-center justify-center">
+        <Button
+          className="w-[25rem]"
+          onClick={() => addLiquidityConfig.setModalView(selected)}
+        >
+          {t("pools.createPool.buttonNext")}
+        </Button>
+      </div>
+    </>
+  );
+});
 
 const StrategySelector: FunctionComponent<{
   title: string;

--- a/packages/web/components/complex/all-pools-table.tsx
+++ b/packages/web/components/complex/all-pools-table.tsx
@@ -224,25 +224,29 @@ export const AllPoolsTable: FunctionComponent<{
           }
 
           // Filter out pools that do not match the pool filter.
-          if (poolFilterQuery && !poolFilterQuery.includes(p.pool.type)) {
+          if (poolFilterQuery && !poolFilterQuery.includes(p.queryPool.type)) {
             return false;
           }
 
           if (incentiveFilterQuery.includes("superfluid")) {
             const isSuperfluid =
-              queriesOsmosis.querySuperfluidPools.isSuperfluidPool(p.pool.id);
+              queriesOsmosis.querySuperfluidPools.isSuperfluidPool(
+                p.queryPool.id
+              );
             if (isSuperfluid) return true;
           }
 
           if (incentiveFilterQuery.includes("internal")) {
             const isInternallyIncentivized =
-              queriesOsmosis.queryIncentivizedPools.isIncentivized(p.pool.id);
+              queriesOsmosis.queryIncentivizedPools.isIncentivized(
+                p.queryPool.id
+              );
             if (isInternallyIncentivized) return true;
           }
 
           if (incentiveFilterQuery.includes("external")) {
             const gauges = queryActiveGauges.getExternalGaugesForPool(
-              p.pool.id
+              p.queryPool.id
             );
             const isExternallyIncentivized = gauges && gauges.length > 0;
             if (isExternallyIncentivized) return true;
@@ -250,10 +254,12 @@ export const AllPoolsTable: FunctionComponent<{
 
           if (incentiveFilterQuery.includes("noIncentives")) {
             const gauges = queryActiveGauges.getExternalGaugesForPool(
-              p.pool.id
+              p.queryPool.id
             );
             const isInternallyIncentivized =
-              queriesOsmosis.queryIncentivizedPools.isIncentivized(p.pool.id);
+              queriesOsmosis.queryIncentivizedPools.isIncentivized(
+                p.queryPool.id
+              );
 
             const hasNoIncentives =
               !(gauges && gauges.length > 0) && !isInternallyIncentivized;
@@ -303,7 +309,7 @@ export const AllPoolsTable: FunctionComponent<{
                 ObservablePoolWithMetric
               >
             ) => {
-              const poolAssets = props.row.original.pool.poolAssets.map(
+              const poolAssets = props.row.original.queryPool.poolAssets.map(
                 (poolAsset) => ({
                   coinImageUrl: poolAsset.amount.currency.coinImageUrl,
                   coinDenom: poolAsset.amount.currency.coinDenom,
@@ -313,8 +319,10 @@ export const AllPoolsTable: FunctionComponent<{
               return (
                 <PoolCompositionCell
                   poolAssets={poolAssets}
-                  poolId={props.row.original.pool.id}
-                  stableswapPool={props.row.original.pool.type === "stable"}
+                  poolId={props.row.original.queryPool.id}
+                  stableswapPool={
+                    props.row.original.queryPool.type === "stable"
+                  }
                 />
               );
             }
@@ -439,7 +447,7 @@ export const AllPoolsTable: FunctionComponent<{
               >
             ) => {
               const poolWithMetrics = props.row.original;
-              const poolId = poolWithMetrics.pool.id;
+              const poolId = poolWithMetrics.queryPool.id;
               return (
                 <PoolQuickActionCell
                   poolId={poolId}
@@ -490,7 +498,7 @@ export const AllPoolsTable: FunctionComponent<{
         const nextId: string | undefined = nextState[0]?.id;
 
         const accessors: Record<string, keyof ObservablePoolWithMetric> = {
-          pool: "pool",
+          queryPool: "queryPool",
           liquidity: "liquidity",
           volume24h: "volume24h",
           feesSpent7d: "feesSpent7d",

--- a/packages/web/components/complex/all-pools-table.tsx
+++ b/packages/web/components/complex/all-pools-table.tsx
@@ -281,13 +281,13 @@ export const AllPoolsTable: FunctionComponent<{
         if (search === "") {
           setIsSearching(false);
         } else {
-          queriesOsmosis.queryGammPools.fetchRemainingPools();
+          queriesOsmosis.queryPools.fetchRemainingPools();
           setIsSearching(true);
         }
         setSorting([]);
         _setQuery(search);
       },
-      [_setQuery, queriesOsmosis.queryGammPools, setSorting]
+      [_setQuery, queriesOsmosis.queryPools, setSorting]
     );
 
     const columnHelper = createColumnHelper<ObservablePoolWithMetric>();
@@ -484,7 +484,7 @@ export const AllPoolsTable: FunctionComponent<{
       getCoreRowModel: getCoreRowModel(),
       getSortedRowModel: getSortedRowModel(),
       onSortingChange: (updaterOrValue) => {
-        queriesOsmosis.queryGammPools.fetchRemainingPools();
+        queriesOsmosis.queryPools.fetchRemainingPools();
 
         const nextState = runIfFn(updaterOrValue, sorting);
         const nextId: string | undefined = nextState[0]?.id;
@@ -507,13 +507,13 @@ export const AllPoolsTable: FunctionComponent<{
     });
 
     const handleFetchRemaining = useCallback(
-      () => queriesOsmosis.queryGammPools.fetchRemainingPools(),
-      [queriesOsmosis.queryGammPools]
+      () => queriesOsmosis.queryPools.fetchRemainingPools(),
+      [queriesOsmosis.queryPools]
     );
 
     const paginatePoolsQueryStore = useCallback(() => {
-      queriesOsmosis.queryGammPools.paginate();
-    }, [queriesOsmosis.queryGammPools]);
+      queriesOsmosis.queryPools.paginate();
+    }, [queriesOsmosis.queryPools]);
 
     const [mobileSortMenuIsOpen, setMobileSortMenuIsOpen] = useState(false);
 

--- a/packages/web/components/complex/my-positions-section.tsx
+++ b/packages/web/components/complex/my-positions-section.tsx
@@ -16,6 +16,7 @@ export const MyPositionsSection: FunctionComponent<{ forPoolId?: string }> =
     const osmosisQueries = queriesStore.get(chainId).osmosis!;
     const [viewMore, setViewMore] = useState(false);
 
+    // positions filtered by pool ID if forPoolId is given
     const positions = osmosisQueries.queryAccountsPositions
       .get(account.bech32Address)
       .positions.filter((position) => {

--- a/packages/web/components/complex/paginated-table.tsx
+++ b/packages/web/components/complex/paginated-table.tsx
@@ -69,8 +69,8 @@ export const PaginatedTable = ({
           const row = rows[virtualRow.index] as Row<ObservablePoolWithMetric>;
           return (
             <Link
-              key={row.original.pool.id}
-              href={`/pool/${row.original.pool.id}`}
+              key={row.original.queryPool.id}
+              href={`/pool/${row.original.queryPool.id}`}
             >
               <a
                 style={{
@@ -156,19 +156,22 @@ export const PaginatedTable = ({
             <tr
               key={row.id}
               className="transition-colors focus-within:bg-osmoverse-700 focus-within:outline-none hover:cursor-pointer hover:bg-osmoverse-800"
-              onClick={() => router.push(`/pool/${row.original.pool.id}`)}
+              onClick={() => router.push(`/pool/${row.original.queryPool.id}`)}
             >
               {row.getVisibleCells().map((cell) => {
                 return (
-                  <td key={cell.id} onClick={(e) => e.stopPropagation()}>
+                  <td key={cell.id}>
                     <Link
-                      href={`/pool/${row.original.pool.id}`}
+                      href={`/pool/${row.original.queryPool.id}`}
                       key={virtualRow.index}
+                      passHref
                     >
-                      {flexRender(
-                        cell.column.columnDef.cell,
-                        cell.getContext()
-                      )}
+                      <a onClick={(e) => e.stopPropagation()}>
+                        {flexRender(
+                          cell.column.columnDef.cell,
+                          cell.getContext()
+                        )}
+                      </a>
                     </Link>
                   </td>
                 );
@@ -188,7 +191,7 @@ export const PaginatedTable = ({
 
 const MobileTableRow = observer(
   ({ row }: { row: Row<ObservablePoolWithMetric> }) => {
-    const poolAssets = row.original.pool.poolAssets.map((poolAsset) => ({
+    const poolAssets = row.original.queryPool.poolAssets.map((poolAsset) => ({
       coinImageUrl: poolAsset.amount.currency.coinImageUrl,
       coinDenom: poolAsset.amount.currency.coinDenom,
     }));

--- a/packages/web/components/pool-detail/concentrated.tsx
+++ b/packages/web/components/pool-detail/concentrated.tsx
@@ -62,9 +62,7 @@ export const ConcentratedLiquidityPool: FunctionComponent<{ poolId: string }> =
     const poolLiquidity = pool?.computeTotalValueLocked(priceStore);
 
     const currentPrice = pool?.concentratedLiquidityPoolInfo
-      ? pool.concentratedLiquidityPoolInfo.currentSqrtPrice.mul(
-          pool.concentratedLiquidityPoolInfo.currentSqrtPrice
-        )
+      ? pool.concentratedLiquidityPoolInfo.currentPrice
       : undefined;
 
     return (
@@ -186,7 +184,9 @@ export const ConcentratedLiquidityPool: FunctionComponent<{ poolId: string }> =
                     xRange={xRange}
                     data={depthChartData}
                     annotationDatum={{
-                      price: lastChartData?.close || 0,
+                      price: currentPrice
+                        ? Number(currentPrice.toString())
+                        : lastChartData?.close ?? 0,
                       depth: xRange[1],
                     }}
                     offset={{

--- a/packages/web/components/pool-detail/share.tsx
+++ b/packages/web/components/pool-detail/share.tsx
@@ -87,19 +87,19 @@ export const SharePool: FunctionComponent<{ poolId: string }> = observer(
             superfluidPoolDetail: undefined,
             poolBonding: undefined,
           };
-    const pool = poolDetail?.pool;
+    const pool = poolDetail?.querySharePool;
     const { superfluidDelegateToValidator } = useSuperfluidPool();
 
     // feature flag check
     useEffect(() => {
       // redirect if CL pool and CL feature is off
       if (
-        poolDetail?.pool?.type === "concentrated" &&
+        pool?.type === "concentrated" &&
         !featureFlags.concentratedLiquidity
       ) {
         router.push("/pools");
       }
-    }, [poolDetail?.pool?.type, featureFlags.concentratedLiquidity, router]);
+    }, [pool?.type, featureFlags.concentratedLiquidity, router]);
 
     // user analytics
     const { poolName, poolWeight } = useMemo(
@@ -138,7 +138,7 @@ export const SharePool: FunctionComponent<{ poolId: string }> = observer(
       unlockTokens,
     } = useLockTokenConfig(
       pool
-        ? queryOsmosis.queryGammPoolShare.getShareCurrency(pool.id)
+        ? queryOsmosis.queryGammPoolShare.makeShareCurrency(pool.id)
         : undefined
     );
     const [showSuperfluidValidatorModal, setShowSuperfluidValidatorsModal] =

--- a/packages/web/components/pool-detail/share.tsx
+++ b/packages/web/components/pool-detail/share.tsx
@@ -79,15 +79,15 @@ export const SharePool: FunctionComponent<{ poolId: string }> = observer(
     const queryAccountPoolRewards = queryAccountsPoolRewards.get(bech32Address);
 
     // initialize pool data stores once root pool store is loaded
-    const { poolDetail, superfluidPoolDetail, poolBonding } =
-      typeof poolId === "string"
+    const { sharePoolDetail, superfluidPoolDetail, poolBonding } =
+      typeof poolId === "string" && Boolean(poolId)
         ? derivedDataStore.getForPool(poolId as string)
         : {
-            poolDetail: undefined,
+            sharePoolDetail: undefined,
             superfluidPoolDetail: undefined,
             poolBonding: undefined,
           };
-    const pool = poolDetail?.querySharePool;
+    const pool = sharePoolDetail?.querySharePool;
     const { superfluidDelegateToValidator } = useSuperfluidPool();
 
     // feature flag check
@@ -249,7 +249,7 @@ export const SharePool: FunctionComponent<{ poolId: string }> = observer(
     );
     const onUnlockTokens = useCallback(
       (duration: Duration) => {
-        const lockIds = poolDetail?.userLockedAssets.reduce<string[]>(
+        const lockIds = sharePoolDetail?.userLockedAssets.reduce<string[]>(
           (foundLockIds, lock) => {
             if (lock.duration.asMilliseconds() === duration.asMilliseconds()) {
               return foundLockIds.concat(...lock.lockIds);
@@ -273,7 +273,7 @@ export const SharePool: FunctionComponent<{ poolId: string }> = observer(
           logEvent([E.unbondAllCompleted, unlockEvent]);
         });
       },
-      [poolDetail?.userLockedAssets, baseEventInfo, logEvent, unlockTokens]
+      [sharePoolDetail?.userLockedAssets, baseEventInfo, logEvent, unlockTokens]
     );
     // TODO: re-add unpool functionality
     const handleSuperfluidDelegateToValidator = useCallback(
@@ -449,7 +449,7 @@ export const SharePool: FunctionComponent<{ poolId: string }> = observer(
                       {t("pool.liquidity")}
                     </span>
                     <h4 className="text-osmoverse-100">
-                      {poolDetail?.totalValueLocked.toString()}
+                      {sharePoolDetail?.totalValueLocked.toString()}
                     </h4>
                   </div>
                   <div className="space-y-2">
@@ -518,7 +518,7 @@ export const SharePool: FunctionComponent<{ poolId: string }> = observer(
               </div>
             </Button>
           </div>
-          {poolDetail?.userStats && (
+          {sharePoolDetail?.userStats && (
             <div className="flex w-full gap-4 1.5lg:flex-col">
               <div className="flex flex-col gap-3 rounded-4xl bg-osmoverse-1000 px-8 py-7">
                 <span className="body2 text-osmoverse-300">
@@ -527,11 +527,11 @@ export const SharePool: FunctionComponent<{ poolId: string }> = observer(
                 <div className="flex place-content-between  gap-6 sm:flex-col sm:items-start">
                   <div className="flex shrink-0 flex-col gap-1">
                     <h4 className="text-osmoverse-100">
-                      {poolDetail.userStats.totalShareValue.toString()}
+                      {sharePoolDetail.userStats.totalShareValue.toString()}
                     </h4>
                     <h6 className="subtitle1 text-osmoverse-300">
                       {t("pool.sharesAmount", {
-                        shares: poolDetail.userStats.totalShares
+                        shares: sharePoolDetail.userStats.totalShares
                           .maxDecimals(6)
                           .hideDenom(true)
                           .toString(),
@@ -539,7 +539,7 @@ export const SharePool: FunctionComponent<{ poolId: string }> = observer(
                     </h6>
                   </div>
 
-                  <PoolComposition assets={poolDetail.userPoolAssets} />
+                  <PoolComposition assets={sharePoolDetail.userPoolAssets} />
                 </div>
               </div>
 
@@ -549,11 +549,11 @@ export const SharePool: FunctionComponent<{ poolId: string }> = observer(
                     prices={[
                       {
                         label: t("pool.bonded"),
-                        price: poolDetail.userStats.bondedValue,
+                        price: sharePoolDetail.userStats.bondedValue,
                       },
                       {
                         label: t("pool.available"),
-                        price: poolDetail.userStats.unbondedValue,
+                        price: sharePoolDetail.userStats.unbondedValue,
                       },
                     ]}
                   />
@@ -574,7 +574,7 @@ export const SharePool: FunctionComponent<{ poolId: string }> = observer(
                     </h4>
                   </div>
 
-                  {poolDetail?.userAvailableValue.toDec().gt(new Dec(0)) &&
+                  {sharePoolDetail?.userAvailableValue.toDec().gt(new Dec(0)) &&
                     bondDurations.some((duration) => duration.bondable) && (
                       <ArrowButton
                         className="text-left"
@@ -650,7 +650,7 @@ export const SharePool: FunctionComponent<{ poolId: string }> = observer(
                   <div className="flex flex-col gap-4 lg:w-full">
                     <div className="hidden flex-col items-end lg:flex">
                       <h4 className="text-osmoverse-100">
-                        {poolDetail?.userAvailableValue.toString()}
+                        {sharePoolDetail?.userAvailableValue.toString()}
                       </h4>
                       <h6 className="subtitle1 text-osmoverse-300">
                         {t("pool.sharesAmount", {
@@ -699,7 +699,7 @@ export const SharePool: FunctionComponent<{ poolId: string }> = observer(
                 </div>
                 <div className="flex flex-col items-end text-right lg:hidden">
                   <h4 className="text-osmoverse-100">
-                    {poolDetail?.userAvailableValue.toString()}
+                    {sharePoolDetail?.userAvailableValue.toString()}
                   </h4>
                   <h6 className="subtitle1 text-osmoverse-300">
                     {t("pool.sharesAmount", {
@@ -801,17 +801,17 @@ export const SharePool: FunctionComponent<{ poolId: string }> = observer(
                         setShowSuperfluidValidatorsModal(true);
                       }}
                       splashImageSrc={
-                        poolDetail && poolDetail.isIncentivized
-                          ? poolDetail.lockableDurations.length > 0 &&
-                            poolDetail.lockableDurations[0].asDays() ===
+                        sharePoolDetail && sharePoolDetail.isIncentivized
+                          ? sharePoolDetail.lockableDurations.length > 0 &&
+                            sharePoolDetail.lockableDurations[0].asDays() ===
                               bondDuration.duration.asDays()
                             ? "/images/small-vial.svg"
-                            : poolDetail.lockableDurations.length > 1 &&
-                              poolDetail.lockableDurations[1].asDays() ===
+                            : sharePoolDetail.lockableDurations.length > 1 &&
+                              sharePoolDetail.lockableDurations[1].asDays() ===
                                 bondDuration.duration.asDays()
                             ? "/images/medium-vial.svg"
-                            : poolDetail.lockableDurations.length > 2 &&
-                              poolDetail.lockableDurations[2].asDays() ===
+                            : sharePoolDetail.lockableDurations.length > 2 &&
+                              sharePoolDetail.lockableDurations[2].asDays() ===
                                 bondDuration.duration.asDays()
                             ? "/images/large-vial.svg"
                             : undefined

--- a/packages/web/components/swap-tool/index.tsx
+++ b/packages/web/components/swap-tool/index.tsx
@@ -138,9 +138,9 @@ export const SwapTool: FunctionComponent<{
     const fetchRemainingPoolsOnce = useCallback(() => {
       if (!fetchedRemainingPoolsRef.current) {
         fetchedRemainingPoolsRef.current = true;
-        queries.osmosis?.queryGammPools.fetchRemainingPools();
+        queries.osmosis?.queryPools.fetchRemainingPools();
       }
-    }, [queries.osmosis?.queryGammPools]);
+    }, [queries.osmosis?.queryPools]);
     const [showFromTokenSelectDropdown, _setFromTokenSelectDropdownLocal] =
       useState(false);
     const setFromTokenSelectDropdownLocal = useCallback(

--- a/packages/web/hooks/ui-config/use-add-concentrated-liquidity-config.ts
+++ b/packages/web/hooks/ui-config/use-add-concentrated-liquidity-config.ts
@@ -19,14 +19,13 @@ export function useAddConcentratedLiquidityConfig(
   addLiquidity: () => Promise<void>;
   increaseLiquidity: (positionId: string) => Promise<void>;
 } {
-  const { accountStore, derivedDataStore, queriesStore } = useStore();
+  const { accountStore, queriesStore } = useStore();
   const osmosisQueries = queriesStore.get(osmosisChainId).osmosis!;
 
   const account = accountStore.getAccount(osmosisChainId);
   const { bech32Address } = account;
 
-  const { poolDetail } = derivedDataStore.getForPool(poolId);
-  const pool = poolDetail!.pool!.pool as ConcentratedLiquidityPool;
+  const queryPool = osmosisQueries.queryGammPools.getPool(poolId);
 
   const [config] = useState(
     () =>
@@ -36,10 +35,12 @@ export function useAddConcentratedLiquidityConfig(
         poolId,
         bech32Address,
         queriesStore,
-        queriesStore.get(osmosisChainId).queryBalances,
-        pool
+        queriesStore.get(osmosisChainId).queryBalances
       )
   );
+
+  if (queryPool && queryPool.pool instanceof ConcentratedLiquidityPool)
+    config.setPool(queryPool.pool);
 
   const addLiquidity = useCallback(() => {
     return new Promise<void>(async (resolve, reject) => {

--- a/packages/web/hooks/ui-config/use-add-concentrated-liquidity-config.ts
+++ b/packages/web/hooks/ui-config/use-add-concentrated-liquidity-config.ts
@@ -25,7 +25,7 @@ export function useAddConcentratedLiquidityConfig(
   const account = accountStore.getAccount(osmosisChainId);
   const { bech32Address } = account;
 
-  const queryPool = osmosisQueries.queryGammPools.getPool(poolId);
+  const queryPool = osmosisQueries.queryPools.getPool(poolId);
 
   const [config] = useState(
     () =>

--- a/packages/web/hooks/ui-config/use-add-liquidity-config.ts
+++ b/packages/web/hooks/ui-config/use-add-liquidity-config.ts
@@ -39,7 +39,7 @@ export function useAddLiquidityConfig(
         bech32Address,
         queriesStore,
         queryOsmosis.queryGammPoolShare,
-        queryOsmosis.queryGammPools,
+        queryOsmosis.queryPools,
         queriesStore.get(osmosisChainId).queryBalances
       )
   );

--- a/packages/web/hooks/ui-config/use-fresh-swap-data.ts
+++ b/packages/web/hooks/ui-config/use-fresh-swap-data.ts
@@ -16,7 +16,7 @@ export function useFreshSwapData(
   const { chainStore, queriesStore, priceStore } = useStore();
 
   const queriesOsmosis = queriesStore.get(chainStore.osmosis.chainId).osmosis!;
-  const queryPools = queriesOsmosis.queryGammPools;
+  const queryPools = queriesOsmosis.queryPools;
 
   // stores to otherwise refresh
   const stores: ObservableQuery[] = useMemo(

--- a/packages/web/hooks/ui-config/use-remove-concentrated-liquidity-config.ts
+++ b/packages/web/hooks/ui-config/use-remove-concentrated-liquidity-config.ts
@@ -16,6 +16,7 @@ export function useRemoveConcentratedLiquidityConfig(
   const { accountStore, queriesStore } = useStore();
 
   const account = accountStore.getAccount(osmosisChainId);
+  const osmosisQueries = queriesStore.get(osmosisChainId).osmosis!;
 
   const [config] = useState(
     () =>
@@ -46,10 +47,14 @@ export function useRemoveConcentratedLiquidityConfig(
                 if (tx.code) {
                   reject(tx.log);
                 } else {
-                  queriesStore
-                    .get(osmosisChainId)
-                    .osmosis!.queryLiquiditiesPerTickRange.getForPoolId(poolId)
+                  // get latest liquidity depths for charts
+                  osmosisQueries.queryLiquiditiesPerTickRange
+                    .getForPoolId(poolId)
                     .waitFreshResponse();
+                  // get latest price, if position removed
+                  osmosisQueries.queryPools
+                    .getPool(poolId)
+                    ?.waitFreshResponse();
                   resolve();
                 }
               }
@@ -60,10 +65,9 @@ export function useRemoveConcentratedLiquidityConfig(
         }
       }),
     [
-      queriesStore,
+      osmosisQueries,
       poolId,
       account.osmosis,
-      osmosisChainId,
       positionId,
       config.effectiveLiquidity,
     ]

--- a/packages/web/hooks/ui-config/use-remove-liquidity-config.ts
+++ b/packages/web/hooks/ui-config/use-remove-liquidity-config.ts
@@ -1,4 +1,3 @@
-import { useState, useCallback } from "react";
 import {
   ChainGetter,
   CosmosQueries,
@@ -6,9 +5,11 @@ import {
   IQueriesStore,
 } from "@keplr-wallet/stores";
 import {
-  OsmosisQueries,
   ObservableRemoveLiquidityConfig,
+  OsmosisQueries,
 } from "@osmosis-labs/stores";
+import { useCallback, useState } from "react";
+
 import { useStore } from "../../stores";
 
 /** Maintains a single instance of `ObservableRemoveLiquidityConfig` for React view lifecycle.
@@ -39,7 +40,7 @@ export function useRemoveLiquidityConfig(
       bech32Address,
       queriesStore,
       queryOsmosis.queryGammPoolShare,
-      queryOsmosis.queryGammPools,
+      queryOsmosis.queryPools,
       initialPercent
     );
     c.setPercentage(initialPercent);

--- a/packages/web/hooks/window/use-token-swap-query-params.ts
+++ b/packages/web/hooks/window/use-token-swap-query-params.ts
@@ -17,14 +17,13 @@ export function useTokenSwapQueryParams(
     chainStore: { osmosis },
     queriesStore,
   } = useStore();
-  const queryGammPools = queriesStore.get(osmosis.chainId).osmosis!
-    .queryGammPools;
+  const queryPools = queriesStore.get(osmosis.chainId).osmosis!.queryPools;
 
   // Set query params to trade config.
   // Loads remaining pools to register remaining currencies if a currency isn't in Osmosis's chainInfo (populated from browser cache).
   // Blocks effect to set browser query params until currencies are loaded (from pools).
   useEffect(() => {
-    if (isInModal || !tradeConfig || !Boolean(queryGammPools.response)) {
+    if (isInModal || !tradeConfig || !Boolean(queryPools.response)) {
       return;
     }
 
@@ -58,7 +57,7 @@ export function useTokenSwapQueryParams(
         );
 
       if (!fromCurrency || !toCurrency) {
-        queryGammPools.fetchRemainingPools();
+        queryPools.fetchRemainingPools();
         return;
       }
 
@@ -72,8 +71,8 @@ export function useTokenSwapQueryParams(
     setFromQueryParams.current = true;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
-    queryGammPools,
-    queryGammPools.response,
+    queryPools,
+    queryPools.response,
     router.query.from,
     router.query.to,
     tradeConfig?.sendableCurrencies,
@@ -81,14 +80,14 @@ export function useTokenSwapQueryParams(
 
   // Set browser query params from trade config.
   useEffect(() => {
-    if (isInModal || !tradeConfig || !Boolean(queryGammPools.response)) {
+    if (isInModal || !tradeConfig || !Boolean(queryPools.response)) {
       return;
     }
 
     // Update current in and out currency to query string.
     // The first effect should be ignored because the query string set when visiting the web page for the first time must be processed.
     if (setFromQueryParams.current) {
-      queryGammPools
+      queryPools
         .waitResponse() // wait for gamm pools to load
         .then(() => {
           if (

--- a/packages/web/modals/add-liquidity.tsx
+++ b/packages/web/modals/add-liquidity.tsx
@@ -45,7 +45,7 @@ export const AddLiquidityModal: FunctionComponent<
     useAddConcentratedLiquidityConfig(chainStore, chainId, poolId);
 
   // initialize pool data stores once root pool store is loaded
-  const queryPool = osmosisQueries.queryGammPools.getPool(poolId);
+  const queryPool = osmosisQueries.queryPools.getPool(poolId);
   const clPool =
     queryPool?.pool && queryPool.pool instanceof ConcentratedLiquidityPool
       ? queryPool.pool

--- a/packages/web/modals/add-liquidity.tsx
+++ b/packages/web/modals/add-liquidity.tsx
@@ -1,7 +1,5 @@
-import {
-  ObservableAddConcentratedLiquidityConfig,
-  ObservableAddLiquidityConfig,
-} from "@osmosis-labs/stores";
+import { ConcentratedLiquidityPool } from "@osmosis-labs/pools";
+import { ObservableAddLiquidityConfig } from "@osmosis-labs/stores";
 import { observer } from "mobx-react-lite";
 import { FunctionComponent, useCallback } from "react";
 import { useTranslation } from "react-multi-lang";
@@ -27,18 +25,14 @@ export const AddLiquidityModal: FunctionComponent<
   } & ModalBaseProps
 > = observer((props) => {
   const { poolId } = props;
-  const {
-    chainStore,
-    accountStore,
-    queriesStore,
-    priceStore,
-    derivedDataStore,
-  } = useStore();
+  const { chainStore, accountStore, queriesStore, priceStore } = useStore();
   const t = useTranslation();
 
   const { chainId } = chainStore.osmosis;
   const account = accountStore.getAccount(chainId);
   const isSendingMsg = account.txTypeInProgress !== "";
+
+  const osmosisQueries = queriesStore.get(chainStore.osmosis.chainId).osmosis!;
 
   const { config: addLiquidityConfig, addLiquidity } = useAddLiquidityConfig(
     chainStore,
@@ -51,23 +45,25 @@ export const AddLiquidityModal: FunctionComponent<
     useAddConcentratedLiquidityConfig(chainStore, chainId, poolId);
 
   // initialize pool data stores once root pool store is loaded
-  const { poolDetail } = derivedDataStore.getForPool(poolId as string);
-  const pool = poolDetail?.pool?.pool;
-  const isConcLiq = pool?.type === "concentrated";
-  const config = isConcLiq ? addConliqConfig : addLiquidityConfig;
+  const queryPool = osmosisQueries.queryGammPools.getPool(poolId);
+  const clPool =
+    queryPool?.pool && queryPool.pool instanceof ConcentratedLiquidityPool
+      ? queryPool.pool
+      : undefined;
+  const config = clPool ? addConliqConfig : addLiquidityConfig;
 
   const { showModalBase, accountActionButton } = useConnectWalletModalRedirect(
     {
       disabled: config.error !== undefined || isSendingMsg,
       onClick: () => {
-        const addLiquidityPromise = isConcLiq
+        const addLiquidityPromise = Boolean(clPool)
           ? addConLiquidity()
           : addLiquidity();
         const addLiquidityResult = addLiquidityPromise.finally(() =>
           props.onRequestClose()
         );
 
-        if (!isConcLiq) {
+        if (!Boolean(clPool)) {
           props.onAddLiquidity?.(
             addLiquidityResult,
             config as ObservableAddLiquidityConfig
@@ -81,7 +77,7 @@ export const AddLiquidityModal: FunctionComponent<
     props.onRequestClose
   );
 
-  if (isConcLiq) {
+  if (Boolean(clPool)) {
     return (
       <ModalBase
         {...props}
@@ -90,9 +86,7 @@ export const AddLiquidityModal: FunctionComponent<
         className="!max-w-[57.5rem]"
       >
         <AddConcLiquidity
-          addLiquidityConfig={
-            addConliqConfig as ObservableAddConcentratedLiquidityConfig
-          }
+          addLiquidityConfig={addConliqConfig}
           actionButton={accountActionButton}
           getFiatValue={useCallback(
             (coin) => priceStore.calculatePrice(coin),

--- a/packages/web/modals/increase-concentrated-liquidity.tsx
+++ b/packages/web/modals/increase-concentrated-liquidity.tsx
@@ -75,7 +75,7 @@ export const IncreaseConcentratedLiquidityModal: FunctionComponent<
   );
 
   // initialize pool data stores once root pool store is loaded
-  const queryPool = osmosisQueries.queryGammPools.getPool(poolId);
+  const queryPool = osmosisQueries.queryPools.getPool(poolId);
   const clPool =
     queryPool?.pool && queryPool.pool instanceof ConcentratedLiquidityPool
       ? queryPool.pool

--- a/packages/web/modals/increase-concentrated-liquidity.tsx
+++ b/packages/web/modals/increase-concentrated-liquidity.tsx
@@ -1,5 +1,4 @@
 import { Dec } from "@keplr-wallet/unit";
-import { ConcentratedLiquidityPool } from "@osmosis-labs/pools";
 import { ObservableQueryLiquidityPositionById } from "@osmosis-labs/stores";
 import { observer } from "mobx-react-lite";
 import dynamic from "next/dynamic";
@@ -76,14 +75,6 @@ export const IncreaseConcentratedLiquidityModal: FunctionComponent<
 
   // initialize pool data stores once root pool store is loaded
   const queryPool = osmosisQueries.queryPools.getPool(poolId);
-  const clPool =
-    queryPool?.pool && queryPool.pool instanceof ConcentratedLiquidityPool
-      ? queryPool.pool
-      : undefined;
-  const currentSqrtPrice = clPool ? clPool.currentSqrtPrice : undefined;
-  const currentPrice = currentSqrtPrice
-    ? currentSqrtPrice.mul(currentSqrtPrice)
-    : new Dec(0);
 
   const { showModalBase, accountActionButton } = useConnectWalletModalRedirect(
     {
@@ -127,7 +118,7 @@ export const IncreaseConcentratedLiquidityModal: FunctionComponent<
           </div>
           {lowerPrices && upperPrices && (
             <MyPositionStatus
-              currentPrice={currentPrice}
+              currentPrice={config.currentPrice}
               lowerPrice={lowerPrices.price}
               upperPrice={upperPrices.price}
               negative
@@ -215,7 +206,10 @@ export const IncreaseConcentratedLiquidityModal: FunctionComponent<
                   xRange={[xRange[0], xRange[1]]}
                   data={depthChartData}
                   annotationDatum={{
-                    price: lastChartData?.close || 0,
+                    price:
+                      Number(config.currentPrice.toString()) ??
+                      lastChartData?.close ??
+                      0,
                     depth: xRange[1],
                   }}
                   rangeAnnotation={[

--- a/packages/web/modals/lock-tokens.tsx
+++ b/packages/web/modals/lock-tokens.tsx
@@ -2,7 +2,7 @@ import { AmountConfig } from "@keplr-wallet/hooks";
 import classNames from "classnames";
 import { Duration } from "dayjs/plugin/duration";
 import { observer } from "mobx-react-lite";
-import { FunctionComponent, useEffect, useState } from "react";
+import { FunctionComponent, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-multi-lang";
 
 import { CheckBox } from "../components/control";
@@ -33,10 +33,13 @@ export const LockTokensModal: FunctionComponent<
   const { bech32Address } = account;
 
   // initialize pool data stores once root pool store is loaded
-  const { poolDetail, superfluidPoolDetail, poolBonding } =
+  const { sharePoolDetail, superfluidPoolDetail, poolBonding } =
     derivedDataStore.getForPool(poolId);
 
-  const bondDurations = poolBonding?.bondDurations ?? [];
+  const bondDurations = useMemo(
+    () => poolBonding?.bondDurations ?? [],
+    [poolBonding?.bondDurations]
+  );
   const availableToken = queryOsmosis.queryGammPoolShare.getAvailableGammShare(
     bech32Address,
     poolId
@@ -59,7 +62,7 @@ export const LockTokensModal: FunctionComponent<
   /** Superfluid duration assumed to be longest duration in lockableDurations
    *  chain parameter.
    */
-  const longestDuration = poolDetail?.longestDuration;
+  const longestDuration = sharePoolDetail?.longestDuration;
   const superfluidDurationSelected =
     selectedDurationIndex !== null &&
     bondDurations.length > selectedDurationIndex &&
@@ -176,10 +179,12 @@ export const LockTokensModal: FunctionComponent<
                 {t("lockToken.superfluidStake")}{" "}
                 {superfluidApr && `(+${superfluidApr.maxDecimals(0)} APR)`}
               </h6>
-              {poolDetail?.longestDuration && (
+              {sharePoolDetail?.longestDuration && (
                 <span className="caption text-osmoverse-300">
                   {t("lockToken.bondingRequirement", {
-                    numDays: poolDetail.longestDuration.asDays().toString(),
+                    numDays: sharePoolDetail.longestDuration
+                      .asDays()
+                      .toString(),
                   })}
                 </span>
               )}

--- a/packages/web/modals/remove-concentrated-liquidity.tsx
+++ b/packages/web/modals/remove-concentrated-liquidity.tsx
@@ -63,7 +63,7 @@ export const RemoveConcentratedLiquidityModal: FunctionComponent<
   const baseAsset = config.effectiveLiquidityAmounts?.base;
   const quoteAsset = config.effectiveLiquidityAmounts?.quote;
 
-  const queryPool = osmosisQueries.queryGammPools.getPool(props.poolId);
+  const queryPool = osmosisQueries.queryPools.getPool(props.poolId);
   const clPool =
     queryPool?.pool && queryPool.pool instanceof ConcentratedLiquidityPool
       ? queryPool.pool

--- a/packages/web/modals/remove-concentrated-liquidity.tsx
+++ b/packages/web/modals/remove-concentrated-liquidity.tsx
@@ -30,11 +30,13 @@ export const RemoveConcentratedLiquidityModal: FunctionComponent<
   } = props.position;
 
   const t = useTranslation();
-  const { chainStore, accountStore, derivedDataStore, priceStore } = useStore();
+  const { chainStore, accountStore, queriesStore, priceStore } = useStore();
 
   const { chainId } = chainStore.osmosis;
   const account = accountStore.getAccount(chainId);
   const isSendingMsg = account.txTypeInProgress !== "";
+
+  const osmosisQueries = queriesStore.get(chainStore.osmosis.chainId).osmosis!;
 
   const { config, removeLiquidity } = useRemoveConcentratedLiquidityConfig(
     chainStore,
@@ -61,12 +63,12 @@ export const RemoveConcentratedLiquidityModal: FunctionComponent<
   const baseAsset = config.effectiveLiquidityAmounts?.base;
   const quoteAsset = config.effectiveLiquidityAmounts?.quote;
 
-  const {
-    poolDetail: { pool },
-  } = derivedDataStore.getForPool(props.poolId);
-  const clPool = pool?.pool as ConcentratedLiquidityPool;
-  const isConcLiq = pool?.type === "concentrated";
-  const currentSqrtPrice = isConcLiq && clPool.currentSqrtPrice;
+  const queryPool = osmosisQueries.queryGammPools.getPool(props.poolId);
+  const clPool =
+    queryPool?.pool && queryPool.pool instanceof ConcentratedLiquidityPool
+      ? queryPool.pool
+      : undefined;
+  const currentSqrtPrice = clPool ? clPool.currentSqrtPrice : undefined;
   const currentPrice = currentSqrtPrice
     ? currentSqrtPrice.mul(currentSqrtPrice)
     : new Dec(0);

--- a/packages/web/modals/remove-liquidity.tsx
+++ b/packages/web/modals/remove-liquidity.tsx
@@ -1,15 +1,16 @@
-import { FunctionComponent } from "react";
-import { observer } from "mobx-react-lite";
 import { ObservableRemoveLiquidityConfig } from "@osmosis-labs/stores";
-import { useStore } from "../stores";
+import { observer } from "mobx-react-lite";
+import { FunctionComponent } from "react";
+import { useTranslation } from "react-multi-lang";
+
+import { RemoveLiquidity } from "../components/complex/remove-liquidity";
+import { tError } from "../components/localization";
 import {
   useConnectWalletModalRedirect,
   useRemoveLiquidityConfig,
 } from "../hooks";
-import { RemoveLiquidity } from "../components/complex/remove-liquidity";
+import { useStore } from "../stores";
 import { ModalBase, ModalBaseProps } from "./base";
-import { useTranslation } from "react-multi-lang";
-import { tError } from "../components/localization";
 
 export const RemoveLiquidityModal: FunctionComponent<
   {

--- a/packages/web/pages/assets/index.tsx
+++ b/packages/web/pages/assets/index.tsx
@@ -319,7 +319,7 @@ const PoolAssets: FunctionComponent = observer(() => {
   }, [ownedPoolIds.length, setUserProperty]);
 
   const dustedPoolIds = useHideDustUserSetting(ownedPoolIds, (poolId) =>
-    queryOsmosis.queryGammPools
+    queryOsmosis.queryPools
       .getPool(poolId)
       ?.computeTotalValueLocked(priceStore)
       .mul(

--- a/packages/web/pages/assets/index.tsx
+++ b/packages/web/pages/assets/index.tsx
@@ -390,9 +390,9 @@ const PoolCardsDisplayer: FunctionComponent<{ poolIds: string[] }> = observer(
 
     const pools = poolIds
       .map((poolId) => {
-        const poolDetail = derivedDataStore.poolDetails.get(poolId);
+        const sharePoolDetail = derivedDataStore.sharePoolDetails.get(poolId);
         const poolBonding = derivedDataStore.poolsBonding.get(poolId);
-        const pool = poolDetail.pool;
+        const pool = sharePoolDetail.querySharePool;
 
         const apr =
           poolBonding.highestBondDuration?.aggregateApr ?? new RatePretty(0);
@@ -406,7 +406,7 @@ const PoolCardsDisplayer: FunctionComponent<{ poolIds: string[] }> = observer(
 
         return [
           pool,
-          poolDetail.userShareValue,
+          sharePoolDetail.userShareValue,
           [
             queryOsmosis.queryIncentivizedPools.isIncentivized(poolId)
               ? {
@@ -427,20 +427,22 @@ const PoolCardsDisplayer: FunctionComponent<{ poolIds: string[] }> = observer(
                     poolBonding.highestBondDuration?.swapFeeApr
                       .maxDecimals(0)
                       .toString() ??
-                    poolDetail.swapFeeApr.maxDecimals(0).toString(),
+                    sharePoolDetail.swapFeeApr.maxDecimals(0).toString(),
                 },
             {
               label: t("assets.poolCards.liquidity"),
-              value: poolDetail.userAvailableValue.maxDecimals(2).toString(),
+              value: sharePoolDetail.userAvailableValue
+                .maxDecimals(2)
+                .toString(),
             },
             queryOsmosis.queryIncentivizedPools.isIncentivized(poolId)
               ? {
                   label: t("assets.poolCards.bonded"),
-                  value: poolDetail.userBondedValue.toString(),
+                  value: sharePoolDetail.userBondedValue.toString(),
                 }
               : {
                   label: t("pools.externalIncentivized.TVL"),
-                  value: formatPretty(poolDetail.totalValueLocked),
+                  value: formatPretty(sharePoolDetail.totalValueLocked),
                 },
           ],
         ] as [ObservableQueryPool, PricePretty, Metric[]];

--- a/packages/web/pages/bootstrap/index.tsx
+++ b/packages/web/pages/bootstrap/index.tsx
@@ -39,7 +39,7 @@ export const LBPOverview: FunctionComponent<{
   const queries = queriesStore.get(chainStore.osmosis.chainId).osmosis!;
   const pools = poolIds
     .map((poolId) => {
-      return queries.queryGammPools.getPool(poolId);
+      return queries.queryPools.getPool(poolId);
     })
     .filter((pool): pool is ObservableQueryPool => pool !== undefined);
 
@@ -120,7 +120,7 @@ const SynthesisItem: FunctionComponent<{
 
   const queries = queriesStore.get(chainStore.osmosis.chainId).osmosis!;
 
-  const pool = queries.queryGammPools.getPool(poolId);
+  const pool = queries.queryPools.getPool(poolId);
 
   const router = useRouter();
 

--- a/packages/web/pages/index.tsx
+++ b/packages/web/pages/index.tsx
@@ -17,7 +17,7 @@ const Home: NextPage = observer(function () {
   const { chainId } = chainStore.osmosis;
 
   const queries = queriesStore.get(chainId);
-  const queryPools = queries.osmosis!.queryGammPools;
+  const queryPools = queries.osmosis!.queryPools;
 
   const allPools = queryPools.getAllPools();
 

--- a/packages/web/pages/pool/[id].tsx
+++ b/packages/web/pages/pool/[id].tsx
@@ -22,7 +22,7 @@ const Pool: FunctionComponent = observer(() => {
   // eject to pools page if pool does not exist
   const poolExists =
     poolId && typeof poolId === "string"
-      ? queryOsmosis.queryGammPools.poolExists(poolId)
+      ? queryOsmosis.queryPools.poolExists(poolId)
       : undefined;
   useEffect(() => {
     if (poolExists === false) {
@@ -30,7 +30,7 @@ const Pool: FunctionComponent = observer(() => {
     }
   }, [poolExists, router]);
 
-  const queryPool = queryOsmosis.queryGammPools.getPool(poolId);
+  const queryPool = queryOsmosis.queryPools.getPool(poolId);
 
   useNavBar(
     useMemo(

--- a/packages/web/pages/pools/index.tsx
+++ b/packages/web/pages/pools/index.tsx
@@ -1,5 +1,5 @@
 import { CoinPretty, Dec, DecUtils, RatePretty } from "@keplr-wallet/unit";
-import { ObservablePoolDetail } from "@osmosis-labs/stores";
+import { ObservableSharePoolDetail } from "@osmosis-labs/stores";
 import { Duration } from "dayjs/plugin/duration";
 import { useFlags } from "launchdarkly-react-client-sdk";
 import { observer } from "mobx-react-lite";
@@ -96,7 +96,7 @@ const Pools: NextPage = observer(function () {
   // lock tokens (& possibly select sfs validator) quick action state
   const { superfluidDelegateToValidator } = useSuperfluidPool();
   const selectedPoolShareCurrency = lockLpTokenModalPoolId
-    ? queryOsmosis.queryGammPoolShare.getShareCurrency(lockLpTokenModalPoolId)
+    ? queryOsmosis.queryGammPoolShare.makeShareCurrency(lockLpTokenModalPoolId)
     : undefined;
   const { config: lockLpTokenConfig, lockToken } = useLockTokenConfig(
     selectedPoolShareCurrency
@@ -320,14 +320,14 @@ const MyPoolsSection = observer(() => {
         ? myPoolIds.slice(0, poolCountShowMoreThreshold)
         : myPoolIds
       )
-        .map((myPoolId) => derivedDataStore.poolDetails.get(myPoolId))
-        .filter((pool): pool is ObservablePoolDetail => {
+        .map((myPoolId) => derivedDataStore.sharePoolDetails.get(myPoolId))
+        .filter((pool): pool is ObservableSharePoolDetail => {
           if (pool === undefined) return false;
 
           // concentrated liquidity liquidity feature flag
           if (
             !featureFlags.concentratedLiquidity &&
-            pool.pool?.type === "concentrated"
+            !Boolean(pool.querySharePool)
           )
             return false;
 
@@ -338,7 +338,7 @@ const MyPoolsSection = observer(() => {
       showMoreMyPools,
       myPoolIds,
       poolCountShowMoreThreshold,
-      derivedDataStore.poolDetails,
+      derivedDataStore.sharePoolDetails,
       featureFlags.concentratedLiquidity,
     ]
   );
@@ -347,7 +347,7 @@ const MyPoolsSection = observer(() => {
     myPools,
     useCallback(
       (pool) => {
-        const _queryPool = pool.pool;
+        const _queryPool = pool.querySharePool;
         if (!_queryPool) return;
         return pool.totalValueLocked.mul(
           queryOsmosis.queryGammPoolShare.getAllGammShareRatio(
@@ -368,7 +368,7 @@ const MyPoolsSection = observer(() => {
       <div className="flex flex-col gap-4">
         <div className="grid-cards mt-5 grid md:gap-3">
           {dustFilteredPools.map((myPool) => {
-            const _queryPool = myPool.pool;
+            const _queryPool = myPool.querySharePool;
 
             if (!_queryPool) return null;
 

--- a/packages/web/stores/assets/index.ts
+++ b/packages/web/stores/assets/index.ts
@@ -223,7 +223,7 @@ export class ObservableAssets {
           "gamm/pool/",
           ""
         );
-        const pool = this.queries.osmosis?.queryGammPools.getPool(poolId);
+        const pool = this.queries.osmosis?.queryPools.getPool(poolId);
         if (pool) {
           const tvl = pool.computeTotalValueLocked(this.priceStore);
           const totalShare = pool.totalShare;

--- a/packages/web/stores/derived-data/concentrated-liquidity/historical-and-liquidity-data.ts
+++ b/packages/web/stores/derived-data/concentrated-liquidity/historical-and-liquidity-data.ts
@@ -53,7 +53,7 @@ export class ObservableHistoricalAndLiquidityData {
 
   @computed
   get pool() {
-    return this.queries.queryGammPools.getPool(this.poolId);
+    return this.queries.queryPools.getPool(this.poolId);
   }
 
   get baseDenom(): string {

--- a/packages/web/stores/derived-data/pools/metrics.ts
+++ b/packages/web/stores/derived-data/pools/metrics.ts
@@ -3,6 +3,7 @@ import { PricePretty, RatePretty } from "@keplr-wallet/unit";
 import {
   ChainStore,
   IPriceStore,
+  ObservableConcentratedPoolDetails,
   ObservablePoolsBonding,
   ObservableQueryActiveGauges,
   ObservableQueryPool,
@@ -17,11 +18,12 @@ import { ObservableVerifiedPoolsStoreMap } from "./verified";
 
 export class ObservablePoolWithMetric {
   @observable
-  pool: ObservableQueryPool;
+  queryPool: ObservableQueryPool;
 
   constructor(
     pool: ObservableQueryPool,
-    protected readonly poolDetails: ObservableSharePoolDetails,
+    protected readonly sharePoolDetails: ObservableSharePoolDetails,
+    protected readonly concentratedPoolDetails: ObservableConcentratedPoolDetails,
     protected readonly poolsBonding: ObservablePoolsBonding,
     protected readonly chainStore: ChainStore,
     protected readonly externalQueries: {
@@ -30,39 +32,54 @@ export class ObservablePoolWithMetric {
     },
     protected readonly priceStore: IPriceStore
   ) {
-    this.pool = pool;
+    this.queryPool = pool;
     makeObservable(this);
   }
 
   @action
-  setPool(pool: ObservableQueryPool) {
-    this.pool = pool;
+  setPool(queryPool: ObservableQueryPool) {
+    this.queryPool = queryPool;
   }
 
-  get poolDetail() {
-    return this.poolDetails.get(this.pool.id);
+  get sharePoolDetail() {
+    if (Boolean(this.queryPool.sharePool))
+      return this.sharePoolDetails.get(this.queryPool.id);
+  }
+
+  get concentratedPoolDetail() {
+    if (Boolean(this.queryPool.concentratedLiquidityPoolInfo))
+      return this.concentratedPoolDetails.get(this.queryPool.id);
   }
 
   get liquidity() {
-    return this.poolDetail.totalValueLocked;
+    return this.queryPool.computeTotalValueLocked(this.priceStore);
   }
 
   get myLiquidity() {
-    return this.poolDetail.userShareValue;
+    return (
+      this.sharePoolDetail?.userShareValue ??
+      this.queryPool.computeTotalValueLocked(this.priceStore)
+    );
   }
 
   get myAvailableLiquidity() {
-    return this.poolDetail.userAvailableValue;
+    return (
+      this.sharePoolDetail?.userAvailableValue ??
+      new PricePretty(
+        this.priceStore.getFiatCurrency(this.priceStore.defaultVsCurrency)!,
+        0
+      )
+    );
   }
 
   get poolName() {
-    return this.pool.poolAssets
+    return this.queryPool.poolAssets
       .map((asset) => asset.amount.currency.coinDenom)
       .join("/");
   }
 
   get networkNames() {
-    return this.pool.poolAssets
+    return this.queryPool.poolAssets
       .map(
         (asset) =>
           this.chainStore.getChainFromCurrency(asset.amount.denom)?.chainName ??
@@ -74,15 +91,16 @@ export class ObservablePoolWithMetric {
   get apr() {
     return (
       this.poolsBonding
-        .get(this.pool.id)
+        .get(this.queryPool.id)
         ?.highestBondDuration?.aggregateApr.maxDecimals(0) ??
-      this.poolDetail.swapFeeApr.maxDecimals(0)
+      this.sharePoolDetail?.swapFeeApr.maxDecimals(0) ??
+      new RatePretty("0")
     );
   }
 
   get feePoolMetrics() {
     return this.externalQueries.queryGammPoolFeeMetrics.getPoolFeesMetrics(
-      this.pool.id,
+      this.queryPool.id,
       this.priceStore
     );
   }
@@ -105,7 +123,8 @@ export class ObservablePoolsWithMetric {
     protected readonly queriesStore: IQueriesStore<OsmosisQueries>,
     protected readonly verifiedPoolsStore: ObservableVerifiedPoolsStoreMap,
     readonly chainId: string,
-    protected readonly poolDetails: ObservableSharePoolDetails,
+    protected readonly sharePoolDetails: ObservableSharePoolDetails,
+    protected readonly concentratedPoolDetails: ObservableConcentratedPoolDetails,
     protected readonly poolsBonding: ObservablePoolsBonding,
     protected readonly chainStore: ChainStore,
     protected readonly externalQueries: {
@@ -138,7 +157,8 @@ export class ObservablePoolsWithMetric {
             pool.id,
             new ObservablePoolWithMetric(
               pool,
-              this.poolDetails,
+              this.sharePoolDetails,
+              this.concentratedPoolDetails,
               this.poolsBonding,
               this.chainStore,
               this.externalQueries,
@@ -151,7 +171,7 @@ export class ObservablePoolsWithMetric {
       const pools = Array.from(poolsMap.values()).filter((pool) => {
         // concentrated liquidity feature
         if (
-          pool.pool.type === "concentrated" &&
+          pool.queryPool.type === "concentrated" &&
           !concentratedLiquidityFeature
         ) {
           return false;
@@ -169,9 +189,9 @@ export class ObservablePoolsWithMetric {
             b[sortingColumn];
 
           // If user is sorting by pool, then sort by pool id
-          if (sortingColumn === "pool") {
-            valueToCompareA = Number(a.pool.id);
-            valueToCompareB = Number(b.pool.id);
+          if (sortingColumn === "queryPool") {
+            valueToCompareA = Number(a.queryPool.id);
+            valueToCompareB = Number(b.queryPool.id);
           }
 
           if (
@@ -188,9 +208,19 @@ export class ObservablePoolsWithMetric {
             valueToCompareB = Number(valueToCompareB.toDec().toString());
           }
 
-          if (valueToCompareA > valueToCompareB) {
+          if (
+            (typeof valueToCompareA !== "number" || isNaN(valueToCompareA)) &&
+            (typeof valueToCompareB !== "number" || isNaN(valueToCompareB))
+          ) {
+            return 0;
+          }
+
+          const aNum = valueToCompareA as number;
+          const bNum = valueToCompareB as number;
+
+          if (aNum > bNum) {
             return isSortingDesc ? -1 : 1;
-          } else if (valueToCompareA < valueToCompareB) {
+          } else if (aNum < bNum) {
             return isSortingDesc ? 1 : -1;
           } else {
             return 0;
@@ -208,7 +238,8 @@ export class ObservablePoolsWithMetrics extends HasMapStore<ObservablePoolsWithM
     protected readonly osmosisChainId: string,
     protected readonly queriesStore: IQueriesStore<OsmosisQueries>,
     protected readonly verifiedPoolsStore: ObservableVerifiedPoolsStoreMap,
-    protected readonly poolDetails: ObservableSharePoolDetails,
+    protected readonly sharePoolDetails: ObservableSharePoolDetails,
+    protected readonly concentratedPoolDetails: ObservableConcentratedPoolDetails,
     protected readonly poolsBonding: ObservablePoolsBonding,
     protected readonly chainStore: ChainStore,
     protected readonly externalQueries: {
@@ -223,7 +254,8 @@ export class ObservablePoolsWithMetrics extends HasMapStore<ObservablePoolsWithM
           queriesStore,
           verifiedPoolsStore,
           chainId,
-          poolDetails,
+          sharePoolDetails,
+          concentratedPoolDetails,
           poolsBonding,
           chainStore,
           externalQueries,

--- a/packages/web/stores/derived-data/pools/metrics.ts
+++ b/packages/web/stores/derived-data/pools/metrics.ts
@@ -3,11 +3,11 @@ import { PricePretty, RatePretty } from "@keplr-wallet/unit";
 import {
   ChainStore,
   IPriceStore,
-  ObservablePoolDetails,
   ObservablePoolsBonding,
   ObservableQueryActiveGauges,
   ObservableQueryPool,
   ObservableQueryPoolFeesMetrics,
+  ObservableSharePoolDetails,
   OsmosisQueries,
 } from "@osmosis-labs/stores";
 import { action, makeObservable, observable } from "mobx";
@@ -21,7 +21,7 @@ export class ObservablePoolWithMetric {
 
   constructor(
     pool: ObservableQueryPool,
-    protected readonly poolDetails: ObservablePoolDetails,
+    protected readonly poolDetails: ObservableSharePoolDetails,
     protected readonly poolsBonding: ObservablePoolsBonding,
     protected readonly chainStore: ChainStore,
     protected readonly externalQueries: {
@@ -105,7 +105,7 @@ export class ObservablePoolsWithMetric {
     protected readonly queriesStore: IQueriesStore<OsmosisQueries>,
     protected readonly verifiedPoolsStore: ObservableVerifiedPoolsStoreMap,
     readonly chainId: string,
-    protected readonly poolDetails: ObservablePoolDetails,
+    protected readonly poolDetails: ObservableSharePoolDetails,
     protected readonly poolsBonding: ObservablePoolsBonding,
     protected readonly chainStore: ChainStore,
     protected readonly externalQueries: {
@@ -208,7 +208,7 @@ export class ObservablePoolsWithMetrics extends HasMapStore<ObservablePoolsWithM
     protected readonly osmosisChainId: string,
     protected readonly queriesStore: IQueriesStore<OsmosisQueries>,
     protected readonly verifiedPoolsStore: ObservableVerifiedPoolsStoreMap,
-    protected readonly poolDetails: ObservablePoolDetails,
+    protected readonly poolDetails: ObservableSharePoolDetails,
     protected readonly poolsBonding: ObservablePoolsBonding,
     protected readonly chainStore: ChainStore,
     protected readonly externalQueries: {

--- a/packages/web/stores/derived-data/pools/verified.ts
+++ b/packages/web/stores/derived-data/pools/verified.ts
@@ -30,19 +30,19 @@ export class ObservableVerifiedPoolsStore
   }
 
   paginate() {
-    this.queriesStore.get(this.chainId).osmosis?.queryGammPools.paginate();
+    this.queriesStore.get(this.chainId).osmosis?.queryPools.paginate();
   }
 
   fetchRemainingPools() {
     this.queriesStore
       .get(this.chainId)
-      .osmosis?.queryGammPools.fetchRemainingPools();
+      .osmosis?.queryPools.fetchRemainingPools();
   }
 
   readonly getAllPools = computedFn((showUnverified?: boolean) => {
     const allPools = this.queriesStore
       .get(this.chainId)
-      .osmosis?.queryGammPools.getAllPools();
+      .osmosis?.queryPools.getAllPools();
 
     // Add all approved assets to a map for faster lookup.
     const approvedAssets = new Map<string, boolean>();

--- a/packages/web/stores/derived-data/store.ts
+++ b/packages/web/stores/derived-data/store.ts
@@ -57,6 +57,7 @@ export class DerivedDataStore extends BaseDerivedDataStore {
       this.queriesStore,
       this.verifiedPoolsStore,
       this.sharePoolDetails,
+      this.concentratedPoolDetails,
       this.poolsBonding,
       this.chainGetter,
       this.externalQueries,

--- a/packages/web/stores/derived-data/store.ts
+++ b/packages/web/stores/derived-data/store.ts
@@ -56,7 +56,7 @@ export class DerivedDataStore extends BaseDerivedDataStore {
       this.osmosisChainId,
       this.queriesStore,
       this.verifiedPoolsStore,
-      this.poolDetails,
+      this.sharePoolDetails,
       this.poolsBonding,
       this.chainGetter,
       this.externalQueries,

--- a/packages/web/stores/root.ts
+++ b/packages/web/stores/root.ts
@@ -187,7 +187,7 @@ export class RootStore {
       "usd",
       this.queriesStore.get(
         this.chainStore.osmosis.chainId
-      ).osmosis!.queryGammPools,
+      ).osmosis!.queryPools,
       PoolPriceRoutes
     );
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

In prep for adding CL pool incentives and superfluid info, I've updated the naming for the pool detail stores to reflect the old pool types, as well as added a new pool detail store for aggregating information for CL pools (including user info). CL pools will contain aggregated query data for positions, incentive gauges, and superfluid. Also contains a fix for the pool table's treatment of CL pools.

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/8677j0mrg)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

- Change name of `queryGammPools` to `queryPools`: since we'll be including pools from the concentrated-liquidity module which are outside the gamm module
- Add a concentrated derived-data store, for calculating pool metrics used in the table and for convenience. Includes user position info (total assets). Will include incentives info
  - Rename old PoolDetail store to SharePoolDetail store since that will only be used for share pools (stable, balancer). As seen in the pools module for CL (see `SharePool` interface), I've categorized stable and balancer/CFMM pools as "share pools" since user's ownership is represented as pro-rata shares (vs positions with CL). All symbols were renamed to reflect this.
- Fix table when rendering concentrated pool
- Simplified the organization and methods for querying for pools throughout the CL components (remove type assertions)

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

- Cl pools are displayed in pool table, without crashing the page