### PR TITLE
[Notifi] Disable notification while connecting through Keplr mobile

### DIFF
--- a/packages/web/config/wallet-registry.ts
+++ b/packages/web/config/wallet-registry.ts
@@ -57,7 +57,7 @@ export const WalletRegistry: RegistryWallet[] = [
     },
     stakeUrl: "https://wallet.keplr.app/chains/osmosis?tab=staking",
     governanceUrl: "https://wallet.keplr.app/chains/osmosis?tab=governance",
-    features: ["notifications"],
+    features: [],
   },
   {
     ...CosmosKitWalletList["leap-extension"],


### PR DESCRIPTION
## Background & Problem
Seems like  [Keplr mobile is not going to support signArbirary anytime soon](https://github.com/chainapsis/keplr-wallet/issues/664). 

## Solution
We need to disable notification while connecting through Keplr mobile