### PR TITLE
fix: Negative Fee CL Error

### DIFF
--- a/packages/pools/src/__tests__/concentrated.spec.ts
+++ b/packages/pools/src/__tests__/concentrated.spec.ts
@@ -24,6 +24,8 @@ export class MockTickProvider implements TickDataProvider {
           '[{"liquidity_net":"1063928513.516692280118630934","tick_index":"244"},{"liquidity_net":"12821176827.612857487321385327","tick_index":"507"},{"liquidity_net":"-19112293.184876715840844082","tick_index":"975"},{"liquidity_net":"-7042487.204272221556955330","tick_index":"1070"},{"liquidity_net":"119846363299223.491923667407418441","tick_index":"1176"},{"liquidity_net":"-12821176827.612857487321385327","tick_index":"1331"},{"liquidity_net":"25864763042758566.825780314141787151","tick_index":"1642"},{"liquidity_net":"789067578720062952.312030597659307660","tick_index":"1767"},{"liquidity_net":"5548573714963426149.345245435735691668","tick_index":"1918"},{"liquidity_net":"-789067578720062952.312030597659307660","tick_index":"1968"},{"liquidity_net":"-7533671.157383740445274322","tick_index":"2118"},{"liquidity_net":"-5548573714963426149.345245435735691668","tick_index":"2133"},{"liquidity_net":"-119846363299223.491923667407418441","tick_index":"2438"},{"liquidity_net":"-13690973.612258627731976066","tick_index":"2593"},{"liquidity_net":"75212224210553284471974.853997539381387792","tick_index":"2677"},{"liquidity_net":"-25864763042758566.825780314141787151","tick_index":"2798"},{"liquidity_net":"-991724173.842077641035110916","tick_index":"2841"},{"liquidity_net":"-1063928513.516692280118630934","tick_index":"2889"},{"liquidity_net":"-75212224210553284471974.853997539381387792","tick_index":"2954"},{"liquidity_net":"2300427651236616516001198205.268726763564344440","tick_index":"3361"},{"liquidity_net":"-2300427651236616516001198205.268726763564344440","tick_index":"3390"}]'
         ) as LiquidityDepth[],
         isMaxTicks: true,
+        currentLiquidity: new Dec(100),
+        currentTick: new Int(0),
       };
     } else {
       // token0
@@ -32,6 +34,8 @@ export class MockTickProvider implements TickDataProvider {
           '[{"liquidity_net":"13690973.612258627731976066","tick_index":"-420"},{"liquidity_net":"7042487.204272221556955330","tick_index":"-770"},{"liquidity_net":"7533671.157383740445274322","tick_index":"-923"},{"liquidity_net":"991724173.842077641035110916","tick_index":"-1014"},{"liquidity_net":"19112293.184876715840844082","tick_index":"-1073"}]'
         ) as LiquidityDepth[],
         isMaxTicks: true,
+        currentLiquidity: new Dec(100),
+        currentTick: new Int(0),
       };
     }
   }
@@ -42,17 +46,27 @@ export class MockTickProvider implements TickDataProvider {
   ): Promise<TickDepths> {
     // TODO: verify
     if (token.denom === pool.token1) {
-      return { allTicks: [], isMaxTicks: false };
+      return {
+        allTicks: [],
+        isMaxTicks: false,
+        currentLiquidity: new Dec(100),
+        currentTick: new Int(0),
+      };
     } else {
       // token0
-      return { allTicks: [], isMaxTicks: false };
+      return {
+        allTicks: [],
+        isMaxTicks: false,
+        currentLiquidity: new Dec(100),
+        currentTick: new Int(0),
+      };
     }
   }
 }
 
 export class MockAmountProvider implements AmountsDataProvider {
   async getPoolAmounts(): Promise<{ token0Amount: Int; token1Amount: Int }> {
-    return { token0Amount: new Int(100), token1Amount: new Int(100) };
+    return { token0Amount: new Int(0), token1Amount: new Int(0) };
   }
 }
 
