### PR TITLE
fix inlang lint command

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "homepage": "https://github.com/osmosis-labs/osmosis-frontend#readme",
   "devDependencies": {
-    "@inlang/cli": "^0.11.1",
+    "@inlang/cli": "^0.11.7",
     "@types/jest": "^27.4.0",
     "@typescript-eslint/eslint-plugin": "^5.9.0",
     "@typescript-eslint/parser": "^5.9.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -9,7 +9,7 @@
     "analyze": "dotenv -v ANALYZE=true -- next build",
     "test": "jest",
     "start": "next start",
-    "lint": "prettier --check \"**/*\" && next lint && inlang lint",
+    "lint": "prettier --check \"**/*\" && next lint && inlang lint --config ../../inlang.config.js",
     "lint:fix": "prettier --write \"**/*\" && next lint --fix",
     "pre-commit": "lint-staged",
     "generate": "yarn generate:chain-info && yarn generate:wallet-assets && yarn generate:wallet-registry",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2825,10 +2825,10 @@
   resolved "https://registry.npmjs.org/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz"
   integrity sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==
 
-"@inlang/cli@^0.11.1":
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/@inlang/cli/-/cli-0.11.1.tgz#cdedc46ac1404788f36757f99514e7cee39d7ead"
-  integrity sha512-nxavmkBucW+C/TxNBxAPRcYt1Tz/lfdMncW762AkZ+5Tq2M+0Xpg78Se3auVdRiqmz+Att1ZIXBMZ2YWW9xSrg==
+"@inlang/cli@^0.11.7":
+  version "0.11.7"
+  resolved "https://registry.yarnpkg.com/@inlang/cli/-/cli-0.11.7.tgz#a1f73601303321f88f93ab63f62ba25263bad049"
+  integrity sha512-ZKR9YYzTS5+RzlTVCVSVFrrRJdbqr5mp0roRTJUIu5ieYix3O5m3kRjGKEuk/oGoIZ9G54dnn2qftaENZ2AwSQ==
 
 "@iov/crypto@2.1.0":
   version "2.1.0"


### PR DESCRIPTION
Fixed the CLI lint error "no inlang config found". 

## Changes

1. Add a `--config` parameter to the lint command. 

2. Update the inlang CLI (because why not).

