### PR TITLE
feat: Make Asset Search Less Fuzzy and Remove Skeleton for Swap Details 

### DIFF
--- a/packages/utils/src/api-client.ts
+++ b/packages/utils/src/api-client.ts
@@ -65,6 +65,14 @@ export async function apiClient<T>(
           });
         }
 
+        if ("status_code" in data && data.status_code >= 400) {
+          throw new ApiClientError({
+            message: data?.message ?? UNEXPECTED_ERROR_MESSAGE,
+            data,
+            response,
+          });
+        }
+
         return data;
       } else {
         throw new ApiClientError({

--- a/packages/web/components/drawers/token-select-drawer.tsx
+++ b/packages/web/components/drawers/token-select-drawer.tsx
@@ -83,11 +83,6 @@ export const TokenSelectDrawer: FunctionComponent<{
       setAssets(swapState.selectableAssets);
     }, [isRequestingClose, swapState.selectableAssets]);
 
-    // maintain focus on search box while typing across re-renders as assets update
-    useEffect(() => {
-      if (swapState.assetsQueryInput !== "") searchBoxRef.current?.focus();
-    }, [swapState.assetsQueryInput, assets]);
-
     const assetsRef = useLatest(assets);
 
     const searchBoxRef = useRef<HTMLInputElement>(null);

--- a/packages/web/components/swap-tool/index.tsx
+++ b/packages/web/components/swap-tool/index.tsx
@@ -107,13 +107,10 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
 
     const [showQuoteDetails, setShowEstimateDetails] = useState(false);
 
-    const isInputAmountGreaterThanZero =
-      swapState.inAmountInput.amount &&
-      !swapState.inAmountInput.amount.toDec().isZero();
-
     /** User has input and there is enough liquidity and routes for given input. */
     const isQuoteDetailRelevant =
-      isInputAmountGreaterThanZero &&
+      swapState.inAmountInput.amount &&
+      !swapState.inAmountInput.amount.toDec().isZero() &&
       !(swapState.error instanceof NotEnoughLiquidityError) &&
       !(swapState.error instanceof NoRouteError);
     // auto collapse on input clear

--- a/packages/web/components/swap-tool/index.tsx
+++ b/packages/web/components/swap-tool/index.tsx
@@ -106,10 +106,14 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
     const routesVisDisclosure = useDisclosure();
 
     const [showQuoteDetails, setShowEstimateDetails] = useState(false);
-    /** User has input and there is enough liqudity and routes for given input. */
-    const isQuoteDetailRelevant =
+
+    const isInputAmountGreaterThanZero =
       swapState.inAmountInput.amount &&
-      !swapState.inAmountInput.amount.toDec().isZero() &&
+      !swapState.inAmountInput.amount.toDec().isZero();
+
+    /** User has input and there is enough liquidity and routes for given input. */
+    const isQuoteDetailRelevant =
+      isInputAmountGreaterThanZero &&
       !(swapState.error instanceof NotEnoughLiquidityError) &&
       !(swapState.error instanceof NoRouteError);
     // auto collapse on input clear
@@ -120,9 +124,6 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
 
     // auto focus from amount on token switch
     const fromAmountInputEl = useRef<HTMLInputElement | null>(null);
-    useEffect(() => {
-      fromAmountInputEl.current?.focus();
-    }, [swapState.fromAsset]);
 
     const showPriceImpactWarning =
       swapState.quote?.priceImpactTokenOut?.toDec().abs().gt(new Dec(0.1)) ??
@@ -450,6 +451,7 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
                       (tokenDenom: string) => {
                         swapState.setFromAssetDenom(tokenDenom);
                         closeTokenSelectDropdowns();
+                        fromAmountInputEl.current?.focus();
                       },
                       [swapState, closeTokenSelectDropdowns]
                     )}
@@ -653,14 +655,17 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
                     20 // padding
                   : 44,
               }}
