### PR TITLE
Update Pool Creation fee

### DIFF
--- a/packages/web/components/complex/pool/create/index.ts
+++ b/packages/web/components/complex/pool/create/index.ts
@@ -4,4 +4,4 @@ export * from "./step2-add-liquidity";
 export * from "./step3-confirm";
 export * from "./types";
 
-export const POOL_CREATION_FEE = "1000 OSMO";
+export const POOL_CREATION_FEE = "400 OSMO";


### PR DESCRIPTION
## What is the purpose of the change

Reduced pool creation warning to 400 OSMO as per https://www.mintscan.io/osmosis/proposals/669

### ClickUp Task

N/A

## Brief Changelog
Reduced pool creation warning to 400 OSMO as per https://www.mintscan.io/osmosis/proposals/669

## Testing and Verifying

This change has not been tested locally, identical in scope to previous change https://github.com/osmosis-labs/osmosis-frontend/commit/f3ba19377e508ed292b9557cbf516f227b715bb4

## Documentation and Release Note

Does this pull request introduce a new feature or user-facing behavior changes? (yes)
- How is the feature or change documented? Will be updated in main docs
