### PR TITLE
Remove keplr-wallet/crypto and therefore crypto-JS import

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "@keplr-wallet/background": "0.10.24-ibc.go.v7.hot.fix",
     "@keplr-wallet/common": "0.10.24-ibc.go.v7.hot.fix",
     "@keplr-wallet/cosmos": "0.10.24-ibc.go.v7.hot.fix",
-    "@keplr-wallet/crypto": "0.10.24-ibc.go.v7.hot.fix",
     "@keplr-wallet/proto-types": "0.10.24-ibc.go.v7.hot.fix",
     "@keplr-wallet/router": "0.10.24-ibc.go.v7.hot.fix",
     "@keplr-wallet/types": "0.10.24-ibc.go.v7.hot.fix",

--- a/packages/keplr-hooks/package.json
+++ b/packages/keplr-hooks/package.json
@@ -26,7 +26,6 @@
     "@keplr-wallet/background": "0.10.24-ibc.go.v7.hot.fix",
     "@keplr-wallet/common": "0.10.24-ibc.go.v7.hot.fix",
     "@keplr-wallet/cosmos": "0.10.24-ibc.go.v7.hot.fix",
-    "@keplr-wallet/crypto": "0.10.24-ibc.go.v7.hot.fix",
     "@keplr-wallet/ens": "0.10.24-ibc.go.v7.hot.fix",
     "@keplr-wallet/popup": "0.10.24-ibc.go.v7.hot.fix",
     "@keplr-wallet/proto-types": "0.10.24-ibc.go.v7.hot.fix",
@@ -39,6 +38,7 @@
     "mobx-utils": "^6.0.3",
     "react": "^16.14.0",
     "react-router": "^5.1.2",
+    "sha.js": "^2.4.11",
     "utility-types": "^3.10.0"
   }
 }

--- a/packages/keplr-stores/package.json
+++ b/packages/keplr-stores/package.json
@@ -47,7 +47,6 @@
     "@keplr-wallet/background": "0.10.24-ibc.go.v7.hot.fix",
     "@keplr-wallet/common": "0.10.24-ibc.go.v7.hot.fix",
     "@keplr-wallet/cosmos": "0.10.24-ibc.go.v7.hot.fix",
-    "@keplr-wallet/crypto": "0.10.24-ibc.go.v7.hot.fix",
     "@keplr-wallet/proto-types": "0.10.24-ibc.go.v7.hot.fix",
     "@keplr-wallet/router": "0.10.24-ibc.go.v7.hot.fix",
     "@keplr-wallet/types": "0.10.24-ibc.go.v7.hot.fix",

--- a/packages/keplr-stores/package.json
+++ b/packages/keplr-stores/package.json
@@ -27,7 +27,6 @@
     "@keplr-wallet/background": "0.10.24-ibc.go.v7.hot.fix",
     "@keplr-wallet/common": "0.10.24-ibc.go.v7.hot.fix",
     "@keplr-wallet/cosmos": "0.10.24-ibc.go.v7.hot.fix",
-    "@keplr-wallet/crypto": "0.10.24-ibc.go.v7.hot.fix",
     "@keplr-wallet/proto-types": "0.10.24-ibc.go.v7.hot.fix",
     "@keplr-wallet/router": "0.10.24-ibc.go.v7.hot.fix",
     "@keplr-wallet/types": "0.10.24-ibc.go.v7.hot.fix",
@@ -40,6 +39,7 @@
     "mobx": "^6.1.7",
     "mobx-utils": "^6.0.3",
     "p-queue": "^6.6.2",
+    "sha.js": "^2.4.11",
     "utility-types": "^3.10.0"
   },
   "gitHead": "53108b832ecce14a9aeb48a46c565724e5904361",

--- a/packages/keplr-stores/src/common/query/json-rpc.ts
+++ b/packages/keplr-stores/src/common/query/json-rpc.ts
@@ -2,7 +2,7 @@ import { ObservableQuery, QueryOptions, QueryResponse } from "./index";
 import { KVStore } from "@keplr-wallet/common";
 import { AxiosInstance } from "axios";
 import { action, makeObservable, observable } from "mobx";
-import { Hash } from "@keplr-wallet/crypto";
+import { sha256 } from "sha.js";
 import { Buffer } from "buffer/";
 import { HasMapStore } from "../map";
 
