### PR TITLE
Prevent showing unverified modal

### DIFF
--- a/packages/web/components/drawers/token-select-drawer.tsx
+++ b/packages/web/components/drawers/token-select-drawer.tsx
@@ -109,12 +109,16 @@ export const TokenSelectDrawer: FunctionComponent<{
     };
 
     const onClickCoin = (coinDenom: string) => {
+      const selectedAsset = assets.find(
+        (asset) => asset.coinDenom === coinDenom
+      );
+      // shouldn't happen, but doing nothing is better
+      if (!selectedAsset) return;
+
       const isRecommended = swapState.recommendedAssets
         .map((asset) => asset.coinDenom)
         .includes(coinDenom);
-      const isVerified = assets.find(
-        (asset) => asset.coinDenom === coinDenom
-      )?.isVerified;
+      const isVerified = selectedAsset.isVerified;
       if (!isRecommended && !shouldShowUnverifiedAssets && !isVerified) {
         return setConfirmUnverifiedAssetDenom(coinDenom);
       }

--- a/packages/web/hooks/input/use-amount-input.ts
+++ b/packages/web/hooks/input/use-amount-input.ts
@@ -53,6 +53,12 @@ export function useAmountInput(currency?: Currency, inputDebounceMs = 500) {
     [fraction]
   );
 
+  // clear fraction when user changes currency
+  // and user has no balance
+  useEffect(() => {
+    if (isBalancesFetched && !rawCurrencyBalance) setFraction(null);
+  }, [isBalancesFetched, rawCurrencyBalance, currency]);
+
   /** Amount derived from user input or from a fraction of the user's balance. */
   const amount = useMemo(() => {
     if (currency && isValidNumericalRawInput(inputAmount)) {


### PR DESCRIPTION
I haven't been able to replicate, but I added an extra check to make sure the asset exists before showing activate unverified assets modal in swap drawer.
