### PR TITLE
(MW) Use Direct Signing for Chains affected by ibc-go-v7

### DIFF
--- a/packages/stores/src/account/base.ts
+++ b/packages/stores/src/account/base.ts
@@ -522,6 +522,10 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
 
     const walletWindowName = getWalletWindowName(wallet.walletName);
 
+    /**
+     * Remove once ibc-go-v7 fix is released.
+     * @see https://github.com/osmosis-labs/osmosis-frontend/pull/1691
+     */
     const currentChain = this.chains.find((c) => c.chain_id === chainId);
     const isChainWithHotfix =
       chainId.startsWith("injective") ||

--- a/packages/stores/src/account/base.ts
+++ b/packages/stores/src/account/base.ts
@@ -534,7 +534,8 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
 
     const forceSignDirect =
       isWalletOfflineDirectSigner(signer, walletWindowName) &&
-      isChainWithHotfix;
+      isChainWithHotfix &&
+      !(wallet.walletInfo.mode === "wallet-connect");
 
     if (
       isChainWithHotfix &&

--- a/packages/stores/src/account/base.ts
+++ b/packages/stores/src/account/base.ts
@@ -62,6 +62,8 @@ import {
   CosmosKitAccountsLocalStorageKey,
   getEndpointString,
   getWalletEndpoints,
+  getWalletWindowName,
+  isWalletOfflineDirectSigner,
   logger,
   removeLastSlash,
 } from "./utils";
@@ -87,7 +89,7 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
   private _wallets: MainWalletBase[] = [];
 
   constructor(
-    protected readonly chains: Chain[],
+    public readonly chains: (Chain & { features?: string[] })[],
     protected readonly assets: AssetList[],
     protected readonly wallets: MainWalletBase[],
     protected readonly queriesStore: QueriesStore<
@@ -518,7 +520,30 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
       chainId: chainId,
     };
 
-    return isOfflineDirectSigner(signer)
+    const walletWindowName = getWalletWindowName(wallet.walletName);
+
+    const currentChain = this.chains.find((c) => c.chain_id === chainId);
+    const isChainWithHotfix =
+      chainId.startsWith("injective") ||
+      chainId.startsWith("stride") ||
+      currentChain?.features?.includes("ibc-go-v7-hot-fix");
+
+    const forceSignDirect =
+      isWalletOfflineDirectSigner(signer, walletWindowName) &&
+      isChainWithHotfix;
+
+    if (
+      isChainWithHotfix &&
+      !isWalletOfflineDirectSigner(signer, walletWindowName)
+    ) {
+      throw new Error(
+        `${
+          currentChain?.pretty_name ?? chainId
+        } chain is currently unavailable for ${wallet.walletPrettyName}.`
+      );
+    }
+
+    return isOfflineDirectSigner(signer) || forceSignDirect
       ? this.signDirect(
           wallet,
           signer,
@@ -526,7 +551,8 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
           messages,
           fee,
           memo,
-          signerData
+          signerData,
+          forceSignDirect
         )
       : this.signAmino(
           wallet,
@@ -623,9 +649,10 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
     messages: readonly EncodeObject[],
     fee: StdFee,
     memo: string,
-    { accountNumber, sequence, chainId }: SignerData
+    { accountNumber, sequence, chainId }: SignerData,
+    forceSignDirect = false
   ): Promise<TxRaw> {
-    if (!isOfflineDirectSigner(signer)) {
+    if (!isOfflineDirectSigner(signer) && !forceSignDirect) {
       throw new Error("Signer has to be OfflineDirectSigner");
     }
 
@@ -662,9 +689,24 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
       chainId,
       accountNumber
     );
-    const { signature, signed } = await (
-      signer as unknown as OfflineDirectSigner
-    ).signDirect(signerAddress, signDoc);
+
+    const walletWindowName = getWalletWindowName(wallet.walletName);
+
+    const { signature, signed } = isWalletOfflineDirectSigner(
+      signer,
+      walletWindowName
+    )
+      ? await signer[walletWindowName].signDirect.call(
+          signer[walletWindowName],
+          wallet.chainId,
+          signerAddress,
+          signDoc
+        )
+      : await (signer as unknown as OfflineDirectSigner).signDirect(
+          signerAddress,
+          signDoc
+        );
+
     return TxRaw.fromPartial({
       bodyBytes: signed.bodyBytes,
       authInfoBytes: signed.authInfoBytes,

--- a/packages/stores/src/account/utils.ts
+++ b/packages/stores/src/account/utils.ts
@@ -1,4 +1,5 @@
 import type { Chain } from "@chain-registry/types";
+import { OfflineDirectSigner, OfflineSigner } from "@cosmjs/proto-signing";
 import {
   ChainName,
   Endpoints,
@@ -40,6 +41,26 @@ export function removeLastSlash(str: string) {
 
 export function getEndpointString(endpoint: string | ExtendedHttpEndpoint) {
   return typeof endpoint === "string" ? endpoint : endpoint.url;
+}
+
+export function isWalletOfflineDirectSigner(
+  signer: OfflineSigner,
+  walletName: string
+): signer is OfflineDirectSigner &
+  Record<
+    string,
+    {
+      signDirect: (
+        chainId: string,
+        ...params: Parameters<OfflineDirectSigner["signDirect"]>
+      ) => ReturnType<OfflineDirectSigner["signDirect"]>;
+    }
+  > {
+  return (signer as Record<string, any>)[walletName]?.signDirect;
+}
+
+export function getWalletWindowName(walletName: string) {
+  return walletName.split("-")[0];
 }
 
 export const CosmosKitAccountsLocalStorageKey = "cosmos-kit@1:core//accounts";

--- a/packages/web/components/table/assets-table.tsx
+++ b/packages/web/components/table/assets-table.tsx
@@ -87,7 +87,7 @@ export const AssetsTable: FunctionComponent<Props> = observer(
             ? (
                 await (window as Record<string, any>)[
                   getWalletWindowName(currentWalletName ?? "")
-                ]?.getKey(chainStore.osmosis.chainId)
+                ]?.getKey?.(chainStore.osmosis.chainId)
               )?.isNanoLedger
             : false
         );

--- a/packages/web/components/table/assets-table.tsx
+++ b/packages/web/components/table/assets-table.tsx
@@ -559,8 +559,7 @@ export const AssetsTable: FunctionComponent<Props> = observer(
                          */
                         const isUnstable =
                           !currentWalletSupportsDirectSigning &&
-                          (cell.chainId?.startsWith("injective") ||
-                            cell.chainId?.startsWith("stride") ||
+                          (cell.chainId?.startsWith("stride") ||
                             chainStore
                               .getChain(cell?.chainId ?? "")
                               .features?.includes("ibc-go-v7-hot-fix"));
@@ -588,8 +587,7 @@ export const AssetsTable: FunctionComponent<Props> = observer(
                          */
                         const isUnstable =
                           !currentWalletSupportsDirectSigning &&
-                          (cell.chainId?.startsWith("injective") ||
-                            cell.chainId?.startsWith("stride") ||
+                          (cell.chainId?.startsWith("stride") ||
                             chainStore
                               .getChain(cell?.chainId ?? "")
                               .features?.includes("ibc-go-v7-hot-fix"));

--- a/packages/web/components/table/assets-table.tsx
+++ b/packages/web/components/table/assets-table.tsx
@@ -106,7 +106,9 @@ export const AssetsTable: FunctionComponent<Props> = observer(
       currentWalletName,
     ]);
     const currentWalletSupportsDirectSigning =
-      !currentWalletName?.startsWith("cosmostation") && !isCurrentWalletALedger;
+      !currentWalletName?.startsWith("cosmostation") &&
+      !isCurrentWalletALedger &&
+      !(currentWallet?.walletInfo?.mode === "wallet-connect");
 
     const onDeposit = useCallback(
       (...depositParams: Parameters<typeof _onDeposit>) => {

--- a/packages/web/components/table/assets-table.tsx
+++ b/packages/web/components/table/assets-table.tsx
@@ -1,7 +1,14 @@
 import { Dec } from "@keplr-wallet/unit";
+import { getWalletWindowName } from "@osmosis-labs/stores";
 import { observer } from "mobx-react-lite";
 import Image from "next/image";
-import { FunctionComponent, useCallback, useMemo, useState } from "react";
+import {
+  FunctionComponent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { useTranslation } from "react-multi-lang";
 
 import {
@@ -56,7 +63,7 @@ export const AssetsTable: FunctionComponent<Props> = observer(
     onDeposit: _onDeposit,
     onWithdraw: _onWithdraw,
   }) => {
-    const { chainStore } = useStore();
+    const { chainStore, accountStore } = useStore();
     const { width, isMobile } = useWindowSize();
     const t = useTranslation();
     const { logEvent } = useAmplitudeAnalytics();
@@ -64,6 +71,42 @@ export const AssetsTable: FunctionComponent<Props> = observer(
       "favoritesList",
       ["OSMO", "ATOM"]
     );
+
+    const currentWallet = accountStore.getWallet(chainStore.osmosis.chainId);
+    const currentWalletName = currentWallet?.walletName;
+
+    /**
+     * Remove once ibc-go-v7 fix is released.
+     * @see https://github.com/osmosis-labs/osmosis-frontend/pull/1691
+     */
+    const [isCurrentWalletALedger, setIsCurrentWalletALedger] = useState(false);
+    useEffect(() => {
+      const main = async () => {
+        setIsCurrentWalletALedger(
+          currentWalletName
+            ? (
+                await (window as Record<string, any>)[
+                  getWalletWindowName(currentWalletName ?? "")
+                ]?.getKey(chainStore.osmosis.chainId)
+              )?.isNanoLedger
+            : false
+        );
+      };
+
+      main();
+
+      // Whenever wallet changes, check if it's a ledger wallet.
+      accountStore.walletManager.on("refresh_connection", main);
+      return () => {
+        accountStore.walletManager.off("refresh_connection", main);
+      };
+    }, [
+      accountStore.walletManager,
+      chainStore.osmosis.chainId,
+      currentWalletName,
+    ]);
+    const currentWalletSupportsDirectSigning =
+      !currentWalletName?.startsWith("cosmostation") && !isCurrentWalletALedger;
 
     const onDeposit = useCallback(
       (...depositParams: Parameters<typeof _onDeposit>) => {
@@ -509,21 +552,56 @@ export const AssetsTable: FunctionComponent<Props> = observer(
                 ? ([
                     {
                       display: t("assets.table.columns.transfer"),
-                      displayCell: (cell) => (
-                        <div>
-                          <TransferButtonCell type="deposit" {...cell} />
-                          <TransferButtonCell type="withdraw" {...cell} />
-                        </div>
-                      ),
+                      displayCell: (cell) => {
+                        /**
+                         * Remove once ibc-go-v7 fix is released.
+                         * @see https://github.com/osmosis-labs/osmosis-frontend/pull/1691
+                         */
+                        const isUnstable =
+                          !currentWalletSupportsDirectSigning &&
+                          (cell.chainId?.startsWith("injective") ||
+                            cell.chainId?.startsWith("stride") ||
+                            chainStore
+                              .getChain(cell?.chainId ?? "")
+                              .features?.includes("ibc-go-v7-hot-fix"));
+                        return (
+                          <div>
+                            <TransferButtonCell
+                              type="deposit"
+                              {...cell}
+                              isUnstable={isUnstable ? true : undefined}
+                            />
+                            <TransferButtonCell type="withdraw" {...cell} />
+                          </div>
+                        );
+                      },
                       className: "text-left max-w-[5rem]",
                     },
                   ] as ColumnDef<TableCell>[])
                 : ([
                     {
                       display: t("assets.table.columns.deposit"),
-                      displayCell: (cell) => (
-                        <TransferButtonCell type="deposit" {...cell} />
-                      ),
+                      displayCell: (cell) => {
+                        /**
+                         * Remove once ibc-go-v7 fix is released.
+                         * @see https://github.com/osmosis-labs/osmosis-frontend/pull/1691
+                         */
+                        const isUnstable =
+                          !currentWalletSupportsDirectSigning &&
+                          (cell.chainId?.startsWith("injective") ||
+                            cell.chainId?.startsWith("stride") ||
+                            chainStore
+                              .getChain(cell?.chainId ?? "")
+                              .features?.includes("ibc-go-v7-hot-fix"));
+
+                        return (
+                          <TransferButtonCell
+                            type="deposit"
+                            {...cell}
+                            isUnstable={isUnstable ? true : undefined}
+                          />
+                        );
+                      },
                       className: "text-left max-w-[5rem]",
                     },
                     {

--- a/packages/web/config/generate-chain-infos/source-chain-infos.ts
+++ b/packages/web/config/generate-chain-infos/source-chain-infos.ts
@@ -2933,7 +2933,7 @@ const mainnetChainInfos: SimplifiedChainInfo[] = [
         coinImageUrl: "/tokens/stumee.svg",
       },
     ],
-    features: ["ibc-transfer", "ibc-go"],
+    features: ["ibc-transfer", "ibc-go", "ibc-go-v7-hot-fix"],
     explorerUrlToTx: "https://explorer.stride.zone/stride/tx/{txHash}",
   },
   {


### PR DESCRIPTION
## What is the purpose of the change

Currently, there is a bug in ibc-go-v7 (#1691), where transactions signed with 'signAmino' result in an error on chains such as Stride and Injective. PR intends to manage these errors by opting for 'signDirect' when required. However, it's important to note that the Cosmostation wallet doesn't support 'signDirect'. As a result, deposits to Injective and Stride have been disabled.

Please note that injective will not be disabled in the assets table since its deposit and withdrawal redirect to an external page.

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/866agfwwq)


## Testing and Verifying

- [ ] Do deposit transactions to Stride with Leap and Keplr. 
- [ ] Verify that deposit link is disabled when connected to Comostation wallet
