### PR TITLE
show IBC denom instead of UNKNOWN

### DIFF
--- a/packages/stores/src/currency-registrar/__tests__/unsafe-ibc.spec.ts
+++ b/packages/stores/src/currency-registrar/__tests__/unsafe-ibc.spec.ts
@@ -113,7 +113,7 @@ describe("UnsafeIbcCurrencyRegistrar", () => {
   test("correctly handles unknown IBC currency", () => {
     // Call unsafeRegisterIbcCurrency with an IBC hash denom that isn't in osmosisIbcAssetsMock
     const unknownIbcDenom =
-      "ibc/9999999999999999999999999999999999999999999999999999999999999999";
+      "ibc/A6E3AF63B3C906416A9AF7A5599959EA4BD50E617EFFE6299B99700CCB780E444";
     osmosisChain.addUnknownCurrencies(unknownIbcDenom);
     const unknownCurrencyOnOsmosis = osmosisChain.findCurrency(
       unknownIbcDenom
@@ -121,7 +121,7 @@ describe("UnsafeIbcCurrencyRegistrar", () => {
 
     // Expect the result to be an object representing an unknown currency
     expect(unknownCurrencyOnOsmosis).toBeDefined();
-    expect(unknownCurrencyOnOsmosis.coinDenom).toBe("UNKNOWN");
+    expect(unknownCurrencyOnOsmosis.coinDenom).toBe("IBC/A6E3");
     expect(unknownCurrencyOnOsmosis.coinDecimals).toBe(0);
     expect(unknownCurrencyOnOsmosis.coinMinimalDenom).toBe(unknownIbcDenom);
   });

--- a/packages/stores/src/currency-registrar/unsafe-ibc.ts
+++ b/packages/stores/src/currency-registrar/unsafe-ibc.ts
@@ -127,8 +127,9 @@ export class UnsafeIbcCurrencyRegistrar<C extends ChainInfo = ChainInfo> {
       }
     } else {
       // it's not configured for our frontend, but it's still an IBC asset, so consider it unknown
+
       return {
-        coinDenom: "UNKNOWN",
+        coinDenom: encounteredIbcHashDenom.slice(0, 8).toUpperCase(),
         coinDecimals: 0,
         coinMinimalDenom: encounteredIbcHashDenom,
       };


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

From discussion with Jeremy and Sunny, we all agreed it would be more useful to display a slice of the IBC denom instead of "UNKNOWN" for the denom. This would at least make the UI usable when differentiating tokens.

<img width="516" alt="Screenshot 2023-08-14 at 10 41 04 AM" src="https://github.com/osmosis-labs/osmosis-frontend/assets/4606373/4c371028-3493-4727-9d58-87927ea69dc3">

