### PR TITLE
[Token Info] Create Asset Page Behind Feature Flag

### DIFF
--- a/packages/web/hooks/use-feature-flags.ts
+++ b/packages/web/hooks/use-feature-flags.ts
@@ -8,7 +8,8 @@ type AvailableFlags =
   | "swapsAdBanner"
   | "notifications"
   | "mobileNotifications"
-  | "upgrades";
+  | "upgrades"
+  | "tokenInfo";
 
 export const useFeatureFlags = () => {
   const launchdarklyFlags: Record<AvailableFlags, boolean> = useFlags();

--- a/packages/web/pages/assets/[denom].tsx
+++ b/packages/web/pages/assets/[denom].tsx
@@ -1,0 +1,24 @@
+import { NextPage } from "next";
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+
+import { useFeatureFlags } from "~/hooks";
+
+const AssetInfoPage: NextPage = () => {
+  const featureFlags = useFeatureFlags();
+  const router = useRouter();
+  const denom = router.query.denom as string;
+
+  useEffect(() => {
+    if (
+      typeof featureFlags.tokenInfo !== "undefined" &&
+      !featureFlags.tokenInfo
+    ) {
+      router.push("/assets");
+    }
+  }, [featureFlags.tokenInfo, router]);
+
+  return <div className="flex">{denom}</div>;
+};
+
+export default AssetInfoPage;


### PR DESCRIPTION
### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/8669axbau)

## Testing and Verifying

You can access the page by navigating to `/assets/osmo`

- [ ] Should redirect users to asset page when `tokenInfo` feature flag is off 
