### PR TITLE
Superfluid share pool detail: fix bonding to longest duration

### DIFF
--- a/.vscode/osmosis-frontend.code-workspace
+++ b/.vscode/osmosis-frontend.code-workspace
@@ -19,6 +19,7 @@
   "settings": {
     "jest.jestCommandLine": "yarn test",
     "jest.disabledWorkspaceFolders": ["proto-codecs"],
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "githubPullRequests.ignoredPullRequestBranches": ["stage"]
   }
 }

--- a/packages/stores/src/derived-data/pool/bonding.ts
+++ b/packages/stores/src/derived-data/pool/bonding.ts
@@ -203,20 +203,26 @@ export class ObservableSharePoolBonding {
             }
           : undefined;
 
-      // return if this gauge is not relevant to user
-      //  * Bonding is pointless with no internal gauges incentivizing this lock duration
-      //    * OR Is superfluid but is not the longest lock duration
-      //  * No external gauges for this lock duration
-      //  * User has no un/locked tokens in locks for this lock duration
       if (
-        (!internalGaugeOfDuration?.apr.toDec().gt(new Dec(0)) ||
-          (this.superfluidPoolDetail.isSuperfluid &&
-            curDuration.asMilliseconds() !==
-              this.sharePoolDetail.longestDuration?.asMilliseconds())) &&
-        externalGaugesOfDuration.length === 0 &&
-        lockedUserShares.toDec().isZero() &&
-        (!userUnlockingShares || userUnlockingShares.shares.toDec().isZero())
+        !(
+          // are external incentives
+          (
+            externalGauges.length > 0 ||
+            // is internally incentivized
+            this.sharePoolDetail.isIncentivized ||
+            // is superfluid and is the longest duration
+            (this.superfluidPoolDetail.isSuperfluid &&
+              curDuration.asMilliseconds() ===
+                this.sharePoolDetail.longestDuration?.asMilliseconds()) ||
+            // this duration has duration locks containing locked shares
+            lockedUserShares.toDec().isPositive() ||
+            // same as above but for unlocking shares
+            (userUnlockingShares &&
+              userUnlockingShares.shares.toDec().isPositive())
+          )
+        )
       ) {
+        // if none of the above apply, return undefined
         return;
       }
 

--- a/packages/stores/src/derived-data/pool/bonding.ts
+++ b/packages/stores/src/derived-data/pool/bonding.ts
@@ -203,11 +203,12 @@ export class ObservableSharePoolBonding {
             }
           : undefined;
 
+      // one of the following must hold:
       if (
         !(
           // are external incentives
           (
-            externalGauges.length > 0 ||
+            externalGaugesOfDuration.length > 0 ||
             // is internally incentivized
             this.sharePoolDetail.isIncentivized ||
             // is superfluid and is the longest duration
@@ -318,7 +319,10 @@ export class ObservableSharePoolBonding {
         duration: curDuration,
         bondable:
           internalGaugeOfDuration !== undefined ||
-          externalGaugesOfDuration.length > 0,
+          externalGaugesOfDuration.length > 0 ||
+          (this.superfluidPoolDetail.isSuperfluid &&
+            curDuration.asMilliseconds() ===
+              this.sharePoolDetail.longestDuration?.asMilliseconds()),
         userShares: lockedUserShares,
         userLockedShareValue,
         userUnlockingShares,

--- a/packages/stores/src/derived-data/pool/share-pool-details.ts
+++ b/packages/stores/src/derived-data/pool/share-pool-details.ts
@@ -108,9 +108,7 @@ export class ObservableSharePoolDetail {
             duration
           );
 
-        const gauge = this.externalQueries.queryActiveGauges.get(
-          gaugeId ?? "1"
-        );
+        const gauge = this.externalQueries.queryActiveGauges.get(gaugeId ?? "");
 
         const apr = this.osmosisQueries.queryIncentivizedPools.computeApr(
           this.poolId,
@@ -118,6 +116,8 @@ export class ObservableSharePoolDetail {
           this.priceStore,
           this._fiatCurrency
         );
+
+        if (!gaugeId) return;
 
         return {
           id: gaugeId,

--- a/packages/web/components/pool-detail/share.tsx
+++ b/packages/web/components/pool-detail/share.tsx
@@ -147,7 +147,7 @@ export const SharePool: FunctionComponent<{ poolId: string }> = observer(
     const [showPoolDetails, setShowPoolDetails] = useState(false);
     const bondDurations = pool ? poolBonding?.bondDurations ?? [] : [];
 
-    const highestAPRBondableDuration = bondDurations[bondDurations?.length - 1];
+    const highestAPRBondableDuration = poolBonding?.highestBondDuration;
 
     const highestAPRDailyPeriodicRate =
       highestAPRBondableDuration?.aggregateApr


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

### ClickUp Task

[ClickUp Task URL](PASTE_CLICKUP_TASK_URL_HERE)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

Fixes showing bond duration for superfluid pools, such as pool 1, if it's superfluid. Even if there are no internal gauges in that pool.

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

* Should be able to bond to superfluid pools, such as pool 1
* Should see external gauges, such as in pool 903. Should just see durations where there are incentives or un/bonded shares.

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
