### PR TITLE
fix: all CL pool APR showing 0%

### DIFF
--- a/packages/web/pages/api/active-gauges.ts
+++ b/packages/web/pages/api/active-gauges.ts
@@ -29,7 +29,8 @@ export default async function activeGauges(
     data: data.filter(
       (gauge) =>
         !gauge.is_perpetual &&
-        gauge.distribute_to.denom.match(/gamm\/pool\/[0-9]+/m) && // only gamm share incentives
+        (gauge.distribute_to.denom.match(/gamm\/pool\/[0-9]+/m) || // only gamm(classic pool) share incentives, or
+          gauge.distribute_to.denom.match(/no-lock\/e\/[0-9]+/m)) && // no-lock (CL pool) share incentives
         !gauge.coins.some((coin) => coin.denom.match(/gamm\/pool\/[0-9]+/m)) && // no gamm share rewards
         gauge.filled_epochs != gauge.num_epochs_paid_over && // no completed gauges
         checkForStaleness(gauge, parseInt(data[data.length - 1].id), epochs)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

To allow CL pools to not only show 0% APR
<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/86a0nxe7u)

## Brief Changelog

-adds no-lock/e/ (CL) pool shares to the incentives query that feeds APR numbers

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying


This change has been tested locally by rebuilding the website and verified content and links are expected
