### PR TITLE
Fix: map y reserve error to `NotEnoughLiquidity` error

### DIFF
--- a/packages/math/src/pool/stable.ts
+++ b/packages/math/src/pool/stable.ts
@@ -1,4 +1,4 @@
-import { Coin, Dec, DecUtils, Int } from "@keplr-wallet/unit";
+import { Coin, Dec, DecUtils } from "@keplr-wallet/unit";
 
 import { BigDec } from "../big-dec";
 import { checkMultiplicativeErrorTolerance } from "../rounding";
@@ -59,18 +59,12 @@ export function solveCalcOutGivenIn(
   if (!tokenOutSupply || !tokenInSupply)
     throw new Error("token supply incorrect");
 
-  let cfmmOut: BigDec | undefined;
-  try {
-    cfmmOut = solveCfmm(
-      tokenOutSupply.amount,
-      tokenInSupply.amount,
-      remReserves,
-      tokenInLessFee
-    );
-  } catch (e: any) {
-    console.error(e.message);
-    return new BigDec(0);
-  }
+  const cfmmOut = solveCfmm(
+    tokenOutSupply.amount,
+    tokenInSupply.amount,
+    remReserves,
+    tokenInLessFee
+  );
 
   return cfmmOut.mul(new BigDec(tokenOutSupply.scalingFactor));
 }
@@ -120,18 +114,12 @@ export function calcInGivenOut(
   if (!tokenOutSupply || !tokenInSupply)
     throw new Error("Invalid token supply");
 
-  let cfmmOut: BigDec | undefined;
-  try {
-    cfmmOut = solveCfmm(
-      tokenInSupply.amount,
-      tokenOutSupply.amount,
-      remReserves,
-      tokenOutScaled.neg()
-    );
-  } catch (e: any) {
-    console.error(e.message);
-    return new Int(0);
-  }
+  const cfmmOut = solveCfmm(
+    tokenInSupply.amount,
+    tokenOutSupply.amount,
+    remReserves,
+    tokenOutScaled.neg()
+  );
 
   // we negate the calculated input since our solver is negative in negative out
   const calculatedInput = cfmmOut.neg();

--- a/packages/pools/src/router/__tests__/routes.spec.ts
+++ b/packages/pools/src/router/__tests__/routes.spec.ts
@@ -852,7 +852,7 @@ describe("OptimizedRoutes", () => {
       }).toThrow();
       expect(() => {
         makeDefaultTestRouterParams({
-          maxSplitIterations: 100,
+          maxSplitIterations: 101,
         });
       }).toThrow();
     });

