### PR TITLE
Make noble.USDC canonical

### DIFF
--- a/packages/web/config/generate-chain-infos/source-chain-infos.ts
+++ b/packages/web/config/generate-chain-infos/source-chain-infos.ts
@@ -3629,10 +3629,10 @@ export const mainnetChainInfos: SimplifiedChainInfo[] = [
         isStakeCurrency: true,
       },
       {
-        coinDenom: "noble.USDC",
+        coinDenom: "USDC",
         coinMinimalDenom: "uusdc",
         coinDecimals: 6,
-        coinImageUrl: "/tokens/noble.usdc.svg",
+        coinImageUrl: "/tokens/usdc.svg",
         coinGeckoId: "usd-coin",
         isFeeCurrency: true,
         gasPriceStep: {
@@ -3873,7 +3873,7 @@ export const mainnetChainInfos: SimplifiedChainInfo[] = [
           "ibc/FA7775734CC73176B7425910DE001A1D2AD9B6D9E93129A5D0750EAD13E4E63A",
         coinDecimals: 6,
         coinGeckoId: "usd-coin",
-        coinImageUrl: "/tokens/usdc.svg",
+        coinImageUrl: "/tokens/usdc.axl.svg",
         isFeeCurrency: true,
         gasPriceStep: {
           low: 0.01,
@@ -4230,11 +4230,11 @@ chainInfos.push({
       coinImageUrl: "/tokens/axl.svg",
     },
     {
-      coinDenom: IS_TESTNET ? "aUSDC" : "USDC",
+      coinDenom: IS_TESTNET ? "aUSDC" : "USDC.axl",
       coinMinimalDenom: IS_TESTNET ? "uausdc" : "uusdc",
       coinDecimals: 6,
       coinGeckoId: IS_TESTNET ? "usd-coin" : "usd-coin",
-      coinImageUrl: "/tokens/usdc.svg",
+      coinImageUrl: "/tokens/usdc.axl.svg",
       pegMechanism: "collateralized",
     },
     {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Making noble.USDC canonical
as per the [Proposal](https://www.mintscan.io/osmosis/proposals/624) making it so
<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

### ClickUp Task

[Assetlist PR](https://github.com/osmosis-labs/assetlists/pull/699)

## Brief Changelog

- noble.USDC gets symbol USDC and the logo to just the regular USDC logo (no Noble badge)
- USDC(.axl) get symbol USDC.axl and the logo to include the Axelar badge
<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

This change has been tested locally by rebuilding the website and verified content and links are expected

## Pending

Validation