### PR TITLE
Update ROAR price

### DIFF
--- a/packages/web/config/price.ts
+++ b/packages/web/config/price.ts
@@ -1802,7 +1802,7 @@ export const PoolPriceRoutes: IntermediateRoute[] = [
   },
   {
     alternativeCoinId: "pool:roar",
-    poolId: "1037",
+    poolId: "1043",
     spotPriceSourceDenom: DenomHelper.ibcDenom(
       [{ portId: "transfer", channelId: "channel-341" }],
       "cw20:terra1lxx40s29qvkrcj8fsa3yzyehy7w50umdvvnls2r830rys6lu2zns63eelv"


### PR DESCRIPTION
## What is the purpose of the change

To update the ROAR pricing. The previously defined dummy pool id number was incorrect, didn't contain the asset, and was causing console errors.

## Brief Changelog

Changed pool:roar to lkook at pool 1043 instead of pool 1037

## Testing and Verifying

This change has not been tested locally, because it's only a pool id number being changed. Automatic deployments are sufficient to validate that the console errors stop. 
