### PR TITLE
refactor: make price to tick clearer and fix bug

### DIFF
--- a/packages/math/src/pool/concentrated/__tests__/tick.spec.ts
+++ b/packages/math/src/pool/concentrated/__tests__/tick.spec.ts
@@ -244,7 +244,8 @@ describe("estimateInitialTickBound", () => {
         currentTickLiquidity: new Dec("1517882343.751510418088349649"),
         currentSqrtPrice: new BigDec("70.710678118654752440"),
 
-        expectedBoundTickIndex: new Int("31975106"),
+        // TODO: confirm if correct
+        expectedBoundTickIndex: new Int("31975105"),
       },
     },
   ];

--- a/packages/math/src/pool/concentrated/__tests__/tick.spec.ts
+++ b/packages/math/src/pool/concentrated/__tests__/tick.spec.ts
@@ -185,9 +185,21 @@ describe("priceToTick", () => {
       price: new Dec("25760000"),
       tickExpected: "64576000",
     },
-    "Boot <> Osmo, tick 64576000 + 100 -> price 25761000": {
-      price: new Dec("25761000"),
-      tickExpected: "64576100",
+    "some large value": {
+      price: new Dec("1661485533773690"),
+      tickExpected: "135661485",
+    },
+    "some large value 2": {
+      price: new Dec("1666545869528215"),
+      tickExpected: "135666545",
+    },
+    "10 -> 9000000": {
+      price: new Dec("10"),
+      tickExpected: "9000000",
+    },
+    "0.1 -> -9000000": {
+      price: new Dec("0.1"),
+      tickExpected: "-9000000",
     },
   };
 
@@ -198,7 +210,8 @@ describe("priceToTick", () => {
         expect(tick.toString()).toEqual(
           testCases[Object.keys(testCases)[i]].tickExpected
         );
-      } catch {
+      } catch (e) {
+        console.error(e);
         expect(expectedError).toBeDefined();
       }
     });

