### PR TITLE
Unskip migrations on previously broken Superfluid pools

### DIFF
--- a/packages/stores/src/ui-config/user-upgrades.ts
+++ b/packages/stores/src/ui-config/user-upgrades.ts
@@ -41,9 +41,6 @@ export class UserUpgradesConfig {
     // find migrations for every user pool that is linked to a CL pool
     const upgrades: UserCfmmToClUpgrade[] = [];
     userSharePoolIds.forEach((poolId) => {
-      if (poolId == "1" || poolId == "678" || poolId == "704") {
-        return;
-      }
       // cfmm pool link to cl pool
       const clPoolId =
         this.osmosisQueries.queryCfmmConcentratedPoolLinks.getLinkedConcentratedPoolId(


### PR DESCRIPTION


## What is the purpose of the change
Superfluid exists on the new pools, migration should be available again: https://www.mintscan.io/osmosis/proposals/621

### ClickUp Task

N/A

## Brief Changelog

Reverted previous PR https://github.com/osmosis-labs/osmosis-frontend/pull/2121

## Testing and Verifying

This change has not been tested locally, just a reversion

## Documentation and Release Note

Enables migration in 3 pools that was previously disabled.
