### PR TITLE
Mattupham/stake amount input 0 issue and overflow fixes

### DIFF
--- a/packages/web/components/cards/estimated-earnings-card.tsx
+++ b/packages/web/components/cards/estimated-earnings-card.tsx
@@ -14,12 +14,13 @@ const PriceCaption: FunctionComponent<{
   term: string;
   osmoPrice: string | undefined;
 }> = ({ price, term, osmoPrice }) => (
-  <span className="caption flex flex-grow flex-col text-sm text-osmoverse-200 md:text-xs">
+  <span className="caption flex flex-grow flex-col overflow-hidden text-sm text-osmoverse-200 md:text-xs">
     <div>
-      <span className="text-base text-white-full">{price}</span>&nbsp;/{term}
+      <span className="truncate text-base text-white-full">{price}</span>&nbsp;/
+      {term}
     </div>
     <div className="mt-2 text-xs">
-      <span>{osmoPrice || "0 OSMO"}</span>/{term}
+      <span className="truncate">{osmoPrice || "0 OSMO"}</span>/{term}
     </div>
   </span>
 );
@@ -75,7 +76,7 @@ export const EstimatedEarningCard: FunctionComponent<{
             <Icon id="info" height="14px" width="14px" fill="#958FC0" />
           </Tooltip>
         </span>
-        <div className="mt-5 mb-2 flex items-center">
+        <div className="mt-5 mb-2 flex items-center gap-2">
           <PriceCaption
             price={calculatedDailyPrice?.toString()}
             term={t("stake.day")}

--- a/packages/web/components/cards/stake-info-card.tsx
+++ b/packages/web/components/cards/stake-info-card.tsx
@@ -6,8 +6,7 @@ import React, { FunctionComponent, useCallback } from "react";
 
 import { Button } from "~/components/buttons";
 import { OsmoverseCard } from "~/components/cards/osmoverse-card";
-import { useTranslation } from "~/hooks";
-import { useWindowSize } from "~/hooks";
+import { useTranslation, useWindowSize } from "~/hooks";
 import { useStore } from "~/stores";
 import { formatPretty } from "~/utils/formatter";
 
@@ -32,7 +31,7 @@ export const StakeInfoCard: FunctionComponent<{
     isHalf = false,
   }) => {
     const { t } = useTranslation();
-    const isMobile = useWindowSize();
+    const { isMobile } = useWindowSize();
 
     const { chainStore, priceStore } = useStore();
     const osmo = chainStore.osmosis.stakeCurrency;
@@ -53,10 +52,18 @@ export const StakeInfoCard: FunctionComponent<{
     const handleInputChange = useCallback(
       (e: React.ChangeEvent<HTMLInputElement>) => {
         e.preventDefault();
-        const { value } = e.target;
-        setInputAmount(value);
+
+        if (
+          !isNaN(Number(e.target.value)) &&
+          Number(e.target.value) >= 0 &&
+          Number(e.target.value) <= Number.MAX_SAFE_INTEGER &&
+          e.target.value.length <= (isMobile ? 19 : 26)
+        ) {
+          const { value } = e.target;
+          setInputAmount(value);
+        }
       },
-      [setInputAmount]
+      [setInputAmount, isMobile]
     );
 
     const formattedAvailableAmount = formatPretty(
@@ -111,12 +118,13 @@ export const StakeInfoCard: FunctionComponent<{
             </h6>
             <span className="caption w-fit text-osmoverse-400">Osmosis</span>
           </div>
-          <div className="flex-end flex w-full flex-grow flex-col place-content-around items-center text-right">
+          <div className="flex-end flex w-full flex-grow flex-col place-content-around items-center overflow-hidden text-right">
             <input
               type="number"
               className={classNames(
                 "placeholder:text-white w-full bg-transparent text-right text-white-full focus:outline-none md:text-subtitle1",
-                "text-h5 font-h5 md:font-subtitle1"
+                "text-h5 font-h5 md:font-subtitle1",
+                "overflow-hidden"
               )}
               placeholder="0"
               onChange={handleInputChange}
@@ -124,7 +132,7 @@ export const StakeInfoCard: FunctionComponent<{
             />
             <h5
               className={classNames(
-                "w-full text-right text-osmoverse-300 transition-opacity md:text-h6 md:font-h6",
+                "w-full truncate text-right text-osmoverse-300 transition-opacity md:text-h6 md:font-h6",
                 outAmountValue ? "opacity-100" : "opacity-50"
               )}
             >


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

- there are some overflow issues with the stake input, as well as the 0 number in the input will get stuck if you place your cursor before / after it and type

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/86a1btwft)
[ClickUp Task URL](https://app.clickup.com/t/86a17cptp)

## Brief Changelog

- fix clipboard overflow issue
- add max digits to stake clipboard (similar to trade clipboard)
- fix overflow issues for PriceCaption / estimations

## Testing and Verifying


https://github.com/osmosis-labs/osmosis-frontend/assets/30577966/4a010d84-e488-44dd-a9f7-a84a6cc66a1a

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
