### PR TITLE
Update Pool liquidity-24h Volume display order

### DIFF
--- a/packages/web/components/pool-detail/share.tsx
+++ b/packages/web/components/pool-detail/share.tsx
@@ -447,20 +447,20 @@ export const SharePool: FunctionComponent<{ poolId: string }> = observer(
                 <div className="flex items-center gap-10 xl:w-full xl:place-content-between lg:w-fit lg:flex-col lg:items-start lg:gap-3">
                   <div className="space-y-2">
                     <span className="body2 gap-2 text-osmoverse-400">
+                      {t("pool.liquidity")}
+                    </span>
+                    <h4 className="text-osmoverse-100">
+                      {sharePoolDetail?.totalValueLocked.toString()}
+                    </h4>
+                  </div>
+                  <div className="space-y-2">
+                    <span className="body2 gap-2 text-osmoverse-400">
                       {t("pool.24hrTradingVolume")}
                     </span>
                     <h4 className="text-osmoverse-100">
                       {queryPoolFeeMetrics
                         .getPoolFeesMetrics(poolId, priceStore)
                         .volume24h.toString()}
-                    </h4>
-                  </div>
-                  <div className="space-y-2">
-                    <span className="body2 gap-2 text-osmoverse-400">
-                      {t("pool.liquidity")}
-                    </span>
-                    <h4 className="text-osmoverse-100">
-                      {sharePoolDetail?.totalValueLocked.toString()}
                     </h4>
                   </div>
                   <div className="space-y-2">


### PR DESCRIPTION
On balancer pools, 24hr Trading Volume is shown first and Pool Liquidity next. It's vice-versa on CL pools.

This PR makes the display consistent among all pools with Pool Liquidity first and 24h Trading Volume next.

**Before:**
![image](https://github.com/osmosis-labs/osmosis-frontend/assets/116148606/92a33d63-42ab-4365-b853-4af6a3a3960f)
![image](https://github.com/osmosis-labs/osmosis-frontend/assets/116148606/2a80bc84-58ef-417d-b0ce-72361dcb7355)

**After changes (testing on localhost):**
![image](https://github.com/osmosis-labs/osmosis-frontend/assets/116148606/e43da94c-ebce-49a2-a421-ad9a7e642a8a)

