### PR TITLE
feat: Use Commit Hash to Generate Asset Lists

### DIFF
--- a/packages/web/.env
+++ b/packages/web/.env
@@ -16,6 +16,7 @@
 # NEXT_PUBLIC_WALLETCONNECT_RELAY_URL=wss://relay.walletconnect.com
 # NEXT_PUBLIC_TIMESERIES_DATA_URL=https://api-osmosis.imperator.co
 # NEXT_PUBLIC_INDEXER_DATA_URL=https://api-osmosis-chain.imperator.co
+# NEXT_PUBLIC_SQUID_INTEGRATOR_ID=""
 
 # Twitter api config, it's only used on server
 # TWITTER_API_URL=https://api.twitter.com/2/
@@ -26,4 +27,4 @@
 # Github Raw API
 # GITHUB_URL=https://raw.githubusercontent.com/osmosis-labs/
 # CMS_REPOSITORY_PATH=token-info/main/contents
-# NEXT_PUBLIC_SQUID_INTEGRATOR_ID=""
+# ASSET_LIST_COMMIT_HASH=

--- a/packages/web/config/env.ts
+++ b/packages/web/config/env.ts
@@ -28,3 +28,5 @@ export const TWITTER_API_ACCESS_TOKEN = process.env.TWITTER_API_ACCESS_TOKEN;
 export const TWITTER_PUBLIC_URL = "https://x.com";
 
 export const COINGECKO_PUBLIC_URL = "https://www.coingecko.com";
+
+export const ASSET_LIST_COMMIT_HASH = process.env.ASSET_LIST_COMMIT_HASH;

--- a/packages/web/config/ibc-overrides.ts
+++ b/packages/web/config/ibc-overrides.ts
@@ -178,7 +178,7 @@ const MainnetIBCAdditionalData: Partial<
       sourceChainTokens: [AxelarSourceChainTokenConfigs.busd.ethereum],
     },
   },
-  axlFIL: {
+  FIL: {
     sourceChainNameOverride: "Filecoin",
     originBridgeInfo: {
       bridge: "axelar" as const,

--- a/packages/web/server/queries/github/index.ts
+++ b/packages/web/server/queries/github/index.ts
@@ -1,3 +1,4 @@
 export * from "./query-github-file";
+export * from "./query-latest-commit-hash";
 
 export const GITHUB_RAW_DEFAULT_BASEURL = "https://raw.githubusercontent.com";

--- a/packages/web/server/queries/github/query-latest-commit-hash.ts
+++ b/packages/web/server/queries/github/query-latest-commit-hash.ts
@@ -1,0 +1,13 @@
+import { apiClient } from "~/utils/api-client";
+
+export async function queryLatestCommitHash({
+  repo,
+  branch = "main",
+}: {
+  repo: string;
+  branch?: string;
+}): Promise<string> {
+  const url = `https://api.github.com/repos/${repo}/commits/${branch}`;
+  const response = await apiClient<{ sha: string }>(url);
+  return response.sha;
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Use commit hash to generate asset lists to avoid waiting for GitHub's CDN to refresh its cache.

## Testing

- [ ] Assets and chains should load like production