### PR TITLE
fix: Update Pool Creation Fee to 1000 OSMO

### DIFF
--- a/packages/web/components/complex/pool/create/index.ts
+++ b/packages/web/components/complex/pool/create/index.ts
@@ -4,4 +4,4 @@ export * from "./step2-add-liquidity";
 export * from "./step3-confirm";
 export * from "./types";
 
-export const POOL_CREATION_FEE = "100 OSMO";
+export const POOL_CREATION_FEE = "1000 OSMO";


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

To update the hardcoded pool creation fee to 1000, as it was changed to after the upgrade.
<img width="499" alt="image" src="https://github.com/osmosis-labs/osmosis-frontend/assets/95667791/598d4163-8870-4666-8e6b-cd30222e8862">
<img width="486" alt="image" src="https://github.com/osmosis-labs/osmosis-frontend/assets/95667791/e161e134-8299-4cc7-affc-d4792cb4033d">


<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/86a0rejp2)

## Brief Changelog

update POOL_CREATION_FEE to "1000 OSMO"
<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

This change has been tested locally by rebuilding the website and verified content and links are expected

Validation successful