### PR TITLE
Support cosmwasm pool in stream query

### DIFF
--- a/packages/web/queries/indexer/filtered-pools.ts
+++ b/packages/web/queries/indexer/filtered-pools.ts
@@ -24,7 +24,8 @@ export type FilteredPoolsResponse = {
     type:
       | "osmosis.gamm.v1beta1.Pool"
       | "osmosis.gamm.poolmodels.stableswap.v1beta1.Pool"
-      | "osmosis.concentratedliquidity.v1beta1.Pool";
+      | "osmosis.concentratedliquidity.v1beta1.Pool"
+      | "osmosis.cosmwasmpool.v1beta1.CosmWasmPool";
     pool_id: number;
 
     // share pool
@@ -52,6 +53,11 @@ export type FilteredPoolsResponse = {
     spread_factor: string;
     exponent_at_price_one: string;
     address: string;
+
+    // cosmwasm pool
+    contract_address: string;
+    instantiate_msg: string;
+    code_id: string;
   }[];
 };
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

Should slightly increase query speed as we don't need to query node for cosmwasm pools.

This only works in the stage environment for now, using the new stage timeseries data endpoint. We should coordinate this release to be able to have cosmwasm pools be served from data services once this goes live. It will deploy safely, but cosmwasm pools won't be included.

### ClickUp Task

[ClickUp Task URL](PASTE_CLICKUP_TASK_URL_HERE)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
