### PR TITLE
feat: Add market cap fallback for details page

### DIFF
--- a/packages/stores/src/queries-external/coingecko-coin-infos/index.ts
+++ b/packages/stores/src/queries-external/coingecko-coin-infos/index.ts
@@ -12,6 +12,9 @@ type Response = {
     total_value_locked: {
       usd: number;
     };
+    market_cap: {
+      usd: number;
+    };
   };
 };
 
@@ -91,6 +94,28 @@ export class ObservableQueryCoingeckoCoinInfos extends ObservableQueryExternalBa
 
       const totalValueLocked =
         this.response.data.market_data.total_value_locked.usd;
+      if (isNaN(totalValueLocked)) return;
+      return totalValueLocked;
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * It return the market cap of the current token.
+   *
+   * @returns If the asset exists, and so does this information, it returns its Market cap in dollars.
+   */
+  @computed
+  get marketCap(): number | undefined {
+    try {
+      if (
+        !this.response ||
+        typeof this.response.data?.market_data.market_cap.usd !== "number"
+      )
+        return;
+
+      const totalValueLocked = this.response.data.market_data.market_cap.usd;
       if (isNaN(totalValueLocked)) return;
       return totalValueLocked;
     } catch {

--- a/packages/web/components/token-details/token-details.tsx
+++ b/packages/web/components/token-details/token-details.tsx
@@ -84,7 +84,9 @@ const TokenDetails = ({
   const marketCapRank = coingeckoCoinInfo?.marketCapRank;
   const totalValueLocked = coingeckoCoinInfo?.totalValueLocked;
   const circulatingSupply = coingeckoCoinInfo?.circulatingSupply;
-  const marketCap = queriesExternalStore.queryMarketCaps.get(denom);
+  const marketCap =
+    queriesExternalStore.queryMarketCaps.get(denom) ??
+    coingeckoCoinInfo?.marketCap;
 
   const toggleExpand = () => {
     logEvent([EventName.TokenInfo.viewMoreClicked, { tokenName: denom }]);


### PR DESCRIPTION
added markecap fallback inside details page.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

### ClickUp Task

[ClickUp Task URL](PASTE_CLICKUP_TASK_URL_HERE)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
