### PR TITLE
Fall back to pre v17 queries

### DIFF
--- a/packages/stores/src/queries/pools/cfmm-cl-link.ts
+++ b/packages/stores/src/queries/pools/cfmm-cl-link.ts
@@ -1,12 +1,27 @@
 import { KVStore } from "@keplr-wallet/common";
-import { ChainGetter, ObservableChainQuery } from "@keplr-wallet/stores";
-import { makeObservable } from "mobx";
+import {
+  ChainGetter,
+  ObservableChainQuery,
+  ObservableChainQueryMap,
+} from "@keplr-wallet/stores";
+import { computed, makeObservable } from "mobx";
 import { computedFn } from "mobx-utils";
 
+import { ObservableQueryNodeInfo } from "../tendermint/node-info";
 import { MigrationRecords } from "./types";
 
 export class ObservableQueryCfmmConcentratedPoolLinks extends ObservableChainQuery<MigrationRecords> {
-  constructor(kvStore: KVStore, chainId: string, chainGetter: ChainGetter) {
+  // BACKWARDS COMPATIBLE QUERIES FOR PRE V17:
+  // TODO: can be safely removed after migration to v17, est Aug 22 '23
+  protected backCompatQueryCfmmToCL: ObservableQueryCfmmToConcentratedLiquidityPoolLinks;
+  protected backCompatQueryClToCfmm: ObservableQueryConcentratedLiquidityToCfmmPoolLinks;
+
+  constructor(
+    kvStore: KVStore,
+    chainId: string,
+    chainGetter: ChainGetter,
+    protected readonly queryNodeInfo: ObservableQueryNodeInfo
+  ) {
     super(
       kvStore,
       chainId,
@@ -14,7 +29,26 @@ export class ObservableQueryCfmmConcentratedPoolLinks extends ObservableChainQue
       "/osmosis/gamm/v1beta1/cfmm_concentrated_pool_links"
     );
 
+    this.backCompatQueryCfmmToCL =
+      new ObservableQueryCfmmToConcentratedLiquidityPoolLinks(
+        kvStore,
+        chainId,
+        chainGetter
+      );
+
+    this.backCompatQueryClToCfmm =
+      new ObservableQueryConcentratedLiquidityToCfmmPoolLinks(
+        kvStore,
+        chainId,
+        chainGetter
+      );
+
     makeObservable(this);
+  }
+
+  @computed
+  protected get isV17() {
+    return (this.queryNodeInfo.nodeVersion ?? 0) >= 17;
   }
 
   /** Link to concentrated liquidity pool from the given balancer/cfmm pool ID.
@@ -22,6 +56,11 @@ export class ObservableQueryCfmmConcentratedPoolLinks extends ObservableChainQue
   readonly getLinkedConcentratedPoolId = computedFn(
     (cfmmPooLId): string | false | undefined => {
       if (!this.response) return;
+
+      if (!this.isV17) {
+        return this.backCompatQueryCfmmToCL.get(cfmmPooLId)
+          .concentratedLiquidityPoolId;
+      }
 
       return (
         this.response.data.migration_records.balancer_to_concentrated_pool_links.find(
@@ -38,6 +77,10 @@ export class ObservableQueryCfmmConcentratedPoolLinks extends ObservableChainQue
     (clPoolId): string | false | undefined => {
       if (!this.response) return;
 
+      if (!this.isV17) {
+        return this.backCompatQueryClToCfmm.get(clPoolId).cfmmPoolId;
+      }
+
       return (
         this.response?.data.migration_records.balancer_to_concentrated_pool_links.find(
           (record) => record.cl_pool_id === clPoolId
@@ -45,4 +88,126 @@ export class ObservableQueryCfmmConcentratedPoolLinks extends ObservableChainQue
       );
     }
   );
+}
+
+// BACKWARDS COMPATIBLE QUERIES FOR V17:
+
+export class ObservableQueryCfmmToConcentratedLiquidityPoolLink extends ObservableChainQuery<{
+  concentrated_pool_id: string;
+}> {
+  constructor(
+    kvStore: KVStore,
+    chainId: string,
+    chainGetter: ChainGetter,
+    protected readonly cfmmPoolId: string
+  ) {
+    super(
+      kvStore,
+      chainId,
+      chainGetter,
+      `/osmosis/gamm/v1beta1/concentrated_pool_id_link_from_cfmm/${cfmmPoolId}`
+    );
+
+    makeObservable(this);
+  }
+
+  protected canFetch(): boolean {
+    return Boolean(this.cfmmPoolId);
+  }
+
+  /** Returns the ID of the linked concentrated liquidity pool if it exists, `false` if there's no link, or `undefined` if the request is in flight. */
+  @computed
+  get concentratedLiquidityPoolId() {
+    // link doesn't exist
+    if (this.response?.status === 400) {
+      return false;
+    }
+
+    return this.response?.data.concentrated_pool_id;
+  }
+}
+
+export class ObservableQueryCfmmToConcentratedLiquidityPoolLinks extends ObservableChainQueryMap<{
+  concentrated_pool_id: string;
+}> {
+  constructor(
+    protected readonly kvStore: KVStore,
+    protected readonly chainId: string,
+    protected readonly chainGetter: ChainGetter
+  ) {
+    super(kvStore, chainId, chainGetter, (cfmmPoolId: string) => {
+      return new ObservableQueryCfmmToConcentratedLiquidityPoolLink(
+        kvStore,
+        chainId,
+        chainGetter,
+        cfmmPoolId
+      );
+    });
+  }
+
+  get(cfmmPoolId: string): ObservableQueryCfmmToConcentratedLiquidityPoolLink {
+    return super.get(
+      cfmmPoolId
+    ) as ObservableQueryCfmmToConcentratedLiquidityPoolLink;
+  }
+}
+
+export class ObservableQueryConcentratedLiquidityToCfmmPoolLink extends ObservableChainQuery<{
+  cfmm_pool_id: string;
+}> {
+  constructor(
+    kvStore: KVStore,
+    chainId: string,
+    chainGetter: ChainGetter,
+    protected readonly clPoolId: string
+  ) {
+    super(
+      kvStore,
+      chainId,
+      chainGetter,
+      `/osmosis/concentratedliquidity/v1beta1/cfmm_pool_id_link_from_concentrated/${clPoolId}`
+    );
+
+    makeObservable(this);
+  }
+
+  protected canFetch(): boolean {
+    return Boolean(this.clPoolId);
+  }
+
+  /** Returns the ID of the linked concentrated liquidity pool if it exists, `false` if there's no link, or `undefined` if the request is in flight. */
+  @computed
+  get cfmmPoolId() {
+    // link doesn't exist
+    if (this.response?.status === 400) {
+      return false;
+    }
+
+    return this.response?.data.cfmm_pool_id;
+  }
+}
+
+export class ObservableQueryConcentratedLiquidityToCfmmPoolLinks extends ObservableChainQueryMap<{
+  cfmm_pool_id: string;
+}> {
+  constructor(
+    protected readonly kvStore: KVStore,
+    protected readonly chainId: string,
+    protected readonly chainGetter: ChainGetter
+  ) {
+    super(kvStore, chainId, chainGetter, (clPoolId: string) => {
+      return new ObservableQueryConcentratedLiquidityToCfmmPoolLink(
+        kvStore,
+        chainId,
+        chainGetter,
+        clPoolId
+      );
+    });
+  }
+
+  get(clPoolId: string): ObservableQueryConcentratedLiquidityToCfmmPoolLink {
+    return super.get(
+      clPoolId
+    ) as ObservableQueryConcentratedLiquidityToCfmmPoolLink;
+  }
 }

--- a/packages/stores/src/queries/pools/cfmm-cl-link.ts
+++ b/packages/stores/src/queries/pools/cfmm-cl-link.ts
@@ -46,8 +46,14 @@ export class ObservableQueryCfmmConcentratedPoolLinks extends ObservableChainQue
     makeObservable(this);
   }
 
