### PR TITLE
test(CL): e2e zero for one swap tests

### DIFF
--- a/packages/stores/src/account/__tests_e2e__/swap-exact-in-positions.spec.ts
+++ b/packages/stores/src/account/__tests_e2e__/swap-exact-in-positions.spec.ts
@@ -211,45 +211,13 @@ describe("Test Swap Exact In - Concentrated Liquidity", () => {
     it("handles basic swap in the direction with liqudity, ofz (right)", async () => {
       await createDefaultValidPositions(new Int(150), new Int(151));
 
-      // get quote
-      const quote = await (
-        queryPool!.pool as ConcentratedLiquidityPool
-      ).getTokenOutByTokenIn(
-        { denom: defaultTokenInDenom, amount: defaultTokenInAmountInt },
-        defaultTokenOutDenom
-      );
-
-      // swap in using quote
-      const tx = await swapExactIn(
-        defaultTokenInDenom,
-        defaultTokenOutDenom,
-        defaultTokenInAmount,
-        quote.amount.toString()
-      );
-
-      // Validate amounts
-      validateAmountsFromTxEvents(tx, defaultTokenInAmountInt, quote.amount);
+      await runBasicSuccessTest(defaultTokenInAmountInt);
     });
 
     it("swap in the direction with far away liqudity with full range position existing, ofz (right)", async () => {
       await createDefaultValidPositions(maxTick.sub(new Int(100)), maxTick);
 
-      const quote = await (
-        queryPool!.pool as ConcentratedLiquidityPool
-      ).getTokenOutByTokenIn(
-        { denom: defaultTokenInDenom, amount: defaultTokenInAmountInt },
-        defaultTokenOutDenom
-      );
-
-      const tx = await swapExactIn(
-        defaultTokenInDenom,
-        defaultTokenOutDenom,
-        defaultTokenInAmount,
-        quote.amount.toString()
-      );
-
-      // Validate amounts
-      validateAmountsFromTxEvents(tx, defaultTokenInAmountInt, quote.amount);
+      await runBasicSuccessTest(defaultTokenInAmountInt);
     });
 
     it("swap in the direction with far away liqudity with NO full range position existing, ofz (right)", async () => {
@@ -258,22 +226,7 @@ describe("Test Swap Exact In - Concentrated Liquidity", () => {
 
       const tokenInAmount = new Int(1000000);
 
-      const amountOut = await (
-        queryPool!.pool as ConcentratedLiquidityPool
-      ).getTokenOutByTokenIn(
-        { denom: defaultTokenInDenom, amount: tokenInAmount },
-        defaultTokenOutDenom
-      );
-
-      const tx = await swapExactIn(
-        defaultTokenInDenom,
-        defaultTokenOutDenom,
-        tokenInAmount.toString(),
-        amountOut.amount.toString()
-      );
-
-      // Validate amounts
-      validateAmountsFromTxEvents(tx, tokenInAmount, amountOut.amount);
+      await runBasicSuccessTest(tokenInAmount);
     });
 
     it("swap in the direction with far away liqudity with NO full range position existing, ofz (right) (fails due to lack of precision, needs fixing)", async () => {
@@ -326,22 +279,7 @@ describe("Test Swap Exact In - Concentrated Liquidity", () => {
     it("swap in the direction with far away liqudity with full range position existing, ofz (right)", async () => {
       await createDefaultValidPositions(maxTick.sub(new Int(100)), maxTick);
 
-      const quote = await (
-        queryPool!.pool as ConcentratedLiquidityPool
-      ).getTokenOutByTokenIn(
-        { denom: defaultTokenInDenom, amount: defaultTokenInAmountInt },
-        defaultTokenOutDenom
-      );
-
-      const tx = await swapExactIn(
-        defaultTokenInDenom,
-        defaultTokenOutDenom,
-        defaultTokenInAmount,
-        quote.amount.toString()
-      );
-
-      // Validate amounts
-      validateAmountsFromTxEvents(tx, defaultTokenInAmountInt, quote.amount);
+      await runBasicSuccessTest(defaultTokenInAmountInt);
     });
 
     it("fails to swap in the direction where no liquidity exists ", async () => {
@@ -502,45 +440,13 @@ describe("Test Swap Exact In - Concentrated Liquidity", () => {
     it("handles basic swap in the direction with liqudity, zfo (left)", async () => {
       await createDefaultValidPositions(new Int(-151), new Int(-150));
 
-      // get quote
-      const quote = await (
-        queryPool!.pool as ConcentratedLiquidityPool
-      ).getTokenOutByTokenIn(
-        { denom: defaultTokenInDenom, amount: defaultTokenInAmountInt },
-        defaultTokenOutDenom
-      );
-
-      // swap in using quote
-      const tx = await swapExactIn(
-        defaultTokenInDenom,
-        defaultTokenOutDenom,
-        defaultTokenInAmount,
-        quote.amount.toString()
-      );
-
-      // Validate amounts
-      validateAmountsFromTxEvents(tx, defaultTokenInAmountInt, quote.amount);
+      await runBasicSuccessTest(defaultTokenInAmountInt);
     });
 
     it("swap in the direction with far away liqudity with full range position existing, zfo (left)", async () => {
       await createDefaultValidPositions(minTick, minTick.add(new Int(100)));
 
-      const quote = await (
-        queryPool!.pool as ConcentratedLiquidityPool
-      ).getTokenOutByTokenIn(
-        { denom: defaultTokenInDenom, amount: defaultTokenInAmountInt },
-        defaultTokenOutDenom
-      );
-
-      const tx = await swapExactIn(
-        defaultTokenInDenom,
-        defaultTokenOutDenom,
-        defaultTokenInAmount,
-        quote.amount.toString()
-      );
-
-      // Validate amounts
-      validateAmountsFromTxEvents(tx, defaultTokenInAmountInt, quote.amount);
+      await runBasicSuccessTest(defaultTokenInAmountInt);
     });
 
     it("swap in the direction with far away liqudity with NO full range position existing, zfo (left)", async () => {
@@ -549,22 +455,7 @@ describe("Test Swap Exact In - Concentrated Liquidity", () => {
 
       const tokenInAmount = new Int(1000000);
 
-      const amountOut = await (
-        queryPool!.pool as ConcentratedLiquidityPool
-      ).getTokenOutByTokenIn(
-        { denom: defaultTokenInDenom, amount: tokenInAmount },
-        defaultTokenOutDenom
-      );
-
-      const tx = await swapExactIn(
-        defaultTokenInDenom,
-        defaultTokenOutDenom,
-        tokenInAmount.toString(),
-        amountOut.amount.toString()
-      );
-
-      // Validate amounts
-      validateAmountsFromTxEvents(tx, tokenInAmount, amountOut.amount);
+      await runBasicSuccessTest(tokenInAmount);
     });
 
     it("swap in the direction with far away liqudity with NO full range position existing, ofz (right) (fails due to lack of precision, needs fixing)", async () => {
@@ -595,22 +486,7 @@ describe("Test Swap Exact In - Concentrated Liquidity", () => {
     it("swap in the direction with far away liqudity with full range position existing, zfo (left)", async () => {
       await createDefaultValidPositions(minTick, minTick.add(new Int(100)));
 
-      const quote = await (
-        queryPool!.pool as ConcentratedLiquidityPool
-      ).getTokenOutByTokenIn(
-        { denom: defaultTokenInDenom, amount: defaultTokenInAmountInt },
-        defaultTokenOutDenom
-      );
-
-      const tx = await swapExactIn(
-        defaultTokenInDenom,
-        defaultTokenOutDenom,
-        defaultTokenInAmount,
-        quote.amount.toString()
-      );
-
-      // Validate amounts
-      validateAmountsFromTxEvents(tx, defaultTokenInAmountInt, quote.amount);
+      await runBasicSuccessTest(defaultTokenInAmountInt);
     });
 
     it("fails to swap in the direction where no liquidity exists ", async () => {
@@ -703,6 +579,25 @@ describe("Test Swap Exact In - Concentrated Liquidity", () => {
         )
         .catch(reject);
     });
+  }
+
+  async function runBasicSuccessTest(tokenInAmount: Int) {
+    const quote = await (
+      queryPool!.pool as ConcentratedLiquidityPool
+    ).getTokenOutByTokenIn(
+      { denom: defaultTokenInDenom, amount: tokenInAmount },
+      defaultTokenOutDenom
+    );
+
+    const tx = await swapExactIn(
+      defaultTokenInDenom,
+      defaultTokenOutDenom,
+      tokenInAmount.toString(),
+      quote.amount.toString()
+    );
+
+    // Validate amounts
+    validateAmountsFromTxEvents(tx, tokenInAmount, quote.amount);
   }
 
   // creates 2 positions with default amounts:


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Adding swap e2e tests in zero for one direction

Noticed that in zero for one direction, an edge case we special-cased on chain is hit frequently:
https://github.com/osmosis-labs/osmosis/blob/844c172f50cb602b6af030e1d7abbca28d2dbddc/x/concentrated-liquidity/swaps.go#L400-L403

However, this is not launch blocking and happens when swapping directly to tick only

### ClickUp Task

https://app.clickup.com/t/860r9zvcv

## Brief Changelog
- added zero for one tests (same as one for zero but other direction)
- small refactor to reduce code duplication

## Testing and Verifying

This change has been tested locally by rebuilding the website and verified content and links are expected


## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? no
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
