### PR TITLE
Hotfix: catch specific error from KV Store

### DIFF
--- a/packages/web/stores/kv-store.ts
+++ b/packages/web/stores/kv-store.ts
@@ -1,24 +1,58 @@
 import {
-  KVStore,
   IndexedDBKVStore,
-  MemoryKVStore,
+  KVStore,
   LocalKVStore,
+  MemoryKVStore,
 } from "@keplr-wallet/common";
+
+const USER_CLEARED_CACHE_MESSAGE =
+  "Failed to execute 'transaction' on 'IDBDatabase': The database connection is closing.";
+
+/** Wrapper class with dep injected KV store to catch and ignore certain errors. */
+class CaughtKVStore implements KVStore {
+  constructor(private readonly kvStore: KVStore) {}
+
+  async get<T = unknown>(key: string): Promise<T | undefined> {
+    try {
+      return await this.kvStore.get<T>(key);
+    } catch (e: unknown) {
+      if ((e as any).message === USER_CLEARED_CACHE_MESSAGE) {
+        // Ignore InvalidStateError
+        return undefined;
+      }
+      throw e;
+    }
+  }
+  async set<T = unknown>(key: string, data: T | null): Promise<void> {
+    try {
+      return await this.kvStore.set<T>(key, data);
+    } catch (e: unknown) {
+      if ((e as any).message === USER_CLEARED_CACHE_MESSAGE) {
+        // Ignore InvalidStateError
+        return;
+      }
+      throw e;
+    }
+  }
+  prefix(): string {
+    return this.kvStore.prefix();
+  }
+}
 
 export function makeIndexedKVStore(prefix: string): KVStore {
   if (typeof window === "undefined") {
     // In server-side (nodejs), use memory kv store (volatile kv store).
     // TODO: investigate sharing kv store on node process
-    return new MemoryKVStore(prefix);
+    return new CaughtKVStore(new MemoryKVStore(prefix));
   }
-  return new IndexedDBKVStore(prefix);
+  return new CaughtKVStore(new IndexedDBKVStore(prefix));
 }
 
 export function makeLocalStorageKVStore(prefix: string): KVStore {
   if (typeof window === "undefined") {
     // In server-side (nodejs), use memory kv store (volatile kv store).
     // TODO: investigate sharing kv store on node process
-    return new MemoryKVStore(prefix);
+    return new CaughtKVStore(new MemoryKVStore(prefix));
   }
-  return new LocalKVStore(prefix);
+  return new CaughtKVStore(new LocalKVStore(prefix));
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

Adding as a hot fix since it's producing so many issues in Sentry.

In short, this wraps our KVStore implementation with a catch block that ignores a specific known error.

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/862k0daaz) (sentry errors linked there)

## Brief Changelog

<!-- _(for example:)_ -->

- Looks for a specific error message on the `get` and `set` methods of the KVStore implementations used on our frontend. I would have preferred to use `e instance of InvalidStateError`, but I couldn't find where `InvalidStateError` is defined.

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

1. Open any fresh page
2. Clear cache in browser
3. Notice error message _does not_ appear in console

Cross examine the same workflow with app.osmosis.zone to ensure it _is_ being logged to the console there.

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
