### PR TITLE
Add TFM and legacy router feature flags

### DIFF
--- a/packages/web/hooks/use-feature-flags.ts
+++ b/packages/web/hooks/use-feature-flags.ts
@@ -17,6 +17,8 @@ export type AvailableFlags =
   | "multiBridgeProviders"
   | "unlistedAssets"
   | "sidecarRouter"
+  | "legacyRouter"
+  | "tfmRouter"
   | "osmosisUpdatesPopUp";
 
 type ModifiedFlags =

--- a/packages/web/hooks/use-swap.ts
+++ b/packages/web/hooks/use-swap.ts
@@ -528,10 +528,19 @@ function useQueryRouterBestQuote(
     () =>
       !featureFlags._isInitialized
         ? []
-        : routerKeys.filter((key) =>
-            featureFlags.sidecarRouter ? true : key !== "sidecar"
-          ),
-    [featureFlags._isInitialized, featureFlags.sidecarRouter, routerKeys]
+        : routerKeys.filter((key) => {
+            if (!featureFlags.sidecarRouter && key === "sidecar") return false;
+            if (!featureFlags.legacyRouter && key === "legacy") return false;
+            if (!featureFlags.tfmRouter && key === "tfm") return false;
+            return true;
+          }),
+    [
+      featureFlags._isInitialized,
+      featureFlags.sidecarRouter,
+      featureFlags.legacyRouter,
+      featureFlags.tfmRouter,
+      routerKeys,
+    ]
   );
 
   const trpcReact = createTRPCReact<AppRouter>();
@@ -543,7 +552,7 @@ function useQueryRouterBestQuote(
           preferredRouter: key,
         },
         {
-          enabled: enabled && featureFlags._isInitialized,
+          enabled: enabled && Boolean(availableRouterKeys.length),
 
           // quotes should not be considered fresh for long, otherwise
           // the gas simulation will fail due to slippage and the user would see errors


### PR DESCRIPTION
In case anything goes wrong with other routers, we can have kill switches for other routers besides sidecar.

[TFM FF](https://app.launchdarkly.com/default/test/features/tfm-router/targeting)
[Legacy FF](https://app.launchdarkly.com/default/test/features/legacy-router/targeting)