### PR TITLE
Refresh position metrics after creating or adding to position

### DIFF
--- a/packages/stores/src/account/osmosis/index.ts
+++ b/packages/stores/src/account/osmosis/index.ts
@@ -913,6 +913,13 @@ export class OsmosisAccountImpl {
           queries.osmosis?.queryAccountsPositions
             .get(this.address)
             .waitFreshResponse();
+
+          // refresh metrics of same position, since it's the same ID after withdrawing
+          setTimeout(() => {
+            this.queriesExternalStore?.queryPositionsPerformaceMetrics
+              .get(positionId)
+              ?.waitFreshResponse();
+          }, 30_000);
         }
         onFulfill?.(tx);
       }

--- a/packages/stores/src/account/osmosis/index.ts
+++ b/packages/stores/src/account/osmosis/index.ts
@@ -728,9 +728,11 @@ export class OsmosisAccountImpl {
           // refresh metrics of new position
           const newPositionID = findNewClPositionId(tx);
           if (newPositionID) {
-            this.queriesExternalStore?.queryPositionsPerformaceMetrics
-              .get(newPositionID)
-              ?.waitFreshResponse();
+            setTimeout(() => {
+              this.queriesExternalStore?.queryPositionsPerformaceMetrics
+                .get(newPositionID)
+                ?.waitFreshResponse();
+            }, 30_000);
           }
         }
         onFulfill?.(tx);
@@ -846,9 +848,12 @@ export class OsmosisAccountImpl {
           // refresh metrics of new position
           const newPositionID = findNewClPositionId(tx);
           if (newPositionID) {
-            this.queriesExternalStore?.queryPositionsPerformaceMetrics
-              .get(newPositionID)
-              ?.waitFreshResponse();
+            // wait a long time for indexer to run
+            setTimeout(() => {
+              this.queriesExternalStore?.queryPositionsPerformaceMetrics
+                .get(newPositionID)
+                ?.waitFreshResponse();
+            }, 30_000);
           }
         }
         onFulfill?.(tx);

--- a/packages/stores/src/account/osmosis/tx-response.ts
+++ b/packages/stores/src/account/osmosis/tx-response.ts
@@ -1,0 +1,16 @@
+import { DeliverTxResponse } from "../types";
+
+/** Try to extract the create_position event from the raw log. */
+export function findNewClPositionId(
+  txResponse: DeliverTxResponse
+): string | undefined {
+  try {
+    const events = JSON.parse(txResponse.rawLog ?? "{}");
+    return events[0].events
+      .find((event: any) => event.type === "create_position")
+      .attributes.find((attr: any) => attr.key === "position_id").value;
+  } catch (e: any) {
+    console.error(e);
+    return undefined;
+  }
+}

--- a/packages/web/stores/root.ts
+++ b/packages/web/stores/root.ts
@@ -98,51 +98,6 @@ export class RootStore {
       OsmosisQueries.use(this.chainStore.osmosis.chainId, IS_TESTNET)
     );
 
-    this.accountStore = new AccountStore(
-      ChainInfos,
-      WalletAssets,
-      /**
-       * No need to add default wallets as we'll lazily install them as needed.
-       * @see wallet-select.tsx
-       * @see wallet-registry.ts
-       */
-      [],
-      this.queriesStore,
-      this.chainStore,
-      {
-        walletConnectOptions: {
-          signClient: {
-            projectId: WALLETCONNECT_PROJECT_KEY ?? "",
-            relayUrl: WALLETCONNECT_RELAY_URL,
-          },
-        },
-        preTxEvents: {
-          onBroadcastFailed: toastOnBroadcastFailed((chainId) =>
-            this.chainStore.getChain(chainId)
-          ),
-          onBroadcasted: toastOnBroadcast(),
-          onFulfill: toastOnFulfill((chainId) =>
-            this.chainStore.getChain(chainId)
-          ),
-        },
-      },
-      OsmosisAccount.use({ queriesStore: this.queriesStore }),
-      CosmosAccount.use({
-        queriesStore: this.queriesStore,
-        msgOptsCreator(chainId) {
-          if (chainId.startsWith("osmosis")) {
-            return { ibcTransfer: { gas: 300000 } };
-          }
-          if (chainId.startsWith("evmos_")) {
-            return { ibcTransfer: { gas: 250000 } };
-          } else {
-            return { ibcTransfer: { gas: 210000 } };
-          }
-        },
-      }),
-      CosmwasmAccount.use({ queriesStore: this.queriesStore })
-    );
-
     this.priceStore = new PoolFallbackPriceStore(
       this.chainStore.osmosis.chainId,
       this.chainStore,
@@ -181,6 +136,54 @@ export class RootStore {
       TIMESERIES_DATA_URL,
       INDEXER_DATA_URL,
       IS_TESTNET
+    );
+
+    this.accountStore = new AccountStore(
+      ChainInfos,
+      WalletAssets,
+      /**
+       * No need to add default wallets as we'll lazily install them as needed.
+       * @see wallet-select.tsx
+       * @see wallet-registry.ts
+       */
+      [],
+      this.queriesStore,
+      this.chainStore,
+      {
+        walletConnectOptions: {
+          signClient: {
+            projectId: WALLETCONNECT_PROJECT_KEY ?? "",
+            relayUrl: WALLETCONNECT_RELAY_URL,
+          },
+        },
+        preTxEvents: {
+          onBroadcastFailed: toastOnBroadcastFailed((chainId) =>
+            this.chainStore.getChain(chainId)
+          ),
+          onBroadcasted: toastOnBroadcast(),
+          onFulfill: toastOnFulfill((chainId) =>
+            this.chainStore.getChain(chainId)
+          ),
+        },
+      },
+      OsmosisAccount.use({
+        queriesStore: this.queriesStore,
+        queriesExternalStore: this.queriesExternalStore,
+      }),
+      CosmosAccount.use({
+        queriesStore: this.queriesStore,
+        msgOptsCreator(chainId) {
+          if (chainId.startsWith("osmosis")) {
+            return { ibcTransfer: { gas: 300000 } };
+          }
+          if (chainId.startsWith("evmos_")) {
+            return { ibcTransfer: { gas: 250000 } };
+          } else {
+            return { ibcTransfer: { gas: 210000 } };
+          }
+        },
+      }),
+      CosmwasmAccount.use({ queriesStore: this.queriesStore })
     );
 
     this.assetsStore = new ObservableAssets(


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

After creating or adding to a position, refresh position metrics with the new position ID with a delay of 30s to wait for indexer to run.

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/86780cqt2)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->
- Import queries external store into account store (optional)
- Refresh position metrics 30s after tx fullfillment

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

Create or add to a position, notice API call 30s later (it will error due to env issues, if not using cl preview).
