### PR TITLE
Show unstake position status

### DIFF
--- a/packages/stores/src/account/osmosis/index.ts
+++ b/packages/stores/src/account/osmosis/index.ts
@@ -1493,6 +1493,14 @@ export class OsmosisAccountImpl {
           this.queries.queryAccountsPositions
             .get(this.address)
             .waitFreshResponse();
+
+          // refresh delegation of positions
+          this.queries.queryAccountsSuperfluidDelegatedPositions
+            .get(this.address)
+            .waitFreshResponse();
+          this.queries.queryAccountsSuperfluidUndelegatingPositions
+            .get(this.address)
+            .waitFreshResponse();
         }
 
         onFulfill?.(tx);

--- a/packages/stores/src/account/osmosis/index.ts
+++ b/packages/stores/src/account/osmosis/index.ts
@@ -1494,7 +1494,7 @@ export class OsmosisAccountImpl {
             .get(this.address)
             .waitFreshResponse();
 
-          // refresh delegation of positions
+          // refresh superfluid delegation of positions
           this.queries.queryAccountsSuperfluidDelegatedPositions
             .get(this.address)
             .waitFreshResponse();

--- a/packages/stores/src/account/utils.ts
+++ b/packages/stores/src/account/utils.ts
@@ -21,10 +21,6 @@ export const createMsgOpts = <
   dict: Dict
 ) => dict;
 
-export async function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 export const logger = new Logger("WARN");
 
 export function getWalletEndpoints(chains: Chain[]) {

--- a/packages/web/components/cards/my-position/expanded.tsx
+++ b/packages/web/components/cards/my-position/expanded.tsx
@@ -110,8 +110,6 @@ export const MyPositionCardExpandedSection: FunctionComponent<{
     }
   }, [lowerPrices, upperPrices, setPriceRange]);
 