-              isLoaded={showQuoteDetails ? true : !swapState.isLoading}
+              isLoaded={
+                Boolean(swapState.toAsset) &&
+                Boolean(swapState.fromAsset) &&
+                Boolean(swapState.spotPriceQuote)
+              }
             >
               <button
                 className={classNames(
                   "flex w-full place-content-between items-center transition-opacity",
                   {
                     "cursor-pointer": isQuoteDetailRelevant,
-                    "opacity-0": !showQuoteDetails && swapState.isQuoteLoading,
                   }
                 )}
                 onClick={() => {
@@ -671,8 +676,9 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
                 <span
                   className={classNames("subtitle2 transition-opacity", {
                     "text-osmoverse-600": !isQuoteDetailRelevant,
-                    "opacity-50": showQuoteDetails && swapState.isQuoteLoading,
-                    "opacity-0": !showQuoteDetails && swapState.isQuoteLoading,
+                    "opacity-50":
+                      swapState.isQuoteLoading ||
+                      swapState.inAmountInput.isTyping,
                   })}
                 >
                   1{" "}

--- a/packages/web/hooks/data/data-filter.ts
+++ b/packages/web/hooks/data/data-filter.ts
@@ -13,6 +13,7 @@ export class DataFilter<TData> implements DataProcessor<TData[]> {
       keys: keys,
       findAllMatches: true,
       useExtendedSearch: true,
+      threshold: 0.2,
     });
   }
 

--- a/packages/web/hooks/data/data-filter.ts
+++ b/packages/web/hooks/data/data-filter.ts
@@ -13,6 +13,7 @@ export class DataFilter<TData> implements DataProcessor<TData[]> {
       keys: keys,
       findAllMatches: true,
       useExtendedSearch: true,
+      // Set the threshold to 0.2 to allow a small amount of fuzzy search
       threshold: 0.2,
     });
   }

--- a/packages/web/pages/assets/[denom].tsx
+++ b/packages/web/pages/assets/[denom].tsx
@@ -558,7 +558,7 @@ export const getStaticProps: GetStaticProps<AssetInfoPageProps> = async ({
     try {
       cachedTokens = await queryAllTokens();
     } catch (e) {
-      console.error("Failed to retrieved tokens from imperator apif: ", e);
+      console.error("Failed to retrieved tokens from imperator api: ", e);
     }
   }
 

--- a/packages/web/server/queries/complex/assets/__tests__/assets.spec.ts
+++ b/packages/web/server/queries/complex/assets/__tests__/assets.spec.ts
@@ -35,7 +35,7 @@ describe("getAssets", () => {
         assetList: AssetLists,
       });
 
-      expect(assets[0].coinDenom).not.toEqual("PYTH");
+      expect(assets).toEqual([]);
     });
   });
 

--- a/packages/web/server/queries/complex/assets/index.ts
+++ b/packages/web/server/queries/complex/assets/index.ts
@@ -74,6 +74,7 @@ export async function getAssets({
       if (params.search) {
         const fuse = new Fuse(assets, {
           keys: searchableKeys,
+          // Set the threshold to 0.2 to allow a small amount of fuzzy search
           threshold: 0.2,
         });
         assets = fuse

--- a/packages/web/server/queries/complex/assets/index.ts
+++ b/packages/web/server/queries/complex/assets/index.ts
@@ -74,6 +74,7 @@ export async function getAssets({
       if (params.search) {
         const fuse = new Fuse(assets, {
           keys: searchableKeys,
+          threshold: 0.2,
         });
         assets = fuse
           .search(params.search.query)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

![image](https://github.com/osmosis-labs/osmosis-frontend/assets/21092519/dc967e0c-2cad-4850-9c91-422a0cae2ed5)

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/86a1g2bb3)

### Testing

- [ ] Totally unrelated assets should not be displayed when searching on the swap tool. For E.g. 'Alter' showing up when searching for 'ether'