### PR TITLE
fix: Swap Tool Memory Leak 

### DIFF
--- a/packages/web/pages/index.tsx
+++ b/packages/web/pages/index.tsx
@@ -1,14 +1,17 @@
+import { Dec } from "@keplr-wallet/unit";
 import { observer } from "mobx-react-lite";
 import type { GetStaticProps, InferGetServerSidePropsType } from "next";
+import { useEffect, useMemo, useRef } from "react";
 
 import { Ad, AdCMS } from "~/components/ad-banner/ad-banner-types";
 import { ProgressiveSvgImage } from "~/components/progressive-svg-image";
 import { SwapTool } from "~/components/swap-tool";
-import { EventName } from "~/config";
+import { EventName, IS_TESTNET } from "~/config";
 import adCMSData from "~/config/ads-banner.json";
-import { useAmplitudeAnalytics } from "~/hooks";
-import { useRoutablePools } from "~/hooks/data/use-routable-pools";
+import { useAmplitudeAnalytics, useFeatureFlags } from "~/hooks";
 import { useWalletSelect } from "~/hooks/wallet-select";
+import { useStore } from "~/stores";
+import { UnverifiedAssetsState } from "~/stores/user-settings";
 
 interface HomeProps {
   ads: Ad[];
@@ -37,9 +40,66 @@ export const getStaticProps: GetStaticProps<HomeProps> = async () => {
 };
 
 const Home = ({ ads }: InferGetServerSidePropsType<typeof getStaticProps>) => {
+  const { chainStore, queriesStore, priceStore, userSettings } = useStore();
+  const { chainId } = chainStore.osmosis;
+
   const { isLoading: isWalletLoading } = useWalletSelect();
 
-  const routablePools = useRoutablePools();
+  const queries = queriesStore.get(chainId);
+  const queryPools = queries.osmosis!.queryPools;
+  const showUnverified =
+    userSettings.getUserSettingById<UnverifiedAssetsState>("unverified-assets")
+      ?.state?.showUnverifiedAssets;
+
+  const allPools = queryPools.getAllPools();
+
+  const flags = useFeatureFlags();
+
+  // Pools should be memoized before passing to trade in config
+  const pools = useMemo(
+    () =>
+      allPools
+        .filter((pool) => {
+          // include all pools on testnet env
+          if (IS_TESTNET) return true;
+
+          if (!IS_TESTNET && pool.id === "895") return false;
+
+          // filter concentrated pools if feature flag is not enabled
+          if (pool.type === "concentrated" && !flags.concentratedLiquidity)
+            return false;
+
+          if (pool.type === "concentrated" && pool.id !== "1066")
+            // TODO: remove, temporary due to tick query bug with v17 with new CL pools
+            return false;
+
+          // some min TVL for balancer pools
+          return pool
+            .computeTotalValueLocked(priceStore)
+            .toDec()
+            .gte(
+              new Dec(
+                showUnverified || pool.type === "concentrated" ? 1_000 : 10_000
+              )
+            );
+        })
+        .sort((a, b) => {
+          // sort by TVL to find routes amongst most valuable pools
+          const aTVL = a.computeTotalValueLocked(priceStore);
+          const bTVL = b.computeTotalValueLocked(priceStore);
+
+          return Number(bTVL.sub(aTVL).toDec().toString());
+        }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [allPools, priceStore.response, flags.concentratedLiquidity]
+  );
+
+  const requestedRemaining = useRef(false);
+  useEffect(() => {
+    if (requestedRemaining.current) return;
+    queryPools.fetchRemainingPools();
+    requestedRemaining.current = true;
+  }, [queryPools]);
 
   useAmplitudeAnalytics({
     onLoadEvent: [EventName.Swap.pageViewed, { isOnHome: true }],
@@ -70,8 +130,8 @@ const Home = ({ ads }: InferGetServerSidePropsType<typeof getStaticProps>) => {
       <div className="my-auto flex h-auto w-full items-center">
         <div className="ml-auto mr-[15%] flex w-[27rem] flex-col gap-4 lg:mx-auto md:mt-mobile-header">
           <SwapTool
-            memoedPools={routablePools ?? []}
-            isDataLoading={!Boolean(routablePools) || isWalletLoading}
+            memoedPools={pools ?? []}
+            isDataLoading={!Boolean(pools) || isWalletLoading}
             ads={ads}
           />
         </div>

--- a/packages/web/pages/index.tsx
+++ b/packages/web/pages/index.tsx
@@ -1,17 +1,14 @@
-import { Dec } from "@keplr-wallet/unit";
 import { observer } from "mobx-react-lite";
 import type { GetStaticProps, InferGetServerSidePropsType } from "next";
-import { useEffect, useMemo, useRef } from "react";
 
 import { Ad, AdCMS } from "~/components/ad-banner/ad-banner-types";
 import { ProgressiveSvgImage } from "~/components/progressive-svg-image";
 import { SwapTool } from "~/components/swap-tool";
-import { EventName, IS_TESTNET } from "~/config";
+import { EventName } from "~/config";
 import adCMSData from "~/config/ads-banner.json";
-import { useAmplitudeAnalytics, useFeatureFlags } from "~/hooks";
+import { useAmplitudeAnalytics } from "~/hooks";
+import { useRoutablePools } from "~/hooks/data/use-routable-pools";
 import { useWalletSelect } from "~/hooks/wallet-select";
-import { useStore } from "~/stores";
-import { UnverifiedAssetsState } from "~/stores/user-settings";
 
 interface HomeProps {
   ads: Ad[];
@@ -40,66 +37,9 @@ export const getStaticProps: GetStaticProps<HomeProps> = async () => {
 };
 
 const Home = ({ ads }: InferGetServerSidePropsType<typeof getStaticProps>) => {
-  const { chainStore, queriesStore, priceStore, userSettings } = useStore();
-  const { chainId } = chainStore.osmosis;
-
   const { isLoading: isWalletLoading } = useWalletSelect();
 
-  const queries = queriesStore.get(chainId);
-  const queryPools = queries.osmosis!.queryPools;
-  const showUnverified =
-    userSettings.getUserSettingById<UnverifiedAssetsState>("unverified-assets")
-      ?.state?.showUnverifiedAssets;
-
-  const allPools = queryPools.getAllPools();
-
-  const flags = useFeatureFlags();
-
-  // Pools should be memoized before passing to trade in config
-  const pools = useMemo(
-    () =>
-      allPools
-        .filter((pool) => {
-          // include all pools on testnet env
-          if (IS_TESTNET) return true;
-
-          if (!IS_TESTNET && pool.id === "895") return false;
-
-          // filter concentrated pools if feature flag is not enabled
-          if (pool.type === "concentrated" && !flags.concentratedLiquidity)
-            return false;
-
-          if (pool.type === "concentrated" && pool.id !== "1066")
-            // TODO: remove, temporary due to tick query bug with v17 with new CL pools
-            return false;
-
-          // some min TVL for balancer pools
-          return pool
-            .computeTotalValueLocked(priceStore)
-            .toDec()
-            .gte(
-              new Dec(
-                showUnverified || pool.type === "concentrated" ? 1_000 : 10_000
-              )
-            );
-        })
-        .sort((a, b) => {
-          // sort by TVL to find routes amongst most valuable pools
-          const aTVL = a.computeTotalValueLocked(priceStore);
-          const bTVL = b.computeTotalValueLocked(priceStore);
-
-          return Number(bTVL.sub(aTVL).toDec().toString());
-        }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [allPools, priceStore.response, flags.concentratedLiquidity]
-  );
-
-  const requestedRemaining = useRef(false);
-  useEffect(() => {
-    if (requestedRemaining.current) return;
-    queryPools.fetchRemainingPools();
-    requestedRemaining.current = true;
-  }, [queryPools]);
+  const routablePools = useRoutablePools();
 
   useAmplitudeAnalytics({
     onLoadEvent: [EventName.Swap.pageViewed, { isOnHome: true }],
@@ -130,8 +70,8 @@ const Home = ({ ads }: InferGetServerSidePropsType<typeof getStaticProps>) => {
       <div className="my-auto flex h-auto w-full items-center">
         <div className="ml-auto mr-[15%] flex w-[27rem] flex-col gap-4 lg:mx-auto md:mt-mobile-header">
           <SwapTool
-            memoedPools={pools ?? []}
-            isDataLoading={!Boolean(pools) || isWalletLoading}
+            memoedPools={routablePools ?? []}
+            isDataLoading={!Boolean(routablePools) || isWalletLoading}
             ads={ads}
           />
         </div>

--- a/packages/web/utils/background-routes/index.ts
+++ b/packages/web/utils/background-routes/index.ts
@@ -37,7 +37,7 @@ export class BackgroundRoutes implements TokenOutGivenInRouter {
    *  This allows us to maintain the Promise-based API of the router, while delegating the work to a background thread via event listeners.
    *  Map: Serial number => Response */
   protected static resolvableResponses = new Map<number, EncodedResponse>();
-  protected static eventEmitter = new EventEmitter();
+  private static eventEmitter = new EventEmitter();
 
   private static getEventName(serialNumber: number) {
     return `optimized-route-response-${serialNumber}`;
@@ -188,21 +188,14 @@ export class BackgroundRoutes implements TokenOutGivenInRouter {
 
     return new Promise(async (resolve, reject) => {
       try {
-        const handleResponse = (response: EncodedResponse) => {
-          // TODO: Remove before merge
-          console.log("Got background event response!", response);
-          if (response) {
-            BackgroundRoutes.resolvableResponses.delete(serialNumber);
-            clearTimeout(tId);
-            resolve(response);
-            return;
-          }
-        };
         const eventName = BackgroundRoutes.getEventName(serialNumber);
+        const handleResponse = (response: EncodedResponse) => {
+          BackgroundRoutes.resolvableResponses.delete(serialNumber);
+          clearTimeout(tId);
+          resolve(response);
+        };
 
         const tId = setTimeout(() => {
-          // TODO: Remove before merge
-          console.log("timeout", eventName);
           BackgroundRoutes.eventEmitter.removeListener(
             eventName,
             handleResponse

--- a/packages/web/utils/background-routes/index.ts
+++ b/packages/web/utils/background-routes/index.ts
@@ -5,6 +5,7 @@ import {
   Token,
   TokenOutGivenInRouter,
 } from "@osmosis-labs/pools";
+import { EventEmitter } from "eventemitter3";
 
 import {
   checkResponseAndDecodeError,
@@ -36,6 +37,11 @@ export class BackgroundRoutes implements TokenOutGivenInRouter {
    *  This allows us to maintain the Promise-based API of the router, while delegating the work to a background thread via event listeners.
    *  Map: Serial number => Response */
   protected static resolvableResponses = new Map<number, EncodedResponse>();
+  protected static eventEmitter = new EventEmitter();
+
+  private static getEventName(serialNumber: number) {
+    return `optimized-route-response-${serialNumber}`;
+  }
 
   constructor(params: OptimizedRoutesParams, worker?: Worker) {
     if (typeof window !== "undefined") {
@@ -53,6 +59,17 @@ export class BackgroundRoutes implements TokenOutGivenInRouter {
               event.data
             );
 
+            const eventName = BackgroundRoutes.getEventName(
+              event.data.serialNumber
+            );
+            if (BackgroundRoutes.eventEmitter.listenerCount(eventName) > 0) {
+              BackgroundRoutes.eventEmitter.emit(
+                `optimized-route-response-${event.data.serialNumber}`,
+                event.data
+              );
+              BackgroundRoutes.eventEmitter.removeAllListeners(eventName);
+            }
+
             // memory leak: clean up old timed out responses some number before current response
             let oldestSerialNumber =
               event.data.serialNumber - MAX_RESOLVABLE_RESPONSES;
@@ -60,6 +77,7 @@ export class BackgroundRoutes implements TokenOutGivenInRouter {
               BackgroundRoutes.resolvableResponses.has(oldestSerialNumber--)
             ) {
               BackgroundRoutes.resolvableResponses.delete(oldestSerialNumber);
+              BackgroundRoutes.eventEmitter.removeAllListeners(eventName);
             }
           }
         );
@@ -170,21 +188,29 @@ export class BackgroundRoutes implements TokenOutGivenInRouter {
 
     return new Promise(async (resolve, reject) => {
       try {
-        const tId = setTimeout(() => {
-          resolve(TIMEOUT_SYMBOL);
-        }, timeoutMs);
-        let maxIterations = 1_000_000;
-        do {
-          await new Promise((resolve) => setTimeout(resolve, 100)); // sleep
-          const result = BackgroundRoutes.resolvableResponses.get(serialNumber);
-          if (result) {
+        const handleResponse = (response: EncodedResponse) => {
+          // TODO: Remove before merge
+          console.log("Got background event response!", response);
+          if (response) {
             BackgroundRoutes.resolvableResponses.delete(serialNumber);
-            resolve(result);
+            clearTimeout(tId);
+            resolve(response);
             return;
           }
-        } while (--maxIterations > 0);
-        clearTimeout(tId);
-        resolve(TIMEOUT_SYMBOL);
+        };
+        const eventName = BackgroundRoutes.getEventName(serialNumber);
+
+        const tId = setTimeout(() => {
+          // TODO: Remove before merge
+          console.log("timeout", eventName);
+          BackgroundRoutes.eventEmitter.removeListener(
+            eventName,
+            handleResponse
+          );
+          resolve(TIMEOUT_SYMBOL);
+        }, timeoutMs);
+
+        BackgroundRoutes.eventEmitter.addListener(eventName, handleResponse);
       } catch (e) {
         reject(e);
       }


### PR DESCRIPTION
## What is the purpose of the change

In the `useRoutablePools` function, reactions were not being disposed of properly. As a result, each time the pools were refreshed, an additional reaction was created, which sent multiple messages to the worker. This led to a continuous infinite loop.

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/86a0rkhne)

## Brief Changelog

- Dispose of `reloadPoolsReaction` correctly to avoid a memory leak
- Use Events to propagate message responses to the background router

## Testing and Verifying

- [x] Swap prices should be calculated and not brick after a while