--- a/packages/math/src/pool/concentrated/__tests__/tick.spec.ts
+++ b/packages/math/src/pool/concentrated/__tests__/tick.spec.ts
@@ -201,6 +201,10 @@ describe("priceToTick", () => {
       price: new Dec("0.1"),
       tickExpected: "-9000000",
     },
+    "WBTC <> Osmo, tick 64576000 + 100 -> price 1666545869528215": {
+      price: new Dec("1666545869528215"),
+      tickExpected: "135666545",
+    },
   };
 
   Object.values(testCases).forEach(({ price, expectedError }, i) => {
@@ -305,7 +309,7 @@ describe("estimateInitialTickBound", () => {
         currentTickLiquidity: new Dec("1517882343.751510418088349649"),
         currentSqrtPrice: new BigDec("70.710678118654752440"),
 
-        expectedBoundTickIndex: new Int("31975106"),
+        expectedBoundTickIndex: new Int("31975105"),
       },
     },
   ];

--- a/packages/math/src/pool/concentrated/tick.ts
+++ b/packages/math/src/pool/concentrated/tick.ts
@@ -86,50 +86,52 @@ export function priceToTick(price: Dec): Int {
 
   let currentPrice = new Dec(1);
   let ticksPassed = new Int(0);
-  let exponentAtCurTick = new Int(exponentAtPriceOne);
 
   let currentAdditiveIncrementInTicks = powTenBigDec(
     new Int(exponentAtPriceOne)
   );
 
+  let exponent;
+
   if (price.gt(new Dec(1))) {
-    while (currentPrice.lt(price)) {
-      currentAdditiveIncrementInTicks = powTenBigDec(exponentAtCurTick);
-      const maxPriceForCurrentAdditiveIncrementInTicks = new BigDec(
-        geometricExponentIncrementDistanceInTicks
-      ).mul(currentAdditiveIncrementInTicks);
-      currentPrice = currentPrice.add(
-        maxPriceForCurrentAdditiveIncrementInTicks.toDec()
-      );
-      exponentAtCurTick = exponentAtCurTick.add(new Int(1));
-      ticksPassed = ticksPassed.add(
-        geometricExponentIncrementDistanceInTicks.truncate()
-      );
+    let maxPriceInTickIncrement = new Dec(10);
+    exponent = new Int(0);
+
+    while (maxPriceInTickIncrement.lt(price)) {
+      exponent = exponent.add(new Int(1));
+      maxPriceInTickIncrement = maxPriceInTickIncrement.mul(new Dec(10));
     }
+
+    // We divide by 10 because we use max price in tick increment which is from the next exponent.
+    currentPrice = maxPriceInTickIncrement.quoTruncate(new Dec(10));
+    ticksPassed = ticksPassed.add(
+      geometricExponentIncrementDistanceInTicks.truncate().mul(exponent)
+    );
   } else {
-    exponentAtCurTick = new Int(exponentAtPriceOne).sub(new Int(1));
-    while (currentPrice.gt(price)) {
-      currentAdditiveIncrementInTicks = powTenBigDec(exponentAtCurTick);
-      const maxPriceForCurrentAdditiveIncrementInTicks = new BigDec(
-        geometricExponentIncrementDistanceInTicks
-      ).mul(currentAdditiveIncrementInTicks);
-      currentPrice = currentPrice.sub(
-        maxPriceForCurrentAdditiveIncrementInTicks.toDec()
-      );
-      exponentAtCurTick = exponentAtCurTick.sub(new Int(1));
-      ticksPassed = ticksPassed.sub(
-        geometricExponentIncrementDistanceInTicks.truncate()
-      );
+    let minPriceInTheExponent = new Dec(0.1);
+    exponent = new Int(-1);
+
+    while (minPriceInTheExponent.gt(price)) {
+      exponent = exponent.sub(new Int(1));
+      minPriceInTheExponent = minPriceInTheExponent.quoTruncate(new Dec(10));
     }
+
+    // We do not divide by 10 because we use min price in the tick increment which is from the current exponent.
+    currentPrice = minPriceInTheExponent;
+    ticksPassed = ticksPassed.sub(
+      geometricExponentIncrementDistanceInTicks.truncate().mul(exponent.neg())
+    );
   }
 
-  const ticksToBeFilledByExponentAtCurrentTick = new BigDec(
+  currentAdditiveIncrementInTicks = powTenBigDec(
+    new Int(exponentAtPriceOne).add(exponent)
+  );
+
+  const ticksToBeFilledByCurrentExponent = new BigDec(
     price.sub(currentPrice)
   ).quo(currentAdditiveIncrementInTicks);
 
-  return ticksPassed.add(
-    ticksToBeFilledByExponentAtCurrentTick.toDec().truncate()
-  );
+  return ticksPassed.add(ticksToBeFilledByCurrentExponent.toDec().truncate());
 }
 
 /** Estimates the initial first tick index bound for querying ticks efficiently (not requesting too many ticks).

--- a/packages/pools/src/concentrated/fetch-tick-data-provider.ts
+++ b/packages/pools/src/concentrated/fetch-tick-data-provider.ts
@@ -178,9 +178,11 @@ export class FetchTickDataProvider implements TickDataProvider {
       } else if (getMoreTicks) {
         // have fetched ticks, but requested to get more
         let nextBoundIndex = prevBoundIndex.mul(this.nextTicksRampMultiplier);
-        if (zeroForOne && nextBoundIndex.lt(minTick)) {
+
+        if (zeroForOne && nextBoundIndex.lte(minTick)) {
           nextBoundIndex = minTick;
-        } else if (!zeroForOne && nextBoundIndex.gt(maxTick)) {
+        }
+        if (!zeroForOne && nextBoundIndex.gte(maxTick)) {
           nextBoundIndex = maxTick;
         }
 

--- a/packages/stores/src/queries/concentrated-liquidity/tick-data-provider.ts
+++ b/packages/stores/src/queries/concentrated-liquidity/tick-data-provider.ts
@@ -2,6 +2,7 @@ import { Int } from "@keplr-wallet/unit";
 import { estimateInitialTickBound } from "@osmosis-labs/math";
 import {
   ConcentratedLiquidityPool,
+  rampNextQueryTick,
   TickDataProvider,
   TickDepths,
 } from "@osmosis-labs/pools";
@@ -149,7 +150,12 @@ export class ConcentratedLiquidityPoolTickDataProvider
       setLatestBoundTickIndex(initialBoundTick);
     } else if (fetchMoreTicks) {
       // have fetched ticks, but requested to get more
-      const nextBoundIndex = prevBoundIndex.mul(this.nextTicksRampMultiplier);
+      const nextBoundIndex = rampNextQueryTick(
+        zeroForOne,
+        pool.currentTick,
+        prevBoundIndex,
+        this.nextTicksRampMultiplier
+      );
       await queryDepths.fetchUpToTickIndex(nextBoundIndex);
       setLatestBoundTickIndex(nextBoundIndex);
     } // else have fetched ticks, but not requested to get more. do nothing and return existing ticks


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Currently, there is a bug in price to tick conversion when converting prices greater than 1. This PR refactors the conversion to make it simpler, and, as a result, fixes the bug. The 2 problematic cases are added as unit tests. This PR also fixes the logic for ramping the next tick bound to query by better handling pools with a negative current tick.

### ClickUp Task

[ClickUp Task URL](PASTE_CLICKUP_TASK_URL_HERE)

## Brief Changelog

- Add test cases
- Refactor
- Fix tick ramping query logic

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
