### PR TITLE
CL: Prevent ticks from being the same

### DIFF
--- a/packages/stores/src/ui-config/manage-liquidity/add-concentrated-liquidity.ts
+++ b/packages/stores/src/ui-config/manage-liquidity/add-concentrated-liquidity.ts
@@ -403,14 +403,21 @@ export class ObservableAddConcentratedLiquidityConfig {
       const lowerTick = priceToTick(this.range[0]);
       const upperTick = priceToTick(this.range[1]);
 
-      const lowerTickRounded = roundToNearestDivisible(
+      let lowerTickRounded = roundToNearestDivisible(
         lowerTick,
         this.tickDivisor
       );
-      const upperTickRounded = roundToNearestDivisible(
+      let upperTickRounded = roundToNearestDivisible(
         upperTick,
         this.tickDivisor
       );
+
+      // If they rounded to the same value, pad both to respect the
+      // user's desired range.
+      if (lowerTickRounded.equals(upperTickRounded)) {
+        lowerTickRounded = lowerTickRounded.sub(this.tickDivisor);
+        upperTickRounded = upperTickRounded.add(this.tickDivisor);
+      }
 
       return [
         lowerTickRounded.lt(minTick) ? minTick : lowerTickRounded,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

If the user specifies a very tight range, the ticks could be the same. If they round to the same value, I add +/- padding of 1000 ticks to both min and max in the tick range.

### ClickUp Task

[ClickUp Task URL](PASTE_CLICKUP_TASK_URL_HERE)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->
* Added padding to min and max tick if rounded ticks are the same

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

If you select a super tight range, the add liquidity message should still succeed

