### PR TITLE
fix: double router timeout and decrease max split iterations to 10

### DIFF
--- a/packages/stores/src/ui-config/trade-token-in-config.ts
+++ b/packages/stores/src/ui-config/trade-token-in-config.ts
@@ -428,7 +428,7 @@ export class ObservableTradeTokenInConfig extends AmountConfig {
       incentivizedPoolIds: this._incentivizedPoolIds,
       stakeCurrencyMinDenom,
       getPoolTotalValueLocked,
-      maxSplitIterations: 25,
+      maxSplitIterations: 10,
     });
   }
 

--- a/packages/web/utils/background-routes/index.ts
+++ b/packages/web/utils/background-routes/index.ts
@@ -175,7 +175,7 @@ export class BackgroundRoutes implements TokenOutGivenInRouter {
    *  @returns Promise containing the encoded response, or a symbol to indicate the promise timed out waiting for the given serial numberm response. */
   static postSerialMessage(
     request: EncodedRequest,
-    timeoutMs = 6_000
+    timeoutMs = 12_000
   ): Promise<EncodedResponse | typeof TIMEOUT_SYMBOL> {
     if (!BackgroundRoutes.singletonWorker) {
       throw new Error("Worker not initialized");


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Currently, for some amounts our router completely breaks in the ATOM / USDC.axl pool.

This is because the quotes are not able to complete under 6 seconds.

This PR doubles the timeout to 12 seconds.

The bottleneck has been identified in performing too many iterations of the split routing search.

By decreasing it to 10, we will only perform 10 iterations per recursive call. This dropped quote latency from ~20 seconds to ~4 seconds on my machine for the problematic hand-picked amounts cases.

While this might decrease the router efficiency, it will help us stabilize it for the time-being. We can find the perfect split after we figure out a way to optimize the current recursive algorithm.

Tested locally in my environment