### PR TITLE
Make assets table no longer sort 0-balance native assets to top

### DIFF
--- a/packages/web/components/table/assets-table-v1.tsx
+++ b/packages/web/components/table/assets-table-v1.tsx
@@ -116,33 +116,40 @@ export const AssetsTableV1: FunctionComponent<Props> = observer(
     const cells: TableCell[] = useMemo(
       () => [
         // hardcode native Osmosis assets (OSMO, ION) at the top initially
-        ...nativeBalances.map(({ balance, fiatValue }) => {
-          const value = fiatValue?.maxDecimals(2);
+        // TODO: Only do this for OSMO
+        ...nativeBalances
+          .filter(
+            ({ balance, fiatValue }) =>
+              balance.denom === "OSMO" ||
+              fiatValue?.maxDecimals(2).toDec().gt(new Dec(0))
+          )
+          .map(({ balance, fiatValue }) => {
+            const value = fiatValue?.maxDecimals(2);
 
-          return {
-            value: balance.toString(),
-            currency: balance.currency,
-            chainId: chainStore.osmosis.chainId,
-            chainName: "",
-            coinDenom: balance.denom,
-            coinImageUrl: balance.currency.coinImageUrl,
-            amount: balance
-              .hideDenom(true)
-              .trim(true)
-              .maxDecimals(6)
-              .toString(),
-            fiatValue:
-              value && value.toDec().gt(new Dec(0))
-                ? value.toString()
-                : undefined,
-            fiatValueRaw:
-              value && value.toDec().gt(new Dec(0))
-                ? value?.toDec().toString()
-                : "0",
-            isCW20: false,
-            isVerified: true,
-          };
-        }),
+            return {
+              value: balance.toString(),
+              currency: balance.currency,
+              chainId: chainStore.osmosis.chainId,
+              chainName: "",
+              coinDenom: balance.denom,
+              coinImageUrl: balance.currency.coinImageUrl,
+              amount: balance
+                .hideDenom(true)
+                .trim(true)
+                .maxDecimals(6)
+                .toString(),
+              fiatValue:
+                value && value.toDec().gt(new Dec(0))
+                  ? value.toString()
+                  : undefined,
+              fiatValueRaw:
+                value && value.toDec().gt(new Dec(0))
+                  ? value?.toDec().toString()
+                  : "0",
+              isCW20: false,
+              isVerified: true,
+            };
+          }),
         ...initialAssetsSort(
           /** If user is searching, display all balances */
           (isSearching ? unverifiedIbcBalances : ibcBalances).map(

--- a/packages/web/components/table/assets-table-v1.tsx
+++ b/packages/web/components/table/assets-table-v1.tsx
@@ -13,6 +13,7 @@ import {
   AssetCell as TableCell,
   AssetNameCell,
   BalanceCell,
+  SortableAssetCell as SortableTableCell,
   TransferButtonCell,
 } from "~/components/table/cells";
 import { TransferHistoryTable } from "~/components/table/transfer-history";
@@ -57,8 +58,6 @@ interface Props {
 }
 
 const zeroDec = new Dec(0);
-
-type SortableTableCell = TableCell & { fiatValueRaw: Dec | undefined };
 
 function mapCommonFields(
   balance: CoinPretty,

--- a/packages/web/components/table/assets-table-v2.tsx
+++ b/packages/web/components/table/assets-table-v2.tsx
@@ -185,8 +185,8 @@ export const AssetsTableV2: FunctionComponent<Props> = observer(
                     : undefined,
                 fiatValueRaw:
                   value && value.toDec().gt(new Dec(0))
-                    ? value?.toDec().toString()
-                    : "0",
+                    ? value?.toDec()
+                    : new Dec(0),
                 queryTags: [
                   ...(isCW20 ? ["CW20"] : []),
                   ...(pegMechanism ? ["stable", pegMechanism] : []),

--- a/packages/web/components/table/cells/types.ts
+++ b/packages/web/components/table/cells/types.ts
@@ -1,4 +1,5 @@
 import { Currency } from "@keplr-wallet/types";
+import { Dec } from "@keplr-wallet/unit";
 
 import { BaseCell } from "~/components/table";
 
@@ -33,3 +34,5 @@ export type AssetCell = BaseCell & {
 export interface ValidatorInfo extends BaseCell {
   imgSrc?: string;
 }
+
+export type SortableAssetCell = AssetCell & { fiatValueRaw: Dec | undefined };

--- a/packages/web/config/initial-assets-sort.ts
+++ b/packages/web/config/initial-assets-sort.ts
@@ -3,8 +3,7 @@ import { Dec } from "@keplr-wallet/unit";
 // TODO: Change this type from TBalance generic to SortableTableCell
 /** Sorts assets by positive fiat value first, then by order in config (as received). */
 export function initialAssetsSort<TBalance extends { fiatValueRaw?: Dec }>(
-  ibcBalances: TBalance[],
-  sortAboveZero?: TBalance[]
+  ibcBalances: TBalance[]
 ): TBalance[] {
   const posBals = ibcBalances.filter((b) => !b.fiatValueRaw?.isZero());
   const posBalsSorted = posBals.sort((a, b) => {
@@ -21,7 +20,6 @@ export function initialAssetsSort<TBalance extends { fiatValueRaw?: Dec }>(
 
   return [
     ...posBalsSorted,
-    ...(sortAboveZero || []),
     ...ibcBalances.filter((b) => b.fiatValueRaw?.isZero()),
   ];
 }

--- a/packages/web/config/initial-assets-sort.ts
+++ b/packages/web/config/initial-assets-sort.ts
@@ -3,7 +3,8 @@ import { Dec } from "@keplr-wallet/unit";
 // TODO: Change this type from TBalance generic to SortableTableCell
 /** Sorts assets by positive fiat value first, then by order in config (as received). */
 export function initialAssetsSort<TBalance extends { fiatValueRaw?: Dec }>(
-  ibcBalances: TBalance[]
+  ibcBalances: TBalance[],
+  sortAboveZero?: TBalance[]
 ): TBalance[] {
   const posBals = ibcBalances.filter((b) => !b.fiatValueRaw?.isZero());
   const posBalsSorted = posBals.sort((a, b) => {
@@ -20,6 +21,7 @@ export function initialAssetsSort<TBalance extends { fiatValueRaw?: Dec }>(
 
   return [
     ...posBalsSorted,
+    ...(sortAboveZero || []),
     ...ibcBalances.filter((b) => b.fiatValueRaw?.isZero()),
   ];
 }

--- a/packages/web/config/initial-assets-sort.ts
+++ b/packages/web/config/initial-assets-sort.ts
@@ -1,14 +1,15 @@
 import { Dec } from "@keplr-wallet/unit";
 
+// TODO: Change this type from TBalance generic to SortableTableCell
 /** Sorts assets by positive fiat value first, then by order in config (as received). */
-export function initialAssetsSort<TBalance extends { fiatValueRaw?: string }>(
+export function initialAssetsSort<TBalance extends { fiatValueRaw?: Dec }>(
   ibcBalances: TBalance[]
 ): TBalance[] {
-  const posBals = ibcBalances.filter((b) => b.fiatValueRaw !== "0");
+  const posBals = ibcBalances.filter((b) => !b.fiatValueRaw?.isZero());
   const posBalsSorted = posBals.sort((a, b) => {
     if (!a.fiatValueRaw || !b.fiatValueRaw) return 0;
-    const aDec = new Dec(a.fiatValueRaw);
-    const bDec = new Dec(b.fiatValueRaw);
+    const aDec = a.fiatValueRaw;
+    const bDec = b.fiatValueRaw;
     if (aDec.gt(bDec)) {
       return -1;
     } else if (aDec.lt(bDec)) {
@@ -19,6 +20,6 @@ export function initialAssetsSort<TBalance extends { fiatValueRaw?: string }>(
 
   return [
     ...posBalsSorted,
-    ...ibcBalances.filter((b) => b.fiatValueRaw === "0"),
+    ...ibcBalances.filter((b) => b.fiatValueRaw?.isZero()),
   ];
 }


### PR DESCRIPTION
I know assets v2 is coming out, but I think this is a nice win in the interrim. (It currently makes the assets page low utility for me as a user). Currently putting 0 balance osmosis native assets to the top prevents a lot of utility for me.

This PR:
- Reduces some code duplication in constructing the TableCell object
- Changes FiatValueRaw from a string to a Decimal
- Removes `isCw20` from native asset (seems like a leftover bug that it was there)
- Removes sorting 0 balance native assets to the top. Right now it puts them at the bottom which isn't ideal, but I think significantly better than now. Should get unified with however else we determine default asset sorting.
