### PR TITLE
fix: Handle Modal Overflow

### DIFF
--- a/packages/web/modals/base.tsx
+++ b/packages/web/modals/base.tsx
@@ -55,7 +55,7 @@ export const ModalBase: FunctionComponent<ModalBaseProps> = ({
         overlayClassName
       )}
       className={classNames(
-        "absolute flex w-full max-w-modal flex-col rounded-3xl bg-osmoverse-800 p-8 outline-none md:w-[98%] md:px-4",
+        "absolute flex max-h-[95vh] w-full max-w-modal flex-col overflow-auto rounded-3xl bg-osmoverse-800 p-8 outline-none md:w-[98%] md:px-4",
         className
       )}
       closeTimeoutMS={150}


### PR DESCRIPTION
Before: 
![image](https://github.com/osmosis-labs/osmosis-frontend/assets/21092519/962090e5-e1c6-4d38-b8ae-2b05da8f0f00)

After:
![image](https://github.com/osmosis-labs/osmosis-frontend/assets/21092519/7e0d0e9f-324c-44f2-85ee-5f897485befc)
