### PR TITLE
fix: USDC.axl appearing as Quasar source

### DIFF
--- a/packages/web/config/generate-chain-infos/source-chain-infos.ts
+++ b/packages/web/config/generate-chain-infos/source-chain-infos.ts
@@ -3840,7 +3840,7 @@ export const mainnetChainInfos: SimplifiedChainInfo[] = [
         isStakeCurrency: true,
       },
       {
-        coinDenom: "OSMO",
+        coinDenom: "quasar.OSMO",
         coinMinimalDenom:
           "ibc/0471F1C4E7AFD3F07702BEF6DC365268D64570F7C1FDC98EA6098DD6DE59817B",
         coinDecimals: 6,
@@ -3854,7 +3854,7 @@ export const mainnetChainInfos: SimplifiedChainInfo[] = [
         },
       },
       {
-        coinDenom: "ATOM",
+        coinDenom: "quasar.ATOM",
         coinMinimalDenom:
           "ibc/FA0006F056DB6719B8C16C551FC392B62F5729978FC0B125AC9A432DBB2AA1A5",
         coinDecimals: 6,
@@ -3868,7 +3868,7 @@ export const mainnetChainInfos: SimplifiedChainInfo[] = [
         },
       },
       {
-        coinDenom: "USDC.axl",
+        coinDenom: "quasar.USDC.axl",
         coinMinimalDenom:
           "ibc/FA7775734CC73176B7425910DE001A1D2AD9B6D9E93129A5D0750EAD13E4E63A",
         coinDecimals: 6,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

To fix that USDC.axl looks like it's from Quasar in the Swap page
![image](https://github.com/osmosis-labs/osmosis-frontend/assets/95667791/7585b474-b1c0-4a02-8764-1ac3934e2876)


<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/86a0vqfd4)

## Brief Changelog

- Add quasar.- prefix to quasar ibc fee assets
<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying


This change has been tested locally by rebuilding the website and verified content and links are expected

Validation successful
<img width="187" alt="image" src="https://github.com/osmosis-labs/osmosis-frontend/assets/95667791/9b84d4a3-533a-4199-8a9a-e1b6108bd66f">
