### PR TITLE
[Notifi] Support closing notification popover/ modal while clicking internal link

### DIFF
--- a/packages/web/integrations/notifi/notifi-modal-context.tsx
+++ b/packages/web/integrations/notifi/notifi-modal-context.tsx
@@ -34,6 +34,10 @@ interface NotifiModalFunctions {
   setIsCardOpen: React.Dispatch<React.SetStateAction<boolean>>;
   isPreventingCardClosed: boolean; // Preventing card from closing while isCardOpen is true
   setIsPreventingCardClosed: React.Dispatch<React.SetStateAction<boolean>>;
+  closeCard?: () => void; // close notification popover/modalBase
+  setCloseCard: React.Dispatch<
+    React.SetStateAction<(() => void | undefined) | undefined>
+  >;
 }
 
 const NotifiModalContext = createContext<NotifiModalFunctions>({
@@ -53,6 +57,7 @@ export const NotifiModalContextProvider: FunctionComponent<
   const [selectedHistoryEntry, setSelectedHistoryEntry] = useState<
     HistoryRowData | undefined
   >(undefined);
+  const [closeCard, setCloseCard] = useState<() => void>();
   const config = useNotifiConfig();
   const titles = useMemo(() => {
     if (config.state === "fetched" && config.data.titles?.active) {
@@ -135,6 +140,8 @@ export const NotifiModalContextProvider: FunctionComponent<
         isCardOpen,
         setIsCardOpen,
         setInnerState,
+        closeCard,
+        setCloseCard,
       }}
     >
       {children}

--- a/packages/web/integrations/notifi/notifi-modal.tsx
+++ b/packages/web/integrations/notifi/notifi-modal.tsx
@@ -75,7 +75,7 @@ export const NotifiModal: FunctionComponent<Props> = (props) => {
           />
         )}
         <NotifiSubscriptionCard
-          parentType={finalProps.isOpen ? "modalBase" : undefined}
+          isPopoverOrModalBaseOpen={finalProps.isOpen ? true : false}
         />
       </div>
     </ModalBase>

--- a/packages/web/integrations/notifi/notifi-modal.tsx
+++ b/packages/web/integrations/notifi/notifi-modal.tsx
@@ -76,6 +76,7 @@ export const NotifiModal: FunctionComponent<Props> = (props) => {
         )}
         <NotifiSubscriptionCard
           isPopoverOrModalBaseOpen={finalProps.isOpen ? true : false}
+          closeCard={finalProps.onRequestClose}
         />
       </div>
     </ModalBase>

--- a/packages/web/integrations/notifi/notifi-popover.tsx
+++ b/packages/web/integrations/notifi/notifi-popover.tsx
@@ -187,7 +187,7 @@ export const NotifiPopover: FunctionComponent<NotifiButtonProps> = ({
           pb-0`}
                   >
                     <NotifiSubscriptionCard
-                      parentType={popOverOpen ? "popover" : undefined}
+                      isPopoverOrModalBaseOpen={popOverOpen ? true : false}
                     />
                   </div>
                 </Popover.Panel>

--- a/packages/web/integrations/notifi/notifi-popover.tsx
+++ b/packages/web/integrations/notifi/notifi-popover.tsx
@@ -118,7 +118,7 @@ export const NotifiPopover: FunctionComponent<NotifiButtonProps> = ({
         ></div>
       )}
       <Popover className="relative z-[1]">
-        {({ open: popOverOpen }) => {
+        {({ open: popOverOpen, close }) => {
           return (
             <>
               <Popover.Button as={Fragment}>
@@ -188,6 +188,7 @@ export const NotifiPopover: FunctionComponent<NotifiButtonProps> = ({
                   >
                     <NotifiSubscriptionCard
                       isPopoverOrModalBaseOpen={popOverOpen ? true : false}
+                      closeCard={close}
                     />
                   </div>
                 </Popover.Panel>

--- a/packages/web/integrations/notifi/notifi-subscription-card/fetched-card/history-rows.tsx
+++ b/packages/web/integrations/notifi/notifi-subscription-card/fetched-card/history-rows.tsx
@@ -94,8 +94,13 @@ const validateHistoryRow = (
 };
 
 export const HistoryRow: FunctionComponent<RowProps> = ({ row }) => {
-  const { renderView, selectedHistoryEntry, setSelectedHistoryEntry } =
-    useNotifiModalContext();
+  const {
+    renderView,
+    selectedHistoryEntry,
+    setSelectedHistoryEntry,
+    closeCard,
+    setIsOverLayEnabled,
+  } = useNotifiModalContext();
   const router = useRouter();
   const t = useTranslation();
   const { logEvent } = useAmplitudeAnalytics();
@@ -282,10 +287,15 @@ export const HistoryRow: FunctionComponent<RowProps> = ({ row }) => {
   }, [row]);
 
   const handleClick = useCallback(() => {
+    setIsOverLayEnabled(false);
+
     if (popOutUrl) {
-      popOutUrl.startsWith("/")
-        ? router.push(popOutUrl)
-        : window.open(popOutUrl, "_blank");
+      if (popOutUrl.startsWith("/")) {
+        router.push(popOutUrl);
+        closeCard?.();
+        return;
+      }
+      router.push(popOutUrl);
       return;
     }
 

--- a/packages/web/integrations/notifi/notifi-subscription-card/notifi-subscription-card.tsx
+++ b/packages/web/integrations/notifi/notifi-subscription-card/notifi-subscription-card.tsx
@@ -13,12 +13,14 @@ import { LoadingCard } from "~/integrations/notifi/notifi-subscription-card/load
 
 type Props = {
   isPopoverOrModalBaseOpen: boolean;
+  closeCard: () => void;
 };
 
 export const NotifiSubscriptionCard: FunctionComponent<Props> = ({
   isPopoverOrModalBaseOpen,
+  closeCard,
 }) => {
-  const { setIsOverLayEnabled, renderView, setIsCardOpen } =
+  const { setIsOverLayEnabled, renderView, setIsCardOpen, setCloseCard } =
     useNotifiModalContext();
 
   const { client } = useNotifiClientContext();
@@ -31,6 +33,7 @@ export const NotifiSubscriptionCard: FunctionComponent<Props> = ({
 
   useEffect(() => {
     setIsCardOpen(isPopoverOrModalBaseOpen);
+    setCloseCard(() => closeCard);
   }, [isPopoverOrModalBaseOpen]);
 
   useEffect(() => {

--- a/packages/web/integrations/notifi/notifi-subscription-card/notifi-subscription-card.tsx
+++ b/packages/web/integrations/notifi/notifi-subscription-card/notifi-subscription-card.tsx
@@ -12,11 +12,11 @@ import { FetchedCard } from "~/integrations/notifi/notifi-subscription-card/fetc
 import { LoadingCard } from "~/integrations/notifi/notifi-subscription-card/loading-card";
 
 type Props = {
-  parentType?: "popover" | "modalBase";
+  isPopoverOrModalBaseOpen: boolean;
 };
 
 export const NotifiSubscriptionCard: FunctionComponent<Props> = ({
-  parentType,
+  isPopoverOrModalBaseOpen,
 }) => {
   const { setIsOverLayEnabled, renderView, setIsCardOpen } =
     useNotifiModalContext();
@@ -30,8 +30,8 @@ export const NotifiSubscriptionCard: FunctionComponent<Props> = ({
   const firstLoadRef = useRef(false);
 
   useEffect(() => {
-    setIsCardOpen(parentType ? true : false);
-  }, [parentType]);
+    setIsCardOpen(isPopoverOrModalBaseOpen);
+  }, [isPopoverOrModalBaseOpen]);
 
   useEffect(() => {
     if (client.isInitialized && firstLoadRef.current !== true) {


### PR DESCRIPTION
## Release notes

1. Support closing popover/ modal while clicking internal link
2. Related to the [comment](https://github.com/osmosis-labs/osmosis-frontend/pull/2035#discussion_r1322053181) in previous PR, refactor the card open effect. 