### PR TITLE
feat: Clear Pairings on Disconnect

### DIFF
--- a/packages/web/integrations/core-walletconnect/client.ts
+++ b/packages/web/integrations/core-walletconnect/client.ts
@@ -468,6 +468,13 @@ export class WCClient implements WalletClient {
       return;
     }
 
+    const pairings = this.signClient.pairing.getAll();
+    if (Array.isArray(pairings)) {
+      for (const pairing of pairings) {
+        this.signClient.core.expirer.set(pairing.topic, 0);
+      }
+    }
+
     await Promise.all(
       this.sessions.map(async (session) => {
         if (!this.signClient) return;
@@ -488,14 +495,6 @@ export class WCClient implements WalletClient {
     );
 
     this.sessions = [];
-
-    const pairings = this.signClient.pairing.getAll();
-    if (Array.isArray(pairings)) {
-      for (const pairing of pairings) {
-        this.signClient.core.expirer.set(pairing.topic, 0);
-      }
-    }
-
     this.emitter?.emit("sync_disconnect");
     this.logger?.debug("[WALLET EVENT] Emit `sync_disconnect`");
   }

--- a/packages/web/integrations/core-walletconnect/client.ts
+++ b/packages/web/integrations/core-walletconnect/client.ts
@@ -488,6 +488,14 @@ export class WCClient implements WalletClient {
     );
 
     this.sessions = [];
+
+    const pairings = this.signClient.pairing.getAll();
+    if (Array.isArray(pairings)) {
+      for (const pairing of pairings) {
+        this.signClient.core.expirer.set(pairing.topic, 0);
+      }
+    }
+
     this.emitter?.emit("sync_disconnect");
     this.logger?.debug("[WALLET EVENT] Emit `sync_disconnect`");
   }


### PR DESCRIPTION
## What is the purpose of the change

Display WalletConnect QR code after disconnect so that users can change between devices if needed. 

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/38nrqwm)

## Brief Changelog

- Cleanup WalletConnect V2 pairings 

## Testing and Verifying

- [ ] Should display QR code after disconnecting from WalletConnect. 
