### PR TITLE
update ld config to check for laptoporlarger

### DIFF
--- a/packages/web/pages/_app.tsx
+++ b/packages/web/pages/_app.tsx
@@ -170,10 +170,31 @@ const ldAnonymousContext = {
   anonymous: true,
 };
 
+// Determine the device type based on screen width:
+const getDeviceType = () => {
+  // Change this value based on your definition of mobile vs desktop
+  const mobileScreenWidthThreshold = 768;
+
+  if (typeof window !== "undefined") {
+    if (window.innerWidth < mobileScreenWidthThreshold) {
+      return "mobile";
+    } else {
+      return "laptopOrLarger";
+    }
+  }
+
+  // Default device type if window is not defined (like in server-side rendering)
+  return "unknown";
+};
+
 export default withLDProvider({
   clientSideID: process.env.NEXT_PUBLIC_LAUNCH_DARKLY_CLIENT_SIDE_ID || "",
   user: {
     anonymous: true,
+    // Add the custom attribute for device type
+    custom: {
+      deviceType: getDeviceType(),
+    },
   },
   options: {
     bootstrap: "localStorage",


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Adding the 'laptopOrLarger' flag to our Launch Darkly initialization. This should allow us to target whether or not a user is on mobile when LD initializes i.e. and hide certain features from mobile users.

## Brief Changelog

- Add laptopOrLargerFlags
- bunch of linting fixes

## Testing and Verifying

This change has been tested locally by rebuilding the website and verified content and links are expected


