### PR TITLE
Update `inlang.config.js` & `@inlang/cli` to fix lint command

### DIFF
--- a/inlang.config.js
+++ b/inlang.config.js
@@ -7,7 +7,7 @@ export async function defineConfig(env) {
   );
 
   const { default: standardLintRules } = await env.$import(
-    "https://cdn.jsdelivr.net/gh/inlang/standard-lint-rules@2/dist/index.js"
+    "https://cdn.jsdelivr.net/npm/@inlang/plugin-standard-lint-rules@3/dist/index.js"
   );
 
   return {
@@ -16,7 +16,7 @@ export async function defineConfig(env) {
       jsonPlugin({
         pathPattern: "./packages/web/localizations/{language}.json",
         variableReferencePattern: ["{", "}"],
-        ignore: ["__tests__"]
+        ignore: ["__tests__"],
       }),
       standardLintRules(),
     ],

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "homepage": "https://github.com/osmosis-labs/osmosis-frontend#readme",
   "devDependencies": {
-    "@inlang/cli": "^0.11.7",
+    "@inlang/cli": "^0.13.3",
     "@types/jest": "^27.4.0",
     "@typescript-eslint/eslint-plugin": "^5.9.0",
     "@typescript-eslint/parser": "^5.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2851,10 +2851,10 @@
   resolved "https://registry.npmjs.org/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz"
   integrity sha512-H9XAx3hc0BQHY6l+IFSWHDySypcXsvsuLhgYLUGywmJ5pswRVQJUHpOsobnLYp2ZUaUlKiKDrgWWhosOwAEM8Q==
 
-"@inlang/cli@^0.11.7":
-  version "0.11.7"
-  resolved "https://registry.yarnpkg.com/@inlang/cli/-/cli-0.11.7.tgz#a1f73601303321f88f93ab63f62ba25263bad049"
-  integrity sha512-ZKR9YYzTS5+RzlTVCVSVFrrRJdbqr5mp0roRTJUIu5ieYix3O5m3kRjGKEuk/oGoIZ9G54dnn2qftaENZ2AwSQ==
+"@inlang/cli@^0.13.3":
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/@inlang/cli/-/cli-0.13.3.tgz#e7cd0c8f3ae8a283dad3c8e1beeb1a2188f32cd8"
+  integrity sha512-6pdLmdHuaTJAfW+Zct2yHwHIIKE01zrDw+/fPXyzFe0ycq/W9YNj7CVA+KElqRhHjwJWqYbhvpJ3G6RABIO4Hw==
 
 "@iov/crypto@2.1.0":
   version "2.1.0"


### PR DESCRIPTION
## What is the purpose of the change

Make `inlang lint` command work again

**Note:** to always use the newest version change `inlang lint` to `npx @inlang/cli@latest lint` in the lint command.

## Brief Changelog

- update @inlang/cli to newest version (^0.11.7" > ^0.13.3")
- update `inlang.config.js` with the newest version of `@inlang/plugin-standard-lint-rules@3`

## Testing and Verifying

This change has been tested locally by rebuilding the website and verified content and links are expected
