### PR TITLE
Clean up max decimals for rewards formatPretty

### DIFF
--- a/packages/web/components/cards/estimated-earnings-card.tsx
+++ b/packages/web/components/cards/estimated-earnings-card.tsx
@@ -7,6 +7,7 @@ import { OsmoverseCard } from "~/components/cards/osmoverse-card";
 import { Tooltip } from "~/components/tooltip";
 import { useTranslation } from "~/hooks";
 import { useStore } from "~/stores";
+import { formatPretty } from "~/utils/formatter";
 
 const PriceCaption: FunctionComponent<{
   price: string | undefined;
@@ -48,17 +49,15 @@ export const EstimatedEarningCard: FunctionComponent<{
     new Dec(12)
   );
 
-  const prettifiedDailyAmount = perDayCalculation
-    ? new CoinPretty(osmo, perDayCalculation).moveDecimalPointRight(
-        osmo.coinDecimals
-      )
-    : "";
+  const prettifiedDailyAmount = new CoinPretty(
+    osmo,
+    perDayCalculation || new Dec(0)
+  ).moveDecimalPointRight(osmo.coinDecimals);
 
-  const prettifiedMonthlyAmount = perMonthCalculation
-    ? new CoinPretty(osmo, perMonthCalculation).moveDecimalPointRight(
-        osmo.coinDecimals
-      )
-    : "";
+  const prettifiedMonthlyAmount = new CoinPretty(
+    osmo,
+    perMonthCalculation || new Dec(0)
+  ).moveDecimalPointRight(osmo.coinDecimals);
 
   const calculatedDailyPrice = prettifiedDailyAmount
     ? priceStore.calculatePrice(prettifiedDailyAmount)
@@ -80,12 +79,16 @@ export const EstimatedEarningCard: FunctionComponent<{
           <PriceCaption
             price={calculatedDailyPrice?.toString()}
             term={t("stake.day")}
-            osmoPrice={prettifiedDailyAmount?.toString()}
+            osmoPrice={formatPretty(prettifiedDailyAmount, {
+              maxDecimals: 2,
+            })?.toString()}
           />
           <PriceCaption
             price={calculatedMonthlyPrice?.toString()}
             term={t("stake.month")}
-            osmoPrice={prettifiedMonthlyAmount?.toString()}
+            osmoPrice={formatPretty(prettifiedMonthlyAmount, {
+              maxDecimals: 2,
+            })?.toString()}
           />
         </div>
       </div>


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

- trade clipboard was congested on small desktops

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/86a0y9kb3)

## Brief Changelog

- add max dec 2 for the rewards amounts on higher numbers, this fixes the congestion on the trade card

## Testing and Verifying

<img width="1044" alt="Screenshot 2023-10-19 at 9 42 57 PM" src="https://github.com/osmosis-labs/osmosis-frontend/assets/30577966/ec044cb3-62b4-47e2-8a6a-9838e2be2f2f">
<img width="536" alt="Screenshot 2023-10-19 at 9 41 48 PM" src="https://github.com/osmosis-labs/osmosis-frontend/assets/30577966/a4136323-796a-4361-a308-063d8fc19ca3">

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