@@ -86,12 +86,16 @@ export class ObservableJsonRPCQuery<
 
   protected getCacheKey(): string {
     const paramsHash = Buffer.from(
-      Hash.sha256(Buffer.from(JSON.stringify(this.params))).slice(0, 8)
+      sha256_fn(Buffer.from(JSON.stringify(this.params))).slice(0, 8)
     ).toString("hex");
 
     return `${super.getCacheKey()}-${this.method}-${paramsHash}`;
   }
 }
+
+const sha256_fn = (data: Uint8Array): Uint8Array => {
+  return new Uint8Array(new sha256().update(data).digest());
+};
 
 export class ObservableJsonRPCQueryMap<
   T = unknown,

--- a/packages/stores/package.json
+++ b/packages/stores/package.json
@@ -56,7 +56,6 @@
     "@cosmos-kit/core": "2.2.2",
     "@keplr-wallet/common": "0.10.24-ibc.go.v7.hot.fix",
     "@keplr-wallet/cosmos": "0.10.24-ibc.go.v7.hot.fix",
-    "@keplr-wallet/crypto": "0.10.24-ibc.go.v7.hot.fix",
     "@osmosis-labs/keplr-hooks": "0.10.24-ibc.go.v7.hot.fix",
     "@osmosis-labs/keplr-stores": "0.10.24-ibc.go.v7.hot.fix",
     "@keplr-wallet/types": "0.10.24-ibc.go.v7.hot.fix",
@@ -74,6 +73,7 @@
     "mobx": "^6.3.10",
     "mobx-utils": "^6.0.4",
     "protobufjs": "^6.11.2",
