### PR TITLE
Fix Background Image

### DIFF
--- a/packages/web/pages/index.tsx
+++ b/packages/web/pages/index.tsx
@@ -113,7 +113,7 @@ const Home = ({ ads }: InferGetServerSidePropsType<typeof getStaticProps>) => {
         >
           <g>
             <ProgressiveSvgImage
-              lowResXlinkHref={"/images/supercharged-wosmongton-low.png.png"}
+              lowResXlinkHref={"/images/supercharged-wosmongton-low.png"}
               xlinkHref={"/images/supercharged-wosmongton.png"}
               x="56"
               y="175"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Fixes he Low Res versions of the background image (the supercharged Wosmongton) had a broken reference (accidentally doubled the extension as: .png.png).

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

<img width="883" alt="image" src="https://github.com/osmosis-labs/osmosis-frontend/assets/95667791/d8af5fcc-5cbd-4304-8e88-d0bfb1491955">

<img width="779" alt="image" src="https://github.com/osmosis-labs/osmosis-frontend/assets/95667791/3e5a4425-cd12-4e5c-bb86-b2d80d763e24">



## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

- removes '.png' from the double .png.png in the low res supercharged wosmo background image reference in /pages/index.tsx

## Testing and Verifying


This change has been tested locally by rebuilding the website and verified content and links are expected
