### PR TITLE
support cosmostation mobile via cosmos-kit

### DIFF
--- a/packages/web/config/generate-wallet-registry.ts
+++ b/packages/web/config/generate-wallet-registry.ts
@@ -1,6 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import type { Wallet } from "@cosmos-kit/core";
 import { cosmostationExtensionInfo } from "@cosmos-kit/cosmostation-extension";
+import { cosmostationMobileInfo } from "@cosmos-kit/cosmostation-mobile";
 import { keplrExtensionInfo } from "@cosmos-kit/keplr-extension";
 import { keplrMobileInfo } from "@cosmos-kit/keplr-mobile";
 import { leapExtensionInfo } from "@cosmos-kit/leap-extension";
@@ -35,15 +36,17 @@ const WalletRegistry: (Wallet & {
   {
     ...cosmostationExtensionInfo,
     logo: "/wallets/cosmostation.png",
+    mobileDisabled: false,
     lazyInstallUrl: "@cosmos-kit/cosmostation-extension",
     walletClassName: "CosmostationExtensionWallet",
   },
-  // {
-  //   ...cosmostationMobileInfo,
-  //   logo: "/wallets/cosmostation.png",
-  //   lazyInstallUrl: "@cosmos-kit/cosmostation-mobile",
-  //   walletClassName: "CosmostationMobileWallet",
-  // },
+  {
+    ...cosmostationMobileInfo,
+    logo: "/wallets/cosmostation.png",
+    mobileDisabled: false,
+    lazyInstallUrl: "@cosmos-kit/cosmostation-mobile",
+    walletClassName: "CosmostationMobileWallet",
+  },
   // {
   //   ...frontierExtensionInfo,
   //   logo: "/wallets/frontier.png",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -26,7 +26,7 @@
     "@cosmjs/proto-signing": "0.29.0",
     "@cosmjs/stargate": "0.29.0",
     "@cosmos-kit/core": "1.7.0",
-    "@cosmos-kit/cosmostation": "0.15.38",
+    "@cosmos-kit/cosmostation": "2.0.2",
     "@cosmos-kit/keplr": "0.33.40",
     "@cosmos-kit/leap": "0.15.10",
     "@ethersproject/abi": "^5.7.0",


### PR DESCRIPTION
## What is the purpose of the change
This pr request supports cosmostation mobile wallet.

## Brief Changelog

- Update @cosmos-kit/cosmostation version
- Add cosmostation mobile to generate-wallet-registry

## Testing and Verifying

This change has been tested locally in cosmostation mobile wallet


## Documentation and Release Note

-