### PR TITLE
fix: inlang.config.js ignore `__tests__` folder

### DIFF
--- a/inlang.config.js
+++ b/inlang.config.js
@@ -16,6 +16,7 @@ export async function defineConfig(env) {
       jsonPlugin({
         pathPattern: "./packages/web/localizations/{language}.json",
         variableReferencePattern: ["{", "}"],
+        ignore: ["__tests__"]
       }),
       standardLintRules(),
     ],

--- a/inlang.config.js
+++ b/inlang.config.js
@@ -3,7 +3,7 @@
  */
 export async function defineConfig(env) {
   const { default: jsonPlugin } = await env.$import(
-    "https://cdn.jsdelivr.net/npm/@inlang/plugin-json@3.0.9/dist/index.js"
+    "https://cdn.jsdelivr.net/npm/@inlang/plugin-json@3/dist/index.js"
   );
 
   const { default: standardLintRules } = await env.$import(

--- a/inlang.config.js
+++ b/inlang.config.js
@@ -3,7 +3,7 @@
  */
 export async function defineConfig(env) {
   const { default: jsonPlugin } = await env.$import(
-    "https://cdn.jsdelivr.net/npm/@inlang/plugin-json@3/dist/index.js"
+    "https://cdn.jsdelivr.net/npm/@inlang/plugin-json@3.0.9/dist/index.js"
   );
 
   const { default: standardLintRules } = await env.$import(


### PR DESCRIPTION
This PR is based on this issue: https://github.com/inlang/inlang/issues/1082

## What changed
- Added ignore to inlang.config.js
- Should work with the new patch of the plugin 