### PR TITLE
chore: mergify backport to master configuration

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,15 @@
+defaults:
+  actions:
+    backport:
+      assignees:
+        - "{{ author }}"
+
+pull_request_rules:
+  - name: backport patches to master branch
+    conditions:
+      - base=main
+      - label=A:backport/master
+    actions:
+      backport:
+        branches:
+          - master


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

This is a convenient configuration for we need to backport individual PRs from stage to master without publishing all updates.

In such a case, the label "A:backport/master" can be applied to PR. Upon application, mergify opens a new PR against `master`.

This is useful for emergencies when there are a lot of updates on stage but we want to merge an individual fix
