### PR TITLE
feat: Open Create Position When Query Param is Present

### DIFF
--- a/packages/web/components/pool-detail/concentrated.tsx
+++ b/packages/web/components/pool-detail/concentrated.tsx
@@ -27,6 +27,7 @@ import { useStore } from "~/stores";
 import { ObservableHistoricalAndLiquidityData } from "~/stores/derived-data";
 import { formatPretty } from "~/utils/formatter";
 import { getNumberMagnitude } from "~/utils/number";
+import { removeQueryParam } from "~/utils/url";
 
 const ConcentratedLiquidityDepthChart = dynamic(
   () => import("~/components/chart/concentrated-liquidity-depth"),
@@ -166,6 +167,7 @@ export const ConcentratedLiquidityPool: FunctionComponent<{ poolId: string }> =
     useEffect(() => {
       if (openCreatePosition === "true") {
         setActiveModal("add-liquidity");
+        removeQueryParam(OpenCreatePositionSearchParam);
       }
     }, [openCreatePosition]);
 

--- a/packages/web/components/pool-detail/concentrated.tsx
+++ b/packages/web/components/pool-detail/concentrated.tsx
@@ -3,7 +3,9 @@ import classNames from "classnames";
 import { observer } from "mobx-react-lite";
 import dynamic from "next/dynamic";
 import Image from "next/image";
+import { useEffect } from "react";
 import { FunctionComponent, useState } from "react";
+import { useSearchParam } from "react-use";
 
 import { Icon, PoolAssetsIcon, PoolAssetsName } from "~/components/assets";
 import { Button } from "~/components/buttons";
@@ -35,6 +37,8 @@ const TokenPairHistoricalChart = dynamic(
   { ssr: false }
 );
 
+const OpenCreatePositionSearchParam = "open_create_position";
+
 export const ConcentratedLiquidityPool: FunctionComponent<{ poolId: string }> =
   observer(({ poolId }) => {
     const {
@@ -45,9 +49,11 @@ export const ConcentratedLiquidityPool: FunctionComponent<{ poolId: string }> =
       accountStore,
       derivedDataStore,
     } = useStore();
+    const { t } = useTranslation();
+    const openCreatePosition = useSearchParam(OpenCreatePositionSearchParam);
+
     const { chainId } = chainStore.osmosis;
     const chartConfig = useHistoricalAndLiquidityData(chainId, poolId);
-    const { t } = useTranslation();
     const [activeModal, setActiveModal] = useState<
       "add-liquidity" | "learn-more" | null
     >(null);
@@ -156,6 +162,12 @@ export const ConcentratedLiquidityPool: FunctionComponent<{ poolId: string }> =
         )
         .catch(console.error);
     };
+
+    useEffect(() => {
+      if (openCreatePosition === "true") {
+        setActiveModal("add-liquidity");
+      }
+    }, [openCreatePosition]);
 
     return (
       <main className="m-auto flex min-h-screen max-w-container flex-col gap-8 bg-osmoverse-900 px-8 py-4 md:gap-4 md:p-4">


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Open the CL create position modal with the `open_create_position` query parameter. URLs will look like the following: `https://app.osmosis.zone/pool/1267?open_create_position=true`.

## Testing and Verifying

- [ ] Should open create position modal when passing `?open_create_position=true` to the URL
