### PR TITLE
fix: invert in over out spot price

### DIFF
--- a/packages/pools/src/concentrated.ts
+++ b/packages/pools/src/concentrated.ts
@@ -175,7 +175,8 @@ export class ConcentratedLiquidityPool implements BasePool, RoutablePool {
   ): Promise<Quote> {
     this.validateDenoms(tokenIn.denom, tokenOutDenom);
 
-    /** Reminder: currentSqrtPrice: amountToken1/amountToken0 or token 1 per token 0  */
+    /** Reminder: currentSqrtPrice: amountToken1/amountToken0 or token 1 per token 0.
+     *  0 for 1 is how prices are represented in CL pool model. */
     const is0For1 = tokenIn.denom === this.raw.token0;
 
     /** Spot price as stored in pool model. */
@@ -240,11 +241,11 @@ export class ConcentratedLiquidityPool implements BasePool, RoutablePool {
     );
 
     const beforeSpotPriceInOverOut = is0For1
-      ? before1Over0SpotPrice
-      : new Dec(1).quoTruncate(before1Over0SpotPrice);
+      ? new Dec(1).quoTruncate(before1Over0SpotPrice)
+      : before1Over0SpotPrice;
     const afterSpotPriceInOverOut = is0For1
-      ? after1Over0SpotPrice
-      : new Dec(1).quoTruncate(after1Over0SpotPrice);
+      ? new Dec(1).quoTruncate(after1Over0SpotPrice)
+      : after1Over0SpotPrice;
 
     const priceImpactTokenOut = effectivePriceInOverOut
       .quo(beforeSpotPriceInOverOut)
@@ -275,12 +276,12 @@ export class ConcentratedLiquidityPool implements BasePool, RoutablePool {
   ): Promise<Quote> {
     this.validateDenoms(tokenInDenom, tokenOut.denom);
 
-    /** Reminder: currentSqrtPrice: amountToken1/amountToken0 or token 1 per token 0  */
+    /** Reminder: currentSqrtPrice: amountToken1/amountToken0 or token 1 per token 0.
+     *  0 for 1 is how prices are represented in CL pool model. */
     const is0For1 = tokenInDenom === this.raw.token0;
 
     /** Spot price as stored in pool model.
-     *  reminder: the token being swapped, even though the token out is the amount specified
-     */
+     *  reminder: the token being swapped, even though the token out is the amount specified */
     const before1Over0SpotPrice = this.spotPrice(
       is0For1 ? tokenInDenom : tokenOut.denom
     );
@@ -337,11 +338,11 @@ export class ConcentratedLiquidityPool implements BasePool, RoutablePool {
     }
 
     const beforeSpotPriceInOverOut = is0For1
-      ? before1Over0SpotPrice
-      : new Dec(1).quoTruncate(before1Over0SpotPrice);
+      ? new Dec(1).quoTruncate(before1Over0SpotPrice)
+      : before1Over0SpotPrice;
     const afterSpotPriceInOverOut = is0For1
-      ? after1Over0SpotPrice
-      : new Dec(1).quoTruncate(after1Over0SpotPrice);
+      ? new Dec(1).quoTruncate(after1Over0SpotPrice)
+      : after1Over0SpotPrice;
 
     const effectivePriceInOverOut = new Dec(amountIn).quoTruncate(
       new Dec(tokenOut.amount)

--- a/packages/stores/src/ui-config/trade-token-in-config.ts
+++ b/packages/stores/src/ui-config/trade-token-in-config.ts
@@ -260,10 +260,8 @@ export class ObservableTradeTokenInConfig extends AmountConfig {
 
     return (
       quote?.case({
-        fulfilled: (quote) => {
-          return this.makePrettyQuote(quote)
-            .beforeSpotPriceWithoutSwapFeeOutOverIn;
-        },
+        fulfilled: (quote) =>
+          this.makePrettyQuote(quote).beforeSpotPriceWithoutSwapFeeOutOverIn,
         rejected: (e) => {
           // these are expected
           if (e instanceof NoRouteError) return undefined;


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

When calculating the display spot price for a CL pool, we messed up the in over out logic depending on the token being swapped in. This should fix the swap tool for CL pools.

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/86780cqt2)

