### PR TITLE
filter 895

### DIFF
--- a/packages/web/pages/index.tsx
+++ b/packages/web/pages/index.tsx
@@ -48,6 +48,8 @@ const Home = ({ ads }: InferGetServerSidePropsType<typeof getStaticProps>) => {
           // include all pools on testnet env
           if (IS_TESTNET) return true;
 
+          if (pool.id === "895") return false;
+
           // filter concentrated pools if feature flag is not enabled
           if (pool.type === "concentrated" && !flags.concentratedLiquidity)
             return false;


### PR DESCRIPTION
From conversation here:

https://t.me/c/1430596792/17849

Assets in 895 are for a scam project, and the router often routes USDC trades through that pool.