### PR TITLE
Fix input price

### DIFF
--- a/packages/stores/src/ui-config/decimal.ts
+++ b/packages/stores/src/ui-config/decimal.ts
@@ -1,0 +1,66 @@
+import { Dec } from "@keplr-wallet/unit";
+import { action, makeObservable, observable } from "mobx";
+import { computedFn } from "mobx-utils";
+
+/** Manages user input of decimal values. */
+export class DecimalConfig {
+  @observable
+  protected _decRaw: string;
+
+  constructor() {
+    this._decRaw = "0";
+
+    makeObservable(this);
+  }
+
+  get decimal() {
+    return this._decRaw;
+  }
+
+  @action
+  input(value: string | Dec) {
+    console.log(value);
+    if (value instanceof Dec) {
+      this._decRaw = value.toString();
+    } else if (value === "") {
+      this._decRaw = "0";
+    } else if (value.startsWith(".")) {
+      this._decRaw = "0" + value;
+    } else {
+      this._decRaw = value;
+    }
+  }
+
+  readonly toDec = computedFn(() => {
+    if (this._decRaw.endsWith(".")) {
+      return new Dec(this._decRaw.slice(0, -1));
+    }
+    return new Dec(this._decRaw);
+  });
+
+  /** Raw value, which may be terminated with a `'.'`. `0`s are trimmed. */
+  toString() {
+    return trimZerosFromEnd(this._decRaw);
+  }
+}
+
+export function trimZerosFromEnd(str: string) {
+  const decimalPointIndex = str.indexOf(".");
+
+  if (decimalPointIndex === -1) {
+    // No decimal point in this string, so return original
+    return str;
+  }
+
+  let i = str.length - 1;
+  while (i > decimalPointIndex && str.charAt(i) === "0") {
+    i--;
+  }
+
+  // If we have only . left from the trimming, remove it as well
+  if (str.charAt(i) === ".") {
+    i--;
+  }
+
+  return str.substring(0, i + 1);
+}

