### PR TITLE
fix: Select Recommended Assets

### DIFF
--- a/packages/web/components/drawers/token-select-drawer.tsx
+++ b/packages/web/components/drawers/token-select-drawer.tsx
@@ -108,18 +108,26 @@ export const TokenSelectDrawer: FunctionComponent<{
       onClose();
     };
 
-    const onClickCoin = (coinDenom: string) => {
-      const selectedAsset = assets.find(
-        (asset) => asset.coinDenom === coinDenom
-      );
+    const onClickAsset = (coinDenom: string) => {
+      let isRecommended = false;
+      const selectedAsset =
+        assets.find((asset) => asset.coinDenom === coinDenom) ??
+        swapState.recommendedAssets.find((asset) => {
+          if (asset.coinDenom === coinDenom) {
+            isRecommended = true;
+            return true;
+          }
+          return false;
+        });
+
       // shouldn't happen, but doing nothing is better
       if (!selectedAsset) return;
 
-      const isRecommended = swapState.recommendedAssets
-        .map((asset) => asset.coinDenom)
-        .includes(coinDenom);
-      const isVerified = selectedAsset.isVerified;
-      if (!isRecommended && !shouldShowUnverifiedAssets && !isVerified) {
+      if (
+        !isRecommended &&
+        !shouldShowUnverifiedAssets &&
+        !selectedAsset.isVerified
+      ) {
         return setConfirmUnverifiedAssetDenom(coinDenom);
       }
 
@@ -170,7 +178,7 @@ export const TokenSelectDrawer: FunctionComponent<{
         if (!asset) return;
         const { coinDenom } = asset;
 
-        onClickCoin(coinDenom);
+        onClickAsset(coinDenom);
       },
     });
 
@@ -288,7 +296,7 @@ export const TokenSelectDrawer: FunctionComponent<{
                         )}
                         onClick={(e) => {
                           e.stopPropagation();
-                          onClickCoin(coinDenom);
+                          onClickAsset(coinDenom);
                         }}
                       >
                         {coinImageUrl && (
@@ -338,7 +346,7 @@ export const TokenSelectDrawer: FunctionComponent<{
                         )}
                         onClick={(e) => {
                           e.stopPropagation();
-                          onClickCoin?.(coinDenom);
+                          onClickAsset?.(coinDenom);
                         }}
                         onMouseOver={() => setKeyboardSelectedIndex(index)}
                         onFocus={() => setKeyboardSelectedIndex(index)}

--- a/packages/web/hooks/use-swap.ts
+++ b/packages/web/hooks/use-swap.ts
@@ -503,7 +503,7 @@ function useToFromDenoms(
 /** Will query for an individual asset of any type of denom (symbol, min denom)
  *  if it's not already in the list of existing assets. */
 function useSwapAsset(
-  anyDenom?: string,
+  minDenomOrSymbol?: string,
   existingAssets: MaybeUserAsset[] = []
 ) {
   const { chainStore, accountStore } = useStore();
@@ -515,12 +515,14 @@ function useSwapAsset(
    *  a more comprehensive search. */
   const existingAsset = existingAssets.find(
     (asset) =>
-      asset.coinDenom === anyDenom || asset.coinMinimalDenom === anyDenom
+      asset.coinDenom === minDenomOrSymbol ||
+      asset.coinMinimalDenom === minDenomOrSymbol
   );
-  const queryEnabled = Boolean(anyDenom) && !isLoadingWallet && !existingAsset;
+  const queryEnabled =
+    Boolean(minDenomOrSymbol) && !isLoadingWallet && !existingAsset;
   const { data: asset, isLoading } = api.edge.assets.getAssets.useQuery(
     {
-      matchDenom: anyDenom,
+      findMinDenomOrSymbol: minDenomOrSymbol,
       userOsmoAddress: account?.address,
     },
     { enabled: queryEnabled }

--- a/packages/web/server/queries/complex/assets/index.ts
+++ b/packages/web/server/queries/complex/assets/index.ts
@@ -9,12 +9,6 @@ import { AssetLists } from "~/config/generated/asset-lists";
 
 import { Search, Sort } from "../parameter-types";
 
-export type GetAssetsParams = {
-  sort?: Partial<Sort>;
-  search?: Search;
-  /** Explicitly match the base or symbol denom. */
-  matchDenom?: string;
-};
 const searchableKeys = ["symbol", "base", "name", "display"];
 
 const cache = new LRUCache<string, CacheEntry>(DEFAULT_LRU_OPTIONS);
@@ -25,7 +19,7 @@ export async function getAsset({
 }: {
   anyDenom: string;
 }): Promise<ReturnType<typeof makeMinimalAsset> | undefined> {
-  const assets = await getAssets({ matchDenom: anyDenom });
+  const assets = await getAssets({ findMinDenomOrSymbol: anyDenom });
   return assets[0];
 }
 
@@ -36,11 +30,17 @@ export async function getAsset({
 export async function getAssets({
   assetList = AssetLists,
   ...params
-}: GetAssetsParams & { assetList?: AssetList[] }) {
+}: {
+  sort?: Partial<Sort>;
+  search?: Search;
+  /** Explicitly match the base or symbol denom. */
+  findMinDenomOrSymbol?: string;
+  assetList?: AssetList[];
+}) {
   return cachified({
     cache,
     getFreshValue: async () => {
-      // create new array with just assets
+      // Create new array with just assets
       const coinMinimalDenomSet = new Set<string>();
 
       const listedAssets = assetList
@@ -51,10 +51,12 @@ export async function getAssets({
         );
 
       let assets = listedAssets.filter((asset) => {
-        if (params.matchDenom) {
+        if (params.findMinDenomOrSymbol) {
           return (
-            params.matchDenom.toUpperCase() === asset.base.toUpperCase() ||
-            params.matchDenom.toUpperCase() === asset.symbol.toUpperCase()
+            params.findMinDenomOrSymbol.toUpperCase() ===
+              asset.base.toUpperCase() ||
+            params.findMinDenomOrSymbol.toUpperCase() ===
+              asset.symbol.toUpperCase()
           );
         }
 
@@ -68,7 +70,7 @@ export async function getAssets({
         }
       });
 
-      // search
+      // Search
       if (params.search) {
         const fuse = new Fuse(assets, {
           keys: searchableKeys,
@@ -79,10 +81,10 @@ export async function getAssets({
           .slice(0, params.search.limit);
       }
 
-      // transform into a more compact object
+      // Transform into a more compact object
       const minimalAssets = assets.map(makeMinimalAsset);
 
-      // sort
+      // Sort
       if (params.sort && params.sort.keyPath && !params.search) {
         const keyPath = params.sort.keyPath;
         minimalAssets.sort((a, b) => {

--- a/packages/web/utils/trpc.ts
+++ b/packages/web/utils/trpc.ts
@@ -92,7 +92,7 @@ export const api = createTRPCNext<AppRouter>({
    *
    * @see https://trpc.io/docs/nextjs#ssr-boolean-default-false
    */
-  ssr: true,
+  ssr: false,
 });
 
 /**


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

The initial attempt to select a recommended asset like USDT was broken because the asset was not available in the assets array during the first fetch. To resolve this, we now also include a search for the asset within the recommended assets array.

## Testing and Verifying

- [ ] Can Select Tokens not available on first fetch like USDT and TIA