### PR TITLE
feat: Hide Notifications Based on Feature Flag on Mobile Phones

### DIFF
--- a/packages/web/components/navbar/index.tsx
+++ b/packages/web/components/navbar/index.tsx
@@ -25,6 +25,7 @@ import {
   useAmplitudeAnalytics,
   useDisclosure,
   useLocalStorageState,
+  useWindowSize,
 } from "~/hooks";
 import { useFeatureFlags } from "~/hooks/use-feature-flags";
 import { useWalletSelect } from "~/hooks/wallet-select";
@@ -64,6 +65,7 @@ export const NavBar: FunctionComponent<
   const t = useTranslation();
 
   const featureFlags = useFeatureFlags();
+  const { isMobile } = useWindowSize();
 
   const { query } = useRouter();
 
@@ -161,6 +163,10 @@ export const NavBar: FunctionComponent<
     featureFlags.concentratedLiquidity &&
     (!Announcement.pageRoute || router.pathname === Announcement.pageRoute);
 
+  const areNotificationsEnabled = isMobile
+    ? featureFlags.mobileNotifications
+    : featureFlags.notifications;
+
   return (
     <>
       <div
@@ -191,7 +197,7 @@ export const NavBar: FunctionComponent<
                 ),
               });
 
-              if (featureFlags.notifications && walletSupportsNotifications) {
+              if (areNotificationsEnabled && walletSupportsNotifications) {
                 mobileMenus = mobileMenus.concat({
                   label: "Notifications",
                   link: (e) => {
@@ -312,7 +318,7 @@ export const NavBar: FunctionComponent<
               />
             </div>
           )}
-          {featureFlags.notifications && walletSupportsNotifications && (
+          {areNotificationsEnabled && walletSupportsNotifications && (
             <NotifiContextProvider>
               <NotifiPopover
                 hasUnreadNotification={hasUnreadNotification}

--- a/packages/web/components/navbar/index.tsx
+++ b/packages/web/components/navbar/index.tsx
@@ -25,7 +25,6 @@ import {
   useAmplitudeAnalytics,
   useDisclosure,
   useLocalStorageState,
-  useWindowSize,
 } from "~/hooks";
 import { useFeatureFlags } from "~/hooks/use-feature-flags";
 import { useWalletSelect } from "~/hooks/wallet-select";
@@ -65,7 +64,6 @@ export const NavBar: FunctionComponent<
   const t = useTranslation();
 
   const featureFlags = useFeatureFlags();
-  const { isMobile } = useWindowSize();
 
   const { query } = useRouter();
 
@@ -163,10 +161,6 @@ export const NavBar: FunctionComponent<
     featureFlags.concentratedLiquidity &&
     (!Announcement.pageRoute || router.pathname === Announcement.pageRoute);
 
-  const areNotificationsEnabled = isMobile
-    ? featureFlags.mobileNotifications
-    : featureFlags.notifications;
-
   return (
     <>
       <div
@@ -197,7 +191,7 @@ export const NavBar: FunctionComponent<
                 ),
               });
 
-              if (areNotificationsEnabled && walletSupportsNotifications) {
+              if (featureFlags.notifications && walletSupportsNotifications) {
                 mobileMenus = mobileMenus.concat({
                   label: "Notifications",
                   link: (e) => {
@@ -318,7 +312,7 @@ export const NavBar: FunctionComponent<
               />
             </div>
           )}
-          {areNotificationsEnabled && walletSupportsNotifications && (
+          {featureFlags.notifications && walletSupportsNotifications && (
             <NotifiContextProvider>
               <NotifiPopover
                 hasUnreadNotification={hasUnreadNotification}

--- a/packages/web/hooks/use-feature-flags.ts
+++ b/packages/web/hooks/use-feature-flags.ts
@@ -19,5 +19,8 @@ export const useFeatureFlags = () => {
     concentratedLiquidity: Boolean(
       !isMobile && launchdarklyFlags.concentratedLiquidity
     ),
-  } as Record<AvailableFlags, boolean>;
+    notifications: isMobile
+      ? launchdarklyFlags.mobileNotifications
+      : launchdarklyFlags.notifications,
+  } as Record<Exclude<AvailableFlags, "mobileNotifications">, boolean>;
 };

--- a/packages/web/hooks/use-feature-flags.ts
+++ b/packages/web/hooks/use-feature-flags.ts
@@ -7,6 +7,7 @@ type AvailableFlags =
   | "staking"
   | "swapsAdBanner"
   | "notifications"
+  | "mobileNotifications"
   | "upgrades";
 
 export const useFeatureFlags = () => {


### PR DESCRIPTION
### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/86a0nk2ut)

## Brief Changelog

- Add a feature flag to show/hide notifications on mobile phones

## Testing and Verifying

- [ ] Display notifications icon according to `mobile-notifications` feature flag state 