+  protected canFetch(): boolean {
+    return Boolean(this.queryNodeInfo.response);
+  }
+
   @computed
   protected get isV17() {
+    if (this.queryNodeInfo.isDevelopmentEnv) return true;
+
     return (this.queryNodeInfo.nodeVersion ?? 0) >= 17;
   }
 

--- a/packages/stores/src/queries/pools/cfmm-cl-link.ts
+++ b/packages/stores/src/queries/pools/cfmm-cl-link.ts
@@ -61,12 +61,12 @@ export class ObservableQueryCfmmConcentratedPoolLinks extends ObservableChainQue
    *  Returns `undefined` if not loaded, `false`, if nonexistent, or the CL pool ID if it exists. */
   readonly getLinkedConcentratedPoolId = computedFn(
     (cfmmPooLId): string | false | undefined => {
-      if (!this.response) return;
-
       if (!this.isV17) {
         return this.backCompatQueryCfmmToCL.get(cfmmPooLId)
           .concentratedLiquidityPoolId;
       }
+
+      if (!this.response) return;
 
       return (
         this.response.data.migration_records.balancer_to_concentrated_pool_links.find(
@@ -81,11 +81,11 @@ export class ObservableQueryCfmmConcentratedPoolLinks extends ObservableChainQue
    * Returns `undefined` if not loaded, `false`, if nonexistent, or the CFMM pool ID if it exists. */
   readonly getLinkedCfmmPoolId = computedFn(
     (clPoolId): string | false | undefined => {
-      if (!this.response) return;
-
       if (!this.isV17) {
         return this.backCompatQueryClToCfmm.get(clPoolId).cfmmPoolId;
       }
+
+      if (!this.response) return;
 
       return (
         this.response?.data.migration_records.balancer_to_concentrated_pool_links.find(

--- a/packages/stores/src/queries/store.ts
+++ b/packages/stores/src/queries/store.ts
@@ -255,7 +255,8 @@ export class OsmosisQueriesImpl {
       new ObservableQueryCfmmConcentratedPoolLinks(
         kvStore,
         chainId,
-        chainGetter
+        chainGetter,
+        this.queryNodeInfo
       );
 
     this.queryGammPoolShare = new ObservableQueryPoolShare(

--- a/packages/stores/src/queries/tendermint/node-info.ts
+++ b/packages/stores/src/queries/tendermint/node-info.ts
@@ -1,6 +1,6 @@
 import { KVStore } from "@keplr-wallet/common";
 import { ChainGetter, ObservableChainQuery } from "@keplr-wallet/stores";
-import { makeObservable } from "mobx";
+import { computed, makeObservable } from "mobx";
 
 import { NodeInfoResponse } from "./types";
 
@@ -17,6 +17,17 @@ export class ObservableQueryNodeInfo extends ObservableChainQuery<NodeInfoRespon
     makeObservable(this);
   }
 
+  /** If the node is under dev, the version string is typically `""` */
+  @computed
+  get isDevelopmentEnv(): boolean {
+    if (!this.response) {
+      return false;
+    }
+
+    return this.response?.data.application_version.version === "";
+  }
+
+  @computed
   get nodeVersion(): number | undefined {
     if (!this.response) {
       return undefined;


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->


Falls back to pre v17 queries in the CFMM <> CL link query store if pre v17.

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/863hazkth)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

* I still use the new single links query store, but now check the node version and fall back to the old individual query stores as needed

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

Connect dev env to edgenet, which is on v17 dev env:

<img width="730" alt="Screenshot 2023-08-10 at 5 17 58 PM" src="https://github.com/osmosis-labs/osmosis-frontend/assets/4606373/316e9190-3a2a-4aaf-ab52-6bc5a0e494b7">

Change env to point to mainnet:
* You should be able to see now on stage that the old link queries are called. Remember, the 400s are expected since that's what's returned when a link doesn't exist for a give pool ID:
<img width="674" alt="Screenshot 2023-08-10 at 5 02 18 PM" src="https://github.com/osmosis-labs/osmosis-frontend/assets/4606373/77c69170-ab7b-4a8e-b78b-11876d2e3354">

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
