### PR TITLE
Prevent trying to withdraw nBTC with a zero balance

### DIFF
--- a/packages/web/integrations/nomic/transfer.tsx
+++ b/packages/web/integrations/nomic/transfer.tsx
@@ -181,18 +181,6 @@ const NomicTransfer: FunctionComponent<
         return;
       }
 
-      if (withdrawAmountConfig.sendCurrency.coinDenom !== "usat") {
-        displayToast(
-          {
-            message: "Invalid Withdraw Currency",
-            caption: "User does not have a nBTC balance.",
-          },
-          ToastType.ERROR
-        );
-
-        return;
-      }
-
       if (
         !validate(
           withdrawAddress,
@@ -419,6 +407,10 @@ const NomicTransfer: FunctionComponent<
                       className={classNames(
                         "transition-opacity duration-300 hover:opacity-75"
                       )}
+                      disabled={
+                        withdrawAmountConfig.sendCurrency.coinDenom.toLowerCase() !==
+                        "nbtc"
+                      }
                       onClick={withdraw}
                     >
                       {t("assets.ibcTransfer.titleWithdraw", {

--- a/packages/web/integrations/nomic/transfer.tsx
+++ b/packages/web/integrations/nomic/transfer.tsx
@@ -181,6 +181,18 @@ const NomicTransfer: FunctionComponent<
         return;
       }
 
+      if (withdrawAmountConfig.sendCurrency.coinDenom !== "usat") {
+        displayToast(
+          {
+            message: "Invalid Withdraw Currency",
+            caption: "User does not have a nBTC balance.",
+          },
+          ToastType.ERROR
+        );
+
+        return;
+      }
+
       if (
         !validate(
           withdrawAddress,


### PR DESCRIPTION
Fixes an issue where the incorrect denom was selected when the user tried to withdraw nBTC without having an nBTC balance. h/t @kamal-sutra 