### PR TITLE
refactor: de-duplicate summing coins

### DIFF
--- a/packages/web/components/cards/my-position/expanded.tsx
+++ b/packages/web/components/cards/my-position/expanded.tsx
@@ -33,6 +33,7 @@ import { RemoveConcentratedLiquidityModal } from "~/modals/remove-concentrated-l
 import { useStore } from "~/stores";
 import { ObservableHistoricalAndLiquidityData } from "~/stores/derived-data/concentrated-liquidity/historical-and-liquidity-data";
 import { formatPretty } from "~/utils/formatter";
+import { coinsToFiatPricePretty, coinsToFiatValue } from "~/utils/total-value";
 
 const ConcentratedLiquidityDepthChart = dynamic(
   () => import("~/components/chart/concentrated-liquidity-depth"),
@@ -141,18 +142,10 @@ export const MyPositionCardExpandedSection: FunctionComponent<{
 
       const rewardAmountUSD =
         positionConfig.totalClaimableRewards.length > 0 && fiat
-          ? Number(
+          ? coinsToFiatValue(
+              priceStore,
+              fiat,
               positionConfig.totalClaimableRewards
-                .reduce(
-                  (sum, asset) =>
-                    sum.add(
-                      priceStore.calculatePrice(asset) ??
-                        new PricePretty(fiat, 0)
-                    ),
-                  new PricePretty(fiat, 0)
-                )
-                .toDec()
-                .toString()
             )
           : undefined;
 
@@ -514,13 +507,7 @@ const AssetsInfo: FunctionComponent<
     const totalValue =
       totalValueProp ??
       (assets.length > 0 && fiat
-        ? assets.reduce(
-            (sum, asset) =>
-              sum.add(
-                priceStore.calculatePrice(asset) ?? new PricePretty(fiat, 0)
-              ),
-            new PricePretty(fiat, 0)
-          )
+        ? coinsToFiatPricePretty(priceStore, fiat, assets)
         : undefined);
 
     return (

--- a/packages/web/pages/index.tsx
+++ b/packages/web/pages/index.tsx
@@ -57,6 +57,10 @@ const Home = ({ ads }: InferGetServerSidePropsType<typeof getStaticProps>) => {
   const flags = useFeatureFlags();
 
   // Pools should be memoized before passing to trade in config
+  // TODO: (1) Move to its own function
+  // TODO: (2) Make only a far more minimal component blocking
+  // TODO: (3) Remove the many extra type casts
+  // TODO: (4) Add Types
   const pools = useMemo(
     () =>
       allPools

--- a/packages/web/pages/pools/index.tsx
+++ b/packages/web/pages/pools/index.tsx
@@ -1,10 +1,4 @@
-import {
-  CoinPretty,
-  Dec,
-  DecUtils,
-  PricePretty,
-  RatePretty,
-} from "@keplr-wallet/unit";
+import { CoinPretty, Dec, DecUtils, RatePretty } from "@keplr-wallet/unit";
 import {
   ObservableConcentratedPoolDetail,
   ObservableQueryPool,
@@ -47,6 +41,7 @@ import { ConcentratedLiquidityLearnMoreModal } from "~/modals/concentrated-liqui
 import { UserUpgradesModal } from "~/modals/user-upgrades";
 import { useStore } from "~/stores";
 import { formatPretty } from "~/utils/formatter";
+import { objCoinsToFiatPricePretty } from "~/utils/total-value";
 
 const Pools: NextPage = observer(function () {
   const { chainStore, accountStore, queriesStore, userUpgrades } = useStore();
@@ -436,14 +431,13 @@ const MyPoolsSection = observer(() => {
             )
           );
         // user positions' assets value
-        if (pool instanceof ObservableConcentratedPoolDetail)
-          return pool.userPoolAssets.reduce(
-            (sum, { asset }) =>
-              sum.add(
-                priceStore.calculatePrice(asset) ?? new PricePretty(fiat, 0)
-              ),
-            new PricePretty(fiat, 0)
+        if (pool instanceof ObservableConcentratedPoolDetail) {
+          return objCoinsToFiatPricePretty(
+            priceStore,
+            fiat,
+            pool.userPoolAssets
           );
+        }
       },
       [queryOsmosis, account, fiat, priceStore]
     )
@@ -472,15 +466,11 @@ const MyPoolsSection = observer(() => {
             const userValue =
               poolDetail instanceof ObservableSharePoolDetail
                 ? formatPretty(poolDetail.userBondedValue)
-                : poolDetail.userPoolAssets
-                    .reduce(
-                      (sum, { asset }) =>
-                        sum.add(
-                          priceStore.calculatePrice(asset) ??
-                            new PricePretty(fiat, 0)
-                        ),
-                      new PricePretty(fiat, 0)
-                    )
+                : objCoinsToFiatPricePretty(
+                    priceStore,
+                    fiat,
+                    poolDetail.userPoolAssets
+                  )
                     .maxDecimals(2)
                     .toString();
 

--- a/packages/web/utils/total-value.ts
+++ b/packages/web/utils/total-value.ts
@@ -1,0 +1,36 @@
+import { FiatCurrency } from "@keplr-wallet/types";
+import { CoinPretty, PricePretty } from "@keplr-wallet/unit";
+import { PoolFallbackPriceStore } from "@osmosis-labs/stores";
+
+// TODO: Change this out of the price pretty overhead, in a later iteration.
+export function coinsToFiatValue(
+  priceStore: PoolFallbackPriceStore,
+  fiat: FiatCurrency,
+  coins: CoinPretty[]
+): number {
+  return Number(
+    coinsToFiatPricePretty(priceStore, fiat, coins).toDec().toString()
+  );
+}
+
+// TODO: Do we actually want this anywhere?
+export function coinsToFiatPricePretty(
+  priceStore: PoolFallbackPriceStore,
+  fiat: FiatCurrency,
+  coins: CoinPretty[]
+): PricePretty {
+  return coins.reduce(
+    (sum, asset) =>
+      sum.add(priceStore.calculatePrice(asset) ?? new PricePretty(fiat, 0)),
+    new PricePretty(fiat, 0)
+  );
+}
+
+export function objCoinsToFiatPricePretty(
+  priceStore: PoolFallbackPriceStore,
+  fiat: FiatCurrency,
+  coins: { asset: CoinPretty }[]
+): PricePretty {
+  let coinPrettyArr: CoinPretty[] = coins.map((obj) => obj.asset);
+  return coinsToFiatPricePretty(priceStore, fiat, coinPrettyArr);
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

De-duplicates some logic for summing coin pretty's. I plan to then make a PR speeding these up later.

## Testing and Verifying

This change has not been tested locally, because I expect CI & unit tests to catch any difference here.

## Documentation and Release Note

- Does this pull request introduce a new feature or user-facing behavior changes? no
- How is the feature or change documented? N/A
