### PR TITLE
[Notifi] fix email regex mismatch issue

### DIFF
--- a/packages/web/integrations/notifi/notifi-subscription-card/fetched-card/input-email.tsx
+++ b/packages/web/integrations/notifi/notifi-subscription-card/fetched-card/input-email.tsx
@@ -44,7 +44,7 @@ export const InputEmail: FunctionComponent<Props> = ({
       targetGroupName: "Default",
     });
 
-  const emailRegex = new RegExp("^[^s@]+@[^s@]+.[^s@]+$");
+  const emailRegex = new RegExp(/^[^\s@]+@[^\s@]+\.[^\s@]+$/);
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
## Background 
Reported by Aris:
 in the verify targets section, after I put my email the verify button still disable(gray out) not tuning blue like the picture
<img width="353" alt="Screenshot 2023-09-12 at 22 31 26" src="https://github.com/osmosis-labs/osmosis-frontend/assets/127958634/839ea931-cb03-480a-8f91-32759fbdfee3">


## Reason and fix

It is caused by the mistaken email regex validation auto remove back slash by prettier.
Add it back can fix it.