### PR TITLE
[Notifi] transaction.hash not found issue

### DIFF
--- a/packages/web/integrations/notifi/notifi-subscription-card/fetched-card/history-rows.tsx
+++ b/packages/web/integrations/notifi/notifi-subscription-card/fetched-card/history-rows.tsx
@@ -135,10 +135,11 @@ export const HistoryRow: FunctionComponent<HistoryRowProps> = ({ row }) => {
 
             if (poolEventDetailsJson?.EventData.isAssetTransfer) {
               const txHash =
-                poolEventDetailsJson?.EventData.assetTransfer?.transaction.hash;
+                poolEventDetailsJson?.EventData.assetTransfer?.transaction
+                  ?.hash;
               const blockHeight =
                 poolEventDetailsJson?.EventData.assetTransfer?.transaction
-                  .height;
+                  ?.height;
               const token =
                 poolEventDetailsJson?.EventData.assetTransfer?.denomMetadata.display?.toUpperCase() ??
                 "UNKNOWN";
@@ -216,9 +217,11 @@ export const HistoryRow: FunctionComponent<HistoryRowProps> = ({ row }) => {
             const transferEventDetailsJson = jsonDetail as
               | TransferEventDetailsJson
               | undefined;
-            const txHash = transferEventDetailsJson?.EventData.transaction.hash;
+            const txHash =
+              transferEventDetailsJson?.EventData?.transaction?.hash ??
+              transferEventDetailsJson?.EventData?.txHash;
             const blockHeight =
-              transferEventDetailsJson?.EventData.transaction.height;
+              transferEventDetailsJson?.EventData.transaction?.height;
             const token =
               transferEventDetailsJson?.EventData.denomMetadata.display.toUpperCase();
             const amount =
@@ -390,6 +393,7 @@ type TransferEventDetailsJson = {
   AlertData: Object;
   NotifiData: Object & { EventTypeId: string };
   EventData: {
+    txHash: string;
     transaction: Transaction;
     recipient: string;
     sender: string;
@@ -441,9 +445,6 @@ type Coin = {
 type Transaction = {
   hash: string;
   height: string;
-  index: number;
-  tx: string;
-  tx_result: Object;
 };
 
 type DenomMetadata = {


### PR DESCRIPTION
## Background & Problem
There was a minor interface change of notifi BE data yesterday. This causes the interface mis-match  with FE side.
<img width="348" alt="Screenshot 2023-10-20 at 23 26 46" src="https://github.com/osmosis-labs/osmosis-frontend/assets/127958634/b73a850b-6064-40cc-805f-aa339ad29eb2">


## Solution
Make fallback value to changed data interface.