### PR TITLE
[Token Info] Add Token Chart Section

### DIFF
--- a/packages/stores/src/queries-external/token-historical-chart/index.ts
+++ b/packages/stores/src/queries-external/token-historical-chart/index.ts
@@ -23,9 +23,9 @@ import { TokenHistoricalPrice } from "./types";
  * 120   - 2 hours
  * 240   - 4 hours
  * 720   - 12 hours
- * 1440  - 1 day AKA also known as '1D' in chart
- * 10080 - 1 week AKA also known as '1W' in chart
- * 43800 - 1 month AKA also known as '30D' in chart
+ * 1440  - 1 day also known as '1D' in chart
+ * 10080 - 1 week also known as '1W' in chart
+ * 43800 - 1 month also known as '30D' in chart
  */
 const AvailableRangeValues = [
   5, 15, 30, 60, 120, 240, 720, 1440, 10080, 43800,

--- a/packages/stores/src/queries-external/token-pair-historical-chart/types.ts
+++ b/packages/stores/src/queries-external/token-pair-historical-chart/types.ts
@@ -9,4 +9,4 @@ export interface TokenPairHistoricalPrice {
   time: number;
 }
 
-export type PriceRange = "7d" | "1mo" | "1y";
+export type PriceRange = "1h" | "7d" | "1mo" | "1y";

--- a/packages/stores/src/queries-external/token-pair-historical-chart/types.ts
+++ b/packages/stores/src/queries-external/token-pair-historical-chart/types.ts
@@ -9,4 +9,4 @@ export interface TokenPairHistoricalPrice {
   time: number;
 }
 
-export type PriceRange = "1h" | "7d" | "1mo" | "1y";
+export type PriceRange = "7d" | "1mo" | "1y";

--- a/packages/stores/src/ui-config/asset-info-config.ts
+++ b/packages/stores/src/ui-config/asset-info-config.ts
@@ -1,0 +1,154 @@
+import { PricePretty } from "@keplr-wallet/unit";
+import { action, autorun, computed, makeObservable, observable } from "mobx";
+import { TokenHistoricalPrice } from "src/queries-external/token-historical-chart/types";
+
+import { IPriceStore } from "../price";
+import {
+  PriceRange,
+  QueriesExternalStore,
+  TimeFrame,
+} from "../queries-external";
+
+const INITIAL_ZOOM = 1.05;
+const ZOOM_STEP = 0.05;
+
+export class ObservableAssetInfoConfig {
+  denom: string;
+
+  @observable
+  protected _historicalRange: PriceRange = "1h";
+
+  @observable
+  protected _zoom: number = INITIAL_ZOOM;
+
+  @observable
+  protected _hoverPrice: number = 0;
+
+  protected _disposers: (() => void)[] = [];
+
+  @computed
+  protected get queryTokenHistoricalChart() {
+    let tf: TimeFrame = 60;
+
+    if (this._historicalRange === "1h") {
+      tf = 60;
+    } else if (this._historicalRange === "7d") {
+      tf = 10080;
+    } else if (this._historicalRange === "1mo") {
+      tf = 43800;
+    }
+
+    return this.queriesExternalStore.queryTokenHistoricalChart.get(
+      this.denom,
+      tf
+    );
+  }
+
+  @computed
+  get historicalChartData(): TokenHistoricalPrice[] {
+    return this.queryTokenHistoricalChart.getRawChartPrices;
+  }
+
+  @computed
+  get isHistoricalChartUnavailable(): boolean {
+    return (
+      !this.isHistoricalChartLoading && this.historicalChartData.length === 0
+    );
+  }
+
+  @computed
+  get isHistoricalChartLoading(): boolean {
+    return this.queryTokenHistoricalChart.isFetching;
+  }
+
+  @computed
+  get yRange(): [number, number] {
+    const prices = this.historicalChartData?.map(({ close }) => close) || [];
+    const zoom = this._zoom;
+    const padding = 0.1;
+
+    const chartMin = Math.max(0, Math.min(...prices));
+    const chartMax = Math.max(...prices);
+
+    const delta = Math.abs(chartMax - chartMin);
+
+    const minWithPadding = Math.max(0, chartMin - delta * padding);
+    const maxWithPadding = chartMax + delta * padding;
+
+    const zoomAdjustedMin = zoom > 1 ? chartMin / zoom : chartMin * zoom;
+    const zoomAdjustedMax = chartMax * zoom;
+
+    const finalMin = Math.min(minWithPadding, zoomAdjustedMin);
+    const finalMax = Math.max(maxWithPadding, zoomAdjustedMax);
+
+    return [finalMin, finalMax];
+  }
+
+  @computed
+  get hoverPrice(): PricePretty | undefined {
+    const fiat = this.priceStore.getFiatCurrency("usd");
+    if (!fiat) {
+      return undefined;
+    }
+    return new PricePretty(fiat, this._hoverPrice);
+  }
+
+  @computed
+  get lastChartPrice(): TokenHistoricalPrice | undefined {
+    return this.historicalChartData[this.historicalChartData.length - 1];
+  }
+
+  get historicalRange(): PriceRange {
+    return this._historicalRange;
+  }
+
+  constructor(
+    denom: string,
+    private readonly queriesExternalStore: QueriesExternalStore,
+    private readonly priceStore: IPriceStore
+  ) {
+    this.denom = denom;
+    makeObservable(this);
+
+    // Init last hover price to current price in pool once loaded
+    this._disposers.push(
+      autorun(() => {
+        if (this.lastChartPrice) this.setHoverPrice(this.lastChartPrice.close);
+      })
+    );
+  }
+
+  @action
+  readonly setHoverPrice = (price: number) => {
+    this._hoverPrice = price;
+  };
+
+  @action
+  readonly setZoom = (zoom: number) => {
+    this._zoom = zoom;
+  };
+
+  @action
+  readonly resetZoom = () => {
+    this._zoom = INITIAL_ZOOM;
+  };
+
+  @action
+  readonly zoomIn = () => {
+    this._zoom = Math.max(1, this._zoom - ZOOM_STEP);
+  };
+
+  @action
+  readonly zoomOut = () => {
+    this._zoom = this._zoom + ZOOM_STEP;
+  };
+
+  @action
+  setHistoricalRange = (range: PriceRange) => {
+    this._historicalRange = range;
+  };
+
+  dispose() {
+    this._disposers.forEach((dispose) => dispose());
+  }
+}

--- a/packages/stores/src/ui-config/asset-info-config.ts
+++ b/packages/stores/src/ui-config/asset-info-config.ts
@@ -16,7 +16,7 @@ export class ObservableAssetInfoConfig {
   denom: string;
 
   @observable
-  protected _historicalRange: PriceRange = "1h";
+  protected _historicalRange: PriceRange = "7d";
 
   @observable
   protected _zoom: number = INITIAL_ZOOM;
@@ -30,9 +30,7 @@ export class ObservableAssetInfoConfig {
   protected get queryTokenHistoricalChart() {
     let tf: TimeFrame = 60;
 
-    if (this._historicalRange === "1h") {
-      tf = 60;
-    } else if (this._historicalRange === "7d") {
+    if (this._historicalRange === "7d") {
       tf = 10080;
     } else if (this._historicalRange === "1mo") {
       tf = 43800;

--- a/packages/stores/src/ui-config/index.ts
+++ b/packages/stores/src/ui-config/index.ts
@@ -1,3 +1,4 @@
+export * from "./asset-info-config";
 export * from "./convert-to-stake";
 export * from "./create-pool";
 export * from "./errors";

--- a/packages/web/components/buttons/button.tsx
+++ b/packages/web/components/buttons/button.tsx
@@ -129,7 +129,7 @@ export const buttonCVA = cva(
         ],
         "icon-social": [
           "rounded-full",
-          "bg-[#201B43]",
+          "bg-osmoverse-850",
           "hover:bg-osmoverse-700",
           "active:bg-osmoverse-700",
         ],

--- a/packages/web/components/chart/token-pair-historical.tsx
+++ b/packages/web/components/chart/token-pair-historical.tsx
@@ -40,7 +40,7 @@ const TokenPairHistoricalChart: FunctionComponent<{
   domain,
   onPointerHover,
   onPointerOut,
-  showGradient,
+  showGradient = true,
 }) => {
   return (
     <ParentSize className="flex-shrink-1 flex-1 overflow-hidden">
@@ -255,11 +255,6 @@ export const PriceChartHeader: FunctionComponent<{
               classes?.buttons
             )}
           >
-            <ChartButton
-              label="1 Hour"
-              onClick={() => setHistoricalRange("1h")}
-              selected={historicalRange === "1h"}
-            />
             <ChartButton
               label="7 day"
               onClick={() => setHistoricalRange("7d")}

--- a/packages/web/components/chart/token-pair-historical.tsx
+++ b/packages/web/components/chart/token-pair-historical.tsx
@@ -1,8 +1,10 @@
 import { Dec } from "@keplr-wallet/unit";
 import { PriceRange } from "@osmosis-labs/stores";
 import { curveNatural } from "@visx/curve";
+import { LinearGradient } from "@visx/gradient";
 import { ParentSize } from "@visx/responsive";
 import {
+  AnimatedAreaSeries,
   AnimatedAxis,
   AnimatedGrid,
   AnimatedLineSeries,
@@ -31,7 +33,15 @@ const TokenPairHistoricalChart: FunctionComponent<{
   domain: [number, number];
   onPointerHover?: (price: number) => void;
   onPointerOut?: () => void;
-}> = ({ data, annotations, domain, onPointerHover, onPointerOut }) => {
+  showGradient?: boolean;
+}> = ({
+  data,
+  annotations,
+  domain,
+  onPointerHover,
+  onPointerOut,
+  showGradient,
+}) => {
   return (
     <ParentSize className="flex-shrink-1 flex-1 overflow-hidden">
       {({ height, width }) => (
@@ -52,7 +62,7 @@ const TokenPairHistoricalChart: FunctionComponent<{
           onPointerOut={onPointerOut}
           theme={buildChartTheme({
             backgroundColor: "transparent",
-            colors: ["white"],
+            colors: showGradient ? [theme.colors.wosmongton["300"]] : ["white"],
             gridColor: theme.colors.osmoverse["600"],
             gridColorDark: theme.colors.osmoverse["300"],
             svgLabelSmall: {
@@ -80,15 +90,40 @@ const TokenPairHistoricalChart: FunctionComponent<{
           <AnimatedAxis orientation="bottom" numTicks={4} />
           <AnimatedAxis orientation="left" numTicks={5} strokeWidth={0} />
           <AnimatedGrid columns={false} numTicks={5} />
-          <AnimatedLineSeries
-            key={data.length}
-            dataKey="close"
-            data={data}
-            curve={curveNatural}
-            xAccessor={(d: { time: number; close: number }) => d?.time}
-            yAccessor={(d: { time: number; close: number }) => d?.close}
-            stroke={theme.colors.wosmongton["200"]}
-          />
+
+          {showGradient ? (
+            <>
+              <AnimatedAreaSeries
+                dataKey="close"
+                data={data}
+                xAccessor={(d: { time: number; close: number }) => d?.time}
+                yAccessor={(d: { time: number; close: number }) => d?.close}
+                fillOpacity={0.4}
+                curve={curveNatural}
+                fill="url(#gradient)"
+              />
+              <LinearGradient
+                id="gradient"
+                from="#C41BFF"
+                to="#1867FF"
+                rotate={-8}
+                fromOffset="13.08%"
+                fromOpacity={1}
+                toOpacity={0}
+                toOffset="85.36%"
+              />
+            </>
+          ) : (
+            <AnimatedLineSeries
+              key={data.length}
+              dataKey="close"
+              data={data}
+              curve={curveNatural}
+              xAccessor={(d: { time: number; close: number }) => d?.time}
+              yAccessor={(d: { time: number; close: number }) => d?.close}
+              stroke={theme.colors.wosmongton["200"]}
+            />
+          )}
           {annotations.map((dec, i) => (
             <Annotation
               key={i}

--- a/packages/web/components/chart/token-pair-historical.tsx
+++ b/packages/web/components/chart/token-pair-historical.tsx
@@ -142,16 +142,18 @@ export default TokenPairHistoricalChart;
 export const PriceChartHeader: FunctionComponent<{
   historicalRange: PriceRange;
   setHistoricalRange: (pr: PriceRange) => void;
-  baseDenom: string;
-  quoteDenom: string;
   hoverPrice: number;
   decimal: number;
+  fiatSymbol?: string;
+  baseDenom?: string;
+  quoteDenom?: string;
   hideButtons?: boolean;
   classes?: {
     buttons?: string;
     priceHeaderClass?: string;
     priceSubheaderClass?: string;
     pricesHeaderContainerClass?: string;
+    pricesHeaderRootContainer?: string;
   };
 }> = observer(
   ({
@@ -163,11 +165,17 @@ export const PriceChartHeader: FunctionComponent<{
     decimal,
     hideButtons,
     classes,
+    fiatSymbol,
   }) => {
     const t = useTranslation();
 
     return (
-      <div className="flex flex-row">
+      <div
+        className={classNames(
+          "flex flex-row",
+          classes?.pricesHeaderRootContainer
+        )}
+      >
         <div
           className={classNames(
             "flex flex-1 flex-row",
@@ -180,27 +188,30 @@ export const PriceChartHeader: FunctionComponent<{
               classes?.priceHeaderClass
             )}
           >
+            {fiatSymbol}
             {formatPretty(new Dec(hoverPrice), {
               maxDecimals: decimal,
               notation: "compact",
             }) || ""}
           </h4>
-          <div
-            className={classNames(
-              "flex flex-col justify-center font-caption",
-              classes?.priceSubheaderClass
-            )}
-          >
-            <div className="text-caption text-osmoverse-300">
-              {t("addConcentratedLiquidity.currentPrice")}
+          {baseDenom && quoteDenom ? (
+            <div
+              className={classNames(
+                "flex flex-col justify-center font-caption",
+                classes?.priceSubheaderClass
+              )}
+            >
+              <div className="text-caption text-osmoverse-300">
+                {t("addConcentratedLiquidity.currentPrice")}
+              </div>
+              <div className="whitespace-nowrap text-caption text-osmoverse-300">
+                {t("addConcentratedLiquidity.basePerQuote", {
+                  base: baseDenom,
+                  quote: quoteDenom,
+                })}
+              </div>
             </div>
-            <div className="whitespace-nowrap text-caption text-osmoverse-300">
-              {t("addConcentratedLiquidity.basePerQuote", {
-                base: baseDenom,
-                quote: quoteDenom,
-              })}
-            </div>
-          </div>
+          ) : undefined}
         </div>
         {!hideButtons && (
           <div
@@ -209,6 +220,11 @@ export const PriceChartHeader: FunctionComponent<{
               classes?.buttons
             )}
           >
+            <ChartButton
+              label="1 Hour"
+              onClick={() => setHistoricalRange("1h")}
+              selected={historicalRange === "1h"}
+            />
             <ChartButton
               label="7 day"
               onClick={() => setHistoricalRange("7d")}

--- a/packages/web/components/chart/token-pair-historical.tsx
+++ b/packages/web/components/chart/token-pair-historical.tsx
@@ -104,8 +104,8 @@ const TokenPairHistoricalChart: FunctionComponent<{
               />
               <LinearGradient
                 id="gradient"
-                from="#C41BFF"
-                to="#1867FF"
+                from={theme.colors.chartGradientPrimary}
+                to={theme.colors.chartGradientSecondary}
                 rotate={-8}
                 fromOffset="13.08%"
                 fromOpacity={1}

--- a/packages/web/components/navbar-osmo-price.tsx
+++ b/packages/web/components/navbar-osmo-price.tsx
@@ -20,7 +20,10 @@ import { useStore } from "~/stores";
  * @param prices - prices by hour
  */
 function getChartData(prices: PricePretty[] = []) {
-  // subtract length by 24 to get current day's data
+  /**
+   * We are querying the 1H chart which returns a bar for each hour.
+   * So we need to subtract length by 24 to get current day's data.
+   *  */
   const chunkedPrices = [...prices]
     .splice(prices.length - 24)
     .map((price) => Number(price.toDec().toString()));

--- a/packages/web/hooks/ui-config/index.ts
+++ b/packages/web/hooks/ui-config/index.ts
@@ -1,6 +1,7 @@
 export * from "./use-add-concentrated-liquidity-config";
 export * from "./use-add-liquidity-config";
 export * from "./use-amount-config";
+export * from "./use-asset-info-config";
 export * from "./use-create-pool-config";
 export * from "./use-fake-fee-config";
 export * from "./use-lock-token-config";

--- a/packages/web/hooks/ui-config/use-asset-info-config.ts
+++ b/packages/web/hooks/ui-config/use-asset-info-config.ts
@@ -1,0 +1,17 @@
+import {
+  IPriceStore,
+  ObservableAssetInfoConfig,
+  QueriesExternalStore,
+} from "@osmosis-labs/stores";
+import { useState } from "react";
+
+export const useAssetInfoConfig = (
+  denom: string,
+  queriesExternalStore: QueriesExternalStore,
+  priceStore: IPriceStore
+) => {
+  const [assetsInfoConfig] = useState(
+    new ObservableAssetInfoConfig(denom, queriesExternalStore, priceStore)
+  );
+  return assetsInfoConfig;
+};

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -59,6 +59,7 @@
     "@tippyjs/react": "^4.2.6",
     "@transak/transak-sdk": "^1.2.2",
     "@visx/curve": "^2.17.0",
+    "@visx/gradient": "^3.3.0",
     "@visx/responsive": "^2.17.0",
     "@visx/scale": "^2.18.0",
     "@visx/xychart": "^2.18.0",

--- a/packages/web/pages/assets/[denom].tsx
+++ b/packages/web/pages/assets/[denom].tsx
@@ -201,6 +201,7 @@ const TokenChart = observer(() => {
       ) : !assetInfoConfig.isHistoricalChartUnavailable ? (
         <>
           <TokenPairHistoricalChart
+            showGradient
             data={assetInfoConfig.historicalChartData}
             annotations={[]}
             domain={assetInfoConfig.yRange}

--- a/packages/web/tailwind.config.js
+++ b/packages/web/tailwind.config.js
@@ -50,6 +50,7 @@ module.exports = {
         600: "#565081",
         700: "#3C356D",
         800: "#282750",
+        850: "#201B43",
         900: "#140F34",
         1000: "#090524",
       },
@@ -247,6 +248,7 @@ module.exports = {
         "2xlinset": "0.938rem", // 1 px smaller than rounded-2xl
         "4x4pxlinset": "1.5rem", // 4px smaller than 4xl
         "4xl": "1.75rem",
+        "5xl": "2rem",
       },
       transitionTimingFunction: {
         bounce: "cubic-bezier(0.175, 0.885, 0.32, 1.275)",

--- a/packages/web/tailwind.config.js
+++ b/packages/web/tailwind.config.js
@@ -78,6 +78,8 @@ module.exports = {
       black: "black",
       inherit: "inherit",
       barFill: "#4f4aa2",
+      chartGradientPrimary: "#C41BFF",
+      chartGradientSecondary: "#1867FF",
     },
     fontSize: {
       xxs: "0.5rem",

--- a/packages/web/utils/__tests__/number.ts
+++ b/packages/web/utils/__tests__/number.ts
@@ -1,7 +1,11 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import cases from "jest-in-case";
 
-import { getNumberMagnitude, toScientificNotation } from "~/utils/number";
+import {
+  getDecimalCount,
+  getNumberMagnitude,
+  toScientificNotation,
+} from "~/utils/number";
 
 cases(
   "getNumberMagnitude(value)",
@@ -97,6 +101,75 @@ cases(
       name: "should return correct scientific notation for small negative fraction with many leading zeros",
       number: "-0.00000000000000000000000000000000000000001234567890",
       result: "-1.23456789*10^-41",
+    },
+  ]
+);
+
+cases(
+  "getDecimalCount(value)",
+  (opts) => {
+    expect(getDecimalCount(opts.number)).toEqual(opts.result);
+  },
+  [
+    {
+      name: "should return correct decimal count for integer",
+      number: "1000",
+      result: 0,
+    },
+    {
+      name: "should return correct decimal count for decimal number",
+      number: "1000.123",
+      result: 3,
+    },
+    {
+      name: "should return correct decimal count for negative integer",
+      number: "-1000",
+      result: 0,
+    },
+    {
+      name: "should return correct decimal count for negative decimal number",
+      number: "-1000.123",
+      result: 3,
+    },
+    {
+      name: "should return correct decimal count for zero",
+      number: "0",
+      result: 0,
+    },
+    {
+      name: "should return correct decimal count for decimal fraction",
+      number: "0.123",
+      result: 3,
+    },
+    {
+      name: "should return correct decimal count for negative decimal fraction",
+      number: "-0.123",
+      result: 3,
+    },
+    {
+      name: "should return correct decimal count for number with no decimal part",
+      number: "1.",
+      result: 0,
+    },
+    {
+      name: "should return correct decimal count for number without counting trailing zeros",
+      number: "1.200",
+      result: 1,
+    },
+    {
+      name: "should return correct decimal count for a really big decimal number",
+      number: "0.12345678901234",
+      result: 14,
+    },
+    {
+      name: "should return correct decimal count for a really big decimal number",
+      number: "0.0000000000004",
+      result: 13,
+    },
+    {
+      name: "should return correct decimal count for a really big decimal number",
+      number: "0.0000000168",
+      result: 8,
     },
   ]
 );

--- a/packages/web/utils/number.ts
+++ b/packages/web/utils/number.ts
@@ -5,6 +5,22 @@ export function getNumberMagnitude(val: string | number) {
   return Number(Number(val).toExponential().split("e")[1]);
 }
 
+export function getDecimalCount(val: string | number) {
+  if (!isNumeric(val)) return 0;
+  const valAsNumber = Number(val);
+
+  if (valAsNumber.toString() === valAsNumber.toExponential()) {
+    return Math.abs(Number(valAsNumber.toString().split("e")[1] || 0));
+  }
+  if (valAsNumber > Number.MAX_SAFE_INTEGER) {
+    console.warn("getDecimalCount: value is too large to get count.");
+    return 0;
+  }
+
+  if (Math.floor(valAsNumber) === valAsNumber) return 0;
+  return valAsNumber.toString().split(".")[1].length || 0;
+}
+
 export function toScientificNotation(
   val: string | number,
   maxDecimals?: number

--- a/yarn.lock
+++ b/yarn.lock
@@ -6515,6 +6515,14 @@
     d3-shape "^1.2.0"
     prop-types "^15.6.2"
 
+"@visx/gradient@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@visx/gradient/-/gradient-3.3.0.tgz#c0d0a7435b78053742e61731dae22c7464cd342c"
+  integrity sha512-t3vqukahDQsJ64/fcm85woFm2XPpSPMBz92gFvaY4J8EJY3e6rFOg382v5Dm17fgNsLRKJA0Vqo7mUtDe2pWOw==
+  dependencies:
+    "@types/react" "*"
+    prop-types "^15.5.7"
+
 "@visx/grid@2.18.0":
   version "2.18.0"
   resolved "https://registry.yarnpkg.com/@visx/grid/-/grid-2.18.0.tgz#ae68e975d4b203a626ddba3a39d67a135816d6be"
@@ -14779,7 +14787,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.10, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.8.1"
   resolved "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==


### PR DESCRIPTION
## What is the purpose of the change

This PR adds the initial section for token chart. Due to a change in priorities, I won't proceed with the token info page at this time. Still, we should consider merging this update, as it incorporates a gradient design for token charts, which will also enhance the CL pools chart.

![image](https://github.com/osmosis-labs/osmosis-frontend/assets/21092519/783d3a93-9ae6-44ba-91d6-c0c789cbef20)

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/86a0pv1q1)

## Brief Changelog

- Add token info UI config
- Add Gradient to token pair chart

## Testing and Verifying

- [ ] CL Pools chart should include a gradient