### PR TITLE
Cosmos Kit Upgrade type fix

### DIFF
--- a/packages/web/components/navbar/index.tsx
+++ b/packages/web/components/navbar/index.tsx
@@ -141,7 +141,7 @@ export const NavBar: FunctionComponent<
 
   const account = accountStore.getWallet(chainId);
   const walletSupportsNotifications =
-    account?.walletInfo?.features.includes("notifications");
+    account?.walletInfo?.features?.includes("notifications");
   const icnsQuery = queriesExternalStore.queryICNSNames.getQueryContract(
     account?.address ?? ""
   );

--- a/packages/web/config/wallet-registry.ts
+++ b/packages/web/config/wallet-registry.ts
@@ -15,6 +15,9 @@ export const WalletRegistry: RegistryWallet[] = [
     stakeUrl: "https://wallet.keplr.app/chains/osmosis?tab=staking",
     governanceUrl: "https://wallet.keplr.app/chains/osmosis?tab=governance",
     features: ["notifications"],
+    signOptions: {
+      preferNoSetFee: false,
+    },
   },
   {
     ...CosmosKitWalletList["keplr-mobile"],
@@ -58,6 +61,9 @@ export const WalletRegistry: RegistryWallet[] = [
     stakeUrl: "https://wallet.keplr.app/chains/osmosis?tab=staking",
     governanceUrl: "https://wallet.keplr.app/chains/osmosis?tab=governance",
     features: [],
+    signOptions: {
+      preferNoSetFee: false,
+    },
   },
   {
     ...CosmosKitWalletList["leap-extension"],
@@ -69,6 +75,9 @@ export const WalletRegistry: RegistryWallet[] = [
     stakeUrl: "https://cosmos.leapwallet.io/staking",
     governanceUrl: "https://cosmos.leapwallet.io/gov",
     features: ["notifications"],
+    signOptions: {
+      preferNoSetFee: false,
+    },
   },
   {
     ...CosmosKitWalletList["cosmostation-extension"],
@@ -81,6 +90,9 @@ export const WalletRegistry: RegistryWallet[] = [
     stakeUrl: "https://wallet.cosmostation.io/osmosis/delegate",
     governanceUrl: "https://cosmos.leapwallet.io/gov",
     features: ["notifications"],
+    signOptions: {
+      preferNoSetFee: false,
+    },
   },
   {
     ...CosmosKitWalletList["xdefi-extension"],
@@ -103,6 +115,9 @@ export const WalletRegistry: RegistryWallet[] = [
         .catch(() => false);
     },
     features: [],
+    signOptions: {
+      preferNoSetFee: false,
+    },
   },
   // {
   //   ...CosmosKitWalletList["okxwallet-extension"],

--- a/packages/web/modals/profile.tsx
+++ b/packages/web/modals/profile.tsx
@@ -276,7 +276,7 @@ export const ProfileModal: FunctionComponent<
             <div className="flex justify-between 1.5xl:gap-4 1.5xs:flex-col">
               <div className="flex gap-3">
                 <div className="h-12 w-12 shrink-0">
-                  <Image
+                  <img
                     alt="wallet-icon"
                     src={navBarStore.walletInfo.logoUrl}
                     height={48}

--- a/packages/web/modals/wallet-select.tsx
+++ b/packages/web/modals/wallet-select.tsx
@@ -412,12 +412,14 @@ const LeftModalContent: FunctionComponent<
                       key={wallet.name}
                       onClick={() => onConnect(false, wallet)}
                     >
-                      <Image
-                        src={wallet.logo ?? "/"}
-                        width={40}
-                        height={40}
-                        alt={`${wallet.prettyName} logo`}
-                      />
+                      {typeof wallet.logo === "string" && (
+                        <img
+                          src={wallet.logo}
+                          width={40}
+                          height={40}
+                          alt="Wallet logo"
+                        />
+                      )}
                       <span>{wallet.prettyName}</span>
                     </button>
                   ))}
@@ -466,7 +468,15 @@ const RightModalContent: FunctionComponent<
       return (
         <div className="mx-auto flex h-full max-w-sm flex-col items-center justify-center gap-12 pt-6">
           <div className="flex h-16 w-16 items-center justify-center after:absolute after:h-32 after:w-32 after:rounded-full after:border-2 after:border-error">
-            <Image
+            {!!walletInfo && typeof walletInfo?.logo === "string" && (
+              <img
+                width={40}
+                height={40}
+                src={walletInfo.logo}
+                alt="Wallet logo"
+              />
+            )}
+            <img
               width={64}
               height={64}
               src={
@@ -496,7 +506,7 @@ const RightModalContent: FunctionComponent<
       return (
         <div className="mx-auto flex h-full max-w-sm flex-col items-center justify-center gap-12 pt-6">
           <div className="flex h-16 w-16 items-center justify-center after:absolute after:h-32 after:w-32 after:rounded-full after:border-2 after:border-error">
-            <Image
+            <img
               width={64}
               height={64}
               src={
@@ -541,16 +551,14 @@ const RightModalContent: FunctionComponent<
       return (
         <div className="mx-auto flex h-full max-w-sm flex-col items-center justify-center gap-12 pt-6">
           <div className="flex h-16 w-16 items-center justify-center after:absolute after:h-32 after:w-32 after:rounded-full after:border-2 after:border-error">
-            <Image
-              width={64}
-              height={64}
-              src={
-                typeof walletInfo?.logo === "string"
-                  ? walletInfo?.logo ?? "/"
-                  : "/"
-              }
-              alt="Wallet logo"
-            />
+            {!!walletInfo && typeof walletInfo?.logo === "string" && (
+              <img
+                width={64}
+                height={64}
+                src={walletInfo.logo}
+                alt="Wallet logo"
+              />
+            )}
           </div>
 
           <div className="flex flex-col gap-2">
@@ -590,16 +598,14 @@ const RightModalContent: FunctionComponent<
       return (
         <div className="mx-auto flex h-full max-w-sm flex-col items-center justify-center gap-12 pt-3">
           <div className="flex h-16 w-16 items-center justify-center after:absolute after:h-32 after:w-32 after:animate-spin-slow after:rounded-full after:border-2 after:border-t-transparent after:border-b-transparent after:border-l-wosmongton-300 after:border-r-wosmongton-300">
-            <Image
-              width={64}
-              height={64}
-              src={
-                typeof walletInfo?.logo === "string"
-                  ? walletInfo?.logo ?? "/"
-                  : "/"
-              }
-              alt="Wallet logo"
-            />
+            {!!walletInfo && typeof walletInfo?.logo === "string" && (
+              <img
+                width={64}
+                height={64}
+                src={walletInfo.logo}
+                alt="Wallet logo"
+              />
+            )}
           </div>
 
           <div className="flex flex-col gap-2">


### PR DESCRIPTION
## What is the purpose of the change

This fixes some bugs introduced by breaking changes in the latest Cosmos Kit upgrade.

## Brief Changelog

- Type error fix
- Change wallet image tag to `img` from Next's `Image` to support externally linked wallet images
- Fix Cosmos Kit breaking change fee setting

## Testing and Verifying

This change has been tested locally by rebuilding the website.
