### PR TITLE
CL Add Liq: use pool tick spacing instead of 1000

### DIFF
--- a/packages/stores/src/ui-config/manage-liquidity/add-concentrated-liquidity.ts
+++ b/packages/stores/src/ui-config/manage-liquidity/add-concentrated-liquidity.ts
@@ -205,8 +205,7 @@ export class ObservableAddConcentratedLiquidityConfig {
 
   /** Used to ensure ticks are cleanly divisible by. */
   protected get tickDivisor() {
-    // TODO: use tickspacing from pool going forward
-    return new Int(1000);
+    return new Int(this.pool?.tickSpacing ?? 100);
   }
 
   @computed


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

Uses pool tick spacing param instead of 1000 for rounding the tick when a user is creating a position. This should allow users to make tighter positions with no issue.

I was told by @czarcas7ic that we no longer need to round to 1000th nearest tick, which was a concern at launch.

### ClickUp Task

[ClickUp Task URL](PASTE_CLICKUP_TASK_URL_HERE)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
