### PR TITLE
fix: Missing Generated Images

### DIFF
--- a/packages/web/.gitignore
+++ b/packages/web/.gitignore
@@ -41,3 +41,4 @@ yarn-error.log*
 
 # config files
 generated
+generated-test

--- a/packages/web/.gitignore
+++ b/packages/web/.gitignore
@@ -41,4 +41,3 @@ yarn-error.log*
 
 # config files
 generated
-generated-test

--- a/packages/web/components/table/assets-table-v1.tsx
+++ b/packages/web/components/table/assets-table-v1.tsx
@@ -1,6 +1,7 @@
 import { CoinPretty, Dec, PricePretty } from "@keplr-wallet/unit";
 import { getAssetFromAssetList } from "@osmosis-labs/utils";
 import { observer } from "mobx-react-lite";
+import Image from "next/image";
 import Link from "next/link";
 import { FunctionComponent, useCallback, useMemo, useState } from "react";
 
@@ -576,7 +577,7 @@ export const AssetsTableV1: FunctionComponent<Props> = observer(
                 <div className="flex items-center gap-2">
                   {assetData.coinImageUrl && (
                     <div className="flex w-10 shrink-0 items-center">
-                      <img
+                      <Image
                         alt="token icon"
                         src={assetData.coinImageUrl}
                         height={40}

--- a/packages/web/components/table/cells/asset-name.tsx
+++ b/packages/web/components/table/cells/asset-name.tsx
@@ -62,12 +62,11 @@ export const AssetNameCell: FunctionComponent<Partial<Cell>> = observer(
           <div className="flex items-center gap-4">
             <div>
               {coinImageUrl && (
-                <img
+                <Image
                   alt={coinDenom}
                   src={coinImageUrl}
                   height={40}
                   width={40}
-                  loading="lazy"
                 />
               )}
             </div>

--- a/packages/web/config/asset-list/utils.ts
+++ b/packages/web/config/asset-list/utils.ts
@@ -60,7 +60,7 @@ function findMinDenomAndDecimals({
   return { minimalDenom, displayDecimals };
 }
 
-const tokensDir = "/tokens/generated-test";
+const tokensDir = "/tokens/generated";
 export function getImageRelativeFilePath(imageUrl: string, symbol: string) {
   const urlParts = imageUrl.split("/");
   const fileNameSplit = urlParts[urlParts.length - 1].split(".");

--- a/packages/web/config/asset-list/utils.ts
+++ b/packages/web/config/asset-list/utils.ts
@@ -60,7 +60,7 @@ function findMinDenomAndDecimals({
   return { minimalDenom, displayDecimals };
 }
 
-const tokensDir = "/tokens/generated";
+const tokensDir = "/tokens/generated-test";
 export function getImageRelativeFilePath(imageUrl: string, symbol: string) {
   const urlParts = imageUrl.split("/");
   const fileNameSplit = urlParts[urlParts.length - 1].split(".");
@@ -108,6 +108,12 @@ export async function downloadAndSaveImage(
     );
   }
 
+  if (!response.body) {
+    throw new Error(
+      `Failed to fetch image from ${imageUrl}: ${response.statusText}`
+    );
+  }
+
   // Save the image to the file system.
   const fileStream = fs.createWriteStream(filePath, { flags: "w" });
   await finished(
@@ -115,6 +121,11 @@ export async function downloadAndSaveImage(
       response.body as import("stream/web").ReadableStream<any>
     ).pipe(fileStream)
   );
+
+  // verify the image has been added
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Failed to save image to ${filePath}`);
+  }
 
   const splitPath = filePath.split("/");
   return splitPath[splitPath.length - 1];
@@ -234,7 +245,6 @@ export function getKeplrCompatibleChain({
         }
 
         acc.push({
-          // @ts-ignore
           type,
           coinDenom: asset.symbol,
           /**
@@ -331,7 +341,6 @@ export function getKeplrCompatibleChain({
       }
 
       acc.push({
-        // @ts-ignore
         type,
         coinDenom: asset.symbol,
         /**

--- a/packages/web/pages/assets/[denom].tsx
+++ b/packages/web/pages/assets/[denom].tsx
@@ -622,9 +622,7 @@ export const getStaticProps: GetStaticProps<AssetInfoPageProps> = async ({
               const res = await getTokenInfo(tokenDenom, lang.value);
 
               return [lang.value, res];
-            } catch (error) {
-              console.error(error);
-            }
+            } catch (error) {}
 
             return [lang.value, null];
           })

--- a/turbo.json
+++ b/turbo.json
@@ -8,7 +8,8 @@
         "!.next/cache/**",
         "src/codegen/**",
         "scripts/generated/**",
-        "config/generated/**"
+        "config/generated/**",
+        "public/tokens/generated-test/**"
       ],
       "dependsOn": ["^build"]
     },

--- a/turbo.json
+++ b/turbo.json
@@ -9,7 +9,7 @@
         "src/codegen/**",
         "scripts/generated/**",
         "config/generated/**",
-        "public/tokens/generated-test/**"
+        "public/tokens/generated/**"
       ],
       "dependsOn": ["^build"]
     },


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Fixes missing generated images by including the generated token images folder on Turbo Output. So that whenever Vercel tries to use the cache, the images are available. 

