### PR TITLE
fix: transmuter is not being picked up in router

### DIFF
--- a/packages/pools/src/router/routes.ts
+++ b/packages/pools/src/router/routes.ts
@@ -194,19 +194,27 @@ export class OptimizedRoutes implements TokenOutGivenInRouter {
     }, [] as Route[]);
 
     // prioritize (pick) routes by preference
+
+    // Maintain order of preferred routes.
+    const preferredRoutes: Route[] = [];
+    // Maintain order of non-preferred routes.
+    const nonPreferredRoutes: Route[] = [];
     if (this._preferredPoolIds && this._preferredPoolIds.length > 0) {
       routes = routes.reduce((routes, route) => {
         if (
           this._preferredPoolIds &&
           route.pools.some((pool) => this._preferredPoolIds?.includes(pool.id))
         ) {
-          routes.unshift(route);
+          preferredRoutes.push(route);
         } else {
-          routes.push(route);
+          nonPreferredRoutes.push(route);
         }
         return routes;
       }, [] as Route[]);
     }
+
+    // Preferred routes first, then non-preferred routes.
+    routes = [...preferredRoutes, ...nonPreferredRoutes];
 
     this._logger?.info(
       "Candidate routes",

--- a/packages/pools/src/router/routes.ts
+++ b/packages/pools/src/router/routes.ts
@@ -194,13 +194,13 @@ export class OptimizedRoutes implements TokenOutGivenInRouter {
     }, [] as Route[]);
 
     // prioritize (pick) routes by preference
-
-    // Maintain order of preferred routes.
-    const preferredRoutes: Route[] = [];
-    // Maintain order of non-preferred routes.
-    const nonPreferredRoutes: Route[] = [];
     if (this._preferredPoolIds && this._preferredPoolIds.length > 0) {
-      routes = routes.reduce((routes, route) => {
+      // Maintain order of preferred routes.
+      const preferredRoutes: Route[] = [];
+      // Maintain order of non-preferred routes.
+      const nonPreferredRoutes: Route[] = [];
+
+      routes.forEach((route) => {
         if (
           this._preferredPoolIds &&
           route.pools.some((pool) => this._preferredPoolIds?.includes(pool.id))
@@ -209,12 +209,11 @@ export class OptimizedRoutes implements TokenOutGivenInRouter {
         } else {
           nonPreferredRoutes.push(route);
         }
-        return routes;
-      }, [] as Route[]);
-    }
+      });
 
-    // Preferred routes first, then non-preferred routes.
-    routes = [...preferredRoutes, ...nonPreferredRoutes];
+      // Preferred routes first, then non-preferred routes.
+      routes = [...preferredRoutes, ...nonPreferredRoutes];
+    }
 
     this._logger?.info(
       "Candidate routes",


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Transmuter is currently not being picked up in the router:
https://app.osmosis.zone/?from=USDC.axl&to=USDC

The bug stems from the fact that we change the order of pools with the `unshift` call while validating preferred pools. As a result, all the preferred pools end up getting reversed in terms of the order. Eventually, due to the max split parameter, tranmsuter ends up being filtered out.

The solution is to maintain two arrays:
1. Preferred pool array that maintains the original order where transmuter is most preferred
2. Non-preferred pools

Then, merge the two arrays into 1 while preserving the order.

## Testing and Verifying

Tested locally.

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
