### PR TITLE
Switch USDC.axl to USDC on Swap widget

### DIFF
--- a/packages/web/config/feature-flag.ts
+++ b/packages/web/config/feature-flag.ts
@@ -52,7 +52,7 @@ export const TransmuterPoolCodeIds = IS_TESTNET ? ["3084"] : ["148"];
 
 export const RecommendedSwapDenoms = [
   "OSMO",
-  "USDC.axl",
+  "USDC",
   "USDT",
   "ATOM",
   "TIA",


### PR DESCRIPTION
## What is the purpose of the change

With CCTP launching and USDC liquidity overtaking USDC.axl on Osmosis we should switch this recommended asset to USDC via Noble.

### ClickUp Task

N/A

## Brief Changelog

Changes USDC.axl on swap page to USDC

## Testing and Verifying

This change has not been tested locally

## Documentation and Release Note

- Does this pull request introduce a new feature or user-facing behavior changes? Yes
- How is the feature or change documented? (not documented)
No documentation for changing highlighted swap assets.
