### PR TITLE
Include position assets in assets page total assets

### DIFF
--- a/packages/web/pages/assets/index.tsx
+++ b/packages/web/pages/assets/index.tsx
@@ -255,6 +255,7 @@ const AssetsOverview: FunctionComponent = observer(() => {
         if (position.quoteAsset) {
           addToMap(position.quoteAsset);
         }
+        position.totalClaimableRewards.forEach(addToMap);
         return balances;
       }, new Map<string, CoinPretty>())
       .values()


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

Includes account's position balances and all rewards in "Total assets" portion of assets page overview:

<img width="1077" alt="Screenshot 2023-07-19 at 3 16 40 PM" src="https://github.com/osmosis-labs/osmosis-frontend/assets/4606373/766d4a2c-7bc7-47a3-afca-4d0b95acc9e6">
