### PR TITLE
fix: Individual Pools Query

### DIFF
--- a/packages/web/pages/api/pool/[id].ts
+++ b/packages/web/pages/api/pool/[id].ts
@@ -6,8 +6,8 @@ type Response = {
 
 export default async function pools(req: Request) {
   const url = new URL(req.url);
-  const poolIdParam = url.searchParams.has("id")
-    ? url.searchParams.get("id")
+  const poolIdParam = url.pathname.split("/").slice(-1)
+    ? url.pathname.split("/").slice(-1)
     : undefined;
   const poolId = Array.isArray(poolIdParam) ? poolIdParam[0] : poolIdParam;
 

--- a/packages/web/pages/api/pool/[id].ts
+++ b/packages/web/pages/api/pool/[id].ts
@@ -20,9 +20,12 @@ export default async function pools(req: Request) {
     }
   } catch (e) {
     const error = e as { status?: number };
-    return new Response(error?.status === 404 ? "Not Found" : "Unknown Error", {
-      status: error?.status || 500,
-    });
+    return new Response(
+      error?.status === 404 ? "Not Found" : "Unexpected Error",
+      {
+        status: error?.status || 500,
+      }
+    );
   }
 }
 

--- a/packages/web/pages/api/pool/[id].ts
+++ b/packages/web/pages/api/pool/[id].ts
@@ -1,4 +1,5 @@
 import { PoolRaw, queryPaginatedPools } from "~/queries/complex/pools";
+import { isNumeric } from "~/utils/assertion";
 
 type Response = {
   pool: PoolRaw;
@@ -6,20 +7,23 @@ type Response = {
 
 export default async function pools(req: Request) {
   const url = new URL(req.url);
-  const poolIdParam = url.pathname.split("/").slice(-1)
-    ? url.pathname.split("/").slice(-1)
-    : undefined;
-  const poolId = Array.isArray(poolIdParam) ? poolIdParam[0] : poolIdParam;
+  const poolId = url.pathname.split("/").slice(-1)[0];
 
-  if (!poolId) return new Response("", { status: 400 });
+  if (!isNumeric(poolId))
+    return new Response("Invalid pool id", { status: 400 });
 
-  const { status, pools } = await queryPaginatedPools({ poolId });
-
-  if (pools && pools.length === 1) {
-    const response: Response = { pool: pools[0] };
-    return new Response(JSON.stringify(response), { status });
+  try {
+    const { status, pools } = await queryPaginatedPools({ poolId });
+    if (pools && pools.length === 1) {
+      const response: Response = { pool: pools[0] };
+      return new Response(JSON.stringify(response), { status });
+    }
+  } catch (e) {
+    const error = e as { status?: number };
+    return new Response(error?.status === 404 ? "Not Found" : "Unknown Error", {
+      status: error?.status || 500,
+    });
   }
-  return new Response("", { status });
 }
 
 export const config = {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Individual get pool by id is failing because the API route is trying to get the id from search parameters instead of the pathname. 
