### PR TITLE
Minor speedup to pool TVL logic

### DIFF
--- a/packages/stores/src/queries-external/pools/pool.ts
+++ b/packages/stores/src/queries-external/pools/pool.ts
@@ -457,24 +457,31 @@ export class ObservableQueryPool extends ObservableQueryExternalBase<{
     this.raw = raw;
   }
 
+  // TODO: Improve performance, to do so, we should in sequence try:
+  // - add a += op to Dec
+  // - Make priceStore.calculatePrice return something in the form of a Dec
+  // - Try changing the Dec usage to Number (float) in the codebase
+  // - Make a priceStore function to calculate result in float
   readonly computeTotalValueLocked = computedFn((priceStore: IPriceStore) => {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const fiatCurrency = priceStore.getFiatCurrency(
       priceStore.defaultVsCurrency
     )!;
-    let price = new PricePretty(fiatCurrency, 0);
-
+    let mutPrice = new Dec(0);
     for (const poolAsset of this.poolAssets) {
+      // TODO: Get this into a dec to begin with
       const poolPrice = priceStore.calculatePrice(
         poolAsset.amount,
         fiatCurrency.currency
       );
       if (poolPrice) {
-        price = price.add(poolPrice);
+        // TODO Get this into a += op to begin with. Were wasting heap.
+        // TODO (Later refactor), stay in floats all the way through.
+        mutPrice = mutPrice.add(poolPrice.toDec());
       }
     }
 
-    return price;
+    return new PricePretty(fiatCurrency, mutPrice);
   });
 
   protected setResponse(


### PR DESCRIPTION
Removes some extra cloning of price pretty data overhead. Expected speedup to be a bit minor as we still have the same number of heap allocations going on.

From looking at profiles, it appears to me we are spending 200-350ms of JS execution time in this function.

Once #2188 is in, will try further speedups:
```

  // TODO: Improve performance, to do so, we should in sequence try:
  // - add a += op to Dec
  // - Make priceStore.calculatePrice return something in the form of a Dec
  // - Try changing the Dec usage to Number (float) in the codebase
  // - Make a priceStore function to calculate result in float
```

In the meantime, I'm trying to see if theres a reliable way for me to unit benchmark the speed improvement, besides comparing manual chrome perf profiles. 