### PR TITLE
fix: router is bricked due to invalidating long routes

### DIFF
--- a/packages/pools/src/router/routes.ts
+++ b/packages/pools/src/router/routes.ts
@@ -96,7 +96,7 @@ export class OptimizedRoutes implements TokenOutGivenInRouter {
     stakeCurrencyMinDenom,
     getPoolTotalValueLocked,
     maxHops = 4,
-    maxRoutes = 4,
+    maxRoutes = 6,
     maxSplit = 2,
     maxSplitIterations = 10,
     logger,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

The current status on the ATOM / USDCaxl bug:
- Noticed that route finder selects routes with 4 hops that get filtered out because # of tokenOutDenoms do not match the # of pools
  * Reasons are still unclreas

- Realized that there are a bunch of pools with fewer hops
- However, the router greedily selects 4 (4 hop) routes that are buggy and get invalidated

The temporary solution is to allow  the router to search up to not 4 but 6 routes. As a result, we decrease the frequency of the bug happening in prod.

This was tested locally and fixed the ATOM / USDCaxl bug.

A proper solution to the mismatch between # of tokenOuteDenoms and # of pools is to be found in a subsequent change

### ClickUp Task

[ClickUp Task URL](PASTE_CLICKUP_TASK_URL_HERE)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
