### PR TITLE
save repsonse to keep validators in local storage. Wire up stake call…

### DIFF
--- a/packages/web/modals/validator-next-step.tsx
+++ b/packages/web/modals/validator-next-step.tsx
@@ -10,11 +10,18 @@ import { ModalBase, ModalBaseProps } from "~/modals/base";
 interface ExtendedModalBaseProps extends ModalBaseProps {
   setShowValidatorModal: (val: boolean) => void;
   isNewUser: boolean;
+  stakeCall: () => void;
 }
 
 export const ValidatorNextStepModal: FunctionComponent<
   ExtendedModalBaseProps
-> = ({ onRequestClose, isOpen, setShowValidatorModal, isNewUser }) => {
+> = ({
+  onRequestClose,
+  isOpen,
+  setShowValidatorModal,
+  isNewUser,
+  stakeCall,
+}) => {
   const t = useTranslation();
 
   const { logEvent } = useAmplitudeAnalytics();
@@ -31,9 +38,10 @@ export const ValidatorNextStepModal: FunctionComponent<
 
   const handleExistingUserKeepClick = useCallback(() => {
     logEvent([EventName.Stake.squadOptionClicked, { option: "keep" }]);
+    localStorage.setItem("keepValidators", "true");
     onRequestClose();
-    alert("make stake call now");
-  }, [logEvent, onRequestClose]);
+    stakeCall();
+  }, [logEvent, onRequestClose, stakeCall]);
 
   const handleExistingUserSelectClick = useCallback(() => {
     logEvent([EventName.Stake.squadOptionClicked, { option: "new" }]);

--- a/packages/web/pages/stake/index.tsx
+++ b/packages/web/pages/stake/index.tsx
@@ -59,7 +59,7 @@ export const Staking: React.FC = observer(() => {
       setLoading(false);
     }
 
-    // checkFeatureFlag();
+    checkFeatureFlag();
 
     setLoading(false);
   }, [flags.staking]);

--- a/packages/web/pages/stake/index.tsx
+++ b/packages/web/pages/stake/index.tsx
@@ -59,7 +59,9 @@ export const Staking: React.FC = observer(() => {
       setLoading(false);
     }
 
-    checkFeatureFlag();
+    // checkFeatureFlag();
+
+    setLoading(false);
   }, [flags.staking]);
 
   useEffect(() => {
@@ -206,10 +208,14 @@ export const Staking: React.FC = observer(() => {
       return;
     }
 
-    // TODO add showValidatorNextStepModal here
+    const selectedKeepValidators = localStorage.getItem("keepValidators");
 
     if (activeTab === "Stake") {
-      stakeCall();
+      if (selectedKeepValidators) {
+        stakeCall();
+      } else {
+        setShowValidatorModal(true);
+      }
     } else {
       unstakeCall();
     }
@@ -313,6 +319,7 @@ export const Staking: React.FC = observer(() => {
         isOpen={showValidatorNextStepModal}
         onRequestClose={() => setShowValidatorNextStepModal(false)}
         setShowValidatorModal={setShowValidatorModal}
+        stakeCall={stakeCall}
       />
     </main>
   );

--- a/packages/web/pages/stake/index.tsx
+++ b/packages/web/pages/stake/index.tsx
@@ -60,8 +60,6 @@ export const Staking: React.FC = observer(() => {
     }
 
     checkFeatureFlag();
-
-    setLoading(false);
   }, [flags.staking]);
 
   useEffect(() => {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

This PR will save the response to keep validators in local storage so that users don't see it every time they press stake.

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/8678m12z5)

## Testing and Verifying

This change has been tested locally by rebuilding the website and verified content and links are expected