@@ -70,7 +84,7 @@ class TestPool extends ConcentratedLiquidityPool {
 }
 
 const raw1: ConcentratedLiquidityPoolRaw = JSON.parse(
-  '{"@type":"/osmosis.concentratedliquidity.v1beta1.Pool","address":"osmo1lzwv0glchfcw0fpwzdwfdsepmvluv6z6eh4qunxdml33sj06q3yq7xwtde","id":"4","current_tick_liquidity":"141421356.237309510000200000","token0":"uion","token1":"uosmo","current_sqrt_price":"0.014142135623730951","current_tick":"-350000","tick_spacing":"1","precision_factor_at_price_one":"-4","swap_fee":"0.010000000000000000","last_liquidity_update":"2023-03-21T02:07:13.890847048Z"}'
+  '{"@type":"/osmosis.concentratedliquidity.v1beta1.Pool","address":"osmo1lzwv0glchfcw0fpwzdwfdsepmvluv6z6eh4qunxdml33sj06q3yq7xwtde","id":"4","current_tick_liquidity":"141421356.2373095000200000","token0":"uion","token1":"uosmo","current_sqrt_price":"0.014142135623730951","current_tick":"-350000","tick_spacing":"1","precision_factor_at_price_one":"-4","swap_fee":"0.0000000000000000","last_liquidity_update":"2023-03-21T02:07:13.890847048Z"}'
 );
 
 describe("ConcentratedLiquidityPool", () => {
@@ -152,6 +166,8 @@ describe("ConcentratedLiquidityPool.getTokenOutByTokenIn", () => {
     tickDataProvider.getTickDepthsTokenOutGivenIn.mockResolvedValueOnce({
       allTicks: mockTicks,
       isMaxTicks: false,
+      currentLiquidity: mockClPool.current_tick_liquidity,
+      currentTick: new Int(0),
     });
 
     const tokenIn = { denom: "uosmo", amount: new Int(1_000_000) };
@@ -170,22 +186,32 @@ describe("ConcentratedLiquidityPool.getTokenOutByTokenIn", () => {
       .mockResolvedValueOnce({
         allTicks: [],
         isMaxTicks: false,
+        currentLiquidity: mockClPool.current_tick_liquidity,
+        currentTick: new Int(0),
       })
       .mockResolvedValueOnce({
         allTicks: [],
         isMaxTicks: false,
+        currentLiquidity: mockClPool.current_tick_liquidity,
+        currentTick: new Int(0),
       })
       .mockResolvedValueOnce({
         allTicks: [],
         isMaxTicks: false,
+        currentLiquidity: mockClPool.current_tick_liquidity,
+        currentTick: new Int(0),
       })
       .mockResolvedValueOnce({
         allTicks: [],
         isMaxTicks: false,
+        currentLiquidity: mockClPool.current_tick_liquidity,
+        currentTick: new Int(0),
       })
       .mockResolvedValueOnce({
         allTicks: mockTicks.slice(0, 1),
         isMaxTicks: false,
+        currentLiquidity: mockClPool.current_tick_liquidity,
+        currentTick: new Int(0),
       });
 
     const tokenIn = { denom: "uosmo", amount: new Int(1_000_000) };
@@ -204,10 +230,14 @@ describe("ConcentratedLiquidityPool.getTokenOutByTokenIn", () => {
       .mockResolvedValueOnce({
         allTicks: [],
         isMaxTicks: false,
+        currentLiquidity: new Dec(100),
+        currentTick: new Int(0),
       })
       .mockResolvedValueOnce({
         allTicks: [],
         isMaxTicks: true,
+        currentLiquidity: new Dec(100),
+        currentTick: new Int(0),
       });
 
     const tokenIn = { denom: "uosmo", amount: new Int(1_000_000) };

--- a/packages/pools/src/concentrated/pool.ts
+++ b/packages/pools/src/concentrated/pool.ts
@@ -24,6 +24,8 @@ export interface ConcentratedLiquidityPoolRaw {
 }
 
 export type TickDepths = {
+  currentLiquidity: Dec;
+  currentTick: Int;
   allTicks: LiquidityDepth[];
   isMaxTicks: boolean;
 };
@@ -93,10 +95,6 @@ export class ConcentratedLiquidityPool implements BasePool, RoutablePool {
     return new Dec(0);
   }
 
-  get currentTick(): Int {
-    return new Int(this.raw.current_tick);
-  }
-
   /** amountToken1/amountToken0 or token 1 per token 0 */
   get currentSqrtPrice(): BigDec {
     return new BigDec(this.raw.current_sqrt_price);
@@ -104,16 +102,6 @@ export class ConcentratedLiquidityPool implements BasePool, RoutablePool {
 
   get currentTickLiquidity(): Dec {
     return new Dec(this.raw.current_tick_liquidity);
-  }
-
-  get currentTickLiquidityXY(): [Dec, Dec] {
-    const baseAmount = new BigDec(this.currentTickLiquidity)
-      .quo(this.currentSqrtPrice)
-      .toDec();
-    const quoteAmount = new BigDec(this.currentTickLiquidity)
-      .mul(this.currentSqrtPrice)
-      .toDec();
-    return [baseAmount, quoteAmount];
   }
 
   get tickSpacing(): number {
@@ -196,7 +184,7 @@ export class ConcentratedLiquidityPool implements BasePool, RoutablePool {
     let calcResult = undefined;
     do {
       const needMoreTicks = calcResult === "no-more-ticks";
-      const { allTicks, isMaxTicks } =
+      const { allTicks, isMaxTicks, currentLiquidity } =
         await this.tickDataProvider.getTickDepthsTokenOutGivenIn(
           this,
           tokenIn,
@@ -206,7 +194,7 @@ export class ConcentratedLiquidityPool implements BasePool, RoutablePool {
       calcResult = ConcentratedLiquidityMath.calcOutGivenIn({
         tokenIn: new Coin(tokenIn.denom, tokenIn.amount),
         tokenDenom0: this.raw.token0,
-        poolLiquidity: this.currentTickLiquidity,
+        poolLiquidity: currentLiquidity,
         inittedTicks: allTicks,
         curSqrtPrice: this.currentSqrtPrice,
         swapFee,
@@ -302,17 +290,20 @@ export class ConcentratedLiquidityPool implements BasePool, RoutablePool {
     let calcResult = undefined;
     do {
       const needMoreTicks = calcResult === "no-more-ticks";
-      const { allTicks: inittedTicks, isMaxTicks } =
-        await this.tickDataProvider.getTickDepthsTokenInGivenOut(
-          this,
-          tokenOut,
-          needMoreTicks
-        );
+      const {
+        allTicks: inittedTicks,
+        isMaxTicks,
+        currentLiquidity,
+      } = await this.tickDataProvider.getTickDepthsTokenInGivenOut(
+        this,
+        tokenOut,
+        needMoreTicks
+      );
 
       calcResult = ConcentratedLiquidityMath.calcInGivenOut({
         tokenOut: new Coin(tokenOut.denom, tokenOut.amount),
         tokenDenom0: this.raw.token0,
-        poolLiquidity: this.currentTickLiquidity,
+        poolLiquidity: currentLiquidity,
         inittedTicks,
         curSqrtPrice: this.currentSqrtPrice,
         swapFee,

--- a/packages/stores/src/queries/concentrated-liquidity/tick-data-provider.ts
+++ b/packages/stores/src/queries/concentrated-liquidity/tick-data-provider.ts
@@ -1,4 +1,4 @@
-import { Int } from "@keplr-wallet/unit";
+import { Dec, Int } from "@keplr-wallet/unit";
 import { estimateInitialTickBound } from "@osmosis-labs/math";
 import {
   ConcentratedLiquidityPool,
@@ -16,6 +16,9 @@ import { ObservableQueryLiquiditiesNetInDirection } from "./liquidity-net-in-dir
 export class ConcentratedLiquidityPoolTickDataProvider
   implements TickDataProvider
 {
+  protected _currentLiquidity: Dec = new Dec(0);
+  protected _currentTick: Int = new Int(0);
+
   protected _oneForZeroBoundIndex: Int | undefined;
   protected _zeroForOneBoundIndex: Int | undefined;
 
@@ -123,6 +126,8 @@ export class ConcentratedLiquidityPoolTickDataProvider
     // check if has fetched all ticks is true
     if (queryDepths.hasFetchedAllTicks) {
       return {
+        currentLiquidity: queryDepths.currentLiquidity,
+        currentTick: queryDepths.currentTick,
         allTicks: queryDepths.depthsInDirection,
         isMaxTicks: true,
       };
@@ -152,7 +157,7 @@ export class ConcentratedLiquidityPoolTickDataProvider
       // have fetched ticks, but requested to get more
       const nextBoundIndex = rampNextQueryTick(
         zeroForOne,
-        pool.currentTick,
+        queryDepths.currentTick,
         prevBoundIndex,
         this.nextTicksRampMultiplier
       );
@@ -162,12 +167,16 @@ export class ConcentratedLiquidityPoolTickDataProvider
 
     if (Boolean(queryDepths.error)) {
       return {
+        currentLiquidity: queryDepths.currentLiquidity,
+        currentTick: queryDepths.currentTick,
         allTicks: queryDepths.depthsInDirection,
         isMaxTicks: true,
       };
     }
 
     return {
+      currentLiquidity: queryDepths.currentLiquidity,
+      currentTick: queryDepths.currentTick,
       allTicks: queryDepths.depthsInDirection,
       isMaxTicks: queryDepths.hasFetchedAllTicks,
     };


### PR DESCRIPTION
## What is the purpose of the change

This PR addresses the data discrepancy in Imperator’s CL pool's current tick liquidity, which caused a negative fee error when referencing outdated ticks. The issue likely stemmed from a network delay. To ensure accuracy, we now retrieve the latest `currentLiquidity` data directly from the on-chain `liquidity_net_in_direction` query.

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/86a0tz493)

## Brief Changelog

- Use `currentLiqudity` from `liquidity_net_in_direction` query

## Testing and Verifying

- [ ] There should be no negative fee error
