### PR TITLE
Hot Fix: Handle Leap and Keplr App Web Connection

### DIFF
--- a/packages/web/integrations/keplr-walletconnect/client.ts
+++ b/packages/web/integrations/keplr-walletconnect/client.ts
@@ -188,7 +188,7 @@ export class KeplrWCClient implements WalletClient {
       if (!this.connector.connected) {
         await this.connector.createSession();
       } else {
-        this.restoreSession();
+        this.client = this.createKeplrClient();
         return;
       }
 


### PR DESCRIPTION
## Brief Description 

If on mobile and `leap` or `keplr` is in `window`, it means that the user enters the front end from that particular wallet app in the app browser. So, there is no need to use wallet connect, as it resembles the browser's extension's usage.

## Testing

- [ ] Use Leap mobile browser to access this preview link, and test its connection
- [ ] Check that in the normal browser only WalletConnect is visible and no extension wallet
           