### PR TITLE
Arkh unstable - disable IBC from frontend

### DIFF
--- a/packages/web/config/ibc-assets.ts
+++ b/packages/web/config/ibc-assets.ts
@@ -1602,6 +1602,7 @@ export const IBCAssetInfos: (IBCAsset & {
         sourceChannelId: "channel-648",
         destChannelId: "channel-12",
         coinMinimalDenom: "arkh",
+        isUnstable: true,
       },
       {
         counterpartyChainId: "quicksilver-2",


### PR DESCRIPTION
This project seems to be dead. <$200 liquidity... There are an increasing number of pending IBC transfers out of Osmosis yet the project no longer has any relayers, and therefore the ability to deposit/withdraw should be disabled.

I haven't tested this change locally, but I looked at past PRs and this seems to be acceptable.

![image](https://github.com/osmosis-labs/osmosis-frontend/assets/1925470/4468b672-0d82-49bc-82ab-a24923ab07af)