### PR TITLE
fix: $QWOYN Price

### DIFF
--- a/packages/web/config/price.ts
+++ b/packages/web/config/price.ts
@@ -2380,8 +2380,11 @@ const mainnetPoolPriceRoutes: IntermediateRoute[] = [
       [{ portId: "transfer", channelId: "channel-880" }],
       "uqwoyn"
     ),
-    spotPriceDestDenom: "uosmo",
-    destCoinId: "pool:uosmo",
+    spotPriceDestDenom: DenomHelper.ibcDenom(
+      [{ portId: "transfer", channelId: "channel-208" }],
+      "uusdc"
+    ),
+    destCoinId: "usd-coin",
   },
 ];
 

--- a/packages/web/config/price.ts
+++ b/packages/web/config/price.ts
@@ -2375,7 +2375,7 @@ const mainnetPoolPriceRoutes: IntermediateRoute[] = [
   },
   {
     alternativeCoinId: "pool:uqwoyn",
-    poolId: "1291",
+    poolId: "1295",
     spotPriceSourceDenom: DenomHelper.ibcDenom(
       [{ portId: "transfer", channelId: "channel-880" }],
       "uqwoyn"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

To fix the pricing for QWOYN. The last PR to define its price was not validated. It was configured to look for osmo as the destCoin, when it's really in a USDC.axl pool.

They also made a new pool 1295

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->


## Brief Changelog

- update qwoyn in price.ts to have dest coin of usdc.axl instead of OSMO, and switched from 1291 to 1295

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying


This change has been tested locally by rebuilding the website and verified content and links are expected

Validation successful