### PR TITLE
fix: Remove Dollar Sign from Explorer URL

### DIFF
--- a/packages/web/config/asset-list/__tests__/asset-lists.ts
+++ b/packages/web/config/asset-list/__tests__/asset-lists.ts
@@ -199,7 +199,7 @@ describe("getKeplrCompatibleChain", () => {
             "type": undefined,
           },
         ],
-        "explorerUrlToTx": "https://www.mintscan.io/cosmos/txs/\${txHash}",
+        "explorerUrlToTx": "https://www.mintscan.io/cosmos/txs/{txHash}",
         "features": [
           "ibc-go",
           "ibc-transfer",
@@ -800,7 +800,7 @@ describe("getKeplrCompatibleChain", () => {
             "type": undefined,
           },
         ],
-        "explorerUrlToTx": "https://www.mintscan.io/juno/txs/\${txHash}",
+        "explorerUrlToTx": "https://www.mintscan.io/juno/txs/{txHash}",
         "features": [
           "ibc-transfer",
           "ibc-go",
@@ -884,7 +884,7 @@ describe("getKeplrCompatibleChain", () => {
             "type": undefined,
           },
         ],
-        "explorerUrlToTx": "https://explorer.injective.network/transaction/\${txHash}",
+        "explorerUrlToTx": "https://explorer.injective.network/transaction/{txHash}",
         "features": [
           "ibc-transfer",
           "ibc-go",
@@ -1064,7 +1064,7 @@ describe("getKeplrCompatibleChain", () => {
             "type": "secret20",
           },
         ],
-        "explorerUrlToTx": "https://secretnodes.com/secret/chains/secret-4/transactions/\${txHash}",
+        "explorerUrlToTx": "https://secretnodes.com/secret/chains/secret-4/transactions/{txHash}",
         "features": [
           "ibc-transfer",
           "ibc-go",
@@ -1533,7 +1533,7 @@ describe("getKeplrCompatibleChain", () => {
             "type": undefined,
           },
         ],
-        "explorerUrlToTx": "https://axelarscan.io/tx/\${txHash}",
+        "explorerUrlToTx": "https://axelarscan.io/tx/{txHash}",
         "features": [
           "ibc-transfer",
           "ibc-go",

--- a/packages/web/config/asset-list/utils.ts
+++ b/packages/web/config/asset-list/utils.ts
@@ -358,7 +358,7 @@ export function getKeplrCompatibleChain({
       return acc;
     }, []),
     bech32Config: chain.bech32_config,
-    explorerUrlToTx: chain.explorers[0].tx_page,
+    explorerUrlToTx: chain.explorers[0].tx_page.replace("${", "{"),
     features: chain.features,
   };
 }
@@ -410,6 +410,10 @@ export function getChainList({
                 ? [{ address: OSMOSIS_REST_OVERWRITE }]
                 : chain.apis.rest,
           },
+          explorers: chain.explorers.map((explorer) => ({
+            ...explorer,
+            tx_page: explorer.tx_page.replace("${", "{"),
+          })),
           keplrChain,
         };
       }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Match our explorer URL with the previous chain info URL syntax by removing the dollar sign coming from the chain registry.

## Testing and Verifying

- [ ] Explorer URLs should work after transactions