### PR TITLE
fix: Consider Pagination When Retrieving Pools in `poolExists`

### DIFF
--- a/packages/stores/src/queries-external/pools/pools.ts
+++ b/packages/stores/src/queries-external/pools/pools.ts
@@ -95,10 +95,8 @@ export class ObservableQueryPools
   readonly getPool = computedFn(
     (id: string): ObservableQueryPool | undefined => {
       if (this.poolIdBlacklist.includes(id)) return undefined;
+      if (!this.response && !this._pools.get(id)) return undefined;
 
-      if (!this.response && !this._pools.get(id)) {
-        return undefined;
-      }
       return this._pools.get(id);
     }
   );
@@ -106,13 +104,40 @@ export class ObservableQueryPools
   /** Returns `undefined` if pool data has not loaded, and `true`/`false` for if the pool exists. */
   readonly poolExists = computedFn((id: string): boolean | undefined => {
     if (this.poolIdBlacklist.includes(id)) return false;
-    // TODO: address pagination limit
-    const r = this.response;
-    if (r && !this.isFetching) {
-      return r.data.pools.some(
-        (raw) => ("pool_id" in raw ? raw.pool_id : raw.id) === id
-      );
+
+    const response = this.response;
+
+    if (!response || this.isFetching) return undefined;
+
+    let found = false;
+
+    found = response.data.pools.some(
+      (raw) => ("pool_id" in raw ? raw.pool_id : raw.id) === id
+    );
+    if (found) return true;
+
+    /**
+     * If the current page has a next page, then there are more pools that have not been fetched.
+     * Fetch next page.
+     */
+    if (response.data.pageInfo?.hasNextPage) {
+      this.paginate();
+      return undefined;
     }
+
+    /**
+     * If the total number of pools is greater than the number of pools fetched,
+     * then there are more pools that have not been fetched. Fetch all remaining pools.
+     */
+    if (Number(response.data.totalNumberOfPools) > this._pools.size) {
+      this.fetchRemainingPools({
+        limit: Number(response.data.totalNumberOfPools),
+        minLiquidity: 0,
+      });
+      return undefined;
+    }
+
+    return false;
   }, true);
 
   /** Gets all pools in the current pages. */

--- a/packages/stores/src/queries-external/pools/pools.ts
+++ b/packages/stores/src/queries-external/pools/pools.ts
@@ -109,9 +109,7 @@ export class ObservableQueryPools
 
     if (!response || this.isFetching) return undefined;
 
-    let found = false;
-
-    found = response.data.pools.some(
+    const found = response.data.pools.some(
       (raw) => ("pool_id" in raw ? raw.pool_id : raw.id) === id
     );
     if (found) return true;
@@ -129,7 +127,7 @@ export class ObservableQueryPools
      * If the total number of pools is greater than the number of pools fetched,
      * then there are more pools that have not been fetched. Fetch all remaining pools.
      */
-    if (Number(response.data.totalNumberOfPools) > this._pools.size) {
+    if (Number(response.data.totalNumberOfPools) > this._queryParams.limit) {
       this.fetchRemainingPools({
         limit: Number(response.data.totalNumberOfPools),
         minLiquidity: 0,

--- a/packages/stores/src/queries-external/pools/types.ts
+++ b/packages/stores/src/queries-external/pools/types.ts
@@ -20,4 +20,8 @@ export interface ObservableQueryPoolGetter
 
 export type Pools = {
   pools: PoolRaw[];
+  totalNumberOfPools: string;
+  pageInfo?: {
+    hasNextPage: boolean;
+  };
 };

--- a/packages/web/pages/api/pools.ts
+++ b/packages/web/pages/api/pools.ts
@@ -3,6 +3,10 @@ import { isNumeric } from "../../utils/assertion";
 
 type Response = {
   pools: PoolRaw[];
+  totalNumberOfPools: string;
+  pageInfo?: {
+    hasNextPage: boolean;
+  };
 };
 
 export default async function pools(req: Request) {
@@ -18,12 +22,13 @@ export default async function pools(req: Request) {
     ? Number(url.searchParams.get("min_liquidity") as string)
     : undefined;
 
-  const { status, pools } = await queryPaginatedPools({
-    page,
-    limit,
-    minimumLiquidity,
-  });
-  const response: Response = { pools };
+  const { status, pools, totalNumberOfPools, pageInfo } =
+    await queryPaginatedPools({
+      page,
+      limit,
+      minimumLiquidity,
+    });
+  const response: Response = { pools, totalNumberOfPools, pageInfo };
 
   if (pools) {
     return new Response(JSON.stringify(response), { status });

--- a/packages/web/pages/index.tsx
+++ b/packages/web/pages/index.tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react-lite";
-import type { GetStaticProps, InferGetServerSidePropsType } from "next";
+import type { GetStaticProps, InferGetStaticPropsType } from "next";
 
 import { Ad, AdCMS } from "~/components/ad-banner/ad-banner-types";
 import { ProgressiveSvgImage } from "~/components/progressive-svg-image";
@@ -36,7 +36,7 @@ export const getStaticProps: GetStaticProps<HomeProps> = async () => {
   return { props: { ads } };
 };
 
-const Home = ({ ads }: InferGetServerSidePropsType<typeof getStaticProps>) => {
+const Home = ({ ads }: InferGetStaticPropsType<typeof getStaticProps>) => {
   const { isLoading: isWalletLoading } = useWalletSelect();
 
   const routablePools = useRoutablePools();

--- a/packages/web/pages/pool/[id].tsx
+++ b/packages/web/pages/pool/[id].tsx
@@ -9,6 +9,7 @@ import {
   ConcentratedLiquidityPool,
   SharePool,
 } from "~/components/pool-detail";
+import SkeletonLoader from "~/components/skeleton-loader";
 import { useNavBar } from "~/hooks";
 import { useFeatureFlags } from "~/hooks/use-feature-flags";
 import { TradeTokens } from "~/modals";
@@ -72,23 +73,34 @@ const Pool: FunctionComponent = observer(() => {
       <NextSeo
         title={t("seo.pool.title", { id: poolId ? poolId.toString() : "-" })}
       />
-      {showTradeModal && queryPool && (
-        <TradeTokens
-          className="md:!p-0"
-          isOpen={showTradeModal}
-          onRequestClose={() => {
-            setShowTradeModal(false);
-          }}
-          memoedPools={memoedPools}
-        />
+      {!poolExists ? (
+        <div className="mx-auto flex max-w-container flex-col gap-4 py-6 px-6">
+          <SkeletonLoader className="h-96" />
+          <SkeletonLoader className="h-40" />
+          <SkeletonLoader className="h-8" />
+          <SkeletonLoader className="h-40" />
+        </div>
+      ) : (
+        <>
+          {showTradeModal && queryPool && (
+            <TradeTokens
+              className="md:!p-0"
+              isOpen={showTradeModal}
+              onRequestClose={() => {
+                setShowTradeModal(false);
+              }}
+              memoedPools={memoedPools}
+            />
+          )}
+          {flags.concentratedLiquidity && queryPool?.type === "concentrated" ? (
+            <ConcentratedLiquidityPool poolId={poolId} />
+          ) : Boolean(queryPool?.sharePool) ? (
+            queryPool && <SharePool poolId={poolId} />
+          ) : queryPool ? (
+            <BasePoolDetails pool={queryPool!.pool} />
+          ) : null}
+        </>
       )}
-      {flags.concentratedLiquidity && queryPool?.type === "concentrated" ? (
-        <ConcentratedLiquidityPool poolId={poolId} />
-      ) : Boolean(queryPool?.sharePool) ? (
-        queryPool && <SharePool poolId={poolId} />
-      ) : queryPool ? (
-        <BasePoolDetails pool={queryPool.pool} />
-      ) : null}
     </>
   );
 });

--- a/packages/web/pages/pool/[id].tsx
+++ b/packages/web/pages/pool/[id].tsx
@@ -74,11 +74,11 @@ const Pool: FunctionComponent = observer(() => {
         title={t("seo.pool.title", { id: poolId ? poolId.toString() : "-" })}
       />
       {!poolExists ? (
-        <div className="mx-auto flex max-w-container flex-col gap-4 py-6 px-6">
-          <SkeletonLoader className="h-96" />
-          <SkeletonLoader className="h-40" />
-          <SkeletonLoader className="h-8" />
-          <SkeletonLoader className="h-40" />
+        <div className="mx-auto flex max-w-container flex-col gap-10 py-6 px-6">
+          <SkeletonLoader className="h-[30rem] !rounded-3xl" />
+          <SkeletonLoader className="h-40 !rounded-3xl" />
+          <SkeletonLoader className="h-8 !rounded-xl" />
+          <SkeletonLoader className="h-40 !rounded-3xl" />
         </div>
       ) : (
         <>


### PR DESCRIPTION
## What is the purpose of the change

Low liquidity pools aren't instantly accessible on the paginated pool query. This causes an unnecessary redirect to the `/pools` page after reloading since the pools aren't present during the initial request, and `poolExists` does fetch more data despite it being available. This PR fixes `poolExists` method by fetching pools as needed until the desired pool is found. 

### ClickUp Task

[Assetlists PR](https://github.com/osmosis-labs/assetlists/pull/669/)

## Brief Changelog

- Fetch pools in `poolExists` despite them not being available on first request
- Add skeleton loader to individual pools page, while `poolExists` is loading

## Testing and Verifying

- [ ] https://stage.osmosis.zone/pool/1146 should be able to load
- [ ] Typing a non-existent pool id will redirect users to the `/pools` page
