### PR TITLE
Replace libsodium with a no-op functionality

### DIFF
--- a/packages/web/etc/noop/README.md
+++ b/packages/web/etc/noop/README.md
@@ -1,0 +1,7 @@
+# Noop
+
+This is copied as a design pattern from Keplr-wallet!
+
+https://github.com/chainapsis/keplr-wallet/tree/v0.12.25/etc/noop
+
+> This directory isn’t actually used, and would be preferred to not be added. But it is needed to explicitly ignore specific libraries used by the dependency. Specifically, libsodium isn’t actually used and WebAssembly can’t be used in the extension’s sandbox environment but creates various errors so the directory exists to ignore libsodium.

--- a/packages/web/etc/noop/index.js
+++ b/packages/web/etc/noop/index.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/packages/web/etc/noop/package.json
+++ b/packages/web/etc/noop/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "noop",
+    "version": "0.0.1",
+    "main": "index.js",
+    "private": true,
+    "scripts": {},
+    "dependencies": {}
+  }

--- a/packages/web/etc/noop/package.json
+++ b/packages/web/etc/noop/package.json
@@ -1,8 +1,8 @@
 {
-    "name": "noop",
-    "version": "0.0.1",
-    "main": "index.js",
-    "private": true,
-    "scripts": {},
-    "dependencies": {}
-  }
+  "name": "noop",
+  "version": "0.0.1",
+  "main": "index.js",
+  "private": true,
+  "scripts": {},
+  "dependencies": {}
+}

--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -47,6 +47,13 @@ const config = {
           "noop",
           "index.js"
         ),
+        "libsodium-sumo": path.resolve(__dirname, "etc", "noop", "index.js"),
+        "libsodium-wrappers-sumo": path.resolve(
+          __dirname,
+          "etc",
+          "noop",
+          "index.js"
+        ),
       },
     };
 

--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -1,3 +1,5 @@
+const path = require("path");
+
 /** @type {import('next').NextConfig} */
 const config = {
   reactStrictMode: true,
@@ -27,15 +29,26 @@ const config = {
       commons: { chunks: "initial" },
     };
 
-    // Mark libsodium as an external dependency. It is only imported from within cosmJS to support
+    // Replace libsodium with a no-op API. It is only imported from within cosmJS to support
     // argon2i and ed25519, both functionalities which in the context of Cosmos would only get used within
     // an extension wallet. Libsodium is ~190kb gzipped, 500kb parsed, so this meaningfully reduces client load.
     // (And it gets bundled twice)
     //
-    // It should never be imported.
-    // TODO: another alternative is doing a webpack replace to a no-op, similar to what Keplr does:
+    // It should never be getting used. This is copied from what Keplr does:
     // https://github.com/chainapsis/keplr-wallet/blob/master/package.json#L103-L104
-    config.externals.push("libsodium");
+    config.resolve = {
+      ...config.resolve, // This spreads existing resolve configuration (if any)
+      alias: {
+        ...config.resolve.alias, // This spreads any existing alias configurations
+        libsodium: path.resolve(__dirname, "etc", "noop", "index.js"),
+        "libsodium-wrappers": path.resolve(
+          __dirname,
+          "etc",
+          "noop",
+          "index.js"
+        ),
+      },
+    };
 
     return config;
   },

--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -27,6 +27,16 @@ const config = {
       commons: { chunks: "initial" },
     };
 
+    // Mark libsodium as an external dependency. It is only imported from within cosmJS to support
+    // argon2i and ed25519, both functionalities which in the context of Cosmos would only get used within
+    // an extension wallet. Libsodium is ~190kb gzipped, 500kb parsed, so this meaningfully reduces client load.
+    // (And it gets bundled twice)
+    //
+    // It should never be imported.
+    // TODO: another alternative is doing a webpack replace to a no-op, similar to what Keplr does:
+    // https://github.com/chainapsis/keplr-wallet/blob/master/package.json#L103-L104
+    config.externals.push("libsodium");
+
     return config;
   },
 };


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

This performance boost is copied from Keplr!

Copied from my code comment:
```
    // Replace libsodium with a no-op API. It is only imported from within cosmJS to support
    // argon2i and ed25519, both functionalities which in the context of Cosmos would only get used within
    // an extension wallet. Libsodium is ~190kb gzipped, 500kb parsed, so this meaningfully reduces client load.
    // (And it gets bundled twice)
    //
    // It should never be getting used. This is copied from what Keplr does:
    // https://github.com/chainapsis/keplr-wallet/blob/master/package.json#L103-L104
```

Thank you @JoseRFelix for the help with understanding how we use webpack vs turbopack, and @MaxMillington for discussions leading to this!

### ClickUp Task

N/A

## Brief Changelog

Lower bundle size by marking 

## Testing and Verifying

I have tested that yarn analyze no longer shows the copies of libsodium in the client bundle, saving 190kb gzipped, 500kb parsed from the main bundle, and the same savings in a second bundle.

Have not tested that all FE functionality generally works. (My understanding is QA does this?)

## Documentation and Release Note

- Does this pull request introduce a new feature or user-facing behavior changes? no
- How is the feature or change documented?  Code comment