--- a/packages/stores/src/ui-config/decimal.ts
+++ b/packages/stores/src/ui-config/decimal.ts
@@ -19,7 +19,6 @@ export class DecimalConfig {
 
   @action
   input(value: string | Dec) {
-    console.log(value);
     if (value instanceof Dec) {
       this._decRaw = value.toString();
     } else if (value === "") {

--- a/packages/stores/src/ui-config/index.ts
+++ b/packages/stores/src/ui-config/index.ts
@@ -1,4 +1,5 @@
 export * from "./create-pool";
+export * from "./decimal";
 export * from "./errors";
 export * from "./fake-fee-config";
 export * from "./manage-liquidity";

--- a/packages/stores/src/ui-config/manage-liquidity/add-concentrated-liquidity.ts
+++ b/packages/stores/src/ui-config/manage-liquidity/add-concentrated-liquidity.ts
@@ -469,30 +469,22 @@ export class ObservableAddConcentratedLiquidityConfig {
   };
 
   @action
-  readonly setMinRange = (min: Dec | number) => {
+  readonly setMinRange = (min: Dec) => {
     if (!this.pool) return;
 
     this._priceRange = [
-      roundPriceToNearestTick(
-        typeof min === "number" ? new Dec(min) : min,
-        this.pool.tickSpacing,
-        true
-      ),
+      roundPriceToNearestTick(min, this.pool.tickSpacing, true),
       this._priceRange[1],
     ];
   };
 
   @action
-  readonly setMaxRange = (max: Dec | number) => {
+  readonly setMaxRange = (max: Dec) => {
     if (!this.pool) return;
 
     this._priceRange = [
       this._priceRange[0],
-      roundPriceToNearestTick(
-        typeof max === "number" ? new Dec(max) : max,
-        this.pool.tickSpacing,
-        false
-      ),
+      roundPriceToNearestTick(max, this.pool.tickSpacing, false),
     ];
   };
 

--- a/packages/web/components/complex/add-conc-liquidity.tsx
+++ b/packages/web/components/complex/add-conc-liquidity.tsx
@@ -733,7 +733,7 @@ const PriceInputBox: FunctionComponent<{
             // otherwise, display the nearest tick rounded price
             isFocused
               ? config.rangeRaw[forPriceIndex]
-              : formatPretty(config.range[forPriceIndex])
+              : formatPretty(config.range[forPriceIndex], { maxDecimals: 8 })
           }
           onFocus={() => setIsFocused(true)}
           onInput={(val) =>

--- a/packages/web/components/complex/add-conc-liquidity.tsx
+++ b/packages/web/components/complex/add-conc-liquidity.tsx
@@ -393,13 +393,15 @@ const AddConcLiqView: FunctionComponent<
                   [chartConfig.xRange, currentPrice]
                 )}
                 // eslint-disable-next-line react-hooks/exhaustive-deps
-                onMoveMax={useCallback(debounce(setMaxRange, 500), [
-                  priceDecimal,
-                ])}
+                onMoveMax={useCallback(
+                  debounce((num) => setMaxRange(new Dec(num)), 500),
+                  [priceDecimal]
+                )}
                 // eslint-disable-next-line react-hooks/exhaustive-deps
-                onMoveMin={useCallback(debounce(setMinRange, 500), [
-                  priceDecimal,
-                ])}
+                onMoveMin={useCallback(
+                  debounce((num) => setMinRange(new Dec(num)), 500),
+                  [priceDecimal]
+                )}
                 onSubmitMin={useCallback(
                   (val) => {
                     setMinRange(val);
@@ -422,20 +424,24 @@ const AddConcLiqView: FunctionComponent<
             <div className="flex flex-col items-center justify-center gap-4 pr-8">
               <PriceInputBox
                 currentValue={
-                  fullRange ? "" : formatPretty(inputRange[1]).toString()
+                  fullRange ? "" : formatPretty(inputRange[1], {}).toString()
                 }
                 label={t("addConcentratedLiquidity.high")}
-                onChange={(val) => setMaxRange(Number(val))}
-                onBlur={(e) => setMaxRange(+e.target.value)}
+                onChange={(val) =>
+                  setMaxRange(val === "" ? new Dec(0) : new Dec(val))
+                }
+                onBlur={(e) => setMaxRange(new Dec(+e.target.value))}
                 infinity={fullRange}
               />
               <PriceInputBox
                 currentValue={
-                  fullRange ? "0" : formatPretty(inputRange[0]).toString()
+                  fullRange ? "0" : formatPretty(inputRange[0], {}).toString()
                 }
                 label={t("addConcentratedLiquidity.low")}
-                onChange={(val) => setMinRange(Number(val))}
-                onBlur={(e) => setMinRange(+e.target.value)}
+                onChange={(val) =>
+                  setMinRange(val === "" ? new Dec(0) : new Dec(val))
+                }
+                onBlur={(e) => setMinRange(new Dec(+e.target.value))}
               />
             </div>
           </div>

--- a/packages/web/components/complex/add-conc-liquidity.tsx
+++ b/packages/web/components/complex/add-conc-liquidity.tsx
@@ -302,7 +302,7 @@ const AddConcLiqView: FunctionComponent<
   const { chainId } = chainStore.osmosis;
   const chartConfig = useHistoricalAndLiquidityData(chainId, poolId);
 
-  const { priceDecimal, yRange, xRange, depthChartData } = chartConfig;
+  const { yRange, xRange, depthChartData } = chartConfig;
 
   const updateInputAndRangeMinMax = useCallback(
     (min: number, max: number) => {
@@ -395,23 +395,23 @@ const AddConcLiqView: FunctionComponent<
                 // eslint-disable-next-line react-hooks/exhaustive-deps
                 onMoveMax={useCallback(
                   debounce((num) => setMaxRange(new Dec(num)), 500),
-                  [priceDecimal]
+                  []
                 )}
                 // eslint-disable-next-line react-hooks/exhaustive-deps
                 onMoveMin={useCallback(
                   debounce((num) => setMinRange(new Dec(num)), 500),
-                  [priceDecimal]
+                  []
                 )}
                 onSubmitMin={useCallback(
-                  (val) => {
-                    setMinRange(val);
+                  (val: number) => {
+                    setMinRange(new Dec(val));
                     setFullRange(false);
                   },
                   [setMinRange, setFullRange]
                 )}
                 onSubmitMax={useCallback(
-                  (val) => {
-                    setMaxRange(val);
+                  (val: number) => {
+                    setMaxRange(new Dec(val));
                     setFullRange(false);
                   },
                   [setMaxRange, setFullRange]

--- a/packages/web/components/complex/add-conc-liquidity.tsx
+++ b/packages/web/components/complex/add-conc-liquidity.tsx
@@ -708,13 +708,13 @@ const PriceInputBox: FunctionComponent<{
   label: string;
   forPriceIndex: 0 | 1;
   addConcLiquidityConfig: ObservableAddConcentratedLiquidityConfig;
-}> = observer(({ label, forPriceIndex, addConcLiquidityConfig: config }) => {
+}> = observer(({ label, forPriceIndex, addConcLiquidityConfig }) => {
   const [isFocused, setIsFocused] = useState(false);
 
   return (
     <div className="flex w-full max-w-[9.75rem] flex-col items-end rounded-xl bg-osmoverse-800 px-2">
       <span className="caption px-2 pt-2 text-osmoverse-400">{label}</span>
-      {forPriceIndex === 1 && config.fullRange && !isFocused ? (
+      {forPriceIndex === 1 && addConcLiquidityConfig.fullRange && !isFocused ? (
         <div className="flex h-[41px] items-center px-2">
           <Image
             alt="infinity"
@@ -732,14 +732,16 @@ const PriceInputBox: FunctionComponent<{
             // to allow decimals, display the raw string value while typing
             // otherwise, display the nearest tick rounded price
             isFocused
-              ? config.rangeRaw[forPriceIndex]
-              : formatPretty(config.range[forPriceIndex], { maxDecimals: 8 })
+              ? addConcLiquidityConfig.rangeRaw[forPriceIndex]
+              : formatPretty(addConcLiquidityConfig.range[forPriceIndex], {
+                  maxDecimals: 8,
+                })
           }
           onFocus={() => setIsFocused(true)}
           onInput={(val) =>
             forPriceIndex === 0
-              ? config.setMinRange(val)
-              : config.setMaxRange(val)
+              ? addConcLiquidityConfig.setMinRange(val)
+              : addConcLiquidityConfig.setMaxRange(val)
           }
           onBlur={() => setIsFocused(false)}
         />

--- a/packages/web/modals/increase-concentrated-liquidity.tsx
+++ b/packages/web/modals/increase-concentrated-liquidity.tsx
@@ -97,8 +97,8 @@ export const IncreaseConcentratedLiquidityModal: FunctionComponent<
   useEffect(() => {
     if (lowerPrices?.price && upperPrices?.price) {
       setPriceRange([lowerPrices.price, upperPrices.price]);
-      config.setMinRange(lowerPrices.price);
-      config.setMaxRange(upperPrices.price);
+      config.setMinRange(lowerPrices.price.toString());
+      config.setMaxRange(upperPrices.price.toString());
     }
   }, [config, setPriceRange, lowerPrices, upperPrices]);
 

--- a/packages/web/utils/formatter.ts
+++ b/packages/web/utils/formatter.ts
@@ -5,21 +5,34 @@ import {
   PricePretty,
   RatePretty,
 } from "@keplr-wallet/unit";
+import { trimZerosFromEnd } from "@osmosis-labs/stores";
+
+type FormatOptions = Partial<
+  Intl.NumberFormatOptions & { maxDecimals: number }
+>;
+
+type FormatOptionsWithDefaults = Partial<Intl.NumberFormatOptions> & {
+  maxDecimals: number;
+};
+
+const DEFAULT = {
+  maxDecimals: 2,
+};
 
 /** Formats a pretty object as compact by default. i.e. $7.53M or $265K, or 2K%. Validate handled by pretty object. */
 export function formatPretty(
   prettyValue: PricePretty | CoinPretty | RatePretty | Dec,
-  opts?: Partial<Intl.NumberFormatOptions>
+  opts: FormatOptions = {}
 ) {
-  const { ...formatOpts } = opts || {};
+  const optsWithDefaults: FormatOptionsWithDefaults = { ...DEFAULT, ...opts };
   if (prettyValue instanceof PricePretty) {
-    return priceFormatter(prettyValue, opts ?? formatOpts);
+    return priceFormatter(prettyValue, optsWithDefaults);
   } else if (prettyValue instanceof CoinPretty) {
-    return coinFormatter(prettyValue, opts ?? { ...formatOpts });
+    return coinFormatter(prettyValue, optsWithDefaults);
   } else if (prettyValue instanceof RatePretty) {
-    return rateFormatter(prettyValue, opts ?? formatOpts);
+    return rateFormatter(prettyValue, optsWithDefaults);
   } else if (prettyValue instanceof Dec) {
-    return decFormatter(prettyValue, opts ?? formatOpts);
+    return decFormatter(prettyValue, optsWithDefaults);
   } else {
     throw new Error("Unknown pretty value");
   }
@@ -28,7 +41,7 @@ export function formatPretty(
 /** Formats a dec as compact by default. i.e. $7.53M or $265K. Validate handled by `Dec`. */
 function decFormatter(
   dec: Dec,
-  opts?: Partial<Intl.NumberFormatOptions>
+  opts: FormatOptionsWithDefaults = DEFAULT
 ): string {
   const options: Intl.NumberFormatOptions = {
     maximumSignificantDigits: 3,
@@ -36,25 +49,30 @@ function decFormatter(
     compactDisplay: "short",
     ...opts,
   };
-  const numStr = new IntPretty(dec).maxDecimals(2).locale(false).toString();
+  const numStr = new IntPretty(dec)
+    .maxDecimals(opts.maxDecimals)
+    .locale(false)
+    .toString();
   let num = Number(numStr);
   num = isNaN(num) ? 0 : num;
-  if (Object.keys(opts ?? {}).length > 0) {
-    const formatter = new Intl.NumberFormat("en", options);
-    return formatter.format(num);
+  if (hasIntlFormatOptions(opts)) {
+    const formatter = new Intl.NumberFormat("en-US", options);
+    return trimZerosFromEnd(formatter.format(num));
   } else {
-    return new IntPretty(dec)
-      .maxDecimals(0)
-      .locale(false)
-      .shrink(true)
-      .toString();
+    return trimZerosFromEnd(
+      new IntPretty(dec)
+        .maxDecimals(opts.maxDecimals)
+        .locale(false)
+        .shrink(true)
+        .toString()
+    );
   }
 }
 
 /** Formats a price as compact by default. i.e. $7.53M or $265K. Validate handled by `PricePretty`. */
 function priceFormatter(
   price: PricePretty,
-  opts?: Partial<Intl.NumberFormatOptions>
+  opts: FormatOptionsWithDefaults = DEFAULT
 ): string {
   const options: Intl.NumberFormatOptions = {
     maximumSignificantDigits: 3,
@@ -65,7 +83,7 @@ function priceFormatter(
     ...opts,
   };
   let num = Number(
-    new IntPretty(price).maxDecimals(2).locale(false).toString()
+    new IntPretty(price).maxDecimals(opts.maxDecimals).locale(false).toString()
   );
   num = isNaN(num) ? 0 : num;
   const formatter = new Intl.NumberFormat(price.fiatCurrency.locale, options);
@@ -75,10 +93,7 @@ function priceFormatter(
 /** Formats a coin as compact by default. i.e. $7.53 ATOM or $265 OSMO. Validate handled by `CoinPretty`. */
 function coinFormatter(
   coin: CoinPretty,
-  opts?: Partial<Intl.NumberFormatOptions> & {
-    hideCoinDenom?: boolean;
-    maxDecimals?: number;
-  }
+  opts: FormatOptionsWithDefaults = DEFAULT
 ): string {
   const { ...formatOpts } = opts || {};
   const options: Intl.NumberFormatOptions = {
@@ -88,7 +103,9 @@ function coinFormatter(
     style: "decimal",
     ...formatOpts,
   };
-  let num = Number(new IntPretty(coin).maxDecimals(2).locale(false).toString());
+  let num = Number(
+    new IntPretty(coin).maxDecimals(opts.maxDecimals).locale(false).toString()
+  );
   num = isNaN(num) ? 0 : num;
   const formatter = new Intl.NumberFormat("en-US", options);
   return [formatter.format(num), coin.currency.coinDenom.toUpperCase()].join(
@@ -99,7 +116,7 @@ function coinFormatter(
 /** Formats a coin as compact by default. i.e. $7.53 ATOM or $265 OSMO. Validate handled by `CoinPretty`. */
 function rateFormatter(
   rate: RatePretty,
-  opts?: Partial<Intl.NumberFormatOptions>
+  opts: FormatOptionsWithDefaults = DEFAULT
 ): string {
   const options: Intl.NumberFormatOptions = {
     maximumSignificantDigits: 3,
@@ -109,9 +126,20 @@ function rateFormatter(
     ...opts,
   };
   let num = Number(
-    new RatePretty(rate).maxDecimals(2).locale(false).symbol("").toString()
+    new RatePretty(rate)
+      .maxDecimals(opts.maxDecimals)
+      .locale(false)
+      .symbol("")
+      .toString()
   );
   num = isNaN(num) ? 0 : num;
   const formatter = new Intl.NumberFormat("en-US", options);
   return `${formatter.format(num)}${rate.options.symbol}`;
+}
+
+/** Copy opts and remove our custom format opts to reveal whether there are `Intl.NumberFormatOptions`. */
+function hasIntlFormatOptions(opts: FormatOptions) {
+  const copy = { ...opts };
+  if ("maxDecimals" in copy) delete copy.maxDecimals;
+  return Object.keys(copy).length > 0;
 }

--- a/packages/web/utils/formatter.ts
+++ b/packages/web/utils/formatter.ts
@@ -24,7 +24,10 @@ export function formatPretty(
   prettyValue: PricePretty | CoinPretty | RatePretty | Dec,
   opts: FormatOptions = {}
 ) {
-  const optsWithDefaults: FormatOptionsWithDefaults = { ...DEFAULT, ...opts };
+  const optsWithDefaults: FormatOptionsWithDefaults = {
+    ...{ ...DEFAULT },
+    ...opts,
+  };
   if (prettyValue instanceof PricePretty) {
     return priceFormatter(prettyValue, optsWithDefaults);
   } else if (prettyValue instanceof CoinPretty) {
@@ -49,6 +52,7 @@ function decFormatter(
     compactDisplay: "short",
     ...opts,
   };
+  console.log("opts max dec", opts.maxDecimals);
   const numStr = new IntPretty(dec)
     .maxDecimals(opts.maxDecimals)
     .locale(false)

--- a/packages/web/utils/formatter.ts
+++ b/packages/web/utils/formatter.ts
@@ -36,10 +36,19 @@ function decFormatter(
     compactDisplay: "short",
     ...opts,
   };
-  let num = Number(new IntPretty(dec).maxDecimals(2).locale(false).toString());
+  const numStr = new IntPretty(dec).maxDecimals(2).locale(false).toString();
+  let num = Number(numStr);
   num = isNaN(num) ? 0 : num;
-  const formatter = new Intl.NumberFormat("en", options);
-  return formatter.format(num);
+  if (Object.keys(opts ?? {}).length > 0) {
+    const formatter = new Intl.NumberFormat("en", options);
+    return formatter.format(num);
+  } else {
+    return new IntPretty(dec)
+      .maxDecimals(0)
+      .locale(false)
+      .shrink(true)
+      .toString();
+  }
 }
 
 /** Formats a price as compact by default. i.e. $7.53M or $265K. Validate handled by `PricePretty`. */

--- a/packages/web/utils/formatter.ts
+++ b/packages/web/utils/formatter.ts
@@ -52,7 +52,6 @@ function decFormatter(
     compactDisplay: "short",
     ...opts,
   };
-  console.log("opts max dec", opts.maxDecimals);
   const numStr = new IntPretty(dec)
     .maxDecimals(opts.maxDecimals)
     .locale(false)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

Use Dec to support larger direct price inputs. Note: it gets rounded to the nearest tick, so some values are not possible to directly input (especially larger prices). The original issue was likely caused by the Intl number formatter, so I created a way to get around that for Dec type. I use the IntPretty type to trim decimals still. Now all prices (even when rounded to ticks) are derived from raw user input, instead of being set as an action. You'll notice this when the input box is focused, the raw value is there but the derived value is displayed.

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/86780cqt2)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->
- Support large prices with Dec type

TODO
- [x] Support decimal input
- [x] Fix using slider

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

Enter large prices in both inputs.
