### PR TITLE
disable sentry for now

### DIFF
--- a/packages/web/sentry.client.config.ts
+++ b/packages/web/sentry.client.config.ts
@@ -21,7 +21,8 @@ Sentry.init({
 
   environment: process.env.NODE_ENV || "development",
 
-  enabled: process.env.NODE_ENV !== "development",
+  // enabled: process.env.NODE_ENV !== "development",
+  enabled: false,
 
   // You can remove this option if you're not planning to use the Sentry Session Replay feature:
   integrations: [


### PR DESCRIPTION
## What is the purpose of the change

Disabling sentry for now as we are not using it and we are overloading the /monitoring endpoint

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/86a0txnrk)

## Brief Changelog

Disabling sentry

## Testing and Verifying

This change has been tested locally by rebuilding the website and verified content and links are expected


