### PR TITLE
bug: Fix rATOM Chain Placement

### DIFF
--- a/packages/web/config/generate-chain-infos/source-chain-infos.ts
+++ b/packages/web/config/generate-chain-infos/source-chain-infos.ts
@@ -4250,13 +4250,6 @@ export const mainnetChainInfos: SimplifiedChainInfo[] = [
           high: 8000000000,
         },
       },
-      {
-        coinDenom: "rATOM",
-        coinMinimalDenom: "uratom",
-        coinDecimals: 6,
-        coinGeckoId: "pool:uratom",
-        coinImageUrl: "/tokens/ratom.svg",
-      },
     ],
     features: ["ibc-transfer", "ibc-go", "eth-address-gen", "eth-key-sign"],
     explorerUrlToTx: "https://explorer.genznodes.dev/realio/tx/{txHash}",


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

To fix a bug that showed rATOM as a Realio token instead of just a StafiHub token

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

## Brief Changelog

- remove rATOM under Realio in source-chain-config (and was already still under StafiHub)
<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

This change has been tested locally by rebuilding the website and verified content and links are expected
