### PR TITLE
(CL) Set Initial Custom Range when Add Liquidity Modal Mounts

### DIFF
--- a/packages/stores/src/ui-config/manage-liquidity/add-concentrated-liquidity.ts
+++ b/packages/stores/src/ui-config/manage-liquidity/add-concentrated-liquidity.ts
@@ -453,12 +453,39 @@ export class ObservableAddConcentratedLiquidityConfig {
       ),
     ];
 
-    // Set the initial range to be the moderate range
-    this._priceRangeInput[0].input(this.moderatePriceRange[0]);
-    this._priceRangeInput[1].input(this.moderatePriceRange[1]);
-
     const queryAccountBalances =
       this.queryBalances.getQueryBech32Address(sender);
+
+    let initialized = false;
+
+    // Set the initial range to be the initial custom range
+    autorun(() => {
+      if (
+        this.pool &&
+        !initialized &&
+        this._baseDepositAmountIn.sendCurrency &&
+        this._quoteDepositAmountIn.sendCurrency
+      ) {
+        initialized = true;
+
+        const multiplicationQuoteOverBase = DecUtils.getTenExponentN(
+          (this._baseDepositAmountIn.sendCurrency.coinDecimals ?? 0) -
+            (this._quoteDepositAmountIn.sendCurrency.coinDecimals ?? 0)
+        );
+
+        // Set the initial range to be the moderate range
+        this.setMinRange(
+          this.initialCustomPriceRange[0]
+            .mul(multiplicationQuoteOverBase)
+            .toString()
+        );
+        this.setMaxRange(
+          this.initialCustomPriceRange[1]
+            .mul(multiplicationQuoteOverBase)
+            .toString()
+        );
+      }
+    });
 
     // Calculate quote amount when base amount is input and anchor is base
     // Calculate an amount1 given an amount0

--- a/packages/web/components/chart/token-pair-historical.tsx
+++ b/packages/web/components/chart/token-pair-historical.tsx
@@ -37,7 +37,7 @@ const TokenPairHistoricalChart: FunctionComponent<{
       {({ height, width }) => (
         <XYChart
           key="line-chart"
-          margin={{ top: 0, right: 0, bottom: 24, left: 28 }}
+          margin={{ top: 0, right: 0, bottom: 24, left: 36 }}
           height={height}
           width={width}
           xScale={{

--- a/packages/web/components/complex/add-conc-liquidity.tsx
+++ b/packages/web/components/complex/add-conc-liquidity.tsx
@@ -316,7 +316,7 @@ const AddConcLiqView: FunctionComponent<
   // sync the price range of the add liq config and the chart config
   useEffect(() => {
     chartConfig.setPriceRange(rangeWithCurrencyDecimals);
-  }, [chartConfig, fullRange, rangeWithCurrencyDecimals]);
+  }, [chartConfig, rangeWithCurrencyDecimals]);
 
   return (
     <>
@@ -669,8 +669,6 @@ const PresetStrategyCard: FunctionComponent<
       },
       [setMinRange, setMaxRange, baseDepositAmountIn, quoteDepositAmountIn]
     );
-
-    console.log(highSpotPriceInputRef);
 
     const onClick = () => {
       switch (type) {


### PR DESCRIPTION
## Brief Changelog

- Set initial custom range when add liquidity modal mounts. 
