### PR TITLE
[Notifi] fix unread count badge prevents hovering the bell button

### DIFF
--- a/packages/web/integrations/notifi/notifi-popover.tsx
+++ b/packages/web/integrations/notifi/notifi-popover.tsx
@@ -41,7 +41,7 @@ const NotifiIconButton: FunctionComponent<
       />
 
       {hasUnreadNotification ? (
-        <div className="absolute bottom-[-0.375rem] right-[-0.375rem]">
+        <div className="pointer-events-none absolute bottom-[-0.375rem] right-[-0.375rem]">
           <svg
             width="25"
             height="19"


### PR DESCRIPTION
Fix the issue that the Unread Count Badge prevents the mouse from hovering the bell icon button