### PR TITLE
Update get-proto.sh

### DIFF
--- a/packages/proto-codecs/scripts/get-proto.sh
+++ b/packages/proto-codecs/scripts/get-proto.sh
@@ -6,7 +6,7 @@ GREEN='\033[0;32m' # Green color
 NC='\033[0m' # No Color
 
 PROTO_DIR="./chain-proto"
-OSMOSIS_COMMIT_HASH="6506d0dafde9a15b96b480433d58024db35eb953"
+OSMOSIS_COMMIT_HASH="173a8c1c11d577e8f0138a0b003776e36a6d73c8"
 
 ICS23_COMMIT_HASH="f4deb054b697458e7f0aa353c2f45a365361e895"
 
@@ -26,10 +26,10 @@ git -C .repos/osmosis checkout $OSMOSIS_COMMIT_HASH
 
 
 # SDK PROTOS
-COSMOS_SDK_VERSION=$(awk '/github.com\/cosmos\/cosmos-sdk/ {print $2}' .repos/osmosis/go.mod | tr -d '=> ' | sed 's/replace//g' | tr -d '\n')
+COSMOS_SDK_VERSION=$(awk -F '=>' '/github.com\/osmosis-labs\/cosmos-sdk/ {print $2}' .repos/osmosis/go.mod | awk '{print $NF}' | tr -d '\n')
 echo -e "${GREEN}COSMOS_SDK_VERSION: $COSMOS_SDK_VERSION${NC}"
 
-git clone --filter=blob:none --sparse https://github.com/cosmos/cosmos-sdk.git .repos/cosmos-sdk
+git clone --filter=blob:none --sparse https://github.com/osmosis-labs/cosmos-sdk.git .repos/cosmos-sdk
 
 # Checkout to Cosmos hash commit
 git -C .repos/cosmos-sdk sparse-checkout set proto
@@ -49,30 +49,14 @@ git -C .repos/ibc-go sparse-checkout set proto
 git fetch --all --tags
 git -C .repos/ibc-go checkout $IBC_GO_VERSION
 
-
 # WASMD PROTOS
 
 # Extract the Wasmd version from the go.mod file
 WASMD_VERSION=$(awk '/github.com\/osmosis-labs\/wasmd/ {print $4}' .repos/osmosis/go.mod)
-
-
-
-# Split the version string by '-'
-IFS='-' read -ra ADDR <<< "$WASMD_VERSION"
-
-# Get the length of the array
-ADDR_LENGTH=${#ADDR[@]}
-
-# Get the last element of the array
-LAST_ELEMENT=${ADDR[$ADDR_LENGTH-1]}
-
-# Check if the last part of the split is 12 characters long (the length of a git commit hash)
-# example: v0.45.1-0.20231207232630-aba521a80563 only works if pinned to a tag, otherwise use aba521a80563
-if [ ${#LAST_ELEMENT} -eq 12 ]; then
-    WASMD_VERSION=$LAST_ELEMENT
-fi
-
 echo -e "${GREEN}WASMD_VERSION: $WASMD_VERSION${NC}"
+
+# TROUBLESHOOTING
+# if this fails, reach out to chain team to tag the replaced commits instead of using the commit directly - 
 
 git clone --filter=blob:none --sparse https://github.com/osmosis-labs/wasmd.git .repos/wasmd
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

running `get-proto.sh` was breaking for telescope

### ClickUp Task

[ClickUp Task URL](PASTE_CLICKUP_TASK_URL_HERE)

## Brief Changelog

- print versions for clarity
- parse out new lines + "replace" keyword in SDK protos
- pull commit hash for WASMD_VERSION

## Testing and Verifying

- ran telescope `yarn generate` succesfully

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
