### PR TITLE
Fix generate protos: fetch tags after sparse clone

### DIFF
--- a/packages/proto-codecs/scripts/get-proto.sh
+++ b/packages/proto-codecs/scripts/get-proto.sh
@@ -14,85 +14,59 @@ mkdir -p "$PROTO_DIR"
 
 # OSMOSIS PROTOS
 
-# If the osmosis repo is there, fetch, otherwise clone sparse
-if [ -d ".repos/osmosis/.git" ]; then
-  git -C .repos/osmosis fetch --all --tags
-  git -C .repos/osmosis checkout $OSMOSIS_COMMIT_HASH
-  git -C .repos/osmosis pull origin $OSMOSIS_COMMIT_HASH
-else
-  git clone --filter=blob:none --sparse https://github.com/osmosis-labs/osmosis.git .repos/osmosis
+git clone --filter=blob:none --sparse https://github.com/osmosis-labs/osmosis.git .repos/osmosis
 
-  # Checkout to Osmosis hash commit
-  git -C .repos/osmosis sparse-checkout set proto
-  git -C .repos/osmosis checkout $OSMOSIS_COMMIT_HASH
-fi
+# Checkout to Osmosis hash commit
+git -C .repos/osmosis sparse-checkout set proto
+git fetch --all --tags
+git -C .repos/osmosis checkout $OSMOSIS_COMMIT_HASH
+
 
 # SDK PROTOS
 COSMOS_SDK_VERSION=$(awk '/github.com\/cosmos\/cosmos-sdk/ {print $2}' .repos/osmosis/go.mod | tr -d '=> ')
 
-# If the cosmos-sdk repo is there, fetch, otherwise clone sparse
-if [ -d ".repos/cosmos-sdk/.git" ]; then
-  git -C .repos/cosmos-sdk fetch --all --tags
-  git -C .repos/cosmos-sdk checkout $COSMOS_SDK_VERSION
-  git -C .repos/cosmos-sdk pull origin $COSMOS_SDK_VERSION
-else
-  git clone --filter=blob:none --sparse https://github.com/cosmos/cosmos-sdk.git .repos/cosmos-sdk
+git clone --filter=blob:none --sparse https://github.com/cosmos/cosmos-sdk.git .repos/cosmos-sdk
 
-  # Checkout to Cosmos hash commit
-  git -C .repos/cosmos-sdk sparse-checkout set proto
-  git -C .repos/cosmos-sdk checkout $COSMOS_SDK_VERSION  
-fi
+# Checkout to Cosmos hash commit
+git -C .repos/cosmos-sdk sparse-checkout set proto
+git fetch --all --tags
+git -C .repos/cosmos-sdk checkout $COSMOS_SDK_VERSION  
+
 
 # IBC PROTOS
 
 IBC_GO_VERSION=$(awk '/github.com\/cosmos\/ibc-go/ {print $2}' .repos/osmosis/go.mod)
 
-# If the ibc-go repo is there, fetch, otherwise clone sparse
-if [ -d ".repos/ibc-go/.git" ]; then
-  git -C .repos/ibc-go fetch --all --tags
-  git -C .repos/ibc-go checkout $IBC_GO_VERSION
-  git -C .repos/ibc-go pull origin $IBC_GO_VERSION
-else
-  git clone --filter=blob:none --sparse https://github.com/cosmos/ibc-go.git .repos/ibc-go
+git clone --filter=blob:none --sparse https://github.com/cosmos/ibc-go.git .repos/ibc-go
 
-  # Checkout to IBC hash commit
-  git -C .repos/ibc-go sparse-checkout set proto
-  git -C .repos/ibc-go checkout $IBC_GO_VERSION
-fi
+# Checkout to IBC hash commit
+git -C .repos/ibc-go sparse-checkout set proto
+git fetch --all --tags
+git -C .repos/ibc-go checkout $IBC_GO_VERSION
+
 
 # WASMD PROTOS
 
 # Extract the Wasmd version from the go.mod file
 WASMD_VERSION=$(awk '/github.com\/osmosis-labs\/wasmd/ {print $4}' .repos/osmosis/go.mod)
-# Clone or update the wasmd repo (osmosis-labs fork)
-# If the wasmd repo is there, fetch, otherwise clone sparse
-if [ -d ".repos/wasmd/.git" ]; then
-  git -C .repos/wasmd fetch --all --tags
-  git -C .repos/wasmd checkout $WASMD_VERSION
-  git -C .repos/wasmd pull origin $WASMD_VERSION
-else
-  git clone --filter=blob:none --sparse https://github.com/osmosis-labs/wasmd.git .repos/wasmd
 
-  # Checkout to IBC hash commit
-  git -C .repos/wasmd sparse-checkout set proto
-  git -C .repos/wasmd checkout $WASMD_VERSION
-fi
+
+
+git clone --filter=blob:none --sparse https://github.com/osmosis-labs/wasmd.git .repos/wasmd
+
+# Checkout to IBC hash commit
+git -C .repos/wasmd sparse-checkout set proto
+git fetch --all --tags
+git -C .repos/wasmd checkout $WASMD_VERSION
 
 # ICS23 PROTOS
 
-# If the ibc-go repo is there, fetch, otherwise clone sparse
-if [ -d ".repos/ics23/.git" ]; then
-  git -C .repos/ics23 fetch --all --tags
-  git -C .repos/ics23 checkout $ICS23_COMMIT_HASH
-  git -C .repos/ics23 pull origin $ICS23_COMMIT_HASH
-else
-  git clone --filter=blob:none --sparse https://github.com/cosmos/ics23.git .repos/ics23
+git clone --filter=blob:none --sparse https://github.com/cosmos/ics23.git .repos/ics23
 
-  # Checkout to IBC hash commit
-  git -C .repos/ics23 checkout $ICS23_COMMIT_HASH
-
-  git -C .repos/ics23 sparse-checkout set proto
-fi
+# Checkout to IBC hash commit
+git -C .repos/ics23 sparse-checkout set proto
+git fetch --all --tags
+git -C .repos/ics23 checkout $ICS23_COMMIT_HASH
 
 # Remove query.proto files from the repos
 find .repos -type f -name "query.proto" -exec rm -f {} \;


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

Previously the script would immediately try to checkout after a sparse clone. I believe if the checkout was a tag that didn't include changes in the sparse cloned files, it would not be found. Now, I fetch all refs (including tags) before checkout.

Also, I removed the git pull/fetch if the repos already exist since they all get deleted anyways in the beginning of the script. Since it only takes around 60s I think it's safer to clone every time.