### PR TITLE
fix: Pool Creation Broadcast

### DIFF
--- a/packages/stores/src/account/amino-converters.ts
+++ b/packages/stores/src/account/amino-converters.ts
@@ -10,6 +10,8 @@ import { MsgLockTokens } from "@osmosis-labs/proto-codecs/build/codegen/osmosis/
 import { MsgTransfer } from "cosmjs-types/ibc/applications/transfer/v1/tx";
 import Long from "long";
 
+import { changeDecStringToProtoBz } from "./utils";
+
 const osmosisAminoConverters: Record<
   keyof typeof originalOsmosisAminoConverters,
   {
@@ -84,8 +86,12 @@ const osmosisAminoConverters: Record<
       return {
         sender,
         poolParams: {
-          swapFee: pool_params?.swap_fee ?? "",
-          exitFee: pool_params?.exit_fee ?? "",
+          swapFee: pool_params?.swap_fee
+            ? changeDecStringToProtoBz(pool_params.swap_fee)
+            : changeDecStringToProtoBz("0.000000000000000000"),
+          exitFee: pool_params?.swap_fee
+            ? changeDecStringToProtoBz(pool_params.swap_fee)
+            : changeDecStringToProtoBz("0.000000000000000000"),
         },
         poolAssets: pool_assets.map((el0) => ({
           token: {

--- a/packages/stores/src/account/amino-converters.ts
+++ b/packages/stores/src/account/amino-converters.ts
@@ -6,6 +6,7 @@ import {
   osmosisAminoConverters as originalOsmosisAminoConverters,
 } from "@osmosis-labs/proto-codecs";
 import { MsgCreateBalancerPool } from "@osmosis-labs/proto-codecs/build/codegen/osmosis/gamm/pool-models/balancer/tx/tx";
+import { MsgCreateStableswapPool } from "@osmosis-labs/proto-codecs/build/codegen/osmosis/gamm/pool-models/stableswap/tx";
 import { MsgLockTokens } from "@osmosis-labs/proto-codecs/build/codegen/osmosis/lockup/tx";
 import { MsgTransfer } from "cosmjs-types/ibc/applications/transfer/v1/tx";
 import Long from "long";
@@ -41,6 +42,73 @@ const osmosisAminoConverters: Record<
           denom: coin.denom,
           amount: coin.amount,
         })),
+      };
+    },
+  },
+  "/osmosis.gamm.poolmodels.stableswap.v1beta1.MsgCreateStableswapPool": {
+    ...originalOsmosisAminoConverters[
+      "/osmosis.gamm.poolmodels.stableswap.v1beta1.MsgCreateStableswapPool"
+    ],
+    toAmino: ({
+      sender,
+      poolParams,
+      futurePoolGovernor,
+      initialPoolLiquidity,
+      scalingFactorController,
+      scalingFactors,
+    }: MsgCreateStableswapPool) => {
+      return {
+        sender,
+        pool_params: {
+          swap_fee: poolParams?.swapFee,
+          exit_fee: poolParams?.exitFee,
+        },
+        initial_pool_liquidity: Array.isArray(initialPoolLiquidity)
+          ? initialPoolLiquidity.map(({ denom, amount }) => ({
+              denom,
+              amount,
+            }))
+          : [],
+        scaling_factors: Array.isArray(scalingFactors)
+          ? scalingFactors.map((e) => e.toString())
+          : [],
+        future_pool_governor: futurePoolGovernor,
+        scaling_factor_controller: scalingFactorController
+          ? scalingFactorController
+          : undefined,
+      };
+    },
+    fromAmino: ({
+      sender,
+      pool_params,
+      future_pool_governor,
+      initial_pool_liquidity,
+      scaling_factor_controller,
+      scaling_factors,
+    }: Parameters<
+      (typeof originalOsmosisAminoConverters)["/osmosis.gamm.poolmodels.stableswap.v1beta1.MsgCreateStableswapPool"]["fromAmino"]
+    >[0]): MsgCreateStableswapPool => {
+      return {
+        sender,
+        poolParams: {
+          swapFee: pool_params?.swap_fee
+            ? changeDecStringToProtoBz(pool_params.swap_fee)
+            : changeDecStringToProtoBz("0.000000000000000000"),
+          exitFee: pool_params?.exit_fee
+            ? changeDecStringToProtoBz(pool_params.exit_fee)
+            : changeDecStringToProtoBz("0.000000000000000000"),
+        },
+        initialPoolLiquidity: Array.isArray(initial_pool_liquidity)
+          ? initial_pool_liquidity.map(({ denom, amount }) => ({
+              denom,
+              amount,
+            }))
+          : [],
+        scalingFactors: Array.isArray(scaling_factors)
+          ? scaling_factors.map((e: any) => e)
+          : [],
+        futurePoolGovernor: future_pool_governor,
+        scalingFactorController: scaling_factor_controller,
       };
     },
   },
@@ -89,8 +157,8 @@ const osmosisAminoConverters: Record<
           swapFee: pool_params?.swap_fee
             ? changeDecStringToProtoBz(pool_params.swap_fee)
             : changeDecStringToProtoBz("0.000000000000000000"),
-          exitFee: pool_params?.swap_fee
-            ? changeDecStringToProtoBz(pool_params.swap_fee)
+          exitFee: pool_params?.exit_fee
+            ? changeDecStringToProtoBz(pool_params.exit_fee)
             : changeDecStringToProtoBz("0.000000000000000000"),
         },
         poolAssets: pool_assets.map((el0) => ({

--- a/packages/stores/src/account/utils.ts
+++ b/packages/stores/src/account/utils.ts
@@ -63,6 +63,21 @@ export function getWalletWindowName(walletName: string) {
   return walletName.split("-")[0];
 }
 
+/**
+ * Change decimal string to proto bytes. This is
+ *
+ * @param decStr string
+ * @returns string
+ */
+export function changeDecStringToProtoBz(decStr: string): string {
+  let r = decStr;
+  while (r.length >= 2 && (r.startsWith(".") || r.startsWith("0"))) {
+    r = r.slice(1);
+  }
+
+  return r;
+}
+
 export const CosmosKitAccountsLocalStorageKey = "cosmos-kit@1:core//accounts";
 export const CosmosKitWalletLocalStorageKey =
   "cosmos-kit@1:core//current-wallet";


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the pool creation flow, and this message: 

![image](https://github.com/osmosis-labs/osmosis-frontend/assets/21092519/f2d87b34-52da-4b7a-9806-635f5fb4fd2f)

The error pertains to a discrepancy between the amino and proto messages. The proto messages are incapable of incorporating decimal numbers because they are converted into a `BigInt` on the chain side. Considering our need for a decimal number in the amino message, we can still maintain the decimals in the `toAmino`. However, we need to adjust the `fromAmino` function. This function represents the body passed to the proto message and must accommodate a decimal format compatible with the proto buffer. 

To clarify our transaction signing process: we begin by obtaining the amino message object via the `toAmino` function, which is then signed using the wallet. This signed object is then transformed into a proto-compatible message using the `fromAmino` function and encoded accordingly with the proto registry. Following this process, our message is prepared and ready for broadcast.

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/85ztc3hdp)

## Brief Changelog

- update `fromAmino` To convert amino decimal to compatible proto values

## Testing and Verifying

- [ ] Can create balancer pool and data is consistent
- [ ] Can create stableswap pool and data is consistent
