### PR TITLE
[Notifi] denomMetadata.display not found issue

### DIFF
--- a/packages/web/integrations/notifi/notifi-subscription-card/fetched-card/history-rows.tsx
+++ b/packages/web/integrations/notifi/notifi-subscription-card/fetched-card/history-rows.tsx
@@ -141,7 +141,7 @@ export const HistoryRow: FunctionComponent<HistoryRowProps> = ({ row }) => {
                 poolEventDetailsJson?.EventData.assetTransfer?.transaction
                   ?.height;
               const token =
-                poolEventDetailsJson?.EventData.assetTransfer?.denomMetadata.display?.toUpperCase() ??
+                poolEventDetailsJson?.EventData.assetTransfer?.denomMetadata?.display?.toUpperCase() ??
                 "UNKNOWN";
               const amount =
                 poolEventDetailsJson?.EventData.assetTransfer
@@ -223,7 +223,9 @@ export const HistoryRow: FunctionComponent<HistoryRowProps> = ({ row }) => {
             const blockHeight =
               transferEventDetailsJson?.EventData.transaction?.height;
             const token =
-              transferEventDetailsJson?.EventData.denomMetadata.display.toUpperCase();
+              transferEventDetailsJson?.EventData.denomMetadata?.display?.toUpperCase() ??
+              transferEventDetailsJson?.EventData.denomFormatted?.toLowerCase() ??
+              "UNKNOWN";
             const amount =
               transferEventDetailsJson?.EventData.transferAmountFormatted;
             rowProps.title = `${t(
@@ -397,9 +399,12 @@ type TransferEventDetailsJson = {
     transaction: Transaction;
     recipient: string;
     sender: string;
-    denomMetadata: DenomMetadata;
+    // deprecated, migrated to denomFormatted
+    denomMetadata?: DenomMetadata;
+    denomFormatted?: string;
     recipientBalanceFormatted: string;
     transferAmountFormatted: string;
+    date: string;
   };
 };
 


### PR DESCRIPTION
## Background & Problem
The data filed `denomMetadata` is simplified to `denomFormatted`.
<img width="497" alt="Screenshot 2023-10-25 at 18 49 39" src="https://github.com/osmosis-labs/osmosis-frontend/assets/127958634/81516eb7-aef7-4e37-8cee-65828d9ca852">



## Solution
We need to add as fallback to `denomFormatted`