### PR TITLE
Clean up validator squad logic

### DIFF
--- a/packages/web/pages/stake/index.tsx
+++ b/packages/web/pages/stake/index.tsx
@@ -141,9 +141,6 @@ export const Staking: React.FC = observer(() => {
     return validatorSetPreferenceMap;
   }, [userValidatorPreferences]);
 
-
-
-
   const validatorSquadModalAction: "stake" | "edit" = Boolean(
     Number(amountConfig.amount)
   )


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

- consolidate stake / edit logic to be based on amountConfig.amount
- don't allow user to enter a negative amount in the trade clipboard

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/86a0y40a3)

## Brief Changelog

- amount is 0 = "edit", amount is > 0 = "stake"
- user isn't allowed to set a negative amount in trade clipboard
- general cleanup

## Testing and Verifying

https://github.com/osmosis-labs/osmosis-frontend/assets/30577966/05076b48-2bea-4af9-9700-b2c3789a4959

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
