### PR TITLE
fix: Fixed #2481 Pool number in Pool Search issue

### DIFF
--- a/packages/web/components/complex/all-pools-table.tsx
+++ b/packages/web/components/complex/all-pools-table.tsx
@@ -73,7 +73,7 @@ export type Pool = [
 ];
 
 const searchPoolsMemoedKeys = [
-  "pool.id",
+  "queryPool.id",
   "poolName",
   "networkNames",
   "pool.poolAssets.amount.currency.originCurrency.pegMechanism",
@@ -301,7 +301,9 @@ export const AllPoolsTable: FunctionComponent<{
     );
     const setQuery = useCallback(
       (search: string) => {
-        if (search === "") {
+        const sanitizedSearch = search.replace(/#/g, '');
+    
+        if (sanitizedSearch === "") {
           setIsSearching(false);
         } else {
           queriesOsmosis.queryPools.fetchRemainingPools({
@@ -310,7 +312,7 @@ export const AllPoolsTable: FunctionComponent<{
           setIsSearching(true);
         }
         setSorting([]);
-        _setQuery(search);
+        _setQuery(sanitizedSearch);
       },
       [_setQuery, queriesOsmosis.queryPools, setSorting]
     );


### PR DESCRIPTION
## What is the purpose of the change

This pull request improves the pool search functionality by allowing users to search for pools using their ID with or without the '#' sign.

## Brief Changelog

- Implemented pool ID search functionality
- Made the input field ignore the '#' sign

## Testing and Verifying

This change has been tested locally by rebuilding the website and verified that the pool search functionality works as expected with or without the '#' sign in the input.

## Documentation and Release Note

- Does this pull request introduce a new feature or user-facing behavior changes? Yes