### PR TITLE
fix: Remove IBC V7 Hot Fix

### DIFF
--- a/packages/stores/src/account/base.ts
+++ b/packages/stores/src/account/base.ts
@@ -521,38 +521,7 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
       chainId: chainId,
     };
 
-    const walletWindowName = getWalletWindowName(wallet.walletName);
-
-    /**
-     * Remove once ibc-go-v7 fix is released.
-     * @see https://github.com/osmosis-labs/osmosis-frontend/pull/1691
-     */
-    const currentChain = this.chains.find((c) => c.chain_id === chainId);
-    const isChainWithHotfix =
-      chainId.startsWith("injective") ||
-      chainId.startsWith("stride") ||
-      currentChain?.features?.includes("ibc-go-v7-hot-fix");
-    const isMobile =
-      wallet.walletInfo.mode === "wallet-connect" ||
-      wallet.walletName === "keplr-mobile";
-
-    const forceSignDirect =
-      isWalletOfflineDirectSigner(signer, walletWindowName) &&
-      isChainWithHotfix &&
-      !isMobile;
-
-    if (
-      isChainWithHotfix &&
-      (!isWalletOfflineDirectSigner(signer, walletWindowName) || isMobile)
-    ) {
-      throw new Error(
-        `${
-          currentChain?.pretty_name ?? chainId
-        } chain is currently unavailable for ${wallet.walletPrettyName}.`
-      );
-    }
-
-    return isOfflineDirectSigner(signer) || forceSignDirect
+    return isOfflineDirectSigner(signer)
       ? this.signDirect(
           wallet,
           signer,
@@ -560,8 +529,7 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
           messages,
           fee,
           memo,
-          signerData,
-          forceSignDirect
+          signerData
         )
       : this.signAmino(
           wallet,

--- a/packages/web/components/table/assets-table.tsx
+++ b/packages/web/components/table/assets-table.tsx
@@ -1,14 +1,7 @@
 import { Dec } from "@keplr-wallet/unit";
-import { getWalletWindowName } from "@osmosis-labs/stores";
 import { observer } from "mobx-react-lite";
 import Image from "next/image";
-import {
-  FunctionComponent,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
+import { FunctionComponent, useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-multi-lang";
 
 import {
@@ -63,7 +56,7 @@ export const AssetsTable: FunctionComponent<Props> = observer(
     onDeposit: _onDeposit,
     onWithdraw: _onWithdraw,
   }) => {
-    const { chainStore, accountStore } = useStore();
+    const { chainStore } = useStore();
     const { width, isMobile } = useWindowSize();
     const t = useTranslation();
     const { logEvent } = useAmplitudeAnalytics();
@@ -71,42 +64,6 @@ export const AssetsTable: FunctionComponent<Props> = observer(
       "favoritesList",
       ["OSMO", "ATOM"]
     );
-
-    const currentWallet = accountStore.getWallet(chainStore.osmosis.chainId);
-    const currentWalletName = currentWallet?.walletName;
-
-    /**
-     * Remove once ibc-go-v7 fix is released.
-     * @see https://github.com/osmosis-labs/osmosis-frontend/pull/1691
-     */
-    const [isCurrentWalletALedger, setIsCurrentWalletALedger] = useState(false);
-    useEffect(() => {
-      const main = async () => {
-        setIsCurrentWalletALedger(
-          currentWalletName
-            ? (
-                await (window as Record<string, any>)[
-                  getWalletWindowName(currentWalletName ?? "")
-                ]?.getKey?.(chainStore.osmosis.chainId)
-              )?.isNanoLedger
-            : false
-        );
-      };
-
-      main();
-
-      // Whenever wallet changes, check if it's a ledger wallet.
-      accountStore.walletManager.on("refresh_connection", main);
-      return () => {
-        accountStore.walletManager.off("refresh_connection", main);
-      };
-    }, [
-      accountStore.walletManager,
-      chainStore.osmosis.chainId,
-      currentWalletName,
-    ]);
-    const currentWalletSupportsDirectSigning =
-      !currentWalletName?.startsWith("cosmostation") && !isCurrentWalletALedger;
 
     const onDeposit = useCallback(
       (...depositParams: Parameters<typeof _onDeposit>) => {
@@ -552,54 +509,21 @@ export const AssetsTable: FunctionComponent<Props> = observer(
                 ? ([
                     {
                       display: t("assets.table.columns.transfer"),
-                      displayCell: (cell) => {
-                        /**
-                         * Remove once ibc-go-v7 fix is released.
-                         * @see https://github.com/osmosis-labs/osmosis-frontend/pull/1691
-                         */
-                        const isUnstable =
-                          !currentWalletSupportsDirectSigning &&
-                          (cell.chainId?.startsWith("stride") ||
-                            chainStore
-                              .getChain(cell?.chainId ?? "")
-                              .features?.includes("ibc-go-v7-hot-fix"));
-                        return (
-                          <div>
-                            <TransferButtonCell
-                              type="deposit"
-                              {...cell}
-                              isUnstable={isUnstable ? true : undefined}
-                            />
-                            <TransferButtonCell type="withdraw" {...cell} />
-                          </div>
-                        );
-                      },
+                      displayCell: (cell) => (
+                        <div>
+                          <TransferButtonCell type="deposit" {...cell} />
+                          <TransferButtonCell type="withdraw" {...cell} />
+                        </div>
+                      ),
                       className: "text-left max-w-[5rem]",
                     },
                   ] as ColumnDef<TableCell>[])
                 : ([
                     {
                       display: t("assets.table.columns.deposit"),
-                      displayCell: (cell) => {
-                        /**
-                         * Remove once ibc-go-v7 fix is released.
-                         * @see https://github.com/osmosis-labs/osmosis-frontend/pull/1691
-                         */
-                        const isUnstable =
-                          !currentWalletSupportsDirectSigning &&
-                          (cell.chainId?.startsWith("stride") ||
-                            chainStore
-                              .getChain(cell?.chainId ?? "")
-                              .features?.includes("ibc-go-v7-hot-fix"));
-
-                        return (
-                          <TransferButtonCell
-                            type="deposit"
-                            {...cell}
-                            isUnstable={isUnstable ? true : undefined}
-                          />
-                        );
-                      },
+                      displayCell: (cell) => (
+                        <TransferButtonCell type="deposit" {...cell} />
+                      ),
                       className: "text-left max-w-[5rem]",
                     },
                     {

--- a/packages/web/config/generate-chain-infos/source-chain-infos.ts
+++ b/packages/web/config/generate-chain-infos/source-chain-infos.ts
@@ -2949,7 +2949,7 @@ const mainnetChainInfos: SimplifiedChainInfo[] = [
         coinImageUrl: "/tokens/stumee.svg",
       },
     ],
-    features: ["ibc-transfer", "ibc-go", "ibc-go-v7-hot-fix"],
+    features: ["ibc-transfer", "ibc-go"],
     explorerUrlToTx: "https://explorer.stride.zone/stride/tx/{txHash}",
   },
   {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Remove the IBC V7 Hot Fix. This will re-enable the deposit button in the assets table for affected wallets like Ledger and WalletConnect. 

## Brief Changelog

- Re-enable asset deposit button for Stride
- Remove error message for unsupported wallets. 
