### PR TITLE
fix: Unauthorized Error While Signing some IBC Asset Transactions

### DIFF
--- a/packages/stores/src/account/base.ts
+++ b/packages/stores/src/account/base.ts
@@ -423,31 +423,39 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
         onBroadcasted(txHashBuffer);
       }
 
-      const tx = await txTracer
-        .traceTx(txHashBuffer)
-        .then(
-          (tx: {
+      const tx = await txTracer.traceTx(txHashBuffer).then(
+        (tx: {
+          data: string;
+          events: TxEvent;
+          gas_used: string;
+          gas_wanted: string;
+          log: string;
+          code?: number;
+          height?: number;
+          tx_result?: {
             data: string;
+            code?: number;
+            codespace: string;
             events: TxEvent;
             gas_used: string;
             gas_wanted: string;
+            info: string;
             log: string;
-            code?: number;
-            height?: number;
-          }) => {
-            txTracer.close();
+          };
+        }) => {
+          txTracer.close();
 
-            return {
-              transactionHash: broadcasted.txhash.toLowerCase(),
-              code: tx?.code ?? 0,
-              height: tx?.height,
-              rawLog: tx?.log || "",
-              events: tx?.events,
-              gasUsed: tx?.gas_used,
-              gasWanted: tx?.gas_wanted,
-            };
-          }
-        );
+          return {
+            transactionHash: broadcasted.txhash.toLowerCase(),
+            code: tx?.code ?? tx?.tx_result?.code ?? 0,
+            height: tx?.height,
+            rawLog: tx?.log ?? tx?.tx_result?.log ?? "",
+            events: tx?.events ?? tx?.tx_result?.events,
+            gasUsed: tx?.gas_used ?? tx?.tx_result?.gas_used,
+            gasWanted: tx?.gas_wanted ?? tx?.tx_result?.gas_wanted,
+          };
+        }
+      );
 
       runInAction(() => {
         this.txTypeInProgressByChain.set(chainNameOrId, "");

--- a/packages/stores/src/account/base.ts
+++ b/packages/stores/src/account/base.ts
@@ -425,11 +425,11 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
 
       const tx = await txTracer.traceTx(txHashBuffer).then(
         (tx: {
-          data: string;
-          events: TxEvent;
-          gas_used: string;
-          gas_wanted: string;
-          log: string;
+          data?: string;
+          events?: TxEvent;
+          gas_used?: string;
+          gas_wanted?: string;
+          log?: string;
           code?: number;
           height?: number;
           tx_result?: {
@@ -451,8 +451,8 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
             height: tx?.height,
             rawLog: tx?.log ?? tx?.tx_result?.log ?? "",
             events: tx?.events ?? tx?.tx_result?.events,
-            gasUsed: tx?.gas_used ?? tx?.tx_result?.gas_used,
-            gasWanted: tx?.gas_wanted ?? tx?.tx_result?.gas_wanted,
+            gasUsed: tx?.gas_used ?? tx?.tx_result?.gas_used ?? "",
+            gasWanted: tx?.gas_wanted ?? tx?.tx_result?.gas_wanted ?? "",
           };
         }
       );

--- a/packages/stores/src/account/cosmos/index.ts
+++ b/packages/stores/src/account/cosmos/index.ts
@@ -124,6 +124,10 @@ export class CosmosAccountImpl {
       );
     }
 
+    const revisionNumber = ChainIdHelper.parse(
+      destinationInfo.network
+    ).version.toString();
+
     const msg = this.msgOpts.ibcTransfer.messageComposer({
       sourcePort: channel.portId,
       sourceChannel: channel.channelId,
@@ -134,9 +138,13 @@ export class CosmosAccountImpl {
       receiver: recipient,
       sender: this.address,
       timeoutHeight: {
-        revisionNumber: Long.fromString(
-          ChainIdHelper.parse(destinationInfo.network).version.toString()
-        ),
+        /**
+         * Sending the revision number as 0 will cause the transaction to fail.
+         */
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        revisionNumber:
+          revisionNumber !== "0" ? Long.fromString(revisionNumber) : undefined,
         revisionHeight: Long.fromString(
           destinationInfo.latestBlockHeight.add(new Int("150")).toString()
         ),

--- a/packages/stores/src/account/cosmos/index.ts
+++ b/packages/stores/src/account/cosmos/index.ts
@@ -140,7 +140,7 @@ export class CosmosAccountImpl {
       timeoutHeight: {
         /**
          * Omit the revision_number if the chain's version is 0.
-         * Sending the revision number as 0 will cause the transaction to fail.
+         * Sending the value as 0 will cause the transaction to fail.
          */
         revisionNumber:
           revisionNumber !== "0"

--- a/packages/stores/src/account/cosmos/index.ts
+++ b/packages/stores/src/account/cosmos/index.ts
@@ -139,12 +139,13 @@ export class CosmosAccountImpl {
       sender: this.address,
       timeoutHeight: {
         /**
+         * Omit the revision_number if the chain's version is 0.
          * Sending the revision number as 0 will cause the transaction to fail.
          */
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
         revisionNumber:
-          revisionNumber !== "0" ? Long.fromString(revisionNumber) : undefined,
+          revisionNumber !== "0"
+            ? Long.fromString(revisionNumber)
+            : (undefined as any),
         revisionHeight: Long.fromString(
           destinationInfo.latestBlockHeight.add(new Int("150")).toString()
         ),


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

This PR solves the unauthorized error users received when doing IBC transfers to chains like Gitopia. The issue lay in the `revision_number` being "0". If a chain lacks a version number, this value should be omitted from the transaction message, otherwise, it will fail.  

This PR also resolves an issue when transactions are executed before the `TxTracer`'s detection. To maintain accuracy, we'll now utilize the values from tx_result as needed.

### ClickUp Task

## Brief Changelog

- Use `tx_result` when needed if transaction is executed before being found by tracer.
- Remove revision from message if value is "0"

## Testing and Verifying

- [ ] Should allow to withdraw Lore to Gitopia

