### PR TITLE
fix: Stage Build (Asset Mismatch)

### DIFF
--- a/packages/web/config/ibc-overrides.ts
+++ b/packages/web/config/ibc-overrides.ts
@@ -395,7 +395,7 @@ const MainnetIBCAdditionalData: Partial<
       sourceChainTokens: [AxelarSourceChainTokenConfigs.xcn.ethereum],
     },
   },
-  Bonk: {
+  BONK: {
     depositUrlOverride: "https://portalbridge.com/cosmos/",
     withdrawUrlOverride: "https://portalbridge.com/cosmos/",
   },


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Asset list changed `Bonk` symbol. This broke our build because it failed to pass the verification for IBC overrides available assets.
