### PR TITLE
Update CUB price

### DIFF
--- a/packages/web/config/price.ts
+++ b/packages/web/config/price.ts
@@ -1819,8 +1819,11 @@ const mainnetPoolPriceRoutes: IntermediateRoute[] = [
       [{ portId: "transfer", channelId: "channel-341" }],
       "cw20:terra1lalvk0r6nhruel7fvzdppk3tup3mh5j4d4eadrqzfhle4zrf52as58hh9t"
     ),
-    spotPriceDestDenom: "uosmo",
-    destCoinId: "pool:uosmo",
+    spotPriceDestDenom: DenomHelper.ibcDenom(
+      [{ portId: "transfer", channelId: "channel-251" }],
+      "uluna"
+    ),
+    destCoinId: "pool:uluna",
   },
   {
     alternativeCoinId: "pool:blue",

--- a/packages/web/config/price.ts
+++ b/packages/web/config/price.ts
@@ -1814,7 +1814,7 @@ const mainnetPoolPriceRoutes: IntermediateRoute[] = [
   },
   {
     alternativeCoinId: "pool:cub",
-    poolId: "1046",
+    poolId: "1072",
     spotPriceSourceDenom: DenomHelper.ibcDenom(
       [{ portId: "transfer", channelId: "channel-341" }],
       "cw20:terra1lalvk0r6nhruel7fvzdppk3tup3mh5j4d4eadrqzfhle4zrf52as58hh9t"


### PR DESCRIPTION
## What is the purpose of the change

The token CUB was missing a pricing config. Now it has a pool so we can price it.

## Brief Changelog

Added pool 1072 to Cub price config (incorrectly configured to pool 1046, which doesn't have CUB)

## Testing and Verifying

This change has been tested locally by rebuilding the website and verified content and links are expected