### PR TITLE
[Notifi] fix sing-up crash with Leap wallet

### DIFF
--- a/packages/web/integrations/notifi/notifi-context.tsx
+++ b/packages/web/integrations/notifi/notifi-context.tsx
@@ -70,7 +70,7 @@ const NotifiContextProviderImpl: FunctionComponent<PropsWithChildren<{}>> =
           const result = await wallet.client.signArbitrary(
             info.chainId,
             info.account.address,
-            message
+            new TextDecoder().decode(message)
           );
           return Buffer.from(result.signature, "base64");
         }}


### PR DESCRIPTION
### Background

Notification sign up failing with Leap wallet because of Leap's deterministic signature.

### Fix

For Leap wallet to work we need to invoke signArbitrary with a string, not Uint8Array (Leap wallet team updated the built )