### PR TITLE
fix: proper fix for no routes for this trade bug

### DIFF
--- a/packages/pools/src/router/routes.ts
+++ b/packages/pools/src/router/routes.ts
@@ -522,7 +522,13 @@ export class OptimizedRoutes implements TokenOutGivenInRouter {
       }
 
       for (let i = 0; i < pools.length; i++) {
-        if (poolsUsed[i]) {
+        // Create a deep copy of the current route, token outs
+        // and pools used.
+        const currentPoolRoute = currentRoute.slice();
+        const currentPoolTokenOuts = currentTokenOuts.slice();
+        const currentPoolsUsed = poolsUsed.slice();
+
+        if (currentPoolsUsed[i]) {
           continue; // skip pool
         }
 
@@ -544,28 +550,25 @@ export class OptimizedRoutes implements TokenOutGivenInRouter {
           continue; // skip pool
         }
 
-        currentRoute.push(curPool);
+        currentPoolRoute.push(curPool);
         if (
-          currentRoute.length > 1 &&
+          currentPoolRoute.length > 1 &&
           prevPoolCurPoolTokenMatch !== tokenInDenom &&
           prevPoolCurPoolTokenMatch !== tokenOutDenom
         ) {
-          currentTokenOuts.push(prevPoolCurPoolTokenMatch);
+          currentPoolTokenOuts.push(prevPoolCurPoolTokenMatch);
         }
-        poolsUsed[i] = true;
+        currentPoolsUsed[i] = true;
         findRoutes(
           tokenInDenom,
           tokenOutDenom,
-          currentRoute,
-          currentTokenOuts,
-          poolsUsed,
+          currentPoolRoute,
+          currentPoolTokenOuts,
+          currentPoolsUsed,
           curPool.poolAssetDenoms.filter(
             (denom) => denom !== prevPoolCurPoolTokenMatch
           )
         );
-        poolsUsed[i] = false;
-        currentTokenOuts.pop();
-        currentRoute.pop();
       }
     };
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Properly fixes the "no routes for this trade bug" (screenshot attached)

The problem stemmed from the fact that the router selected 4 4-hop routes where, for some of them, the number of token out denoms mismatched the number of pools, falling validation as a result.

In https://github.com/osmosis-labs/osmosis-frontend/pull/2242, we made a hotfix to increase the number of routes considered from 4 to 6. This allowed router to pick up routes with fewer hops and make routing work.

However, that fix is inappropriate and only decreases the frequency of the issue occurring.

It was observed that routes with fewer hops never had this mismatch. As a result, a guess was made that we somehow modify the shared inputs in the recursive function. In JavaScript arrays are pass-by-reference. As a result, if we make an invalid mutation, it would be applied to all recursive calls.

It looks like this is indeed what was happening. By making deep copies of shared array inputs. The manual test started passing against ATOM / USDC axl pool when the max routes is 4

![image](https://github.com/osmosis-labs/osmosis-frontend/assets/34196718/ae86ba2c-8b6c-4324-b96c-e6ce891ba620)


### ClickUp Task

[ClickUp Task URL](PASTE_CLICKUP_TASK_URL_HERE)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
