### PR TITLE
prioritize shorter routes

### DIFF
--- a/packages/pools/src/router/routes.ts
+++ b/packages/pools/src/router/routes.ts
@@ -192,6 +192,9 @@ export class OptimizedRoutes implements TokenOutGivenInRouter {
       throw new NotEnoughLiquidityError();
     }
 
+    // shortest first
+    routes = routes.sort((a, b) => a.pools.length - b.pools.length);
+
     // filter routes by unique pools, maintaining sort order
     const uniquePoolIds = new Set<string>();
     routes = routes.reduce((includedRoutes, route) => {
@@ -218,9 +221,6 @@ export class OptimizedRoutes implements TokenOutGivenInRouter {
         return routes;
       }, [] as Route[]);
     }
-
-    // shortest first
-    routes = routes.sort((a, b) => a.pools.length - b.pools.length);
 
     this._logger?.info(
       "Candidate routes",


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

Prioritize shorter routes before filtering for unique routes. Shorter routes tend to have less fee and total price impact.

The way this works is it sorts by length before they get filtered for unique pools across routes. Then, longer routes will be filtered for uniqueness after shorter routes.

### ClickUp Task

[ClickUp Task URL](PASTE_CLICKUP_TASK_URL_HERE)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
