### PR TITLE
Disable Chihuahua deposit/withdraw button

### DIFF
--- a/packages/web/config/ibc-assets.ts
+++ b/packages/web/config/ibc-assets.ts
@@ -1112,6 +1112,7 @@ export const IBCAssetInfos: (IBCAsset & {
         destChannelId: "channel-7",
         coinMinimalDenom: "uhuahua",
         isVerified: true,
+        isUnstable: true,
       },
       {
         counterpartyChainId: "ixo-5",


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

(JP69) Disables HUAHUA Deposit and Withdraw links.
(JP69) Because the v500 upgrade removed the ibc transfer module from the module manager.

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->
(JP69)-adds isUnstable to huahua in ibc-assets.ts

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->


(JP69) validation after Vercel build....
Confirmed that transfers do not work anymore.
The build indeed disables the Deposit and Withdraw functions.
![image](https://github.com/osmosis-labs/osmosis-frontend/assets/95667791/dff185e4-5b92-441d-bc46-d2341fe87c3a)
