### PR TITLE
refactor: CL math precision increase

### DIFF
--- a/packages/math/src/index.ts
+++ b/packages/math/src/index.ts
@@ -1,2 +1,3 @@
+export * from "./big-dec";
 export * from "./pool";
 export * from "./utils";

--- a/packages/math/src/pool/concentrated/__tests__/math.spec.ts
+++ b/packages/math/src/pool/concentrated/__tests__/math.spec.ts
@@ -1,9 +1,10 @@
 import { Dec } from "@keplr-wallet/unit";
 
+import { BigDec } from "../../../big-dec";
 import { checkMultiplicativeErrorTolerance } from "../../../rounding";
-import { smallestDec } from "../const";
+import { approxRoot } from "../../../utils";
+import { smallestBigDec, smallestDec } from "../const";
 import {
-  approxRoot,
   calcAmount0Delta,
   calcAmount1Delta,
   getFeeChargePerSwapStepOutGivenIn,
@@ -14,58 +15,57 @@ import {
 } from "../math";
 
 describe("calcAmount0Delta: matches chain code tests", () => {
-  // https://github.com/osmosis-labs/osmosis/blob/0f9eb3c1259078035445b3e3269659469b95fd9f/x/concentrated-liquidity/math/math_test.go#L160
+  // https://github.com/osmosis-labs/osmosis/blob/4c7238029997d7d4de1052b0a42f07da0b1dae85/x/concentrated-liquidity/math/math_test.go#L102
   it("normal case", () => {
-    const sqrtPriceA = new Dec("70.710678118654752440");
-    const sqrtPriceB = new Dec("74.161984870956629487");
-    const liquidity = new Dec("1517882343.751510418088349649");
+    const sqrtPriceA = new BigDec("70.710678118654752440");
+    const sqrtPriceB = new BigDec("74.161984870956629487");
+    const liquidity = new BigDec("1517882343.751510418088349649");
     const roundUp = false;
 
     const res = calcAmount0Delta(liquidity, sqrtPriceA, sqrtPriceB, roundUp);
 
-    expect(res.toString()).toBe("998976.618347426388356619");
+    expect(res.toString()).toBe("998976.618347426388356629926969277767437533");
   });
-  // https://github.com/osmosis-labs/osmosis/blob/0f9eb3c1259078035445b3e3269659469b95fd9f/x/concentrated-liquidity/math/math_test.go#L169
+  // https://github.com/osmosis-labs/osmosis/blob/4c7238029997d7d4de1052b0a42f07da0b1dae85/x/concentrated-liquidity/math/math_test.go#L120
   it("round down: large liquidity amount in wide price range", () => {
-    const sqrtPriceA = new Dec("0.000000152731791058");
-    const sqrtPriceB = new Dec("30860351331.852813530648276680");
-    const liquidity = new Dec("931361973132462178951297");
+    const sqrtPriceA = new BigDec("0.000000152731791058");
+    const sqrtPriceB = new BigDec("30860351331.852813530648276680");
+    const liquidity = new BigDec("931361973132462178951297");
     const roundUp = false;
 
     const res = calcAmount0Delta(liquidity, sqrtPriceA, sqrtPriceB, roundUp);
 
-    // with tolerance
-    const expected = new Dec(
-      "6098022989717817431593106314408.888128101590393209"
-    ).truncateDec();
+    const expected = new BigDec(
+      "6098022989717817431593106314408.88812810159039320984467945943"
+    );
 
     const tolerance = checkMultiplicativeErrorTolerance(
       expected,
       res,
-      smallestDec,
+      smallestBigDec,
       "roundDown"
     );
 
     expect(tolerance).toBe(0);
   });
-  // https://github.com/osmosis-labs/osmosis/blob/0f9eb3c1259078035445b3e3269659469b95fd9f/x/concentrated-liquidity/math/math_test.go#L189
+  // https://github.com/osmosis-labs/osmosis/blob/4c7238029997d7d4de1052b0a42f07da0b1dae85/x/concentrated-liquidity/math/math_test.go#L141
   it("round up: large liquidity amount in wide price range", () => {
-    const sqrtPriceA = new Dec("0.000000152731791058");
-    const sqrtPriceB = new Dec("30860351331.852813530648276680");
-    const liquidity = new Dec("931361973132462178951297");
+    const sqrtPriceA = new BigDec("0.000000152731791058");
+    const sqrtPriceB = new BigDec("30860351331.852813530648276680");
+    const liquidity = new BigDec("931361973132462178951297");
     const roundUp = true;
 
     const res = calcAmount0Delta(liquidity, sqrtPriceA, sqrtPriceB, roundUp);
 
     // with tolerance
-    const expected = new Dec(
+    const expected = new BigDec(
       "6098022989717817431593106314408.888128101590393209"
     ).roundUpDec();
 
     const tolerance = checkMultiplicativeErrorTolerance(
       expected,
       res,
-      smallestDec,
+      smallestBigDec,
       "roundUp"
     );
 
@@ -74,43 +74,43 @@ describe("calcAmount0Delta: matches chain code tests", () => {
 });
 
 describe("calcAmount1Delta: matches chain code test", () => {
-  // https://github.com/osmosis-labs/osmosis/blob/0f9eb3c1259078035445b3e3269659469b95fd9f/x/concentrated-liquidity/math/math_test.go#L252
+  // https://github.com/osmosis-labs/osmosis/blob/4c7238029997d7d4de1052b0a42f07da0b1dae85/x/concentrated-liquidity/math/math_test.go#L204
   it("normal case", () => {
-    const sqrtPriceA = new Dec("70.710678118654752440");
-    const sqrtPriceB = new Dec("67.416615162732695594");
-    const liquidity = new Dec("1517882343.751510418088349649");
+    const sqrtPriceA = new BigDec("70.710678118654752440");
+    const sqrtPriceB = new BigDec("67.416615162732695594");
+    const liquidity = new BigDec("1517882343.751510418088349649");
 
     const res = calcAmount1Delta(liquidity, sqrtPriceA, sqrtPriceB, false);
 
     expect(res.toString()).toBe(
-      new Dec("5000000000.000000000000000000").sub(smallestDec).toString()
+      "4999999999.999999999999999999696837821702147054"
     );
   });
-  // https://github.com/osmosis-labs/osmosis/blob/0f9eb3c1259078035445b3e3269659469b95fd9f/x/concentrated-liquidity/math/math_test.go#L260
+  // https://github.com/osmosis-labs/osmosis/blob/4c7238029997d7d4de1052b0a42f07da0b1dae85/x/concentrated-liquidity/math/math_test.go#L212
   it("round down: large liquidity amount in wide price range", () => {
-    const sqrtPriceA = new Dec("0.000000152731791058");
-    const sqrtPriceB = new Dec("30860351331.852813530648276680");
-    const liquidity = new Dec("931361973132462178951297");
+    const sqrtPriceA = new BigDec("0.000000152731791058");
+    const sqrtPriceB = new BigDec("30860351331.852813530648276680");
+    const liquidity = new BigDec("931361973132462178951297");
     const roundUp = false;
 
     const res = calcAmount1Delta(liquidity, sqrtPriceA, sqrtPriceB, roundUp);
 
-    const expected = new Dec(
+    const expected = new BigDec(
       "28742157707995443393876876754535992.801567623738751734"
     );
 
     expect(res.toString()).toBe(expected.toString());
   });
-  // https://github.com/osmosis-labs/osmosis/blob/77c0aa5a5572dc09d6d43ddf75f3bf47683f53d7/x/concentrated-liquidity/math/math_test.go#L278
+  // https://github.com/osmosis-labs/osmosis/blob/4c7238029997d7d4de1052b0a42f07da0b1dae85/x/concentrated-liquidity/math/math_test.go#L231
   it("round up: large liquidity amount in wide price range", () => {
-    const sqrtPriceA = new Dec("0.000000152731791058");
-    const sqrtPriceB = new Dec("30860351331.852813530648276680");
-    const liquidity = new Dec("931361973132462178951297");
+    const sqrtPriceA = new BigDec("0.000000152731791058");
+    const sqrtPriceB = new BigDec("30860351331.852813530648276680");
+    const liquidity = new BigDec("931361973132462178951297");
     const roundUp = true;
 
     const res = calcAmount1Delta(liquidity, sqrtPriceA, sqrtPriceB, roundUp);
 
-    const expected = new Dec(
+    const expected = new BigDec(
       "28742157707995443393876876754535992.801567623738751734"
     ).roundUpDec();
 
@@ -119,11 +119,11 @@ describe("calcAmount1Delta: matches chain code test", () => {
 });
 
 describe("getNextSqrtPriceFromAmount0InRoundingUp", () => {
-  // https://www.github.com/osmosis-labs/osmosis/blob/fffe3a2ad32a8c51d654212e70dfa1e8eff5f323/x/concentrated-liquidity/internal/math/math_test.go#L96
+  // https://github.com/osmosis-labs/osmosis/blob/4c7238029997d7d4de1052b0a42f07da0b1dae85/x/concentrated-liquidity/math/math_test.go#L414
   it("matches chain code test", () => {
-    const sqrtPriceCurrent = new Dec("70.710678118654752440");
-    const liquidity = new Dec("1517882343.751510418088349649");
-    const amountRemaining = new Dec(13370);
+    const sqrtPriceCurrent = new BigDec("70.710678118654752440");
+    const liquidity = new BigDec("1517882343.751510418088349649");
+    const amountRemaining = new BigDec(13370);
 
     const res = getNextSqrtPriceFromAmount0InRoundingUp(
       sqrtPriceCurrent,
@@ -131,13 +131,13 @@ describe("getNextSqrtPriceFromAmount0InRoundingUp", () => {
       amountRemaining
     );
 
-    expect(res.toString()).toBe("70.666663910857144332");
+    expect(res.toString()).toBe("70.666663910857144331148691821263626767");
   });
 
   it("returns current price if amount remaining is zero", () => {
-    const sqrtPriceCurrent = new Dec("70.710678118654752440");
-    const liquidity = new Dec("1517882343.751510418088349649");
-    const amountRemaining = new Dec(0);
+    const sqrtPriceCurrent = new BigDec("70.710678118654752440");
+    const liquidity = new BigDec("1517882343.751510418088349649");
+    const amountRemaining = new BigDec(0);
 
     const res = getNextSqrtPriceFromAmount0InRoundingUp(
       sqrtPriceCurrent,
@@ -145,16 +145,16 @@ describe("getNextSqrtPriceFromAmount0InRoundingUp", () => {
       amountRemaining
     );
 
-    expect(res.toString()).toBe("70.710678118654752440");
+    expect(res.toString()).toBe("70.710678118654752440000000000000000000");
   });
 });
 
 describe("getNextSqrtPriceFromAmount1InRoundingDown", () => {
-  // https://github.com/osmosis-labs/osmosis/blob/fffe3a2ad32a8c51d654212e70dfa1e8eff5f323/x/concentrated-liquidity/internal/math/math_test.go#L126
+  // https://github.com/osmosis-labs/osmosis/blob/4c7238029997d7d4de1052b0a42f07da0b1dae85/x/concentrated-liquidity/math/math_test.go#L463
   it("matches chain code test", () => {
-    const sqrtPriceCurrent = new Dec("70.710678118654752440");
-    const liquidity = new Dec("1519437308.014768571721000000");
-    const amountRemaining = new Dec(42000000);
+    const sqrtPriceCurrent = new BigDec("70.710678118654752440");
+    const liquidity = new BigDec("1519437308.014768571721000000");
+    const amountRemaining = new BigDec(42000000);
 
     const res = getNextSqrtPriceFromAmount1InRoundingDown(
       sqrtPriceCurrent,
@@ -162,15 +162,15 @@ describe("getNextSqrtPriceFromAmount1InRoundingDown", () => {
       amountRemaining
     );
 
-    expect(res.toString()).toBe("70.738319930382329008");
+    expect(res.toString()).toBe("70.738319930382329008049494613660784220");
   });
 
   // more
-  // https://github.com/osmosis-labs/osmosis/blob/fffe3a2ad32a8c51d654212e70dfa1e8eff5f323/x/concentrated-liquidity/internal/math/math_test.go#L325
+  // https://github.com/osmosis-labs/osmosis/blob/4c7238029997d7d4de1052b0a42f07da0b1dae85/x/concentrated-liquidity/math/math_test.go#L449
   it("matches chain code test -- rounded down at precision end", () => {
-    const sqrtPriceCurrent = new Dec("70.710678118654752440");
-    const liquidity = new Dec("3035764687.503020836176699298");
-    const amountRemaining = new Dec("8398");
+    const sqrtPriceCurrent = new BigDec("70.710678118654752440");
+    const liquidity = new BigDec("3035764687.503020836176699298");
+    const amountRemaining = new BigDec("8398");
 
     const res = getNextSqrtPriceFromAmount1InRoundingDown(
       sqrtPriceCurrent,
@@ -178,12 +178,12 @@ describe("getNextSqrtPriceFromAmount1InRoundingDown", () => {
       amountRemaining
     );
 
-    expect(res.toString()).toBe("70.710680885008822823");
+    expect(res.toString()).toBe("70.710680885008822823343339270800000167");
   });
   it("matches chain code test -- no round up due zeroes at precision end", () => {
-    const sqrtPriceCurrent = new Dec("2.5");
-    const liquidity = new Dec("1");
-    const amountRemaining = new Dec("10");
+    const sqrtPriceCurrent = new BigDec("2.5");
+    const liquidity = new BigDec("1");
+    const amountRemaining = new BigDec("10");
 
     const res = getNextSqrtPriceFromAmount1InRoundingDown(
       sqrtPriceCurrent,
@@ -191,16 +191,16 @@ describe("getNextSqrtPriceFromAmount1InRoundingDown", () => {
       amountRemaining
     );
 
-    expect(res.toString()).toBe("12.500000000000000000");
+    expect(res.toString()).toBe("12.500000000000000000000000000000000000");
   });
 });
 
 describe("getNextSqrtPriceFromAmount0OutRoundingUp", () => {
-  // https://github.com/osmosis-labs/osmosis/blob/fffe3a2ad32a8c51d654212e70dfa1e8eff5f323/x/concentrated-liquidity/internal/math/math_test.go#L288
+  // https://github.com/osmosis-labs/osmosis/blob/4c7238029997d7d4de1052b0a42f07da0b1dae85/x/concentrated-liquidity/math/math_test.go#L428
   it("matches chain code test -- rounded up at precision end", () => {
-    const sqrtPriceCurrent = new Dec("70.710678118654752440");
-    const liquidity = new Dec("3035764687.503020836176699298");
-    const amountRemaining = new Dec("8398");
+    const sqrtPriceCurrent = new BigDec("70.710678118654752440");
+    const liquidity = new BigDec("3035764687.503020836176699298");
+    const amountRemaining = new BigDec("8398");
 
     const res = getNextSqrtPriceFromAmount0OutRoundingUp(
       sqrtPriceCurrent,
@@ -208,12 +208,12 @@ describe("getNextSqrtPriceFromAmount0OutRoundingUp", () => {
       amountRemaining
     );
 
-    expect(res.toString()).toBe("70.724512595179305566");
+    expect(res.toString()).toBe("70.724512595179305565323229510645063950");
   });
   it("matches chain code test -- no round up due zeroes at precision end", () => {
-    const sqrtPriceCurrent = new Dec("2");
-    const liquidity = new Dec("10");
-    const amountRemaining = new Dec("1");
+    const sqrtPriceCurrent = new BigDec("2");
+    const liquidity = new BigDec("10");
+    const amountRemaining = new BigDec("1");
 
     const res = getNextSqrtPriceFromAmount0OutRoundingUp(
       sqrtPriceCurrent,
@@ -221,16 +221,16 @@ describe("getNextSqrtPriceFromAmount0OutRoundingUp", () => {
       amountRemaining
     );
 
-    expect(res.toString()).toBe("2.500000000000000000");
+    expect(res.toString()).toBe("2.500000000000000000000000000000000000");
   });
 });
 
 describe("getNextsqrtPriceFromAmount1OutRoundingDown", () => {
-  // https://github.com/osmosis-labs/osmosis/blob/fffe3a2ad32a8c51d654212e70dfa1e8eff5f323/x/concentrated-liquidity/internal/math/math_test.go#L362
+  // https://github.com/osmosis-labs/osmosis/blob/4c7238029997d7d4de1052b0a42f07da0b1dae85/x/concentrated-liquidity/math/math_test.go#L477
   it("matches chain code test -- rounded down at precision end", () => {
-    const sqrtPriceCurrent = new Dec("70.710678118654752440");
-    const liquidity = new Dec("3035764687.503020836176699298");
-    const amountRemaining = new Dec("8398");
+    const sqrtPriceCurrent = new BigDec("70.710678118654752440");
+    const liquidity = new BigDec("3035764687.503020836176699298");
+    const amountRemaining = new BigDec("8398");
 
     const res = getNextSqrtPriceFromAmount1OutRoundingDown(
       sqrtPriceCurrent,
@@ -238,12 +238,12 @@ describe("getNextsqrtPriceFromAmount1OutRoundingDown", () => {
       amountRemaining
     );
 
-    expect(res.toString()).toBe("70.710675352300682056");
+    expect(res.toString()).toBe("70.710675352300682056656660729199999832");
   });
   it("matches chain code test -- no round up due zeroes at precision end", () => {
-    const sqrtPriceCurrent = new Dec("12.5");
-    const liquidity = new Dec("1");
-    const amountRemaining = new Dec("10");
+    const sqrtPriceCurrent = new BigDec("12.5");
+    const liquidity = new BigDec("1");
+    const amountRemaining = new BigDec("10");
 
     const res = getNextSqrtPriceFromAmount1OutRoundingDown(
       sqrtPriceCurrent,
@@ -251,7 +251,7 @@ describe("getNextsqrtPriceFromAmount1OutRoundingDown", () => {
       amountRemaining
     );
 
-    expect(res.toString()).toBe("2.500000000000000000");
+    expect(res.toString()).toBe("2.500000000000000000000000000000000000");
   });
 });
 
@@ -270,7 +270,7 @@ describe("getFeeChargePerSwapStepOutGivenIn", () => {
       fee
     );
 
-    const expectedRes = new Dec(100).mul(fee).quo(new Dec(1).sub(fee));
+    const expectedRes = new Dec(100).mul(fee).quoRoundUp(new Dec(1).sub(fee));
     expect(res.toString()).toBe(expectedRes.toString());
   });
   it("matches chain code test -- did not reach target -> charge fee on the difference between amount remaining and amount in", () => {

--- a/packages/math/src/pool/concentrated/__tests__/quotes.spec.ts
+++ b/packages/math/src/pool/concentrated/__tests__/quotes.spec.ts
@@ -1,14 +1,15 @@
 import { Coin, Dec, Int } from "@keplr-wallet/unit";
 
+import { BigDec } from "../../../big-dec";
 import { maxTick } from "../const";
 import { calcInGivenOut, ConcentratedLiquidityMath } from "../quotes";
 const { calcOutGivenIn } = ConcentratedLiquidityMath;
 
 describe("calcOutGivenIn matches chain code", () => {
-  // Note: liquidity value for the default position is 1517882343.751510418088349649
+  // Note: liquidity value for the default position is 1517882343.751510417627556287
   describe("without fees, base case", () => {
     // eth is denom0
-    // https://github.com/osmosis-labs/osmosis/blob/2be30828d8c8a818652a15c3c19ae27b4c123c60/x/concentrated-liquidity/swaps_test.go#L63
+    // https://github.com/osmosis-labs/osmosis/blob/4c7238029997d7d4de1052b0a42f07da0b1dae85/x/concentrated-liquidity/swaps_test.go#L84
     //  One price range
     //
     //          5000
@@ -16,19 +17,19 @@ describe("calcOutGivenIn matches chain code", () => {
     it("single position within one tick: usdc -> eth", () => {
       const tokenIn = new Coin("usdc", "42000000");
       const tokenDenom0 = "eth";
-      const poolLiquidity = new Dec("1517882343.751510418088349649");
+      const poolLiquidity = new Dec("1517882343.751510417627556287");
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
-          tickIndex: new Int(305450),
-          netLiquidity: new Dec("1517882343.751510418088349649"),
+          tickIndex: new Int(30545000),
+          netLiquidity: new Dec("1517882343.751510417627556287"),
         },
         {
-          tickIndex: new Int(315000),
-          netLiquidity: new Dec("-1517882343.751510418088349649"),
+          tickIndex: new Int(31500000),
+          netLiquidity: new Dec("-1517882343.751510417627556287"),
         },
       ];
-      const curSqrtPrice = new Dec("70.710678118654752440");
+      const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0");
       const result = calcOutGivenIn({
         tokenIn,
@@ -41,9 +42,11 @@ describe("calcOutGivenIn matches chain code", () => {
       if (result === "no-more-ticks") throw new Error("no more ticks");
       const { amountOut, afterSqrtPrice } = result;
       expect(amountOut.toString()).toEqual("8396");
-      expect(afterSqrtPrice.toString()).toEqual("70.738348247484497717");
+      expect(afterSqrtPrice).toEqual(
+        new BigDec("70.738348247484497718514800000003600626")
+      );
     });
-    // https://github.com/osmosis-labs/osmosis/blob/e7b5c4a6f88004fe8a6976fd7e4cb5e90339d629/x/concentrated-liquidity/swaps_test.go#L92
+    // https://github.com/osmosis-labs/osmosis/blob/844c172f50cb602b6af030e1d7abbca28d2dbddc/x/concentrated-liquidity/swaps_test.go#L166
     //  One price range
     //
     //          5000
@@ -51,19 +54,19 @@ describe("calcOutGivenIn matches chain code", () => {
     it("single position within one tick: eth -> usdc", () => {
       const tokenIn = new Coin("eth", "13370");
       const tokenDenom0 = "eth";
-      const poolLiquidity = new Dec("1517882343.751510418088349649");
+      const poolLiquidity = new Dec("1517882343.751510417627556287");
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
-          tickIndex: new Int(305450),
-          netLiquidity: new Dec("1517882343.751510418088349649"),
+          tickIndex: new Int(30545000),
+          netLiquidity: new Dec("1517882343.751510417627556287"),
         },
         {
-          tickIndex: new Int(315000),
-          netLiquidity: new Dec("-1517882343.751510418088349649"),
+          tickIndex: new Int(31500000),
+          netLiquidity: new Dec("-1517882343.751510417627556287"),
         },
       ];
-      const curSqrtPrice = new Dec("70.710678118654752440");
+      const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0");
       const result = calcOutGivenIn({
         tokenIn,
@@ -76,7 +79,9 @@ describe("calcOutGivenIn matches chain code", () => {
       if (result === "no-more-ticks") throw new Error("no more ticks");
       const { amountOut, afterSqrtPrice } = result;
       expect(amountOut.toString()).toEqual("66808388");
-      expect(afterSqrtPrice.toString()).toEqual("70.666663910857144332");
+      expect(afterSqrtPrice.toString()).toEqual(
+        "70.666663910857144332134093938182290274"
+      );
     });
     // https://github.com/osmosis-labs/osmosis/blob/e7b5c4a6f88004fe8a6976fd7e4cb5e90339d629/x/concentrated-liquidity/swaps_test.go#L115
     //  Two equal price ranges
@@ -87,15 +92,15 @@ describe("calcOutGivenIn matches chain code", () => {
     it("two positions within one tick: usdc -> eth", () => {
       const tokenIn = new Coin("usdc", "42000000");
       const tokenDenom0 = "eth";
-      const poolLiquidity = new Dec("3035764687.503020836176699298");
+      const poolLiquidity = new Dec("3035764687.503020835255112574");
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
-          tickIndex: new Int(315000),
-          netLiquidity: new Dec("-3035764687.503020836176699298"),
+          tickIndex: new Int(31500000),
+          netLiquidity: new Dec("-3035764687.503020835255112574"),
         },
       ];
-      const curSqrtPrice = new Dec("70.710678118654752440");
+      const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0");
       const result = calcOutGivenIn({
         tokenIn,
@@ -107,10 +112,12 @@ describe("calcOutGivenIn matches chain code", () => {
       });
       if (result === "no-more-ticks") throw new Error("no more ticks");
       const { amountOut, afterSqrtPrice } = result;
+      expect(afterSqrtPrice.toString()).toEqual(
+        "70.724513183069625079757400000001800313"
+      );
       expect(amountOut.toString()).toEqual("8398");
-      expect(afterSqrtPrice.toString()).toEqual("70.724513183069625078");
     });
-    // https://github.com/osmosis-labs/osmosis/blob/e7b5c4a6f88004fe8a6976fd7e4cb5e90339d629/x/concentrated-liquidity/swaps_test.go#L138
+    // https://github.com/osmosis-labs/osmosis/blob/844c172f50cb602b6af030e1d7abbca28d2dbddc/x/concentrated-liquidity/swaps_test.go#L277
     //  Two equal price ranges
     //
     //          5000
@@ -119,19 +126,19 @@ describe("calcOutGivenIn matches chain code", () => {
     it("two positions within one tick: eth -> usdc", () => {
       const tokenIn = new Coin("eth", "13370");
       const tokenDenom0 = "eth";
-      const poolLiquidity = new Dec("3035764687.503020836176699298");
+      const poolLiquidity = new Dec("3035764687.503020835255112574");
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
           tickIndex: new Int(305450),
-          netLiquidity: new Dec("1517882343.751510418088349649"),
+          netLiquidity: new Dec("1517882343.751510417627556287"),
         },
         {
           tickIndex: new Int(315000),
-          netLiquidity: new Dec("-1517882343.751510418088349649"),
+          netLiquidity: new Dec("-1517882343.751510417627556287"),
         },
       ];
-      const curSqrtPrice = new Dec("70.710678118654752440");
+      const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0");
       const result = calcOutGivenIn({
         tokenIn,
@@ -144,9 +151,11 @@ describe("calcOutGivenIn matches chain code", () => {
       if (result === "no-more-ticks") throw new Error("no more ticks");
       const { amountOut, afterSqrtPrice } = result;
       expect(amountOut.toString()).toEqual("66829187");
-      expect(afterSqrtPrice.toString()).toEqual("70.688664163408836320");
+      expect(afterSqrtPrice.toString()).toEqual(
+        "70.688664163408836320215015370847179540"
+      );
     });
-    // https://github.com/osmosis-labs/osmosis/blob/e7b5c4a6f88004fe8a6976fd7e4cb5e90339d629/x/concentrated-liquidity/swaps_test.go#L167
+    // https://github.com/osmosis-labs/osmosis/blob/844c172f50cb602b6af030e1d7abbca28d2dbddc/x/concentrated-liquidity/swaps_test.go#L321
     //  Consecutive price ranges
     //          5000
     //  4545 -----|----- 5500
@@ -154,19 +163,19 @@ describe("calcOutGivenIn matches chain code", () => {
     it("two positions with consecutive price ranges: usdc -> eth", () => {
       const tokenIn = new Coin("usdc", "10000000000");
       const tokenDenom0 = "eth";
-      const poolLiquidity = new Dec("1517882343.751510418088349649");
+      const poolLiquidity = new Dec("1517882343.751510417627556287");
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
           tickIndex: new Int(31500000),
-          netLiquidity: new Dec("-320114898.796002294865348513"),
+          netLiquidity: new Dec("-320114898.796002294143710268"),
         },
         {
-          tickIndex: new Int(32250000),
-          netLiquidity: new Dec("-1197767444.955508123223001136"),
+          tickIndex: new Int(32250000), // this tick's sqrt price ends up being calculated differently from chain.
+          netLiquidity: new Dec("-1197767444.955508123483846019"),
         },
       ];
-      const curSqrtPrice = new Dec("70.710678118654752440");
+      const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0");
       const result = calcOutGivenIn({
         tokenIn,
@@ -179,9 +188,14 @@ describe("calcOutGivenIn matches chain code", () => {
       if (result === "no-more-ticks") throw new Error("no more ticks");
       const { amountOut, afterSqrtPrice } = result;
       expect(amountOut.toString()).toEqual("1820630");
-      expect(afterSqrtPrice.toString()).toEqual("78.137149196095607129");
+      // TODO: Note this value is actually off by 10^-18 which seems to stem from the difference
+      // in the sqrt function. On-chain out sqrt is monotonic.
+      // True value: 78.137149196095607130096044752300452857
+      expect(afterSqrtPrice).toEqual(
+        new BigDec("78.137149196095607129096044752300452857")
+      );
     });
-    // https://github.com/osmosis-labs/osmosis/blob/e7b5c4a6f88004fe8a6976fd7e4cb5e90339d629/x/concentrated-liquidity/swaps_test.go#L206
+    // https://github.com/osmosis-labs/osmosis/blob/844c172f50cb602b6af030e1d7abbca28d2dbddc/x/concentrated-liquidity/swaps_test.go#L376
     //  Consecutive price ranges
     //          5000
     //  4545 -----|----- 5500
@@ -189,19 +203,19 @@ describe("calcOutGivenIn matches chain code", () => {
     it("two positions with consecutive price ranges: eth -> usdc", () => {
       const tokenIn = new Coin("eth", "2000000");
       const tokenDenom0 = "eth";
-      const poolLiquidity = new Dec("1517882343.751510418088349649");
+      const poolLiquidity = new Dec("1517882343.751510417627556287");
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
           tickIndex: new Int(30545000),
-          netLiquidity: new Dec("319146854.154260122418390252"),
+          netLiquidity: new Dec("319146854.154260121957596890"),
         },
         {
           tickIndex: new Int(30000000),
-          netLiquidity: new Dec("1198735489.597250295669959397"),
+          netLiquidity: new Dec("1199528406.18741366948159633"),
         },
       ];
-      const curSqrtPrice = new Dec("70.710678118654752440");
+      const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0");
       const result = calcOutGivenIn({
         tokenIn,
@@ -213,18 +227,19 @@ describe("calcOutGivenIn matches chain code", () => {
       });
       if (result === "no-more-ticks") throw new Error("no more ticks");
       const { amountOut, afterSqrtPrice } = result;
+      expect(afterSqrtPrice.toString()).toEqual(
+        "63.993489023323078692803734142129673908"
+      );
       expect(amountOut.toString()).toEqual("9103422788");
-      expect(afterSqrtPrice.toString()).toEqual("63.993489023323078693");
     });
-    // https://github.com/osmosis-labs/osmosis/blob/e7b5c4a6f88004fe8a6976fd7e4cb5e90339d629/x/concentrated-liquidity/swaps_test.go#L241
-    ///  Partially overlapping price ranges
+    // https://github.com/osmosis-labs/osmosis/blob/844c172f50cb602b6af030e1d7abbca28d2dbddc/x/concentrated-liquidity/swaps_test.go#L433
     //          5000
     //  4545 -----|----- 5500
     //        5001 ----------- 6250
     it("two positions with partially overlapping price ranges: usdc -> eth", () => {
       const tokenIn = new Coin("usdc", "10000000000");
       const tokenDenom0 = "eth";
-      const poolLiquidity = new Dec("1517882343.751510418088349649");
+      const poolLiquidity = new Dec("1517882343.751510417627556287");
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
@@ -233,14 +248,14 @@ describe("calcOutGivenIn matches chain code", () => {
         },
         {
           tickIndex: new Int(31500000),
-          netLiquidity: new Dec("-1517882343.751510418088349649"),
+          netLiquidity: new Dec("-1517882343.751510417627556287"),
         },
         {
           tickIndex: new Int(32250000),
           netLiquidity: new Dec("-670416088.605668727039240782"),
         },
       ];
-      const curSqrtPrice = new Dec("70.710678118654752440");
+      const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0");
       const result = calcOutGivenIn({
         tokenIn,
@@ -253,13 +268,18 @@ describe("calcOutGivenIn matches chain code", () => {
       if (result === "no-more-ticks") throw new Error("no more ticks");
       const { amountOut, afterSqrtPrice } = result;
       expect(amountOut.toString()).toEqual("1864161");
-      expect(afterSqrtPrice.toString()).toEqual("77.819789636800169392");
+      // TODO: Note this value is actually off by 10^-18 which seems to stem from the difference
+      // in the sqrt function. On-chain out sqrt is monotonic.
+      // 77.819789636800169393792766394158739007
+      expect(afterSqrtPrice.toString()).toEqual(
+        "77.819789636800169392792766394158739007"
+      );
     });
-    // https://github.com/osmosis-labs/osmosis/blob/e7b5c4a6f88004fe8a6976fd7e4cb5e90339d629/x/concentrated-liquidity/swaps_test.go#L273
+    // https://github.com/osmosis-labs/osmosis/blob/844c172f50cb602b6af030e1d7abbca28d2dbddc/x/concentrated-liquidity/swaps_test.go#L487
     it("two positions with partially overlapping price ranges, not utilizing full liquidity of second position: usdc -> eth", () => {
       const tokenIn = new Coin("usdc", "8500000000");
       const tokenDenom0 = "eth";
-      const poolLiquidity = new Dec("1517882343.751510418088349649");
+      const poolLiquidity = new Dec("1517882343.751510417627556287");
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
@@ -268,14 +288,14 @@ describe("calcOutGivenIn matches chain code", () => {
         },
         {
           tickIndex: new Int(31500000),
-          netLiquidity: new Dec("-1517882343.751510418088349649"),
+          netLiquidity: new Dec("-1517882343.751510417627556287"),
         },
         {
           tickIndex: new Int(32250000),
           netLiquidity: new Dec("-670416088.605668727039240782"),
         },
       ];
-      const curSqrtPrice = new Dec("70.710678118654752440");
+      const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0");
       const result = calcOutGivenIn({
         tokenIn,
@@ -288,9 +308,12 @@ describe("calcOutGivenIn matches chain code", () => {
       if (result === "no-more-ticks") throw new Error("no more ticks");
       const { amountOut, afterSqrtPrice } = result;
       expect(amountOut.toString()).toEqual("1609138");
-      expect(afterSqrtPrice.toString()).toEqual("75.582373164412551491");
+      // 75.582373164412551492069079174313215667
+      expect(afterSqrtPrice.toString()).toEqual(
+        "75.582373164412551491069079174313215667"
+      );
     });
-    // https://github.com/osmosis-labs/osmosis/blob/e7b5c4a6f88004fe8a6976fd7e4cb5e90339d629/x/concentrated-liquidity/swaps_test.go#L309
+    // https://github.com/osmosis-labs/osmosis/blob/844c172f50cb602b6af030e1d7abbca28d2dbddc/x/concentrated-liquidity/swaps_test.go#L553
     //  Partially overlapping price ranges
     //                5000
     //        4545 -----|----- 5500
@@ -298,7 +321,7 @@ describe("calcOutGivenIn matches chain code", () => {
     it("two positions with partially overlapping price ranges: eth -> usdc", () => {
       const tokenIn = new Coin("eth", "2000000");
       const tokenDenom0 = "eth";
-      const poolLiquidity = new Dec("1517882343.751510418088349649");
+      const poolLiquidity = new Dec("1517882343.751510417627556287");
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
@@ -307,14 +330,14 @@ describe("calcOutGivenIn matches chain code", () => {
         },
         {
           tickIndex: new Int(30545000),
-          netLiquidity: new Dec("1517882343.751510418088349649"),
+          netLiquidity: new Dec("1517882343.751510417627556287"),
         },
         {
           tickIndex: new Int(30000000),
           netLiquidity: new Dec("670416215.718827443660400593"),
         },
       ];
-      const curSqrtPrice = new Dec("70.710678118654752440");
+      const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0");
       const result = calcOutGivenIn({
         tokenIn,
@@ -327,7 +350,9 @@ describe("calcOutGivenIn matches chain code", () => {
       if (result === "no-more-ticks") throw new Error("no more ticks");
       const { amountOut, afterSqrtPrice } = result;
       expect(amountOut.toString()).toEqual("9321276930");
-      expect(afterSqrtPrice.toString()).toEqual("64.257943794993248954");
+      expect(afterSqrtPrice.toString()).toEqual(
+        "64.257943794993248953756640624575523292"
+      );
     });
     // https://github.com/osmosis-labs/osmosis/blob/e7b5c4a6f88004fe8a6976fd7e4cb5e90339d629/x/concentrated-liquidity/swaps_test.go#L339
     //          		5000
@@ -336,7 +361,7 @@ describe("calcOutGivenIn matches chain code", () => {
     it("two positions with partially overlapping price ranges, not utilizing full liquidity of second position: eth -> usdc", () => {
       const tokenIn = new Coin("eth", "1800000");
       const tokenDenom0 = "eth";
-      const poolLiquidity = new Dec("1517882343.751510418088349649");
+      const poolLiquidity = new Dec("1517882343.751510417627556287");
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
@@ -345,14 +370,14 @@ describe("calcOutGivenIn matches chain code", () => {
         },
         {
           tickIndex: new Int(30545000),
-          netLiquidity: new Dec("1517882343.751510418088349649"),
+          netLiquidity: new Dec("1517882343.751510417627556287"),
         },
         {
           tickIndex: new Int(30000000),
           netLiquidity: new Dec("670416215.718827443660400593"),
         },
       ];
-      const curSqrtPrice = new Dec("70.710678118654752440");
+      const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0");
       const result = calcOutGivenIn({
         tokenIn,
@@ -365,32 +390,34 @@ describe("calcOutGivenIn matches chain code", () => {
       if (result === "no-more-ticks") throw new Error("no more ticks");
       const { amountOut, afterSqrtPrice } = result;
       expect(amountOut.toString()).toEqual("8479320318");
-      expect(afterSqrtPrice.toString()).toEqual("65.513815285481060960");
+      expect(afterSqrtPrice.toString()).toEqual(
+        "65.513815285481060959469337552596846421"
+      );
     });
-    // https://github.com/osmosis-labs/osmosis/blob/e7b5c4a6f88004fe8a6976fd7e4cb5e90339d629/x/concentrated-liquidity/swaps_test.go#L372
+    // https://github.com/osmosis-labs/osmosis/blob/844c172f50cb602b6af030e1d7abbca28d2dbddc/x/concentrated-liquidity/swaps_test.go#L678
     //          5000
     //  4545 -----|----- 5500
     //              5501 ----------- 6250
     it("two sequential positions with a gap: usdc -> eth", () => {
       const tokenIn = new Coin("usdc", "10000000000");
       const tokenDenom0 = "eth";
-      const poolLiquidity = new Dec("1517882343.751510418088349649");
+      const poolLiquidity = new Dec("1517882343.751510417627556287");
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
           tickIndex: new Int(31500000),
-          netLiquidity: new Dec("-1517882343.751510418088349649"),
+          netLiquidity: new Dec("-1517882343.751510417627556287"),
         },
         {
           tickIndex: new Int(31501000),
-          netLiquidity: new Dec("1199528406.187413669220031452"),
+          netLiquidity: new Dec("1199528406.18741366948159633"),
         },
         {
           tickIndex: new Int(32250000),
           netLiquidity: new Dec("670416215.718827443660400593"),
         },
       ];
-      const curSqrtPrice = new Dec("70.710678118654752440");
+      const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0");
       const result = calcOutGivenIn({
         tokenIn,
@@ -403,31 +430,36 @@ describe("calcOutGivenIn matches chain code", () => {
       if (result === "no-more-ticks") throw new Error("no more ticks");
       const { amountOut, afterSqrtPrice } = result;
       expect(amountOut.toString()).toEqual("1820545");
-      expect(afterSqrtPrice.toString()).toEqual("78.138055169663761658");
+      // TODO: Note this value is actually off by 10^-18 which seems to stem from the difference
+      // in the sqrt function. On-chain out sqrt is monotonic.
+      // 78.138055169663761658508234345605157554
+      expect(afterSqrtPrice.toString()).toEqual(
+        "78.138055169663761657508234345605157554"
+      );
     });
     // skipping price limit / slippage test, since we're generating the price limit for the chain to use
   });
 
   describe("with fees", () => {
-    // https://github.com/osmosis-labs/osmosis/blob/e7b5c4a6f88004fe8a6976fd7e4cb5e90339d629/x/concentrated-liquidity/swaps_test.go#L429
+    // https://github.com/osmosis-labs/osmosis/blob/844c172f50cb602b6af030e1d7abbca28d2dbddc/x/concentrated-liquidity/swaps_test.go#L772
     //          5000
     //  4545 -----|----- 5500
-    it("fee 1 - single position within one tick: usdc -> eth (1% fee)", () => {
+    it("spread factor 1 - single position within one tick: usdc -> eth (1% spread factor)", () => {
       const tokenIn = new Coin("usdc", "42000000");
       const tokenDenom0 = "eth";
-      const poolLiquidity = new Dec("1517882343.751510418088349649");
+      const poolLiquidity = new Dec("1517882343.751510417627556287");
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
           tickIndex: new Int(30545000),
-          netLiquidity: new Dec("1517882343.751510418088349649"),
+          netLiquidity: new Dec("1517882343.751510417627556287"),
         },
         {
           tickIndex: new Int(31500000),
-          netLiquidity: new Dec("-1517882343.751510418088349649"),
+          netLiquidity: new Dec("-1517882343.751510417627556287"),
         },
       ];
-      const curSqrtPrice = new Dec("70.710678118654752440");
+      const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0.01");
       const result = calcOutGivenIn({
         tokenIn,
@@ -439,31 +471,33 @@ describe("calcOutGivenIn matches chain code", () => {
       });
       if (result === "no-more-ticks") throw new Error("no more ticks");
       const { amountOut, afterSqrtPrice } = result;
+      expect(afterSqrtPrice.toString()).toEqual(
+        "70.738071546196200265739652000003564619"
+      );
       expect(amountOut.toString()).toEqual("8312");
-      expect(afterSqrtPrice.toString()).toEqual("70.738071546196200264");
     });
-    // https://github.com/osmosis-labs/osmosis/blob/e7b5c4a6f88004fe8a6976fd7e4cb5e90339d629/x/concentrated-liquidity/swaps_test.go#L453
+    // https://github.com/osmosis-labs/osmosis/blob/844c172f50cb602b6af030e1d7abbca28d2dbddc/x/concentrated-liquidity/swaps_test.go#L788
     //  Two equal price ranges
     //
     //          5000
     //  4545 -----|----- 5500
     //  4545 -----|----- 5500
-    it("fee 2 - two positions within one tick: eth -> usdc (3% fee)", () => {
+    it("spread factor 2 - two positions within one tick: eth -> usdc (3% spread factor)", () => {
       const tokenIn = new Coin("eth", "13370");
       const tokenDenom0 = "eth";
-      const poolLiquidity = new Dec("3035764687.503020836176699298");
+      const poolLiquidity = new Dec("3035764687.503020835255112574");
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
           tickIndex: new Int(30545000),
-          netLiquidity: new Dec("1517882343.751510418088349649"),
+          netLiquidity: new Dec("1517882343.751510417627556287"),
         },
         {
           tickIndex: new Int(31500000),
-          netLiquidity: new Dec("-1517882343.751510418088349649"),
+          netLiquidity: new Dec("-1517882343.751510417627556287"),
         },
       ];
-      const curSqrtPrice = new Dec("70.710678118654752440");
+      const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0.03");
       const result = calcOutGivenIn({
         tokenIn,
@@ -476,28 +510,30 @@ describe("calcOutGivenIn matches chain code", () => {
       if (result === "no-more-ticks") throw new Error("no more ticks");
       const { amountOut, afterSqrtPrice } = result;
       expect(amountOut.toString()).toEqual("64824917");
-      expect(afterSqrtPrice.toString()).toEqual("70.689324382628080102");
+      expect(afterSqrtPrice.toString()).toEqual(
+        "70.689324382628080102675847658610048839"
+      );
     });
-    // https://github.com/osmosis-labs/osmosis/blob/e7b5c4a6f88004fe8a6976fd7e4cb5e90339d629/x/concentrated-liquidity/swaps_test.go#L481
+    // https://github.com/osmosis-labs/osmosis/blob/844c172f50cb602b6af030e1d7abbca28d2dbddc/x/concentrated-liquidity/swaps_test.go#L809
     //          		   5000
     //  		   4545 -----|----- 5500
     //  4000 ----------- 4545
-    it("fee 3 - two positions with consecutive price ranges: eth -> usdc (5% fee)", () => {
+    it("spread factor 3 - two positions with consecutive price ranges: eth -> usdc (5% spread factor)", () => {
       const tokenIn = new Coin("eth", "2000000");
       const tokenDenom0 = "eth";
-      const poolLiquidity = new Dec("1517882343.751510418088349649");
+      const poolLiquidity = new Dec("1517882343.751510417627556287");
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
           tickIndex: new Int(30545000),
-          netLiquidity: new Dec("319146854.1542601224183902529"),
+          netLiquidity: new Dec("319146854.1542601219575968909"),
         },
         {
           tickIndex: new Int(30000000),
-          netLiquidity: new Dec("1198735489.597250295669959397"),
+          netLiquidity: new Dec("1199528406.18741366948159633"),
         },
       ];
-      const curSqrtPrice = new Dec("70.710678118654752440");
+      const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0.05");
       const result = calcOutGivenIn({
         tokenIn,
@@ -510,16 +546,18 @@ describe("calcOutGivenIn matches chain code", () => {
       if (result === "no-more-ticks") throw new Error("no more ticks");
       const { amountOut, afterSqrtPrice } = result;
       expect(amountOut.toString()).toEqual("8691708221");
-      expect(afterSqrtPrice.toString()).toEqual("64.336946417392457832");
+      expect(afterSqrtPrice.toString()).toEqual(
+        "64.336946417392457831833484334393884770"
+      );
     });
-    // https://github.com/osmosis-labs/osmosis/blob/e7b5c4a6f88004fe8a6976fd7e4cb5e90339d629/x/concentrated-liquidity/swaps_test.go#L505
+    // https://github.com/osmosis-labs/osmosis/blob/844c172f50cb602b6af030e1d7abbca28d2dbddc/x/concentrated-liquidity/swaps_test.go#L829
     //          5000
     //  4545 -----|----- 5500
     //        5001 ----------- 6250
-    it("fee 4 - two positions with partially overlapping price ranges: usdc -> eth (10% fee)", () => {
+    it("spread factor 4 - two positions with partially overlapping price ranges: usdc -> eth (10% spread factor)", () => {
       const tokenIn = new Coin("usdc", "10000000000");
       const tokenDenom0 = "eth";
-      const poolLiquidity = new Dec("1517882343.751510418088349649");
+      const poolLiquidity = new Dec("1517882343.751510417627556287");
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
@@ -528,14 +566,14 @@ describe("calcOutGivenIn matches chain code", () => {
         },
         {
           tickIndex: new Int(31500000),
-          netLiquidity: new Dec("-1517882343.751510418088349649"),
+          netLiquidity: new Dec("-1517882343.751510417627556287"),
         },
         {
           tickIndex: new Int(32250000),
           netLiquidity: new Dec("-670416088.605668727039240782"),
         },
       ];
-      const curSqrtPrice = new Dec("70.710678118654752440");
+      const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0.1");
       const result = calcOutGivenIn({
         tokenIn,
@@ -548,17 +586,22 @@ describe("calcOutGivenIn matches chain code", () => {
       if (result === "no-more-ticks") throw new Error("no more ticks");
       const { amountOut, afterSqrtPrice } = result;
       expect(amountOut.toString()).toEqual("1695807");
-      expect(afterSqrtPrice.toString()).toEqual("76.328178655208424124");
+      // TODO: Note this value is actually off by 10^-18 which seems to stem from the difference
+      // in the sqrt function. On-chain out sqrt is monotonic.
+      // 76.328178655208424125976974912322629171
+      expect(afterSqrtPrice.toString()).toEqual(
+        "76.328178655208424124976974912322629171"
+      );
     });
-    // https://github.com/osmosis-labs/osmosis/blob/e7b5c4a6f88004fe8a6976fd7e4cb5e90339d629/x/concentrated-liquidity/swaps_test.go#L528
+    // https://github.com/osmosis-labs/osmosis/blob/844c172f50cb602b6af030e1d7abbca28d2dbddc/x/concentrated-liquidity/swaps_test.go#L849
     //  Partially overlapping price ranges
     //                5000
     //        4545 -----|----- 5500
     //  4000 ----------- 4999
-    it("fee 5 - two positions with partially overlapping price ranges, not utilizing full liquidity of second position: eth -> usdc (0.5% fee)", () => {
+    it("spread factor 5 - two positions with partially overlapping price ranges, not utilizing full liquidity of second position: eth -> usdc (0.5% spread factor)", () => {
       const tokenIn = new Coin("eth", "1800000");
       const tokenDenom0 = "eth";
-      const poolLiquidity = new Dec("1517882343.751510418088349649");
+      const poolLiquidity = new Dec("1517882343.751510417627556287");
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
@@ -567,14 +610,14 @@ describe("calcOutGivenIn matches chain code", () => {
         },
         {
           tickIndex: new Int(30545000),
-          netLiquidity: new Dec("1517882343.751510418088349649"),
+          netLiquidity: new Dec("1517882343.751510417627556287"),
         },
         {
           tickIndex: new Int(30000000),
           netLiquidity: new Dec("670416215.718827443660400593"),
         },
       ];
-      const curSqrtPrice = new Dec("70.710678118654752440");
+      const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0.005");
       const result = calcOutGivenIn({
         tokenIn,
@@ -587,32 +630,34 @@ describe("calcOutGivenIn matches chain code", () => {
       if (result === "no-more-ticks") throw new Error("no more ticks");
       const { amountOut, afterSqrtPrice } = result;
       expect(amountOut.toString()).toEqual("8440657775");
-      expect(afterSqrtPrice.toString()).toEqual("65.571484748647169032");
+      expect(afterSqrtPrice.toString()).toEqual(
+        "65.571484748647169031180086346638617316"
+      );
     });
-    // https://github.com/osmosis-labs/osmosis/blob/e7b5c4a6f88004fe8a6976fd7e4cb5e90339d629/x/concentrated-liquidity/swaps_test.go#L548
+    // https://github.com/osmosis-labs/osmosis/blob/844c172f50cb602b6af030e1d7abbca28d2dbddc/x/concentrated-liquidity/swaps_test.go#L869
     //          5000
     //  4545 -----|----- 5500
     //              5501 ----------- 6250
-    it("fee 6 - two sequential positions with a gap usdc -> eth (3% fee)", () => {
+    it("spread factor 6 - two sequential positions with a gap usdc -> eth (3% spread factor)", () => {
       const tokenIn = new Coin("usdc", "10000000000");
       const tokenDenom0 = "eth";
-      const poolLiquidity = new Dec("1517882343.751510418088349649");
+      const poolLiquidity = new Dec("1517882343.751510417627556287");
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
           tickIndex: new Int(31500000),
-          netLiquidity: new Dec("-1517882343.751510418088349649"),
+          netLiquidity: new Dec("-1517882343.751510417627556287"),
         },
         {
           tickIndex: new Int(31501000),
-          netLiquidity: new Dec("1199528406.187413669220031452"),
+          netLiquidity: new Dec("1199528406.18741366948159633"),
         },
         {
           tickIndex: new Int(32250000),
           netLiquidity: new Dec("670416215.718827443660400593"),
         },
       ];
-      const curSqrtPrice = new Dec("70.710678118654752440");
+      const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0.03");
       const result = calcOutGivenIn({
         tokenIn,
@@ -625,7 +670,12 @@ describe("calcOutGivenIn matches chain code", () => {
       if (result === "no-more-ticks") throw new Error("no more ticks");
       const { amountOut, afterSqrtPrice } = result;
       expect(amountOut.toString()).toEqual("1771252");
-      expect(afterSqrtPrice.toString()).toEqual("77.887956882326389372");
+      // TODO: Note this value is actually off by 10^-18 which seems to stem from the difference
+      // in the sqrt function. On-chain out sqrt is monotonic.
+      // 77.887956882326389372687567917665252424
+      expect(afterSqrtPrice.toString()).toEqual(
+        "77.887956882326389371687567917665252424"
+      );
     });
   });
 
@@ -634,15 +684,15 @@ describe("calcOutGivenIn matches chain code", () => {
     it("single position within one tick, trade does not complete due to lack of liquidity: usdc -> eth", () => {
       const tokenIn = new Coin("usdc", "5300000000");
       const tokenDenom0 = "eth";
-      const poolLiquidity = new Dec("1517882343.751510418088349649");
+      const poolLiquidity = new Dec("1517882343.751510417627556287");
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
           tickIndex: new Int(31500000),
-          netLiquidity: new Dec("-1517882343.751510418088349649"),
+          netLiquidity: new Dec("-1517882343.751510417627556287"),
         },
       ];
-      const curSqrtPrice = new Dec("70.710678118654752440");
+      const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0");
       expect(
         calcOutGivenIn({
@@ -659,15 +709,15 @@ describe("calcOutGivenIn matches chain code", () => {
     it("single position within one tick, trade does not complete due to lack of liquidity: eth -> usdc", () => {
       const tokenIn = new Coin("eth", "1100000");
       const tokenDenom0 = "eth";
-      const poolLiquidity = new Dec("1517882343.751510418088349649");
+      const poolLiquidity = new Dec("1517882343.751510417627556287");
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
           tickIndex: new Int(31500000),
-          netLiquidity: new Dec("-1517882343.751510418088349649"),
+          netLiquidity: new Dec("-1517882343.751510417627556287"),
         },
       ];
-      const curSqrtPrice = new Dec("70.710678118654752440");
+      const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0");
       expect(
         calcOutGivenIn({
@@ -683,8 +733,13 @@ describe("calcOutGivenIn matches chain code", () => {
   });
 });
 
-describe("calcInGivenOut matches chain code", () => {
-  // Note: liquidity value for the default position is 1517882343.751510418088349649
+// Note these tests are skipped since precision increase from 18 to 36 made
+// a lot of them break. Due to CL launch timing, we are skipping this as
+// in given out is not supported at launch.
+// If you want to fix this, refer to this PR for a similar fix for out given in:
+// https://github.com/osmosis-labs/osmosis-frontend/pull/1800
+test.skip("calcInGivenOut matches chain code", () => {
+  // Note: liquidity value for the default position is 1517882343.751510417627556287
   describe("without fees, base case", () => {
     // https://github.com/osmosis-labs/osmosis/blob/2be30828d8c8a818652a15c3c19ae27b4c123c60/x/concentrated-liquidity/swaps_test.go#L63
     //  One price range
@@ -694,19 +749,19 @@ describe("calcInGivenOut matches chain code", () => {
     it("single position within one tick: eth (in) -> usdc (out) | zfo", () => {
       const tokenOut = new Coin("usdc", "42000000");
       const tokenDenom0 = "eth";
-      const poolLiquidity = new Dec("1517882343.751510418088349649");
+      const poolLiquidity = new Dec("1517882343.751510417627556287");
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
           tickIndex: new Int(30545000),
-          netLiquidity: new Dec("1517882343.751510418088349649"),
+          netLiquidity: new Dec("1517882343.751510417627556287"),
         },
         {
           tickIndex: new Int(31500000),
-          netLiquidity: new Dec("-1517882343.751510418088349649"),
+          netLiquidity: new Dec("-1517882343.751510417627556287"),
         },
       ];
-      const curSqrtPrice = new Dec("70.710678118654752440");
+      const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0");
       const result = calcInGivenOut({
         tokenOut,
@@ -725,19 +780,19 @@ describe("calcInGivenOut matches chain code", () => {
     it("single position within one tick: usdc (in) -> eth (out) ofz", () => {
       const tokenOut = new Coin("eth", "13370");
       const tokenDenom0 = "eth";
-      const poolLiquidity = new Dec("1517882343.751510418088349649");
+      const poolLiquidity = new Dec("1517882343.751510417627556287");
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
           tickIndex: new Int(30545000),
-          netLiquidity: new Dec("1517882343.751510418088349649"),
+          netLiquidity: new Dec("1517882343.751510417627556287"),
         },
         {
           tickIndex: new Int(31500000),
-          netLiquidity: new Dec("-1517882343.751510418088349649"),
+          netLiquidity: new Dec("-1517882343.751510417627556287"),
         },
       ];
-      const curSqrtPrice = new Dec("70.710678118654752440");
+      const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0");
       const result = calcInGivenOut({
         tokenOut,
@@ -761,19 +816,19 @@ describe("calcInGivenOut matches chain code", () => {
     it("two positions within one tick: eth (in) -> usdc (out) | zfo", () => {
       const tokenOut = new Coin("usdc", "66829187");
       const tokenDenom0 = "eth";
-      const poolLiquidity = new Dec("3035764687.503020836176699298");
+      const poolLiquidity = new Dec("3035764687.503020835255112574");
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
           tickIndex: new Int(30545000),
-          netLiquidity: new Dec("3035764687.503020836176699298"),
+          netLiquidity: new Dec("3035764687.503020835255112574"),
         },
         {
           tickIndex: new Int(31500000),
-          netLiquidity: new Dec("-3035764687.503020836176699298"),
+          netLiquidity: new Dec("-3035764687.503020835255112574"),
         },
       ];
-      const curSqrtPrice = new Dec("70.710678118654752440");
+      const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0");
       const result = calcInGivenOut({
         tokenOut,
@@ -797,19 +852,19 @@ describe("calcInGivenOut matches chain code", () => {
     it("two positions within one tick: usdc (in) -> eth (out) | ofz", () => {
       const tokenOut = new Coin("eth", "8398");
       const tokenDenom0 = "eth";
-      const poolLiquidity = new Dec("3035764687.503020836176699298");
+      const poolLiquidity = new Dec("3035764687.503020835255112574");
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
           tickIndex: new Int(30545000),
-          netLiquidity: new Dec("3035764687.503020836176699298"),
+          netLiquidity: new Dec("3035764687.503020835255112574"),
         },
         {
           tickIndex: new Int(31500000),
-          netLiquidity: new Dec("-3035764687.503020836176699298"),
+          netLiquidity: new Dec("-3035764687.503020835255112574"),
         },
       ];
-      const curSqrtPrice = new Dec("70.710678118654752440");
+      const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0");
       const result = calcInGivenOut({
         tokenOut,
@@ -833,23 +888,23 @@ describe("calcInGivenOut matches chain code", () => {
     it("two positions with consecutive price ranges: eth (in) -> usdc (out) | zfo", () => {
       const tokenOut = new Coin("usdc", "9103422788");
       const tokenDenom0 = "eth";
-      const poolLiquidity = new Dec("1517882343.751510418088349649");
+      const poolLiquidity = new Dec("1517882343.751510417627556287");
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
           tickIndex: new Int(30545000),
-          netLiquidity: new Dec("319146854.154260122418390252"),
+          netLiquidity: new Dec("319146854.154260121957596890"),
         },
         {
           tickIndex: new Int(30000000),
-          netLiquidity: new Dec("1198735489.597250295669959397"),
+          netLiquidity: new Dec("1199528406.18741366948159633"),
         },
         {
           tickIndex: new Int(31500000),
-          netLiquidity: new Dec("-1517882343.751510418088349649"),
+          netLiquidity: new Dec("-1517882343.751510417627556287"),
         },
       ];
-      const curSqrtPrice = new Dec("70.710678118654752440");
+      const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0");
       const result = calcInGivenOut({
         tokenOut,
@@ -872,7 +927,7 @@ describe("calcInGivenOut matches chain code", () => {
     it("two positions with consecutive price ranges: usdc (in) -> eth (out) | ofz", () => {
       const tokenOut = new Coin("eth", "1820630");
       const tokenDenom0 = "eth";
-      const poolLiquidity = new Dec("1517882343.751510418088349649");
+      const poolLiquidity = new Dec("1517882343.751510417627556287");
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
@@ -888,7 +943,7 @@ describe("calcInGivenOut matches chain code", () => {
           netLiquidity: new Dec("1199528406.187413669220031452"),
         },
       ];
-      const curSqrtPrice = new Dec("70.710678118654752440");
+      const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0");
       const result = calcInGivenOut({
         tokenOut,
@@ -911,7 +966,7 @@ describe("calcInGivenOut matches chain code", () => {
     it("two positions with partially overlapping price ranges: eth (in) -> usdc (out) | zfo", () => {
       const tokenOut = new Coin("usdc", "9321276930");
       const tokenDenom0 = "eth";
-      const poolLiquidity = new Dec("1517882343.751510418088349649");
+      const poolLiquidity = new Dec("1517882343.751510417627556287");
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
@@ -920,14 +975,14 @@ describe("calcInGivenOut matches chain code", () => {
         },
         {
           tickIndex: new Int(30545000),
-          netLiquidity: new Dec("1517882343.751510418088349649"),
+          netLiquidity: new Dec("1517882343.751510417627556287"),
         },
         {
           tickIndex: new Int(30000000),
           netLiquidity: new Dec("670416215.718827443660400593"),
         },
       ];
-      const curSqrtPrice = new Dec("70.710678118654752440");
+      const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0");
       const result = calcInGivenOut({
         tokenOut,
@@ -950,7 +1005,7 @@ describe("calcInGivenOut matches chain code", () => {
     it("two positions with partially overlapping price ranges, not utilizing full liquidity of second position: eth (in) -> usdc (out) | zfo", () => {
       const tokenOut = new Coin("usdc", "8479320318");
       const tokenDenom0 = "eth";
-      const poolLiquidity = new Dec("1517882343.751510418088349649");
+      const poolLiquidity = new Dec("1517882343.751510417627556287");
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
@@ -959,14 +1014,14 @@ describe("calcInGivenOut matches chain code", () => {
         },
         {
           tickIndex: new Int(30545000),
-          netLiquidity: new Dec("1517882343.751510418088349649"),
+          netLiquidity: new Dec("1517882343.751510417627556287"),
         },
         {
           tickIndex: new Int(30000000),
           netLiquidity: new Dec("670416215.718827443660400593"),
         },
       ];
-      const curSqrtPrice = new Dec("70.710678118654752440");
+      const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0");
       const result = calcInGivenOut({
         tokenOut,
@@ -989,7 +1044,7 @@ describe("calcInGivenOut matches chain code", () => {
     it("two positions with partially overlapping price ranges: usdc (in) -> eth (out) | ofz", () => {
       const tokenOut = new Coin("eth", "1864161");
       const tokenDenom0 = "eth";
-      const poolLiquidity = new Dec("1517882343.751510418088349649");
+      const poolLiquidity = new Dec("1517882343.751510417627556287");
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
@@ -998,14 +1053,14 @@ describe("calcInGivenOut matches chain code", () => {
         },
         {
           tickIndex: new Int(31500000),
-          netLiquidity: new Dec("-1517882343.751510418088349649"),
+          netLiquidity: new Dec("-1517882343.751510417627556287"),
         },
         {
           tickIndex: new Int(32250000),
           netLiquidity: new Dec("-670416088.605668727039240782"),
         },
       ];
-      const curSqrtPrice = new Dec("70.710678118654752440");
+      const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0");
       const result = calcInGivenOut({
         tokenOut,
@@ -1028,7 +1083,7 @@ describe("calcInGivenOut matches chain code", () => {
     it("two positions with partially overlapping price ranges, not utilizing full liquidity of second position: usdc (in) -> eth (out) | ofz", () => {
       const tokenOut = new Coin("eth", "1609138");
       const tokenDenom0 = "eth";
-      const poolLiquidity = new Dec("1517882343.751510418088349649");
+      const poolLiquidity = new Dec("1517882343.751510417627556287");
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
@@ -1037,14 +1092,14 @@ describe("calcInGivenOut matches chain code", () => {
         },
         {
           tickIndex: new Int(31500000),
-          netLiquidity: new Dec("-1517882343.751510418088349649"),
+          netLiquidity: new Dec("-1517882343.751510417627556287"),
         },
         {
           tickIndex: new Int(32250000),
           netLiquidity: new Dec("-670416088.605668727039240782"),
         },
       ];
-      const curSqrtPrice = new Dec("70.710678118654752440");
+      const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0");
       const result = calcInGivenOut({
         tokenOut,
@@ -1067,12 +1122,12 @@ describe("calcInGivenOut matches chain code", () => {
     it("two sequential positions with a gap usdc (in) -> eth (out) | ofz", () => {
       const tokenOut = new Coin("eth", "1820545");
       const tokenDenom0 = "eth";
-      const poolLiquidity = new Dec("1517882343.751510418088349649");
+      const poolLiquidity = new Dec("1517882343.751510417627556287");
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
           tickIndex: new Int(31500000),
-          netLiquidity: new Dec("-1517882343.751510418088349649"),
+          netLiquidity: new Dec("-1517882343.751510417627556287"),
         },
         {
           tickIndex: new Int(31501000),
@@ -1083,7 +1138,7 @@ describe("calcInGivenOut matches chain code", () => {
           netLiquidity: new Dec("670416215.718827443660400593"),
         },
       ];
-      const curSqrtPrice = new Dec("70.710678118654752440");
+      const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0");
       const result = calcInGivenOut({
         tokenOut,
@@ -1104,22 +1159,22 @@ describe("calcInGivenOut matches chain code", () => {
 
   describe("with fees", () => {
     // https://github.com/osmosis-labs/osmosis/blob/e7b5c4a6f88004fe8a6976fd7e4cb5e90339d629/x/concentrated-liquidity/swaps_test.go#L1105
-    it("fee 1: single position within one tick: eth (in) -> usdc (out) (1% fee) | zfo", () => {
+    it("spread factor 1: single position within one tick: eth (in) -> usdc (out) (1% spread factor) | zfo", () => {
       const tokenOut = new Coin("usdc", "42000000");
       const tokenDenom0 = "eth";
-      const poolLiquidity = new Dec("1517882343.751510418088349649");
+      const poolLiquidity = new Dec("1517882343.751510417627556287");
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
           tickIndex: new Int(30545000),
-          netLiquidity: new Dec("1517882343.751510418088349649"),
+          netLiquidity: new Dec("1517882343.751510417627556287"),
         },
         {
           tickIndex: new Int(31500000),
-          netLiquidity: new Dec("-1517882343.751510418088349649"),
+          netLiquidity: new Dec("-1517882343.751510417627556287"),
         },
       ];
-      const curSqrtPrice = new Dec("70.710678118654752440");
+      const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0.01");
       const result = calcInGivenOut({
         tokenOut,
@@ -1135,22 +1190,22 @@ describe("calcInGivenOut matches chain code", () => {
       expect(afterSqrtPrice.toString()).toEqual("70.683007989825007162");
     });
     // https://github.com/osmosis-labs/osmosis/blob/e7b5c4a6f88004fe8a6976fd7e4cb5e90339d629/x/concentrated-liquidity/swaps_test.go#L1135
-    it("fee 2: two positions within one tick: usdc (in) -> eth (out) (3% fee) | ofz", () => {
+    it("spread factor 2: two positions within one tick: usdc (in) -> eth (out) (3% spread factor) | ofz", () => {
       const tokenOut = new Coin("eth", "8398");
       const tokenDenom0 = "eth";
-      const poolLiquidity = new Dec("3035764687.503020836176699298");
+      const poolLiquidity = new Dec("3035764687.503020835255112574");
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
           tickIndex: new Int(30545000),
-          netLiquidity: new Dec("3035764687.503020836176699298"),
+          netLiquidity: new Dec("3035764687.503020835255112574"),
         },
         {
           tickIndex: new Int(31500000),
-          netLiquidity: new Dec("-3035764687.503020836176699298"),
+          netLiquidity: new Dec("-3035764687.503020835255112574"),
         },
       ];
-      const curSqrtPrice = new Dec("70.710678118654752440");
+      const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0.03");
       const result = calcInGivenOut({
         tokenOut,
@@ -1166,10 +1221,10 @@ describe("calcInGivenOut matches chain code", () => {
       expect(afterSqrtPrice.toString()).toEqual("70.724512595179305566");
     });
     // https://github.com/osmosis-labs/osmosis/blob/e7b5c4a6f88004fe8a6976fd7e4cb5e90339d629/x/concentrated-liquidity/swaps_test.go#L1170
-    it("fee 3: two positions with consecutive price ranges: usdc (in) -> eth (out) (0.1% fee) | ofz", () => {
+    it("spread factor 3: two positions with consecutive price ranges: usdc (in) -> eth (out) (0.1% spread factor) | ofz", () => {
       const tokenOut = new Coin("eth", "1820630");
       const tokenDenom0 = "eth";
-      const poolLiquidity = new Dec("1517882343.751510418088349649");
+      const poolLiquidity = new Dec("1517882343.751510417627556287");
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
@@ -1185,7 +1240,7 @@ describe("calcInGivenOut matches chain code", () => {
           netLiquidity: new Dec("1199528406.187413669220031452"),
         },
       ];
-      const curSqrtPrice = new Dec("70.710678118654752440");
+      const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0.001");
       const result = calcInGivenOut({
         tokenOut,
@@ -1201,10 +1256,10 @@ describe("calcInGivenOut matches chain code", () => {
       expect(afterSqrtPrice.toString()).toEqual("78.137148837036751553");
     });
     // https://github.com/osmosis-labs/osmosis/blob/e7b5c4a6f88004fe8a6976fd7e4cb5e90339d629/x/concentrated-liquidity/swaps_test.go#L1218
-    it("fee 4: two positions with partially overlapping price ranges: eth (in) -> usdc (out) (10% fee) | zfo", () => {
+    it("spread factor 4: two positions with partially overlapping price ranges: eth (in) -> usdc (out) (10% spread factor) | zfo", () => {
       const tokenOut = new Coin("usdc", "9321276930");
       const tokenDenom0 = "eth";
-      const poolLiquidity = new Dec("1517882343.751510418088349649");
+      const poolLiquidity = new Dec("1517882343.751510417627556287");
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
@@ -1213,14 +1268,14 @@ describe("calcInGivenOut matches chain code", () => {
         },
         {
           tickIndex: new Int(30545000),
-          netLiquidity: new Dec("1517882343.751510418088349649"),
+          netLiquidity: new Dec("1517882343.751510417627556287"),
         },
         {
           tickIndex: new Int(30000000),
           netLiquidity: new Dec("670416215.718827443660400593"),
         },
       ];
-      const curSqrtPrice = new Dec("70.710678118654752440");
+      const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0.1");
       const result = calcInGivenOut({
         tokenOut,
@@ -1236,10 +1291,10 @@ describe("calcInGivenOut matches chain code", () => {
       expect(afterSqrtPrice.toString()).toEqual("64.257943796086567725");
     });
     // https://github.com/osmosis-labs/osmosis/blob/e7b5c4a6f88004fe8a6976fd7e4cb5e90339d629/x/concentrated-liquidity/swaps_test.go#L1278
-    it("fee 5: two positions with partially overlapping price ranges, not utilizing full liquidity of second position: usdc (in) -> eth (out) (5% fee) | ofz", () => {
+    it("spread factor 5: two positions with partially overlapping price ranges, not utilizing full liquidity of second position: usdc (in) -> eth (out) (5% spread factor) | ofz", () => {
       const tokenOut = new Coin("eth", "1609138");
       const tokenDenom0 = "eth";
-      const poolLiquidity = new Dec("1517882343.751510418088349649");
+      const poolLiquidity = new Dec("1517882343.751510417627556287");
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
@@ -1248,14 +1303,14 @@ describe("calcInGivenOut matches chain code", () => {
         },
         {
           tickIndex: new Int(31500000),
-          netLiquidity: new Dec("-1517882343.751510418088349649"),
+          netLiquidity: new Dec("-1517882343.751510417627556287"),
         },
         {
           tickIndex: new Int(32250000),
           netLiquidity: new Dec("-670416088.605668727039240782"),
         },
       ];
-      const curSqrtPrice = new Dec("70.710678118654752440");
+      const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0.05");
       const result = calcInGivenOut({
         tokenOut,
@@ -1271,15 +1326,15 @@ describe("calcInGivenOut matches chain code", () => {
       expect(afterSqrtPrice.toString()).toEqual("75.582372355128594341");
     });
     // https://github.com/osmosis-labs/osmosis/blob/e7b5c4a6f88004fe8a6976fd7e4cb5e90339d629/x/concentrated-liquidity/swaps_test.go#L1336
-    it("fee 6: two sequential positions with a gap usdc (in) -> eth (out) (0.03% fee) | ofz", () => {
+    it("spread factor 6: two sequential positions with a gap usdc (in) -> eth (out) (0.03% spread factor) | ofz", () => {
       const tokenOut = new Coin("eth", "1820545");
       const tokenDenom0 = "eth";
-      const poolLiquidity = new Dec("1517882343.751510418088349649");
+      const poolLiquidity = new Dec("1517882343.751510417627556287");
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
           tickIndex: new Int(31500000),
-          netLiquidity: new Dec("-1517882343.751510418088349649"),
+          netLiquidity: new Dec("-1517882343.751510417627556287"),
         },
         {
           tickIndex: new Int(31501000),
@@ -1290,7 +1345,7 @@ describe("calcInGivenOut matches chain code", () => {
           netLiquidity: new Dec("670416215.718827443660400593"),
         },
       ];
-      const curSqrtPrice = new Dec("70.710678118654752440");
+      const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0.0003");
       const result = calcInGivenOut({
         tokenOut,
@@ -1311,8 +1366,8 @@ describe("calcInGivenOut matches chain code", () => {
     it("returns not-enough-ticks if there's not enough ticks to calculate", () => {
       const tokenOut = new Coin("eth", "1820545");
       const tokenDenom0 = "eth";
-      const poolLiquidity = new Dec("1517882343.751510418088349649");
-      const curSqrtPrice = new Dec("70.710678118654752440");
+      const poolLiquidity = new Dec("1517882343.751510417627556287");
+      const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0.0003");
       const result = calcInGivenOut({
         tokenOut,
@@ -1330,15 +1385,15 @@ describe("calcInGivenOut matches chain code", () => {
     it("single position within one tick, trade does not complete due to lack of liquidity: usdc -> eth ", () => {
       const tokenOut = new Coin("usdc", "5300000000");
       const tokenDenom0 = "eth";
-      const poolLiquidity = new Dec("1517882343.751510418088349649");
+      const poolLiquidity = new Dec("1517882343.751510417627556287");
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
           tickIndex: new Int(31500000),
-          netLiquidity: new Dec("-1517882343.751510418088349649"),
+          netLiquidity: new Dec("-1517882343.751510417627556287"),
         },
       ];
-      const curSqrtPrice = new Dec("70.710678118654752440");
+      const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0");
       expect(
         calcInGivenOut({
@@ -1354,15 +1409,15 @@ describe("calcInGivenOut matches chain code", () => {
     it("single position within one tick, trade does not complete due to lack of liquidity: eth -> usdc ", () => {
       const tokenOut = new Coin("eth", "1100000");
       const tokenDenom0 = "eth";
-      const poolLiquidity = new Dec("1517882343.751510418088349649");
+      const poolLiquidity = new Dec("1517882343.751510417627556287");
       // found by printing liquidity net values to console with go test
       const inittedTicks = [
         {
           tickIndex: new Int(31500000),
-          netLiquidity: new Dec("-1517882343.751510418088349649"),
+          netLiquidity: new Dec("-1517882343.751510417627556287"),
         },
       ];
-      const curSqrtPrice = new Dec("70.710678118654752440");
+      const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0");
       expect(
         calcInGivenOut({
@@ -1397,7 +1452,7 @@ describe("calcInGivenOut matches chain code", () => {
           ),
         },
       ];
-      const curSqrtPrice = new Dec("1.000000000000000000");
+      const curSqrtPrice = new BigDec("1.000000000000000000");
       const swapFee = new Dec("0.001");
 
       try {

--- a/packages/math/src/pool/concentrated/__tests__/tick.spec.ts
+++ b/packages/math/src/pool/concentrated/__tests__/tick.spec.ts
@@ -1,7 +1,8 @@
 import { Coin, Dec, Int } from "@keplr-wallet/unit";
 
+import { BigDec } from "../../../big-dec";
+import { approxSqrt } from "../../../utils";
 import { maxSpotPrice, maxTick, minSpotPrice } from "../const";
-import { approxSqrt } from "../math";
 import {
   estimateInitialTickBound,
   priceToTick,
@@ -215,7 +216,7 @@ describe("estimateInitialTickBound", () => {
         token1: "usdc",
         // these values taken from default CL pool in go tests
         currentTickLiquidity: new Dec("1517882343.751510418088349649"),
-        currentSqrtPrice: new Dec("70.710678118654752440"),
+        currentSqrtPrice: new BigDec("70.710678118654752440"),
 
         expectedBoundTickIndex: new Int("-108000000"),
       },
@@ -228,7 +229,7 @@ describe("estimateInitialTickBound", () => {
         token1: "usdc",
         // these values taken from default CL pool in go tests
         currentTickLiquidity: new Dec("1517882343.751510418088349649"),
-        currentSqrtPrice: new Dec("70.710678118654752440"),
+        currentSqrtPrice: new BigDec("70.710678118654752440"),
 
         expectedBoundTickIndex: new Int("31975106"),
       },
@@ -254,8 +255,8 @@ describe("estimateInitialTickBound", () => {
             isOutGivenIn: true,
             token0Denom: token0,
             token1Denom: token1,
-            currentTickLiquidity,
             currentSqrtPrice,
+            currentTickLiquidity,
           });
 
           expect(boundTickIndex.toString()).toBe(
@@ -275,7 +276,7 @@ describe("estimateInitialTickBound", () => {
         token1: "usdc",
         // these values taken from default CL pool in go tests
         currentTickLiquidity: new Dec("1517882343.751510418088349649"),
-        currentSqrtPrice: new Dec("70.710678118654752440"),
+        currentSqrtPrice: new BigDec("70.710678118654752440"),
 
         expectedBoundTickIndex: new Int("-108000000"),
       },
@@ -288,7 +289,7 @@ describe("estimateInitialTickBound", () => {
         token1: "usdc",
         // these values taken from default CL pool in go tests
         currentTickLiquidity: new Dec("1517882343.751510418088349649"),
-        currentSqrtPrice: new Dec("70.710678118654752440"),
+        currentSqrtPrice: new BigDec("70.710678118654752440"),
 
         expectedBoundTickIndex: new Int("31975106"),
       },

--- a/packages/math/src/pool/concentrated/const.ts
+++ b/packages/math/src/pool/concentrated/const.ts
@@ -1,7 +1,11 @@
 import { Dec, Int } from "@keplr-wallet/unit";
 
+import { BigDec } from "../../big-dec";
+
 // https://github.com/osmosis-labs/osmosis/blob/1c5f166d180ca6ffdd0a4068b97422c5c169240c/osmomath/decimal.go#L79
 export const smallestDec = new Dec("1", Dec.precision);
+
+export const smallestBigDec = new BigDec("1", BigDec.precision);
 
 // https://github.com/osmosis-labs/osmosis/blob/1c5f166d180ca6ffdd0a4068b97422c5c169240c/x/concentrated-liquidity/types/constants.go#L24
 export const minSpotPrice = new Dec("0.000000000001");

--- a/packages/math/src/pool/concentrated/one-for-zero.ts
+++ b/packages/math/src/pool/concentrated/one-for-zero.ts
@@ -1,5 +1,6 @@
 import { Dec } from "@keplr-wallet/unit";
 
+import { BigDec } from "../../big-dec";
 import { maxSpotPrice } from "./const";
 import {
   calcAmount0Delta,
@@ -47,35 +48,39 @@ export class OneForZeroStrategy implements SwapStrategy {
     - oneForZeroStrategy assumes moving to the right of the current square root price.
    */
   computeSwapStepOutGivenIn(
-    curSqrtPrice: Dec,
+    curSqrtPrice: BigDec,
     sqrtPriceTarget: Dec,
     liquidity: Dec,
     amountOneInRemaining: Dec
   ): {
-    sqrtPriceNext: Dec;
+    sqrtPriceNext: BigDec;
     amountInConsumed: Dec;
     amountOutComputed: Dec;
     feeChargeTotal: Dec;
   } {
+    const liquidityBigDec = new BigDec(liquidity);
+    const sqrtPriceTargetBigDec = new BigDec(sqrtPriceTarget);
+    const amountOneInRemainingBigDec = new BigDec(amountOneInRemaining);
+
     let amountOneIn = calcAmount1Delta(
-      liquidity,
-      sqrtPriceTarget,
+      liquidityBigDec,
+      sqrtPriceTargetBigDec,
       curSqrtPrice,
       true
     );
 
-    const amountOneInRemainingLessFee = amountOneInRemaining.mul(
-      new Dec(1).sub(this.oneForZero.swapFee)
+    const amountOneInRemainingLessFee = amountOneInRemainingBigDec.mulTruncate(
+      new BigDec(1).sub(new BigDec(this.oneForZero.swapFee))
     );
 
-    let sqrtPriceNext: Dec;
+    let sqrtPriceNext: BigDec;
 
     if (amountOneInRemainingLessFee.gte(amountOneIn)) {
-      sqrtPriceNext = sqrtPriceTarget;
+      sqrtPriceNext = sqrtPriceTargetBigDec;
     } else {
       sqrtPriceNext = getNextSqrtPriceFromAmount1InRoundingDown(
         curSqrtPrice,
-        liquidity,
+        liquidityBigDec,
         amountOneInRemainingLessFee
       );
 
@@ -88,11 +93,11 @@ export class OneForZeroStrategy implements SwapStrategy {
       }
     }
 
-    const hasReachedTarget = sqrtPriceTarget.equals(sqrtPriceNext);
+    const hasReachedTarget = sqrtPriceTargetBigDec.equals(sqrtPriceNext);
 
     if (!hasReachedTarget) {
       amountOneIn = calcAmount1Delta(
-        liquidity,
+        liquidityBigDec,
         sqrtPriceNext,
         curSqrtPrice,
         true
@@ -100,23 +105,26 @@ export class OneForZeroStrategy implements SwapStrategy {
     }
 
     const amountZeroOut = calcAmount0Delta(
-      liquidity,
+      liquidityBigDec,
       sqrtPriceNext,
       curSqrtPrice,
       false
     );
 
+    const amountOneInFinal = amountOneIn.toDec();
+
     const feeChargeTotal = getFeeChargePerSwapStepOutGivenIn(
       hasReachedTarget,
-      amountOneIn,
+      amountOneInFinal,
       amountOneInRemaining,
       this.oneForZero.swapFee
     );
 
     return {
       sqrtPriceNext,
-      amountInConsumed: amountOneIn,
-      amountOutComputed: amountZeroOut,
+      // TODO: amountOneIn needs to be rounded up at precision end
+      amountInConsumed: amountOneInFinal,
+      amountOutComputed: amountZeroOut.toDec(),
       feeChargeTotal,
     };
   }
@@ -142,31 +150,35 @@ export class OneForZeroStrategy implements SwapStrategy {
   - oneForZeroStrategy assumes moving to the right of the current square root price.
    */
   computeSwapStepInGivenOut(
-    curSqrtPrice: Dec,
+    curSqrtPrice: BigDec,
     sqrtPriceTarget: Dec,
     liquidity: Dec,
     amountZeroRemainingOut: Dec
   ): {
-    sqrtPriceNext: Dec;
+    sqrtPriceNext: BigDec;
     amountOutConsumed: Dec;
     amountInComputed: Dec;
     feeChargeTotal: Dec;
   } {
+    const liquidityBigDec = new BigDec(liquidity);
+    const sqrtPriceTargetBigDec = new BigDec(sqrtPriceTarget);
+    const amountZeroOutRemainingBigDec = new BigDec(amountZeroRemainingOut);
+
     let amountZeroOut = calcAmount0Delta(
-      liquidity,
-      sqrtPriceTarget,
+      liquidityBigDec,
+      sqrtPriceTargetBigDec,
       curSqrtPrice,
       false
     );
 
     let sqrtPriceNext;
-    if (amountZeroRemainingOut.gte(amountZeroOut)) {
-      sqrtPriceNext = sqrtPriceTarget;
+    if (amountZeroOutRemainingBigDec.gte(amountZeroOut)) {
+      sqrtPriceNext = sqrtPriceTargetBigDec;
     } else {
       sqrtPriceNext = getNextSqrtPriceFromAmount0OutRoundingUp(
         curSqrtPrice,
-        liquidity,
-        amountZeroRemainingOut
+        liquidityBigDec,
+        amountZeroOutRemainingBigDec
       );
 
       // This may happen due to a lack of precison. We need 36 for this to not happen.
@@ -178,11 +190,11 @@ export class OneForZeroStrategy implements SwapStrategy {
       }
     }
 
-    const hasReachedTarget = sqrtPriceTarget.equals(sqrtPriceNext);
+    const hasReachedTarget = sqrtPriceTargetBigDec.equals(sqrtPriceNext);
 
     if (!hasReachedTarget) {
       amountZeroOut = calcAmount0Delta(
-        liquidity,
+        liquidityBigDec,
         sqrtPriceNext,
         curSqrtPrice,
         false
@@ -190,20 +202,23 @@ export class OneForZeroStrategy implements SwapStrategy {
     }
 
     const amountOneIn = calcAmount1Delta(
-      liquidity,
+      liquidityBigDec,
       sqrtPriceNext,
       curSqrtPrice,
       true
     );
 
-    const feeChargeTotal = amountOneIn
+    // TODO: round up at precision end
+    const amountOneInFinal = amountOneIn.toDec();
+
+    const feeChargeTotal = amountOneInFinal
       .mul(this.oneForZero.swapFee)
       .quo(new Dec(1).sub(this.oneForZero.swapFee));
 
     return {
       sqrtPriceNext,
-      amountOutConsumed: amountZeroOut,
-      amountInComputed: amountOneIn,
+      amountOutConsumed: amountZeroOut.toDec(),
+      amountInComputed: amountOneIn.toDec(),
       feeChargeTotal,
     };
   }

--- a/packages/math/src/pool/concentrated/swap-strategy.ts
+++ b/packages/math/src/pool/concentrated/swap-strategy.ts
@@ -1,28 +1,29 @@
 import { Dec } from "@keplr-wallet/unit";
 
+import { BigDec } from "../../big-dec";
 import { OneForZeroStrategy } from "./one-for-zero";
 import { ZeroForOneStrategy } from "./zero-for-one";
 
 export interface SwapStrategy {
   getSqrtTargetPrice(nextTickSqrtPrice: Dec): Dec;
   computeSwapStepOutGivenIn(
-    curSqrtPrice: Dec,
+    curSqrtPrice: BigDec,
     sqrtPriceTarget: Dec,
     liquidity: Dec,
     amountRemainingIn: Dec
   ): {
-    sqrtPriceNext: Dec;
+    sqrtPriceNext: BigDec;
     amountInConsumed: Dec;
     amountOutComputed: Dec;
     feeChargeTotal: Dec;
   };
   computeSwapStepInGivenOut(
-    curSqrtPrice: Dec,
+    curSqrtPrice: BigDec,
     sqrtPriceTarget: Dec,
     liquidity: Dec,
     amountRemainingOut: Dec
   ): {
-    sqrtPriceNext: Dec;
+    sqrtPriceNext: BigDec;
     amountOutConsumed: Dec;
     amountInComputed: Dec;
     feeChargeTotal: Dec;

--- a/packages/math/src/pool/concentrated/tick.ts
+++ b/packages/math/src/pool/concentrated/tick.ts
@@ -1,6 +1,7 @@
 import { Dec, DecUtils, Int } from "@keplr-wallet/unit";
 
 import { BigDec } from "../../big-dec";
+import { approxSqrt } from "../../utils";
 import {
   exponentAtPriceOne,
   maxSpotPrice,
@@ -8,7 +9,7 @@ import {
   minSpotPrice,
   minTick,
 } from "./const";
-import { approxSqrt, convertTokenInGivenOutToTokenOutGivenIn } from "./math";
+import { convertTokenInGivenOutToTokenOutGivenIn } from "./math";
 const nine = new Dec(9);
 // Note: chosen arbitrarily
 const constantTickEstimateMove = new Int(10000);
@@ -152,11 +153,11 @@ export function estimateInitialTickBound({
   isOutGivenIn: boolean;
   token0Denom: string;
   token1Denom: string;
-  currentSqrtPrice: Dec;
+  currentSqrtPrice: BigDec;
   currentTickLiquidity: Dec;
 }): { boundTickIndex: Int } {
   // modify the input amount based on out given in vs in given out and swap direction
-  const currentPrice = currentSqrtPrice.pow(new Int(2));
+  const currentPrice = currentSqrtPrice.pow(new Int(2)).toDec();
 
   let tokenIn;
   if (isOutGivenIn) {
@@ -197,13 +198,13 @@ export function estimateInitialTickBound({
       tokenIn.amount.isZero() ||
       currentTickLiquidity.quo(new Dec(tokenIn.amount)).isZero()
     ) {
-      const currentTick = priceToTick(currentSqrtPrice.pow(new Int(2)));
+      const currentTick = priceToTick(currentSqrtPrice.pow(new Int(2)).toDec());
       // price is decreasing so move estimate down
       estimate = tickToSqrtPrice(currentTick.sub(constantTickEstimateMove));
     } else {
-      estimate = currentSqrtPrice.sub(
-        currentTickLiquidity.quo(new Dec(tokenIn.amount))
-      );
+      estimate = currentSqrtPrice
+        .sub(new BigDec(currentTickLiquidity).quo(new BigDec(tokenIn.amount)))
+        .toDec();
     }
 
     // Note, that if we only have a few positions in the pool, the estimate will be quite off
@@ -232,13 +233,13 @@ export function estimateInitialTickBound({
       tokenIn.amount.isZero() ||
       new Dec(tokenIn.amount).quo(currentTickLiquidity).isZero()
     ) {
-      const currentTick = priceToTick(currentSqrtPrice.pow(new Int(2)));
+      const currentTick = priceToTick(currentSqrtPrice.pow(new Int(2)).toDec());
       // price is increasing so move estimate up
       estimate = tickToSqrtPrice(currentTick.add(constantTickEstimateMove));
     } else {
-      estimate = currentSqrtPrice.add(
-        new Dec(tokenIn.amount).quo(currentTickLiquidity)
-      );
+      estimate = currentSqrtPrice
+        .add(new BigDec(tokenIn.amount).quo(new BigDec(currentTickLiquidity)))
+        .toDec();
     }
 
     // Similarly to swapping to the left of the current sqrt price,

--- a/packages/math/src/pool/concentrated/types.ts
+++ b/packages/math/src/pool/concentrated/types.ts
@@ -1,5 +1,7 @@
 import { Coin, Dec, Int } from "@keplr-wallet/unit";
 
+import { BigDec } from "../../big-dec";
+
 export interface QuoteParams {
   /** Denom of token 0, left of current price. */
   tokenDenom0: string;
@@ -10,7 +12,7 @@ export interface QuoteParams {
    */
   inittedTicks: LiquidityDepth[];
   /** Current tick as price. */
-  curSqrtPrice: Dec;
+  curSqrtPrice: BigDec;
   /** Swap fee. i.e. `0.01` */
   swapFee: Dec;
 }

--- a/packages/math/src/pool/concentrated/zero-for-one.ts
+++ b/packages/math/src/pool/concentrated/zero-for-one.ts
@@ -1,5 +1,6 @@
 import { Dec } from "@keplr-wallet/unit";
 
+import { BigDec } from "../../big-dec";
 import { minSpotPrice } from "./const";
 import {
   calcAmount0Delta,
@@ -47,34 +48,38 @@ export class ZeroForOneStrategy implements SwapStrategy {
     - zeroForOneStrategy assumes moving to the left of the current square root price.
    */
   computeSwapStepOutGivenIn(
-    curSqrtPrice: Dec,
+    curSqrtPrice: BigDec,
     sqrtPriceTarget: Dec,
     liquidity: Dec,
     amountZeroInRemaining: Dec
   ): {
-    sqrtPriceNext: Dec;
+    sqrtPriceNext: BigDec;
     amountInConsumed: Dec;
     amountOutComputed: Dec;
     feeChargeTotal: Dec;
   } {
+    const liquidityBigDec = new BigDec(liquidity);
+    const sqrtPriceTargetBigDec = new BigDec(sqrtPriceTarget);
+    const amountZeroInRemainingBigDec = new BigDec(amountZeroInRemaining);
+
     let amountZeroIn = calcAmount0Delta(
-      liquidity,
-      sqrtPriceTarget,
+      liquidityBigDec,
+      sqrtPriceTargetBigDec,
       curSqrtPrice,
       true
     );
 
-    const amountZeroInRemainingLessFee = amountZeroInRemaining.mul(
-      new Dec(1).sub(this.zeroForOne.swapFee)
+    const amountZeroInRemainingLessFee = amountZeroInRemainingBigDec.mul(
+      new BigDec(1).sub(new BigDec(this.zeroForOne.swapFee))
     );
 
-    let sqrtPriceNext: Dec;
+    let sqrtPriceNext: BigDec;
     if (amountZeroInRemainingLessFee.gte(amountZeroIn)) {
-      sqrtPriceNext = sqrtPriceTarget;
+      sqrtPriceNext = sqrtPriceTargetBigDec;
     } else {
       sqrtPriceNext = getNextSqrtPriceFromAmount0InRoundingUp(
         curSqrtPrice,
-        liquidity,
+        liquidityBigDec,
         amountZeroInRemainingLessFee
       );
 
@@ -87,11 +92,11 @@ export class ZeroForOneStrategy implements SwapStrategy {
       }
     }
 
-    const hasReachedTarget = sqrtPriceTarget.equals(sqrtPriceNext);
+    const hasReachedTarget = sqrtPriceTargetBigDec.equals(sqrtPriceNext);
 
     if (!hasReachedTarget) {
       amountZeroIn = calcAmount0Delta(
-        liquidity,
+        liquidityBigDec,
         sqrtPriceNext,
         curSqrtPrice,
         true
@@ -99,23 +104,26 @@ export class ZeroForOneStrategy implements SwapStrategy {
     }
 
     const amountOneOut = calcAmount1Delta(
-      liquidity,
+      liquidityBigDec,
       sqrtPriceNext,
       curSqrtPrice,
       false
     );
 
+    // TODO: needs to be rounded up at precision end.
+    const amountZeroInFinal = amountZeroIn.toDec();
+
     const feeChargeTotal = getFeeChargePerSwapStepOutGivenIn(
       hasReachedTarget,
-      amountZeroIn,
+      amountZeroInFinal,
       amountZeroInRemaining,
       this.zeroForOne.swapFee
     );
 
     return {
       sqrtPriceNext: sqrtPriceNext,
-      amountInConsumed: amountZeroIn,
-      amountOutComputed: amountOneOut,
+      amountInConsumed: amountZeroInFinal,
+      amountOutComputed: amountOneOut.toDec(),
       feeChargeTotal,
     };
   }
@@ -141,31 +149,35 @@ export class ZeroForOneStrategy implements SwapStrategy {
     - zeroForOneStrategy assumes moving to the left of the current square root price.
    */
   computeSwapStepInGivenOut(
-    curSqrtPrice: Dec,
+    curSqrtPrice: BigDec,
     sqrtPriceTarget: Dec,
     liquidity: Dec,
     amountOneRemainingOut: Dec
   ): {
-    sqrtPriceNext: Dec;
+    sqrtPriceNext: BigDec;
     amountOutConsumed: Dec;
     amountInComputed: Dec;
     feeChargeTotal: Dec;
   } {
+    const liquidityBigDec = new BigDec(liquidity);
+    const sqrtPriceTargetBigDec = new BigDec(sqrtPriceTarget);
+    const amountOneOutRemainingBigDec = new BigDec(amountOneRemainingOut);
+
     let amountOneOut = calcAmount1Delta(
-      liquidity,
-      sqrtPriceTarget,
+      liquidityBigDec,
+      sqrtPriceTargetBigDec,
       curSqrtPrice,
       false
     );
 
     let sqrtPriceNext;
-    if (amountOneRemainingOut.gte(amountOneOut)) {
-      sqrtPriceNext = sqrtPriceTarget;
+    if (amountOneOutRemainingBigDec.gte(amountOneOut)) {
+      sqrtPriceNext = sqrtPriceTargetBigDec;
     } else {
       sqrtPriceNext = getNextSqrtPriceFromAmount1OutRoundingDown(
         curSqrtPrice,
-        liquidity,
-        amountOneRemainingOut
+        liquidityBigDec,
+        amountOneOutRemainingBigDec
       );
 
       // This may happen due to a lack of precison. We need 36 for this to not happen.
@@ -177,11 +189,11 @@ export class ZeroForOneStrategy implements SwapStrategy {
       }
     }
 
-    const hasReachedTarget = sqrtPriceTarget.equals(sqrtPriceNext);
+    const hasReachedTarget = sqrtPriceTargetBigDec.equals(sqrtPriceNext);
 
     if (!hasReachedTarget) {
       amountOneOut = calcAmount1Delta(
-        liquidity,
+        liquidityBigDec,
         sqrtPriceNext,
         curSqrtPrice,
         false
@@ -189,20 +201,23 @@ export class ZeroForOneStrategy implements SwapStrategy {
     }
 
     const amountZeroIn = calcAmount0Delta(
-      liquidity,
+      liquidityBigDec,
       sqrtPriceNext,
       curSqrtPrice,
       true
     );
 
-    const feeChargeTotal = amountZeroIn
+    // TODO: needs to be rounded up at precision end.
+    const amountZeroInFinal = amountZeroIn.toDec();
+
+    const feeChargeTotal = amountZeroInFinal
       .mul(this.zeroForOne.swapFee)
       .quo(new Dec(1).sub(this.zeroForOne.swapFee));
 
     return {
       sqrtPriceNext,
-      amountOutConsumed: amountOneOut,
-      amountInComputed: amountZeroIn,
+      amountOutConsumed: amountOneOut.toDec(),
+      amountInComputed: amountZeroInFinal,
       feeChargeTotal,
     };
   }

--- a/packages/math/src/utils.ts
+++ b/packages/math/src/utils.ts
@@ -1,5 +1,7 @@
 import { Dec, Int } from "@keplr-wallet/unit";
 
+import { smallestDec } from "./pool/concentrated/const";
+
 const powPrecision = new Dec("0.00000001");
 
 // This file is intended to be a typescript implementation of power matching
@@ -97,4 +99,65 @@ function powInt(base: Dec, power: Int): Dec {
   }
 
   return base.mul(tmp);
+}
+
+/**
+  Approximate root using Newton's method.
+
+  This function approximates the square root of a given decimal.
+  It uses Newton's method to approximate the square root.
+  It does this by iterating through the formula:
+  x_{n+1} = x_n - (x_n^2 - a) / (2 * x_n)
+  where x_0 is the initial approximation, a is the number whose
+  square root we want to find, and x_n is the current approximation.
+  The number of iterations is controlled by maxIters.
+
+   TODO: move to decimal object see: https://github.com/chainapsis/keplr-wallet/pull/674
+ */
+export function approxRoot(dec: Dec, root: number, maxIters = 300): Dec {
+  if (dec.isNegative()) {
+    return approxRoot(dec.neg(), root).neg();
+  }
+
+  if (root === 1 || dec.isZero() || dec.equals(new Dec(1))) {
+    return dec;
+  }
+
+  if (root === 0) {
+    return new Dec(1);
+  }
+
+  let [guess, delta] = [new Dec(1), new Dec(1)];
+  for (let i = 0; delta.abs().gt(smallestDec) && i < maxIters; i++) {
+    let prev = guess.pow(new Int(root - 1));
+    if (prev.isZero()) {
+      prev = smallestDec;
+    }
+    delta = dec.quo(prev);
+    delta = delta.sub(guess);
+    delta = delta.quoTruncate(new Dec(root));
+
+    guess = guess.add(delta);
+  }
+
+  return guess;
+}
+
+export function approxSqrt(dec: Dec, maxIters = 300): Dec {
+  return approxRoot(dec, 2, maxIters);
+}
+
+// monotonicSqrt does a naive 1 ULP shift to the output of approxSqrt to approximate monotonicity.
+// While this function is not technically monotonic, it is close enough for our purposes.
+// True monotonicity can be achieved by replacing the `approxRoot` with a call to big int's lower level
+// square root function (floor sqrt), which in conjunction with the 1 ULP shift will guarantee monotonicity.
+export function monotonicSqrt(dec: Dec, maxIters = 300): Dec {
+  let estimate = approxRoot(dec, 2, maxIters);
+  const inverseValue = estimate.pow(new Int(2));
+
+  if (inverseValue.lt(estimate)) {
+    estimate = estimate.add(smallestDec);
+  }
+
+  return estimate;
 }

--- a/packages/pools/src/concentrated.ts
+++ b/packages/pools/src/concentrated.ts
@@ -1,5 +1,9 @@
 import { Coin, Dec, Int } from "@keplr-wallet/unit";
-import { ConcentratedLiquidityMath, LiquidityDepth } from "@osmosis-labs/math";
+import {
+  BigDec,
+  ConcentratedLiquidityMath,
+  LiquidityDepth,
+} from "@osmosis-labs/math";
 
 import { NotEnoughLiquidityError } from "./errors";
 import { BasePool } from "./interface";
@@ -94,8 +98,8 @@ export class ConcentratedLiquidityPool implements BasePool, RoutablePool {
   }
 
   /** amountToken1/amountToken0 or token 1 per token 0 */
-  get currentSqrtPrice(): Dec {
-    return new Dec(this.raw.current_sqrt_price);
+  get currentSqrtPrice(): BigDec {
+    return new BigDec(this.raw.current_sqrt_price);
   }
 
   get currentTickLiquidity(): Dec {
@@ -103,8 +107,12 @@ export class ConcentratedLiquidityPool implements BasePool, RoutablePool {
   }
 
   get currentTickLiquidityXY(): [Dec, Dec] {
-    const baseAmount = this.currentTickLiquidity.quo(this.currentSqrtPrice);
-    const quoteAmount = this.currentTickLiquidity.mul(this.currentSqrtPrice);
+    const baseAmount = new BigDec(this.currentTickLiquidity)
+      .quo(this.currentSqrtPrice)
+      .toDec();
+    const quoteAmount = new BigDec(this.currentTickLiquidity)
+      .mul(this.currentSqrtPrice)
+      .toDec();
     return [baseAmount, quoteAmount];
   }
 
@@ -223,7 +231,7 @@ export class ConcentratedLiquidityPool implements BasePool, RoutablePool {
     /** final price token1/token0 */
     const after1Over0SpotPrice = this.spotPrice(
       is0For1 ? tokenIn.denom : tokenOutDenom,
-      afterSqrtPrice
+      afterSqrtPrice.toDec()
     );
 
     if (is0For1 && after1Over0SpotPrice.gt(before1Over0SpotPrice)) {
@@ -326,7 +334,7 @@ export class ConcentratedLiquidityPool implements BasePool, RoutablePool {
     /** final price token1/token0 */
     const after1Over0SpotPrice = this.spotPrice(
       is0For1 ? tokenInDenom : tokenOut.denom,
-      afterSqrtPrice
+      afterSqrtPrice.toDec()
     );
 
     if (is0For1 && after1Over0SpotPrice.gt(before1Over0SpotPrice)) {

--- a/packages/stores/src/account/__tests_e2e__/positions.spec.ts
+++ b/packages/stores/src/account/__tests_e2e__/positions.spec.ts
@@ -69,7 +69,7 @@ describe("Create CL Positions Txs", () => {
 
     // get current tick, subtract to be below current price
     const currentTick = priceToTick(
-      queryPool!.concentratedLiquidityPoolInfo!.currentPrice
+      queryPool!.concentratedLiquidityPoolInfo!.currentPrice.toDec()
     ).sub(new Int(1));
 
     // create CL position
@@ -110,7 +110,7 @@ describe("Create CL Positions Txs", () => {
 
     // get current tick, add to be below above price
     const currentTick = priceToTick(
-      queryPool!.concentratedLiquidityPoolInfo!.currentPrice
+      queryPool!.concentratedLiquidityPoolInfo!.currentPrice.toDec()
     ).add(new Int(1));
 
     // create CL position

--- a/packages/stores/src/account/__tests_e2e__/swap-exact-in-positions.spec.ts
+++ b/packages/stores/src/account/__tests_e2e__/swap-exact-in-positions.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { Dec, Int } from "@keplr-wallet/unit";
 import { maxTick, minTick } from "@osmosis-labs/math";
+import { BigDec } from "@osmosis-labs/math/src/big-dec";
 import {
   calcAmount0Delta,
   calcAmount1Delta,
@@ -647,7 +648,7 @@ describe("Test Swap Exact In - Concentrated Liquidity", () => {
       const range = ranges[i];
       const { amountInConsumed, amountOutComputed, feeChargeTotal } =
         strategy.computeSwapStepOutGivenIn(
-          tickToSqrtPrice(range.lowerTick),
+          new BigDec(tickToSqrtPrice(range.lowerTick)),
           tickToSqrtPrice(range.upperTick),
           range.liquidity,
           tokenInAmountRemainingDec
@@ -669,8 +670,8 @@ describe("Test Swap Exact In - Concentrated Liquidity", () => {
     ranges: Range[]
   ) {
     // estimate quote
-    let tokenOutTotal = new Dec(0);
-    let tokenInTotal = new Dec(0);
+    let tokenOutTotal = new BigDec(0);
+    let tokenInTotal = new BigDec(0);
     for (
       let i = 0;
       i < ranges.length && ranges[i].lowerTick < tickToSwapTo;
@@ -679,31 +680,32 @@ describe("Test Swap Exact In - Concentrated Liquidity", () => {
       const range = ranges[i];
 
       const amountZeroOut = calcAmount0Delta(
-        range.liquidity,
-        tickToSqrtPrice(range.lowerTick),
-        tickToSqrtPrice(range.upperTick),
+        new BigDec(range.liquidity),
+        new BigDec(tickToSqrtPrice(range.lowerTick)),
+        new BigDec(tickToSqrtPrice(range.upperTick)),
         false
       );
 
       const amountOneIn = calcAmount1Delta(
-        range.liquidity,
-        tickToSqrtPrice(range.lowerTick),
-        tickToSqrtPrice(range.upperTick),
+        new BigDec(range.liquidity),
+        new BigDec(tickToSqrtPrice(range.lowerTick)),
+        new BigDec(tickToSqrtPrice(range.upperTick)),
         true
       );
 
       // fee charge
+      const spreadFactor = new BigDec(1);
       const feeCharge = amountOneIn
         .mul(spreadFactor)
-        .quo(new Dec(1).sub(spreadFactor));
+        .quo(new BigDec(1).sub(spreadFactor));
 
       tokenOutTotal = tokenOutTotal.add(amountZeroOut);
       tokenInTotal = tokenInTotal.add(amountOneIn).add(feeCharge);
     }
 
     const result: EstimateResult = {
-      amountIn: tokenInTotal,
-      amountOut: tokenOutTotal,
+      amountIn: tokenInTotal.toDec(),
+      amountOut: tokenOutTotal.toDec(),
     };
 
     return result;
@@ -716,8 +718,8 @@ describe("Test Swap Exact In - Concentrated Liquidity", () => {
     ranges: Range[]
   ) {
     // estimate quote
-    let tokenOutTotal = new Dec(0);
-    let tokenInTotal = new Dec(0);
+    let tokenOutTotal = new BigDec(0);
+    let tokenInTotal = new BigDec(0);
     for (
       let i = 0;
       i < ranges.length && ranges[i].lowerTick >= tickToSwapTo;
@@ -726,31 +728,32 @@ describe("Test Swap Exact In - Concentrated Liquidity", () => {
       const range = ranges[i];
 
       const amountOneOut = calcAmount1Delta(
-        range.liquidity,
-        tickToSqrtPrice(range.lowerTick),
-        tickToSqrtPrice(range.upperTick),
+        new BigDec(range.liquidity),
+        new BigDec(tickToSqrtPrice(range.lowerTick)),
+        new BigDec(tickToSqrtPrice(range.upperTick)),
         false
       );
 
       const amountZeroIn = calcAmount0Delta(
-        range.liquidity,
-        tickToSqrtPrice(range.lowerTick),
-        tickToSqrtPrice(range.upperTick),
+        new BigDec(range.liquidity),
+        new BigDec(tickToSqrtPrice(range.lowerTick)),
+        new BigDec(tickToSqrtPrice(range.upperTick)),
         true
       );
 
       // fee charge
+      const spreadFactorBigDec = new BigDec(spreadFactor);
       const feeCharge = amountZeroIn
-        .mul(spreadFactor)
-        .quo(new Dec(1).sub(spreadFactor));
+        .mul(spreadFactorBigDec)
+        .quo(new BigDec(1).sub(spreadFactorBigDec));
 
       tokenOutTotal = tokenOutTotal.add(amountOneOut);
       tokenInTotal = tokenInTotal.add(amountZeroIn).add(feeCharge);
     }
 
     const result: EstimateResult = {
-      amountIn: tokenInTotal,
-      amountOut: tokenOutTotal,
+      amountIn: tokenInTotal.toDec(),
+      amountOut: tokenOutTotal.toDec(),
     };
 
     return result;

--- a/packages/stores/src/account/osmosis/index.ts
+++ b/packages/stores/src/account/osmosis/index.ts
@@ -648,7 +648,7 @@ export class OsmosisAccountImpl {
             queryPool.concentratedLiquidityPoolInfo?.currentSqrtPrice!;
 
           const currentTick = OsmosisMath.priceToTick(
-            currentSqrtPrice.mul(currentSqrtPrice)
+            currentSqrtPrice.mul(currentSqrtPrice).toDec()
           );
 
           const slippageMultiplier = new Dec(1).sub(

--- a/packages/stores/src/ui-config/manage-liquidity/add-concentrated-liquidity.ts
+++ b/packages/stores/src/ui-config/manage-liquidity/add-concentrated-liquidity.ts
@@ -77,7 +77,7 @@ export class ObservableAddConcentratedLiquidityConfig {
     if (!this._pool) return new Dec(0);
 
     return (
-      this._pool.currentSqrtPrice?.mul(this._pool.currentSqrtPrice) ??
+      this._pool.currentSqrtPrice?.mul(this._pool.currentSqrtPrice).toDec() ??
       new Dec(0)
     );
   }

--- a/packages/web/components/cards/my-position/index.tsx
+++ b/packages/web/components/cards/my-position/index.tsx
@@ -129,9 +129,7 @@ export const MyPositionCard: FunctionComponent<{
               lowerPrices &&
               upperPrices && (
                 <MyPositionStatus
-                  currentPrice={
-                    queryPool.concentratedLiquidityPoolInfo.currentPrice
-                  }
+                  currentPrice={queryPool.concentratedLiquidityPoolInfo.currentPrice.toDec()}
                   lowerPrice={lowerPrices.price}
                   upperPrice={upperPrices.price}
                   fullRange={isFullRange}

--- a/packages/web/components/pool-detail/concentrated.tsx
+++ b/packages/web/components/pool-detail/concentrated.tsx
@@ -212,7 +212,7 @@ export const ConcentratedLiquidityPool: FunctionComponent<{ poolId: string }> =
                     offset={{
                       top: 0,
                       right: currentPrice
-                        ? currentPrice.gt(new Dec(100))
+                        ? currentPrice.toDec().gt(new Dec(100))
                           ? 120
                           : 56
                         : 36,
@@ -225,7 +225,7 @@ export const ConcentratedLiquidityPool: FunctionComponent<{ poolId: string }> =
                 {currentPrice && (
                   <h6 className="absolute right-0 top-[51%]">
                     {currentPrice.toString(
-                      currentPrice.gt(new Dec(100)) ? 0 : 2
+                      currentPrice.toDec().gt(new Dec(100)) ? 0 : 2
                     )}
                   </h6>
                 )}

--- a/packages/web/modals/remove-concentrated-liquidity.tsx
+++ b/packages/web/modals/remove-concentrated-liquidity.tsx
@@ -70,7 +70,7 @@ export const RemoveConcentratedLiquidityModal: FunctionComponent<
       : undefined;
   const currentSqrtPrice = clPool ? clPool.currentSqrtPrice : undefined;
   const currentPrice = currentSqrtPrice
-    ? currentSqrtPrice.mul(currentSqrtPrice)
+    ? currentSqrtPrice.mul(currentSqrtPrice).toDec()
     : new Dec(0);
 
   const baseAssetValue = baseAsset


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Updating precision to align closer with the chain for quote estimation. The goal is to avoid failing via frontend due to invalid slippage bound.

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/860r9zvey)

## Brief Changelog

- Changed Dec to BigDec where applicable to match chain
- Refactored dependencies
- Updated test vectors in `math` package

## Testing and Verifying
- Test vectors are taken directly from chain code
- Recalculated in Python manually where no chain test was found
- Ran all static tests
   * Everything passed but `packages/web` . Unfortunately, I cannot build it to run for some reason. @jonator for awareness

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