+    "sha.js": "^2.4.11",
     "utility-types": "^3.10.0"
   },
   "resolutions": {

--- a/packages/stores/src/currency-registrar/unsafe-ibc.ts
+++ b/packages/stores/src/currency-registrar/unsafe-ibc.ts
@@ -1,5 +1,4 @@
 import { DenomHelper } from "@keplr-wallet/common";
-import { Hash } from "@keplr-wallet/crypto";
 import {
   AppCurrency,
   ChainInfo,
@@ -7,6 +6,7 @@ import {
   IBCCurrency,
 } from "@keplr-wallet/types";
 import { ChainStore } from "@osmosis-labs/keplr-stores";
+import { sha256 } from "sha.js";
 
 type OriginChainCurrencyInfo = [
   string, // chain ID
@@ -143,11 +143,13 @@ export function makeIBCMinimalDenom(
   return (
     "ibc/" +
     Buffer.from(
-      Hash.sha256(
-        Buffer.from(`transfer/${sourceChannelId}/${coinMinimalDenom}`)
-      )
+      sha256_fn(Buffer.from(`transfer/${sourceChannelId}/${coinMinimalDenom}`))
     )
       .toString("hex")
       .toUpperCase()
   );
 }
+
+const sha256_fn = (data: Uint8Array): Uint8Array => {
+  return new Uint8Array(new sha256().update(data).digest());
+};

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -39,7 +39,6 @@
     "@headlessui/react": "^1.7.8",
     "@keplr-wallet/common": "0.10.24-ibc.go.v7.hot.fix",
     "@keplr-wallet/cosmos": "0.10.24-ibc.go.v7.hot.fix",
-    "@keplr-wallet/crypto": "0.10.24-ibc.go.v7.hot.fix",
     "@osmosis-labs/keplr-hooks": "0.10.24-ibc.go.v7.hot.fix",
     "@osmosis-labs/keplr-stores": "0.10.24-ibc.go.v7.hot.fix",
     "@keplr-wallet/types": "0.10.24-ibc.go.v7.hot.fix",

--- a/packages/web/stores/assets/utils.ts
+++ b/packages/web/stores/assets/utils.ts
@@ -1,5 +1,5 @@
-import { Hash } from "@keplr-wallet/crypto";
 import { Buffer } from "buffer";
+import { sha256 } from "sha.js";
 
 export function makeIBCMinimalDenom(
   sourceChannelId: string,
@@ -8,11 +8,14 @@ export function makeIBCMinimalDenom(
   return (
     "ibc/" +
     Buffer.from(
-      Hash.sha256(
-        Buffer.from(`transfer/${sourceChannelId}/${coinMinimalDenom}`)
-      )
+      sha256_fn(Buffer.from(`transfer/${sourceChannelId}/${coinMinimalDenom}`))
     )
       .toString("hex")
       .toUpperCase()
   );
 }
+
+// TODO: Move to utils
+const sha256_fn = (data: Uint8Array): Uint8Array => {
+  return new Uint8Array(new sha256().update(data).digest());
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3316,11 +3316,53 @@
     long "^4.0.0"
     protobufjs "^6.11.2"
 
-"@keplr-wallet/crypto@0.10.24-ibc.go.v7.hot.fix", "@keplr-wallet/crypto@0.11.16", "@keplr-wallet/crypto@0.12.12", "@keplr-wallet/crypto@^0.11.12":
+"@keplr-wallet/crypto@0.10.24-ibc.go.v7.hot.fix":
   version "0.10.24-ibc.go.v7.hot.fix"
   resolved "https://registry.npmjs.org/@keplr-wallet/crypto/-/crypto-0.10.24-ibc.go.v7.hot.fix.tgz"
   integrity sha512-XBki1IbT6FKmZjnz89jxS3Gnb0YnUG4WSE1Xl3oTaTFKF6JXpJd0KICLsxn0QsXX3g+mHEtUB/dYjKVQfsA0Gw==
   dependencies:
+    bip32 "^2.0.6"
+    bip39 "^3.0.3"
+    bs58check "^2.1.2"
+    buffer "^6.0.3"
+    crypto-js "^4.0.0"
+    elliptic "^6.5.3"
+    sha.js "^2.4.11"
+
+"@keplr-wallet/crypto@0.11.16":
+  version "0.11.16"
+  resolved "https://registry.yarnpkg.com/@keplr-wallet/crypto/-/crypto-0.11.16.tgz#6cd39fdb7d1df44be05c78bf3244132262c821d4"
+  integrity sha512-th3t05Aq+uQLbhhiqIHbevY3pA4dBKr+vKcUpfdshcc78fI1eGpmzGcQKxlvbectBn4UwamTEANssyplXOGQqg==
+  dependencies:
+    "@ethersproject/keccak256" "^5.5.0"
+    bip32 "^2.0.6"
+    bip39 "^3.0.3"
+    bs58check "^2.1.2"
+    buffer "^6.0.3"
+    crypto-js "^4.0.0"
+    elliptic "^6.5.3"
+    sha.js "^2.4.11"
+
+"@keplr-wallet/crypto@0.12.12":
+  version "0.12.12"
+  resolved "https://registry.yarnpkg.com/@keplr-wallet/crypto/-/crypto-0.12.12.tgz#391d5abdf6de7b45dec41bbe20caf89c98b16165"
+  integrity sha512-JC4R0TzzIKLeltELQUz7wumz//ToYSSnvZaB4TQcadipIIcalDLS+TGfqlOgqJLSAyMAYWz91ghBMkxoC4EepQ==
+  dependencies:
+    "@ethersproject/keccak256" "^5.5.0"
+    bip32 "^2.0.6"
+    bip39 "^3.0.3"
+    bs58check "^2.1.2"
+    buffer "^6.0.3"
+    crypto-js "^4.0.0"
+    elliptic "^6.5.3"
+    sha.js "^2.4.11"
+
+"@keplr-wallet/crypto@^0.11.12":
+  version "0.11.64"
+  resolved "https://registry.yarnpkg.com/@keplr-wallet/crypto/-/crypto-0.11.64.tgz#816aec5b5242e619b084aa7d9ef2821f8c0ebaad"
+  integrity sha512-DMeGhs+UUBpvefYa/0pF8h8D0lVS1T/eTGNKrn7SIO5CBMp1qfght+k1Se0pHGLr4CAtxFSXTDvYm3mr+ovKhg==
+  dependencies:
+    "@ethersproject/keccak256" "^5.5.0"
     bip32 "^2.0.6"
     bip39 "^3.0.3"
     bs58check "^2.1.2"


### PR DESCRIPTION
This PR removes the import keplr-wallet/crypto, and by proxy crypto-js.

I anticipate this saving 50kb of parsed size, and 10kb off of the gzip. I cannot validate this right now, due to seemingly unrelated build issues.