### PR TITLE
Router: Increase necessary TVL of pools

### DIFF
--- a/packages/web/hooks/data/use-routable-pools.ts
+++ b/packages/web/hooks/data/use-routable-pools.ts
@@ -11,10 +11,7 @@ import { useFeatureFlags } from "../use-feature-flags";
 
 /** Minimal number of pools considered routable from prior knowledge. Subject to change */
 export const ROUTABLE_POOL_COUNT = 300;
-const ROUTABLE_POOL_MIN_LIQUIDITY = 1_000;
-
-const DEC_1000 = new Dec(1_000);
-const DEC_10000 = new Dec(10_000);
+const ROUTABLE_POOL_MIN_LIQUIDITY = 10_000;
 
 /** Use memoized pools considered fit for routing, likely within the swap tool component.
  *  Fitness is determined by sufficient TVL per pool type, and whether the pool is verified.
@@ -99,8 +96,8 @@ export function useRoutablePools(
               showUnverified ||
                 pool.type === "concentrated" ||
                 pool.type === "transmuter"
-                ? DEC_1000
-                : DEC_10000
+                ? new Dec(10_000)
+                : new Dec(80_000)
             );
         })
         .sort((a, b) => {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

Seems the limit for routable pools' TVL was lowered, causing low liq pools to be chosen. This increases the limit and therefore increases the liquidity of chosen pools for routing.

### ClickUp Task

[ClickUp Task URL](PASTE_CLICKUP_TASK_URL_HERE)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

USDC.axl > ATOM route should now be fixed and should be lower price impact.

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
