### PR TITLE
[Notifi] handle user reject enable notification

### DIFF
--- a/packages/web/integrations/notifi/notifi-subscription-card/fetched-card/signup-view.tsx
+++ b/packages/web/integrations/notifi/notifi-subscription-card/fetched-card/signup-view.tsx
@@ -179,6 +179,8 @@ const VerifyButton: FunctionComponent<{
         }
       }
       logEvent([EventName.Notifications.enableCompleted]);
+    } catch (e) {
+      console.log("Notification enable failed: ", JSON.stringify(e));
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION


`onClickVeirfy` function of signupView needs a catch clause to prevent the "Request rejected" error from bubbling to the error boundary when a user rejects the enable notifications signature popup

<img width="744" alt="Screenshot 2023-09-04 at 14 03 04" src="https://github.com/osmosis-labs/osmosis-frontend/assets/127958634/c8446a44-6eb9-43ab-99d0-d495a695c308">