### PR TITLE
fix: failing to skip direct quotes with low liq

### DIFF
--- a/packages/pools/src/router/routes.ts
+++ b/packages/pools/src/router/routes.ts
@@ -237,9 +237,9 @@ export class OptimizedRoutes implements TokenOutGivenInRouter {
 
     const directQuotes = (
       await Promise.all(
-        splitableRoutes.map((route, index) => {
+        splitableRoutes.map(async (route, index) => {
           try {
-            return this.calculateTokenOutByTokenIn([
+            return await this.calculateTokenOutByTokenIn([
               {
                 ...route,
                 initialAmount: tokenIn.amount,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Currently, we fail to skip direct quotes with low liquidity due to `Promise.all` never resolving. This stems from not being able to catch errors for individual quotes inside the map.

The solution is to add `await` inside the map logic so that we can handle any error from individual quotes and skip them silently.

Tested locally.