### PR TITLE
refactor: better error message when not enough quoted

### DIFF
--- a/packages/pools/src/concentrated.ts
+++ b/packages/pools/src/concentrated.ts
@@ -5,7 +5,7 @@ import {
   LiquidityDepth,
 } from "@osmosis-labs/math";
 
-import { NotEnoughLiquidityError } from "./errors";
+import { NotEnoughLiquidityError, NotEnoughQuotedError } from "./errors";
 import { BasePool } from "./interface";
 import { Quote, RoutablePool } from "./router";
 
@@ -226,7 +226,10 @@ export class ConcentratedLiquidityPool implements BasePool, RoutablePool {
 
     const { amountOut, afterSqrtPrice } = calcResult;
 
-    if (amountOut.lte(new Int(0))) throw new NotEnoughLiquidityError();
+    if (amountOut.lte(new Int(0)))
+      throw new NotEnoughQuotedError(
+        `The calculated amount of token ${tokenOutDenom} out is smaller than 1 when quoting ${tokenIn.amount}${tokenIn.denom} in.`
+      );
 
     /** final price token1/token0 */
     const after1Over0SpotPrice = this.spotPrice(
@@ -329,7 +332,10 @@ export class ConcentratedLiquidityPool implements BasePool, RoutablePool {
 
     const { amountIn, afterSqrtPrice } = calcResult;
 
-    if (amountIn.lte(new Int(0))) throw new NotEnoughLiquidityError();
+    if (amountIn.lte(new Int(0)))
+      throw new NotEnoughQuotedError(
+        `The calculated amount of token ${tokenInDenom} in is smaller than 1 when quoting ${tokenOut.amount}${tokenOut.denom} out.`
+      );
 
     /** final price token1/token0 */
     const after1Over0SpotPrice = this.spotPrice(

--- a/packages/pools/src/errors.ts
+++ b/packages/pools/src/errors.ts
@@ -5,3 +5,12 @@ export class NotEnoughLiquidityError extends Error {
     Object.setPrototypeOf(this, NotEnoughLiquidityError.prototype);
   }
 }
+
+export class NotEnoughQuotedError extends Error {
+  constructor(string?: string) {
+    const defaultMessage = "Not enough quoted. Try increasing amount.";
+    super(string ? defaultMessage + " " + string : defaultMessage);
+    // Set the prototype explicitly.
+    Object.setPrototypeOf(this, NotEnoughQuotedError.prototype);
+  }
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Better error message to explain what's up with not giving enough tokens in

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/862k3p20d)

## Brief Changelog

- new error message similar to `NotEnoughLiquidity`
- Replace `NotEnoughLiquidity` with new error

## Testing and Verifying

- `Ran yarn test` in root

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? yes
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
