### PR TITLE
Sentry - disable local (let's try this again)

### DIFF
--- a/packages/web/sentry.client.config.ts
+++ b/packages/web/sentry.client.config.ts
@@ -5,10 +5,7 @@
 import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
-  dsn:
-    process.env.NODE_ENV === "development"
-      ? undefined
-      : "https://c696452bb7ce4cc98150142ebea1c32f@o4505285755600896.ingest.sentry.io/4505285757698048",
+  dsn: "https://c696452bb7ce4cc98150142ebea1c32f@o4505285755600896.ingest.sentry.io/4505285757698048",
 
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: 1,
@@ -23,6 +20,8 @@ Sentry.init({
   replaysSessionSampleRate: 0.1,
 
   environment: process.env.NODE_ENV || "development",
+
+  enabled: process.env.NODE_ENV !== "development",
 
   // You can remove this option if you're not planning to use the Sentry Session Replay feature:
   integrations: [

--- a/packages/web/sentry.edge.config.ts
+++ b/packages/web/sentry.edge.config.ts
@@ -6,14 +6,13 @@
 import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
-  dsn:
-    process.env.NODE_ENV === "development"
-      ? undefined
-      : "https://c696452bb7ce4cc98150142ebea1c32f@o4505285755600896.ingest.sentry.io/4505285757698048",
+  dsn: "https://c696452bb7ce4cc98150142ebea1c32f@o4505285755600896.ingest.sentry.io/4505285757698048",
 
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: 1,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,
+
+  enabled: process.env.NODE_ENV !== "development",
 });

--- a/packages/web/sentry.server.config.ts
+++ b/packages/web/sentry.server.config.ts
@@ -5,13 +5,12 @@
 import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
-  dsn:
-    process.env.NODE_ENV === "development"
-      ? undefined
-      : "https://c696452bb7ce4cc98150142ebea1c32f@o4505285755600896.ingest.sentry.io/4505285757698048",
+  dsn: "https://c696452bb7ce4cc98150142ebea1c32f@o4505285755600896.ingest.sentry.io/4505285757698048",
 
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: 1,
+
+  enabled: process.env.NODE_ENV !== "development",
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,


### PR DESCRIPTION
Disable Sentry locally

- it looks like there's an enabled key in the config, this seemed to work when I manually threw an error (this did not log to sentry)
- "TEST TEST TEST" error did not show in Sentry dashboard (or in Slack)
- context [here ](https://stackoverflow.com/questions/64687662/react-sentry-for-error-reporting-how-to-not-send-errors-from-dev-localhost)

<img width="909" alt="Screenshot 2023-07-10 at 3 43 37 PM" src="https://github.com/osmosis-labs/osmosis-frontend/assets/30577966/71837e1a-afbf-4982-a657-ed3956886dbe">

<img width="1481" alt="Screenshot 2023-07-10 at 3 46 43 PM" src="https://github.com/osmosis-labs/osmosis-frontend/assets/30577966/2fa433ef-30d9-4aa1-a773-bdc2d7f34627">



