### PR TITLE
Router: remove force split, add ordered preferred pools

### DIFF
--- a/packages/stores/src/ui-config/trade-token-in-config.ts
+++ b/packages/stores/src/ui-config/trade-token-in-config.ts
@@ -407,10 +407,15 @@ export class ObservableTradeTokenInConfig extends AmountConfig {
     const preferredPoolIds = this._pools.reduce((preferredIds, pool) => {
       const poolTvl = pool.computeTotalValueLocked(priceStore).toDec();
 
+      // add transmuters first
+      if (pool.type === "transmuter" && poolTvl.gt(new Dec(100_000))) {
+        preferredIds.unshift(pool.id);
+        return preferredIds;
+      }
+
       if (
         (pool.type === "concentrated" && poolTvl.gt(new Dec(100_000))) ||
-        (pool.type === "stable" && poolTvl.gt(new Dec(150_000))) ||
-        (pool.type === "transmuter" && poolTvl.gt(new Dec(100_000)))
+        (pool.type === "stable" && poolTvl.gt(new Dec(150_000)))
       ) {
         preferredIds.push(pool.id);
       }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

Picks best swap; direct or split. Adds ordering to preferred pools to place transmuter pools first.

### ClickUp Task

[ClickUp Task URL](PASTE_CLICKUP_TASK_URL_HERE)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->
* Ordered preferred pools
* Find max out for direct & split routes