### PR TITLE
refactor: stricter checks for spot price debugging in CL math

### DIFF
--- a/packages/math/src/pool/concentrated/__tests__/quotes.spec.ts
+++ b/packages/math/src/pool/concentrated/__tests__/quotes.spec.ts
@@ -719,7 +719,7 @@ describe("calcOutGivenIn matches chain code", () => {
       ];
       const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0");
-      expect(
+      try {
         calcOutGivenIn({
           tokenIn,
           tokenDenom0,
@@ -727,8 +727,10 @@ describe("calcOutGivenIn matches chain code", () => {
           inittedTicks,
           curSqrtPrice,
           swapFee,
-        })
-      ).toEqual("no-more-ticks");
+        });
+      } catch (error) {
+        // expected to throw
+      }
     });
   });
 });

--- a/packages/math/src/pool/concentrated/__tests__/quotes.spec.ts
+++ b/packages/math/src/pool/concentrated/__tests__/quotes.spec.ts
@@ -719,7 +719,7 @@ describe("calcOutGivenIn matches chain code", () => {
       ];
       const curSqrtPrice = new BigDec("70.710678118654752441");
       const swapFee = new Dec("0");
-      try {
+      expect(() => {
         calcOutGivenIn({
           tokenIn,
           tokenDenom0,
@@ -728,9 +728,7 @@ describe("calcOutGivenIn matches chain code", () => {
           curSqrtPrice,
           swapFee,
         });
-      } catch (error) {
-        // expected to throw
-      }
+      }).toThrow();
     });
   });
 });

--- a/packages/math/src/pool/concentrated/one-for-zero.ts
+++ b/packages/math/src/pool/concentrated/one-for-zero.ts
@@ -58,6 +58,8 @@ export class OneForZeroStrategy implements SwapStrategy {
     amountOutComputed: Dec;
     feeChargeTotal: Dec;
   } {
+    console.log("one for zero strat");
+    console.log("curSqrtPrice", curSqrtPrice.toString());
     const liquidityBigDec = new BigDec(liquidity);
     const sqrtPriceTargetBigDec = new BigDec(sqrtPriceTarget);
     const amountOneInRemainingBigDec = new BigDec(amountOneInRemaining);
@@ -119,6 +121,15 @@ export class OneForZeroStrategy implements SwapStrategy {
       amountOneInRemaining,
       this.oneForZero.swapFee
     );
+
+    if (sqrtPriceNext.lt(curSqrtPrice)) {
+      throw new Error(
+        "Computed sqrt price in the wrong direction. Must increase for one for zero. Current sqrt price: " +
+          curSqrtPrice.toString() +
+          ", next sqrt price: " +
+          sqrtPriceNext.toString()
+      );
+    }
 
     return {
       sqrtPriceNext,

--- a/packages/math/src/pool/concentrated/one-for-zero.ts
+++ b/packages/math/src/pool/concentrated/one-for-zero.ts
@@ -122,10 +122,10 @@ export class OneForZeroStrategy implements SwapStrategy {
 
     if (sqrtPriceNext.lt(curSqrtPrice)) {
       throw new Error(
-        "Computed sqrt price in the wrong direction. Must increase for one for zero. Current sqrt price: " +
-          curSqrtPrice.toString() +
-          ", next sqrt price: " +
-          sqrtPriceNext.toString()
+        `Computed sqrt price in the wrong direction. Must increase for one for zero. Current sqrt price: 
+          ${curSqrtPrice.toString()} 
+          , next sqrt price: 
+          ${sqrtPriceNext.toString()}`
       );
     }
 

--- a/packages/math/src/pool/concentrated/one-for-zero.ts
+++ b/packages/math/src/pool/concentrated/one-for-zero.ts
@@ -58,8 +58,6 @@ export class OneForZeroStrategy implements SwapStrategy {
     amountOutComputed: Dec;
     feeChargeTotal: Dec;
   } {
-    console.log("one for zero strat");
-    console.log("curSqrtPrice", curSqrtPrice.toString());
     const liquidityBigDec = new BigDec(liquidity);
     const sqrtPriceTargetBigDec = new BigDec(sqrtPriceTarget);
     const amountOneInRemainingBigDec = new BigDec(amountOneInRemaining);

--- a/packages/math/src/pool/concentrated/zero-for-one.ts
+++ b/packages/math/src/pool/concentrated/zero-for-one.ts
@@ -105,10 +105,10 @@ export class ZeroForOneStrategy implements SwapStrategy {
 
     if (sqrtPriceNext.gt(curSqrtPrice)) {
       throw new Error(
-        "Computed sqrt price in the wrong direction. Must decrcease for zero for one. Current sqrt price: " +
-          curSqrtPrice.toString() +
-          ", next sqrt price: " +
-          sqrtPriceNext.toString()
+        `Computed sqrt price in the wrong direction. Must decrcease for zero for one. Current sqrt price:
+          ${curSqrtPrice.toString()}
+          , next sqrt price:
+          ${sqrtPriceNext.toString()}`
       );
     }
 

--- a/packages/math/src/pool/concentrated/zero-for-one.ts
+++ b/packages/math/src/pool/concentrated/zero-for-one.ts
@@ -103,6 +103,15 @@ export class ZeroForOneStrategy implements SwapStrategy {
       );
     }
 
+    if (sqrtPriceNext.gt(curSqrtPrice)) {
+      throw new Error(
+        "Computed sqrt price in the wrong direction. Must decrcease for zero for one. Current sqrt price: " +
+          curSqrtPrice.toString() +
+          ", next sqrt price: " +
+          sqrtPriceNext.toString()
+      );
+    }
+
     const amountOneOut = calcAmount1Delta(
       liquidityBigDec,
       sqrtPriceNext,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

This PR refactors logic for retrieving spot price before and after CL quotes.

It makes it easier to reason about and debug.

Additionally, it adds some checks in the swap strategy to make sure that the next sqrt price is located in the right direction relative to the current given swap strategy. This helps catching errors early.

### ClickUp Task

[ClickUp Task URL](PASTE_CLICKUP_TASK_URL_HERE)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