--- a/packages/pools/src/router/routes.ts
+++ b/packages/pools/src/router/routes.ts
@@ -49,7 +49,7 @@ export type OptimizedRoutesParams = {
   /** Max number of routes a swap should be split through.
    *  Default: 2 */
   maxSplit?: number;
-  /** Max number of iterations to test for route splits. Must be less than 100.
+  /** Max number of iterations to test for route splits. Must be less than or equal to 100.
    *  i.e. 10 means 0%, 10%, 20%, ..., 100% of the in amount.
    *  Default: 10 (schemed above) */
   maxSplitIterations?: number;

--- a/packages/pools/src/stable.ts
+++ b/packages/pools/src/stable.ts
@@ -110,11 +110,18 @@ export class StablePool implements SharePool, RoutablePool {
     const inPoolAsset = this.getPoolAsset(tokenInDenom);
     const outPoolAsset = this.getPoolAsset(tokenOutDenom);
 
-    return StableSwapMath.calcSpotPrice(
-      this.stableSwapTokens,
-      inPoolAsset.denom,
-      outPoolAsset.denom
-    );
+    try {
+      return StableSwapMath.calcSpotPrice(
+        this.stableSwapTokens,
+        inPoolAsset.denom,
+        outPoolAsset.denom
+      );
+    } catch (e: any) {
+      // considered not enough liquidity
+      if (e.message === "cannot input more than y reserve")
+        throw new NotEnoughLiquidityError(e.message);
+      else throw e;
+    }
   }
 
   getSpotPriceInOverOutWithoutSwapFee(
@@ -124,11 +131,18 @@ export class StablePool implements SharePool, RoutablePool {
     const inPoolAsset = this.getPoolAsset(tokenInDenom);
     const outPoolAsset = this.getPoolAsset(tokenOutDenom);
 
-    return StableSwapMath.calcSpotPrice(
-      this.stableSwapTokens,
-      inPoolAsset.denom,
-      outPoolAsset.denom
-    );
+    try {
+      return StableSwapMath.calcSpotPrice(
+        this.stableSwapTokens,
+        inPoolAsset.denom,
+        outPoolAsset.denom
+      );
+    } catch (e: any) {
+      // considered not enough liquidity
+      if (e.message === "cannot input more than y reserve")
+        throw new NotEnoughLiquidityError(e.message);
+      else throw e;
+    }
   }
 
   getSpotPriceOutOverIn(tokenInDenom: string, tokenOutDenom: string): Dec {

--- a/packages/pools/src/stable.ts
+++ b/packages/pools/src/stable.ts
@@ -156,18 +156,27 @@ export class StablePool implements SharePool, RoutablePool {
 
     const coinOut = new Coin(tokenOut.denom, tokenOut.amount);
 
-    const beforeSpotPriceInOverOut = StableSwapMath.calcSpotPrice(
-      this.stableSwapTokens,
-      inPoolAsset.denom,
-      outPoolAsset.denom
-    );
+    let beforeSpotPriceInOverOut: Dec;
+    let tokenInAmount: Int;
+    try {
+      beforeSpotPriceInOverOut = StableSwapMath.calcSpotPrice(
+        this.stableSwapTokens,
+        inPoolAsset.denom,
+        outPoolAsset.denom
+      );
 
-    const tokenInAmount = StableSwapMath.calcInGivenOut(
-      this.stableSwapTokens,
-      coinOut,
-      tokenInDenom,
-      swapFee ?? this.swapFee
-    );
+      tokenInAmount = StableSwapMath.calcInGivenOut(
+        this.stableSwapTokens,
+        coinOut,
+        tokenInDenom,
+        swapFee ?? this.swapFee
+      );
+    } catch (e: any) {
+      // considered not enough liquidity
+      if (e.message === "cannot input more than y reserve")
+        throw new NotEnoughLiquidityError(e.message);
+      else throw e;
+    }
 
     if (tokenInAmount.lte(new Int(0))) throw new NotEnoughLiquidityError();
 
@@ -185,11 +194,22 @@ export class StablePool implements SharePool, RoutablePool {
         return token;
       }
     );
-    const afterSpotPriceInOverOut = StableSwapMath.calcSpotPrice(
-      movedStableTokens,
-      inPoolAsset.denom,
-      outPoolAsset.denom
-    );
+
+    let afterSpotPriceInOverOut;
+    try {
+      afterSpotPriceInOverOut = StableSwapMath.calcSpotPrice(
+        movedStableTokens,
+        inPoolAsset.denom,
+        outPoolAsset.denom
+      );
+    } catch (e: any) {
+      // considered not enough liquidity
+      if (e.message === "cannot input more than y reserve")
+        throw new NotEnoughLiquidityError(e.message);
+      else throw e;
+    }
+
+    // Now you can use the `spotPrice` variable later in your code
 
     if (afterSpotPriceInOverOut.lt(beforeSpotPriceInOverOut)) {
       throw new Error("Spot price can't be decreased after swap");
@@ -224,18 +244,27 @@ export class StablePool implements SharePool, RoutablePool {
 
     const coinIn = new Coin(tokenIn.denom, tokenIn.amount);
 
-    const beforeSpotPriceInOverOut = StableSwapMath.calcSpotPrice(
-      this.stableSwapTokens,
-      inPoolAsset.denom,
-      outPoolAsset.denom
-    );
+    let beforeSpotPriceInOverOut: Dec;
+    let tokenOutAmount: Int;
+    try {
+      beforeSpotPriceInOverOut = StableSwapMath.calcSpotPrice(
+        this.stableSwapTokens,
+        inPoolAsset.denom,
+        outPoolAsset.denom
+      );
 
-    const tokenOutAmount = StableSwapMath.calcOutGivenIn(
-      this.stableSwapTokens,
-      coinIn,
-      outPoolAsset.denom,
-      swapFee ?? this.swapFee
-    );
+      tokenOutAmount = StableSwapMath.calcOutGivenIn(
+        this.stableSwapTokens,
+        coinIn,
+        outPoolAsset.denom,
+        swapFee ?? this.swapFee
+      );
+    } catch (e: any) {
+      // considered not enough liquidity
+      if (e.message === "cannot input more than y reserve")
+        throw new NotEnoughLiquidityError(e.message);
+      else throw e;
+    }
 
     if (tokenOutAmount.lte(new Int(0))) throw new NotEnoughLiquidityError();
 
@@ -256,11 +285,19 @@ export class StablePool implements SharePool, RoutablePool {
         return token;
       }
     );
-    const afterSpotPriceInOverOut = StableSwapMath.calcSpotPrice(
-      movedStableTokens,
-      tokenIn.denom,
-      outPoolAsset.denom
-    );
+    let afterSpotPriceInOverOut;
+    try {
+      afterSpotPriceInOverOut = StableSwapMath.calcSpotPrice(
+        movedStableTokens,
+        tokenIn.denom,
+        outPoolAsset.denom
+      );
+    } catch (e: any) {
+      // considered not enough liquidity
+      if (e.message === "cannot input more than y reserve")
+        throw new NotEnoughLiquidityError(e.message);
+      else throw e;
+    }
 
     if (afterSpotPriceInOverOut.lt(beforeSpotPriceInOverOut)) {
       throw new Error("Spot price can't be decreased after swap");

--- a/packages/stores/src/ui-config/trade-token-in-config.ts
+++ b/packages/stores/src/ui-config/trade-token-in-config.ts
@@ -420,7 +420,7 @@ export class ObservableTradeTokenInConfig extends AmountConfig {
             pool
               .computeTotalValueLocked(this.priceStore)
               .toDec()
-              .gt(new Dec(4_000_000)))
+              .gt(new Dec(150_000)))
         ) {
           preferredIds.push(pool.id);
         }

--- a/packages/web/pages/index.tsx
+++ b/packages/web/pages/index.tsx
@@ -64,14 +64,13 @@ const Home = ({ ads }: InferGetServerSidePropsType<typeof getStaticProps>) => {
           // include all pools on testnet env
           if (IS_TESTNET) return true;
 
-          if (pool.id === "895") return false;
+          if (!IS_TESTNET && pool.id === "895") return false;
 
           // filter concentrated pools if feature flag is not enabled
           if (pool.type === "concentrated" && !flags.concentratedLiquidity)
             return false;
 
-          if (pool.type === "concentrated" || pool.type === "stable")
-            return true;
+          if (pool.type === "concentrated") return true;
 
           // some min TVL for balancer pools
           return pool

--- a/packages/web/pages/index.tsx
+++ b/packages/web/pages/index.tsx
@@ -70,13 +70,15 @@ const Home = ({ ads }: InferGetServerSidePropsType<typeof getStaticProps>) => {
           if (pool.type === "concentrated" && !flags.concentratedLiquidity)
             return false;
 
-          if (pool.type === "concentrated") return true;
-
           // some min TVL for balancer pools
           return pool
             .computeTotalValueLocked(priceStore)
             .toDec()
-            .gte(new Dec(showUnverified ? 1_000 : 10_000));
+            .gte(
+              new Dec(
+                showUnverified || pool.type === "concentrated" ? 1_000 : 10_000
+              )
+            );
         })
         .sort((a, b) => {
           // sort by TVL to find routes amongst most valuable pools


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

With stableswap pools, our math layer would throw a prototype error with `cannot input more than y reserve` as the message. This essentially meant that there was not enough liquidity in the pool for the given amount (confirmed with @AlpinYukseloglu ). 

Problem: that Error would bubble up and would not be handled by our routing and swap UI config layer. It was basically considered an unexpected error. Now, in our pools layer, we catch that specific prototype error and cast it into a `NotEnoughLiquidityError` so it can properly be handled in our router. 

The error would arise _repeatedly_ as our router was testing various splits into a route containing a stableswap pool.

UPDATE: the fix was we were letting some 0 liq stable pools (and CL pools) into the router. The fix was to remove those low liq pools from going to the router, but I still found a bug in the route splitter algorithm that wouldn't handle this case under specific circumstances.

Recorded here within our "Router improvements" parent task: https://app.clickup.com/t/86a0fe27e

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/86a0e8mxt)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

* In stable pool implementation, the `cannot input more than y reserve` prototype error is rethrown as a `NotEnoughLiquidityError`

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

Try trading OSMO>STRD. The router finds a split containing a stable pool and tests swaps through the stable pool. Now, the console should be free of `cannot input more than y reserve` errors, and the swap tool should provide a valid quote now that it knows that route with the stable pool does not contain enough liquidity.

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
