### PR TITLE
feat: Add Wallet Features Array

### DIFF
--- a/packages/stores/src/account/types.ts
+++ b/packages/stores/src/account/types.ts
@@ -50,4 +50,15 @@ export type RegistryWallet = Wallet & {
    * If the error is not recognized or doesn't match predefined conditions, the original error message is returned.
    */
   matchError?: (error: string) => WalletConnectionInProgressError | string;
+
+  /**
+   * An array of features supported by the wallet.
+   *
+   * This can be used to determine the capabilities of the wallet and enable or disable
+   * functionality accordingly within the application.
+   *
+   * For example, if "notifications" is included in the array, the app will display
+   * the notifications button.
+   */
+  features: Array<"notifications">;
 };

--- a/packages/web/components/navbar/index.tsx
+++ b/packages/web/components/navbar/index.tsx
@@ -143,6 +143,8 @@ export const NavBar: FunctionComponent<
   }, [onOpenFrontierMigration, onOpenSettings, query, userSettings]);
 
   const account = accountStore.getWallet(chainId);
+  const walletSupportsNotifications =
+    account?.walletInfo?.features.includes("notifications");
   const icnsQuery = queriesExternalStore.queryICNSNames.getQueryContract(
     account?.address ?? ""
   );
@@ -189,7 +191,7 @@ export const NavBar: FunctionComponent<
                 ),
               });
 
-              if (featureFlags.notifications) {
+              if (featureFlags.notifications && walletSupportsNotifications) {
                 mobileMenus = mobileMenus.concat({
                   label: "Notifications",
                   link: (e) => {
@@ -310,7 +312,7 @@ export const NavBar: FunctionComponent<
               />
             </div>
           )}
-          {featureFlags.notifications && (
+          {featureFlags.notifications && walletSupportsNotifications && (
             <NotifiContextProvider>
               <NotifiPopover
                 hasUnreadNotification={hasUnreadNotification}

--- a/packages/web/config/wallet-registry.ts
+++ b/packages/web/config/wallet-registry.ts
@@ -14,6 +14,7 @@ export const WalletRegistry: RegistryWallet[] = [
     windowPropertyName: "keplr",
     stakeUrl: "https://wallet.keplr.app/chains/osmosis?tab=staking",
     governanceUrl: "https://wallet.keplr.app/chains/osmosis?tab=governance",
+    features: ["notifications"],
   },
   {
     ...CosmosKitWalletList["keplr-mobile"],
@@ -56,6 +57,7 @@ export const WalletRegistry: RegistryWallet[] = [
     },
     stakeUrl: "https://wallet.keplr.app/chains/osmosis?tab=staking",
     governanceUrl: "https://wallet.keplr.app/chains/osmosis?tab=governance",
+    features: ["notifications"],
   },
   {
     ...CosmosKitWalletList["leap-extension"],
@@ -66,6 +68,7 @@ export const WalletRegistry: RegistryWallet[] = [
     windowPropertyName: "leap",
     stakeUrl: "https://cosmos.leapwallet.io/staking",
     governanceUrl: "https://cosmos.leapwallet.io/gov",
+    features: [],
   },
   {
     ...CosmosKitWalletList["cosmostation-extension"],
@@ -77,6 +80,7 @@ export const WalletRegistry: RegistryWallet[] = [
     windowPropertyName: "cosmostation",
     stakeUrl: "https://wallet.cosmostation.io/osmosis/delegate",
     governanceUrl: "https://cosmos.leapwallet.io/gov",
+    features: ["notifications"],
   },
   {
     ...CosmosKitWalletList["xdefi-extension"],
@@ -98,6 +102,7 @@ export const WalletRegistry: RegistryWallet[] = [
         .then(() => true)
         .catch(() => false);
     },
+    features: [],
   },
   // {
   //   ...CosmosKitWalletList["okxwallet-extension"],

--- a/packages/web/integrations/notifi/notifi-popover.tsx
+++ b/packages/web/integrations/notifi/notifi-popover.tsx
@@ -75,13 +75,13 @@ export const NotifiPopover: FunctionComponent<NotifiButtonProps> = ({
     setIsOverLayEnabled,
   } = useNotifiModalContext();
 
-  /**
-   * Disable notifications for Leap temporarily, because of a non-deterministic signature bug
-   * within the wallet.
-   */
-  if (isLeapWallet) {
-    return null;
-  }
+  // /**
+  //  * Disable notifications for Leap temporarily, because of a non-deterministic signature bug
+  //  * within the wallet.
+  //  */
+  // if (isLeapWallet) {
+  //   return null;
+  // }
 
   if (osmosisWallet?.walletStatus !== WalletStatus.Connected) {
     return (

--- a/packages/web/integrations/notifi/notifi-popover.tsx
+++ b/packages/web/integrations/notifi/notifi-popover.tsx
@@ -7,7 +7,7 @@ import { Icon } from "~/components/assets";
 import { Button } from "~/components/buttons";
 import IconButton from "~/components/buttons/icon-button";
 import { Popover } from "~/components/popover";
-import { AvailableWallets, EventName } from "~/config";
+import { EventName } from "~/config";
 import { useAmplitudeAnalytics } from "~/hooks";
 import { useNotifiModalContext } from "~/integrations/notifi/notifi-modal-context";
 import { NotifiSubscriptionCard } from "~/integrations/notifi/notifi-subscription-card";
@@ -66,7 +66,6 @@ export const NotifiPopover: FunctionComponent<NotifiButtonProps> = ({
   const { logEvent } = useAmplitudeAnalytics();
 
   const osmosisWallet = accountStore.getWallet(chainId);
-  const isLeapWallet = osmosisWallet?.walletInfo.name === AvailableWallets.Leap;
 
   const {
     innerState: { onRequestBack, backIcon, title } = {},
@@ -74,14 +73,6 @@ export const NotifiPopover: FunctionComponent<NotifiButtonProps> = ({
     isOverLayEnabled,
     setIsOverLayEnabled,
   } = useNotifiModalContext();
-
-  // /**
-  //  * Disable notifications for Leap temporarily, because of a non-deterministic signature bug
-  //  * within the wallet.
-  //  */
-  // if (isLeapWallet) {
-  //   return null;
-  // }
 
   if (osmosisWallet?.walletStatus !== WalletStatus.Connected) {
     return (


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

In the upcoming updates, Osmosis will be introducing various wallet variations. However, not all these wallets have the features needed for certain services, such as notifications. To address this, we've included a `features` property in the wallet registry in this PR. This allows the frontend to determine which wallets have the essential capabilities for each service.

## Brief Changelog

- Add features property
- Disable notifications for xDefi, and Leap. 

## Testing and Verifying

- [ ] Notifications should be disabled for Leap, and XDefi on [stage.osmosis.zone](https://stage.osmosis.zone)