### PR TITLE
test/fix: more descriptive error message when failing quotes due to lack of precision

### DIFF
--- a/packages/math/src/pool/concentrated/__tests__/tick.spec.ts
+++ b/packages/math/src/pool/concentrated/__tests__/tick.spec.ts
@@ -87,7 +87,7 @@ describe("tickToSqrtPrice", () => {
       expectedPrice: maxSpotPrice,
     },
     "Min tick and max k": {
-      tickIndex: new Int("-162000000"),
+      tickIndex: new Int("-108000000"),
       expectedPrice: minSpotPrice,
     },
     "error: tickIndex less than minimum": {
@@ -217,7 +217,7 @@ describe("estimateInitialTickBound", () => {
         currentTickLiquidity: new Dec("1517882343.751510418088349649"),
         currentSqrtPrice: new Dec("70.710678118654752440"),
 
-        expectedBoundTickIndex: new Int("-162000000"),
+        expectedBoundTickIndex: new Int("-108000000"),
       },
     },
     {
@@ -277,7 +277,7 @@ describe("estimateInitialTickBound", () => {
         currentTickLiquidity: new Dec("1517882343.751510418088349649"),
         currentSqrtPrice: new Dec("70.710678118654752440"),
 
-        expectedBoundTickIndex: new Int("-162000000"),
+        expectedBoundTickIndex: new Int("-108000000"),
       },
     },
     {

--- a/packages/math/src/pool/concentrated/one-for-zero.ts
+++ b/packages/math/src/pool/concentrated/one-for-zero.ts
@@ -78,6 +78,14 @@ export class OneForZeroStrategy implements SwapStrategy {
         liquidity,
         amountOneInRemainingLessFee
       );
+
+      // This may happen due to a lack of precison. We need 36 for this to not happen.
+      // Must be fixed post-launch.
+      if (curSqrtPrice.equals(sqrtPriceNext)) {
+        throw new Error(
+          "Failed to advance the swap step while estimating slippage bound. Please try swapping in a larger amount."
+        );
+      }
     }
 
     const hasReachedTarget = sqrtPriceTarget.equals(sqrtPriceNext);

--- a/packages/math/src/pool/concentrated/one-for-zero.ts
+++ b/packages/math/src/pool/concentrated/one-for-zero.ts
@@ -168,6 +168,14 @@ export class OneForZeroStrategy implements SwapStrategy {
         liquidity,
         amountZeroRemainingOut
       );
+
+      // This may happen due to a lack of precison. We need 36 for this to not happen.
+      // Must be fixed post-launch.
+      if (curSqrtPrice.equals(sqrtPriceNext)) {
+        throw new Error(
+          "Failed to advance the swap step while estimating slippage bound. Please try swapping in a larger amount."
+        );
+      }
     }
 
     const hasReachedTarget = sqrtPriceTarget.equals(sqrtPriceNext);

--- a/packages/math/src/pool/concentrated/zero-for-one.ts
+++ b/packages/math/src/pool/concentrated/zero-for-one.ts
@@ -77,6 +77,14 @@ export class ZeroForOneStrategy implements SwapStrategy {
         liquidity,
         amountZeroInRemainingLessFee
       );
+
+      // This may happen due to a lack of precison. We need 36 for this to not happen.
+      // Must be fixed post-launch.
+      if (curSqrtPrice.equals(sqrtPriceNext)) {
+        throw new Error(
+          "Failed to advance the swap step while estimating slippage bound. Please try swapping in a larger amount."
+        );
+      }
     }
 
     const hasReachedTarget = sqrtPriceTarget.equals(sqrtPriceNext);
@@ -159,6 +167,14 @@ export class ZeroForOneStrategy implements SwapStrategy {
         liquidity,
         amountOneRemainingOut
       );
+
+      // This may happen due to a lack of precison. We need 36 for this to not happen.
+      // Must be fixed post-launch.
+      if (curSqrtPrice.equals(sqrtPriceNext)) {
+        throw new Error(
+          "Failed to advance the swap step while estimating slippage bound. Please try swapping in a larger amount."
+        );
+      }
     }
 
     const hasReachedTarget = sqrtPriceTarget.equals(sqrtPriceNext);


### PR DESCRIPTION
…

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

The issue I've experienced is not being unable to generate quotes due to a lack of precision.

Precision must be increased to 36 post-launch for quote generation to work correctly in all cases.

If liquidity is high enough here:
https://github.com/osmosis-labs/osmosis-frontend/blob/c7889f4e4186bdb5862abc9a0275aeb5f3d377d6/packages/math/src/pool/concentrated/math.ts#L145

It will divide `amountRemaining` all the way to zero, leaving the sqrt price with no update. That will lead to the new sqrt price being equal to the current sqrt price. As a result, we failed to calculate the quoted amount and swap.

## Brief Changelog
- added a more descriptive error to all swap steps
- added a repro test

## Testing and Verifying

Covered by test

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? yes)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
