### PR TITLE
fix check for SF duration

### DIFF
--- a/packages/stores/src/derived-data/pool/bonding.ts
+++ b/packages/stores/src/derived-data/pool/bonding.ts
@@ -118,6 +118,7 @@ export class ObservableSharePoolBonding {
         }
       });
 
+    // add the duration for all the internal & external gauges
     (internalGauges as { duration: Duration }[])
       .concat(
         externalGauges.map((gauge) => ({
@@ -128,13 +129,19 @@ export class ObservableSharePoolBonding {
         durationsMsSet.add(gauge.duration.asMilliseconds());
       });
 
+    // add longest duration if superfluid
+    if (this.superfluidPoolDetail.isSuperfluid) {
+      const longestDuration = this.sharePoolDetail.longestDuration;
+      if (longestDuration) {
+        durationsMsSet.add(longestDuration.asMilliseconds());
+      }
+    }
+
+    // now find the bond duration info for each relevant duration
     return Array.from(durationsMsSet.values())
-      .sort((a, b) => b - a)
-      .reverse()
-      .map((durationMs) => {
-        return this.getBondDuration(durationMs);
-      })
-      .filter((duration) => duration !== undefined) as BondDuration[];
+      .sort((a, b) => a - b)
+      .map((durationMs) => this.getBondDuration(durationMs))
+      .filter((duration): duration is BondDuration => duration !== undefined);
   }
 
   /** Highest APR that can be earned in this share pool. */


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

For some reason it was working before, but I missed adding the check for the longest duration if superfluid enabled.

### ClickUp Task

[ClickUp Task URL](PASTE_CLICKUP_TASK_URL_HERE)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
