### PR TITLE
fix: increase gas per crossed tick in swaps

### DIFF
--- a/packages/stores/src/account/osmosis/types.ts
+++ b/packages/stores/src/account/osmosis/types.ts
@@ -46,13 +46,13 @@ export const osmosisMsgOpts = createMsgOpts({
   swapExactAmountIn: (numPools: number, numTicks = 0) => ({
     messageComposer:
       osmosis.poolmanager.v1beta1.MessageComposer.withTypeUrl.swapExactAmountIn,
-    gas: 500_000 * numPools + 40_000 * numTicks,
+    gas: 500_000 * numPools + 50_000 * numTicks,
   }),
   swapExactAmountOut: (numPools: number, numTicks = 0) => ({
     messageComposer:
       osmosis.poolmanager.v1beta1.MessageComposer.withTypeUrl
         .swapExactAmountOut,
-    gas: 500_000 * numPools + 40_000 * numTicks,
+    gas: 500_000 * numPools + 50_000 * numTicks,
   }),
   lockTokens: {
     gas: 450000,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Prior to this PR, I would get out of gas issues when doing large swaps on edgenet.

For example, a swap crossing 160 ticks would fail. With this change, my manual e2e tests with large swap amounts work out.

There are too many variables to control with CL swaps. As a result, we should err on the side of caution and overestimate the gas amounts per crossed ticks.

For v17, there is already effort started to reduce gas amounts in swaps.

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/860ratnbr)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

- Manually tested swapping large amounts with significant price impact back and forth on edgenet
- Printed the number of crossed ticks. The max number observed was 160

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
