### PR TITLE
fix: go sf should open select validator modal

### DIFF
--- a/packages/web/components/cards/my-position/expanded.tsx
+++ b/packages/web/components/cards/my-position/expanded.tsx
@@ -88,14 +88,6 @@ export const MyPositionCardExpandedSection: FunctionComponent<{
         positionConfig.id
       );
 
-    /** Is defined if there's some other SF position already in this pool.
-     *  On chain invariant: one validator can be selected per pool. */
-    const existingSfValidatorAddress = account?.address
-      ? osmosisQueries.queryAccountsSuperfluidDelegatedPositions.get(
-          account.address
-        ).delegatedPositions?.[0]?.validatorAddress ?? undefined
-      : undefined;
-
     const unbondInfo = osmosisQueries.queryAccountsUnbondingPositions
       .get(account?.address ?? "")
       .getPositionUnbondingInfo(positionConfig.id);
@@ -370,6 +362,11 @@ export const MyPositionCardExpandedSection: FunctionComponent<{
             />
           )}
         <div className="mt-4 flex flex-row flex-wrap justify-end gap-5 sm:flex-wrap sm:justify-start">
+          {showLinkToPool && (
+            <ArrowButton onClick={() => router.push(`/pool/${poolId}`)}>
+              {t("clPositions.goToPool", { poolId })}
+            </ArrowButton>
+          )}
           {positionConfig.isFullRange &&
             superfluidPoolDetail.isSuperfluid &&
             !superfluidDelegation &&
@@ -381,16 +378,7 @@ export const MyPositionCardExpandedSection: FunctionComponent<{
                   className="w-fit rounded-[10px] bg-superfluid py-[2px] px-[2px]"
                   disabled={!Boolean(account)}
                   onClick={() => {
-                    if (!existingSfValidatorAddress) {
-                      setSelectSfValidatorAddress(true);
-                    } else {
-                      account.osmosis
-                        .sendStakeExistingPositionMsg(
-                          positionConfig.id,
-                          existingSfValidatorAddress
-                        )
-                        .catch(console.error);
-                    }
+                    setSelectSfValidatorAddress(true);
                   }}
                 >
                   <div className="w-full rounded-[9px] bg-osmoverse-800 px-3 py-[6px] md:px-2">
@@ -420,11 +408,6 @@ export const MyPositionCardExpandedSection: FunctionComponent<{
                 )}
               </>
             )}
-          {showLinkToPool && (
-            <ArrowButton onClick={() => router.push(`/pool/${poolId}`)}>
-              {t("clPositions.goToPool", { poolId })}
-            </ArrowButton>
-          )}
           <PositionButton
             disabled={
               !positionConfig.hasRewardsAvailable ||


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

Every position can be delegated to a new validator, so, the select validator modal should appear each time instead of defaulting to an existing SF staking validator.

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/86a0jgc8g)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->



## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->
* Clicking go superfluid on a position should always open the select validator modal
## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