-  console.log({ superfluidDelegation, superfluidUndelegation });
-
   return (
     <div className="flex flex-col gap-4" onClick={(e) => e.stopPropagation()}>
       {activeModal === "increase" && (

--- a/packages/web/components/cards/my-position/expanded.tsx
+++ b/packages/web/components/cards/my-position/expanded.tsx
@@ -12,6 +12,7 @@ import Image from "next/image";
 import React, {
   ComponentProps,
   FunctionComponent,
+  useCallback,
   useEffect,
   useMemo,
   useState,
@@ -109,6 +110,8 @@ export const MyPositionCardExpandedSection: FunctionComponent<{
     }
   }, [lowerPrices, upperPrices, setPriceRange]);
 
+  console.log({ superfluidDelegation, superfluidUndelegation });
+
   return (
     <div className="flex flex-col gap-4" onClick={(e) => e.stopPropagation()}>
       {activeModal === "increase" && (
@@ -138,23 +141,32 @@ export const MyPositionCardExpandedSection: FunctionComponent<{
               yRange={yRange}
               xRange={xRange}
               data={depthChartData}
-              annotationDatum={{
-                price: currentPrice
-                  ? Number(currentPrice.toString())
-                  : lastChartData?.close || 0,
-                depth: xRange[1],
-              }}
-              rangeAnnotation={[
-                {
-                  price: Number(lowerPrices?.price.toString() ?? 0),
+              annotationDatum={useMemo(
+                () => ({
+                  price: currentPrice
+                    ? Number(currentPrice.toString())
+                    : lastChartData?.close || 0,
                   depth: xRange[1],
-                },
-                {
-                  price: Number(upperPrices?.price.toString() ?? 0),
-                  depth: xRange[1],
-                },
-              ]}
-              offset={{ top: 0, right: 36, bottom: 24 + 28, left: 0 }}
+                }),
+                [currentPrice, lastChartData, xRange]
+              )}
+              rangeAnnotation={useMemo(
+                () => [
+                  {
+                    price: Number(lowerPrices?.price.toString() ?? 0),
+                    depth: xRange[1],
+                  },
+                  {
+                    price: Number(upperPrices?.price.toString() ?? 0),
+                    depth: xRange[1],
+                  },
+                ],
+                [lowerPrices, upperPrices, xRange]
+              )}
+              offset={useMemo(
+                () => ({ top: 0, right: 36, bottom: 24 + 28, left: 0 }),
+                []
+              )}
               horizontal
               fullRange={isFullRange}
             />
@@ -288,11 +300,11 @@ export const MyPositionCardExpandedSection: FunctionComponent<{
             Boolean(account?.txTypeInProgress) ||
             !Boolean(account)
           }
-          onClick={() => {
+          onClick={useCallback(() => {
             account!.osmosis
               .sendCollectAllPositionsRewardsMsgs([positionConfig.id])
               .catch(console.error);
-          }}
+          }, [account, positionConfig.id])}
         >
           {t("clPositions.collectRewards")}
         </PositionButton>
@@ -301,7 +313,7 @@ export const MyPositionCardExpandedSection: FunctionComponent<{
             Boolean(account?.txTypeInProgress) ||
             Boolean(superfluidUndelegation)
           }
-          onClick={() => {
+          onClick={useCallback(() => {
             if (superfluidDelegation) {
               account?.osmosis
                 .sendBeginUnlockingMsgOrSuperfluidUnbondLockMsgIfSyntheticLock([
@@ -312,7 +324,7 @@ export const MyPositionCardExpandedSection: FunctionComponent<{
                 ])
                 .catch(console.error);
             } else setActiveModal("remove");
-          }}
+          }, [account, superfluidDelegation])}
         >
           {Boolean(superfluidDelegation)
             ? t("clPositions.unstake")
@@ -321,9 +333,10 @@ export const MyPositionCardExpandedSection: FunctionComponent<{
         <PositionButton
           disabled={
             Boolean(account?.txTypeInProgress) ||
+            Boolean(superfluidDelegation) ||
             Boolean(superfluidUndelegation)
           }
-          onClick={() => setActiveModal("increase")}
+          onClick={useCallback(() => setActiveModal("increase"), [])}
         >
           {t("clPositions.increaseLiquidity")}
         </PositionButton>

--- a/packages/web/components/cards/my-position/index.tsx
+++ b/packages/web/components/cards/my-position/index.tsx
@@ -109,7 +109,8 @@ export const MyPositionCard: FunctionComponent<{
                 )}
               />
               <span className="px-2 py-1 text-subtitle1 text-osmoverse-100">
-                {queryPool?.swapFee.toString()} {t("clPositions.spreadFactor")}
+                {queryPool?.swapFee.toString() ?? ""}{" "}
+                {t("clPositions.spreadFactor")}
               </span>
             </div>
             {queryPool?.concentratedLiquidityPoolInfo?.currentSqrtPrice &&

--- a/packages/web/components/cards/my-position/index.tsx
+++ b/packages/web/components/cards/my-position/index.tsx
@@ -74,9 +74,6 @@ export const MyPositionCard: FunctionComponent<{
       positionId
     );
 
-  const isSuperfluidStaked =
-    Boolean(superfluidDelegation) || Boolean(superfluidUndelegation);
-
   const incentivesApr =
     poolId && lowerTick && upperTick
       ? queriesExternalStore.queryPositionsRangeApr
@@ -126,6 +123,7 @@ export const MyPositionCard: FunctionComponent<{
                   upperPrice={upperPrices.price}
                   fullRange={isFullRange}
                   isSuperfluid={Boolean(superfluidDelegation)}
+                  isSuperfluidUnstaking={Boolean(superfluidUndelegation)}
                 />
               )}
           </div>
@@ -151,7 +149,9 @@ export const MyPositionCard: FunctionComponent<{
             <PositionDataGroup
               label={t("clPositions.incentives")}
               value={`${formatPretty(incentivesApr.maxDecimals(0))} APR`}
-              isSuperfluid={isSuperfluidStaked}
+              isSuperfluid={
+                Boolean(superfluidDelegation) || Boolean(superfluidUndelegation)
+              }
             />
           )}
         </div>

--- a/packages/web/components/cards/my-position/status.tsx
+++ b/packages/web/components/cards/my-position/status.tsx
@@ -11,6 +11,7 @@ const enum PositionStatus {
   OutOfRange,
   FullRange,
   SuperfluidStaked,
+  SuperfulidUnstaking,
 }
 export const MyPositionStatus: FunctionComponent<
   {
@@ -20,6 +21,7 @@ export const MyPositionStatus: FunctionComponent<
     negative?: boolean;
     fullRange?: boolean;
     isSuperfluid?: boolean;
+    isSuperfluidUnstaking?: boolean;
   } & CustomClasses
 > = ({
   className,
@@ -28,7 +30,8 @@ export const MyPositionStatus: FunctionComponent<
   upperPrice,
   negative,
   fullRange,
-  isSuperfluid: superfluidStaked,
+  isSuperfluid,
+  isSuperfluidUnstaking,
 }) => {
   const t = useTranslation();
 
@@ -65,9 +68,14 @@ export const MyPositionStatus: FunctionComponent<
     label = t("clPositions.fullRange");
   }
 
-  if (superfluidStaked) {
+  if (isSuperfluid) {
     status = PositionStatus.SuperfluidStaked;
     label = t("clPositions.superfluidStaked");
+  }
+
+  if (isSuperfluidUnstaking) {
+    status = PositionStatus.SuperfulidUnstaking;
+    label = t("clPositions.superfluidUnstakingStatus");
   }
 
   return (
@@ -81,7 +89,9 @@ export const MyPositionStatus: FunctionComponent<
           "bg-rust-600/30": !negative && status === PositionStatus.OutOfRange,
           "bg-[#2994D04D]/30": !negative && status === PositionStatus.FullRange,
           "bg-superfluid/30":
-            !negative && status === PositionStatus.SuperfluidStaked,
+            !negative &&
+            (status === PositionStatus.SuperfluidStaked ||
+              status === PositionStatus.SuperfulidUnstaking),
         },
         className
       )}
@@ -92,7 +102,9 @@ export const MyPositionStatus: FunctionComponent<
           "bg-ammelia-600": status === PositionStatus.NearBounds,
           "bg-rust-500": status === PositionStatus.OutOfRange,
           "bg-ion-400": status === PositionStatus.FullRange,
-          "bg-superfluid": status === PositionStatus.SuperfluidStaked,
+          "bg-superfluid":
+            status === PositionStatus.SuperfluidStaked ||
+            status === PositionStatus.SuperfulidUnstaking,
         })}
       />
       <span className="subtitle1">{label}</span>

--- a/packages/web/localizations/en.json
+++ b/packages/web/localizations/en.json
@@ -67,6 +67,7 @@
     "outOfRange": "OUT OF RANGE",
     "fullRange": "FULL RANGE",
     "superfluidStaked": "SUPERFLUID STAKED",
+    "superfluidUnstakingStatus": "SUPERFLUID UNSTAKING",
     "currentAssets": "Current Assets",
     "principleAssets": "Principle Assets",
     "totalSpreadEarned": "Total Spread Earned",


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

Show unstake status when a user is unstaking a position.

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/86780cqt2)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

Stretch: auto refresh time and requery position status when position end time is reached.

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

Either migrate a staked gamm share position, or stake a full range position, then unstake and ensure status is updated.

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
