### PR TITLE
Force swap in pool in pool detail page

### DIFF
--- a/packages/pools/src/router/routes.ts
+++ b/packages/pools/src/router/routes.ts
@@ -131,8 +131,23 @@ export class OptimizedRoutes implements TokenOutGivenInRouter {
 
   async routeByTokenIn(
     tokenIn: Token,
-    tokenOutDenom: string
+    tokenOutDenom: string,
+    forcePoolId?: string
   ): Promise<SplitTokenInQuote> {
+    if (forcePoolId) {
+      const pool = this._sortedPools.find((pool) => pool.id === forcePoolId);
+      if (!pool) throw new NoRouteError();
+
+      const route: RouteWithInAmount = {
+        pools: [pool],
+        tokenInDenom: tokenIn.denom,
+        tokenOutDenoms: [tokenOutDenom],
+        initialAmount: tokenIn.amount,
+      };
+
+      return await this.calculateTokenOutByTokenIn([route]);
+    }
+
     const split = await this.getOptimizedRoutesByTokenIn(
       tokenIn,
       tokenOutDenom

--- a/packages/pools/src/router/types.ts
+++ b/packages/pools/src/router/types.ts
@@ -13,7 +13,8 @@ export interface TokenOutGivenInRouter {
   /** Route, with splits, given an in token and out denom. */
   routeByTokenIn(
     tokenIn: Token,
-    tokenOutDenom: string
+    tokenOutDenom: string,
+    forcePoolId?: string
   ): Promise<SplitTokenInQuote>;
 }
 

--- a/packages/web/components/swap-tool/index.tsx
+++ b/packages/web/components/swap-tool/index.tsx
@@ -52,6 +52,7 @@ export interface SwapToolProps {
   sendTokenDenom?: string;
   outTokenDenom?: string;
   page?: SwapPage;
+  forceSwapInPoolId?: string;
 }
 
 export const SwapTool: FunctionComponent<SwapToolProps> = observer(
@@ -63,6 +64,7 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
     sendTokenDenom,
     outTokenDenom,
     page = "Swap Page",
+    forceSwapInPoolId,
   }) => {
     const { chainStore, accountStore } = useStore();
     const { t } = useTranslation();
@@ -80,6 +82,7 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
       initialToDenom: outTokenDenom,
       useOtherCurrencies: !isInModal,
       useQueryParams: !isInModal,
+      forceSwapInPoolId,
     });
 
     const manualSlippageInputRef = useRef<HTMLInputElement | null>(null);
@@ -824,11 +827,13 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
                       )}
                   </SkeletonLoader>
                 </div>
-                <SplitRoute
-                  {...routesVisDisclosure}
-                  split={swapState.quote?.split ?? []}
-                  isLoading={isSwapToolLoading}
-                />
+                {!isInModal && (
+                  <SplitRoute
+                    {...routesVisDisclosure}
+                    split={swapState.quote?.split ?? []}
+                    isLoading={isSwapToolLoading}
+                  />
+                )}
               </div>
             </SkeletonLoader>
           </div>

--- a/packages/web/components/swap-tool/index.tsx
+++ b/packages/web/components/swap-tool/index.tsx
@@ -827,7 +827,7 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
                       )}
                   </SkeletonLoader>
                 </div>
-                {!isInModal && (
+                {!forceSwapInPoolId && (
                   <SplitRoute
                     {...routesVisDisclosure}
                     split={swapState.quote?.split ?? []}

--- a/packages/web/hooks/use-swap.ts
+++ b/packages/web/hooks/use-swap.ts
@@ -105,9 +105,6 @@ export function useSwap({
     | undefined = useMemo(() => {
     const error = quoteError ?? spotPriceQuoteError;
 
-    // Various router clients on server should reconcile their error messages
-    // into the following error messages or instances on the server.
-    // Then we can show the user a useful translated error message vs just "Error".
     const errorFromTrpc = makeRouterErrorFromTrpcError(error)?.error;
     if (errorFromTrpc) return errorFromTrpc;
 
@@ -625,6 +622,9 @@ function useQueryRouterBestQuote(
   };
 }
 
+/** Various router clients on server should reconcile their error messages
+ *  into the following error messages or instances on the server.
+ *  Then we can show the user a useful translated error message vs just "Error". */
 function makeRouterErrorFromTrpcError(
   error:
     | TRPCClientError<AppRouter["edge"]["quoteRouter"]["routeTokenOutGivenIn"]>

--- a/packages/web/integrations/sidecar/router.ts
+++ b/packages/web/integrations/sidecar/router.ts
@@ -32,6 +32,7 @@ export class OsmosisSidecarRemoteRouter implements TokenOutGivenInRouter {
     if (forcePoolId) {
       // docs: https://github.com/osmosis-labs/osmosis/blob/e4f91eaf6a0ce475dcd13ee337e27c8e67cd939f/ingest/sqs/README.md?plain=1#L221
       queryUrl.searchParams.append("poolIDs", forcePoolId);
+      queryUrl.pathname = "/router/custom-quote";
     }
     try {
       const {

--- a/packages/web/integrations/sidecar/router.ts
+++ b/packages/web/integrations/sidecar/router.ts
@@ -17,9 +17,11 @@ export class OsmosisSidecarRemoteRouter implements TokenOutGivenInRouter {
     this.baseUrl = new URL(sidecarBaseUrl);
   }
 
+  /** Docs: https://github.com/osmosis-labs/osmosis/blob/e4f91eaf6a0ce475dcd13ee337e27c8e67cd939f/ingest/sqs/README.md?plain=1#L70C5-L70C5 */
   async routeByTokenIn(
     tokenIn: Token,
-    tokenOutDenom: string
+    tokenOutDenom: string,
+    forcePoolId?: string
   ): Promise<SplitTokenInQuote> {
     const queryUrl = new URL("/router/quote", this.baseUrl.toString());
     queryUrl.searchParams.append(
@@ -27,6 +29,10 @@ export class OsmosisSidecarRemoteRouter implements TokenOutGivenInRouter {
       `${tokenIn.amount}${tokenIn.denom}`
     );
     queryUrl.searchParams.append("tokenOutDenom", tokenOutDenom);
+    if (forcePoolId) {
+      // docs: https://github.com/osmosis-labs/osmosis/blob/e4f91eaf6a0ce475dcd13ee337e27c8e67cd939f/ingest/sqs/README.md?plain=1#L221
+      queryUrl.searchParams.append("poolIDs", forcePoolId);
+    }
     try {
       const {
         amount_out,

--- a/packages/web/integrations/tfm/router.ts
+++ b/packages/web/integrations/tfm/router.ts
@@ -22,8 +22,17 @@ export class TfmRemoteRouter implements TokenOutGivenInRouter {
 
   async routeByTokenIn(
     tokenIn: Token,
-    tokenOutDenom: string
+    tokenOutDenom: string,
+    forcePoolId?: string
   ): Promise<SplitTokenInQuote> {
+    // return empty quote since TFM doesn't support forced swap through a pool
+    if (forcePoolId) {
+      return {
+        amount: new Int(0),
+        split: [],
+      };
+    }
+
     // fetch quote
     const tokenInDenomEncoded = encodeURIComponent(tokenIn.denom);
     const tokenOutDenomEncoded = encodeURIComponent(tokenOutDenom);

--- a/packages/web/integrations/tfm/router.ts
+++ b/packages/web/integrations/tfm/router.ts
@@ -70,7 +70,13 @@ export class TfmRemoteRouter implements TokenOutGivenInRouter {
       // TFM responded with an error as custom formatted JSON
       const tfmJsonError = e as {
         data: { error: { code: number; message: string } };
+        status: number;
+        statusText: string;
       };
+
+      if (tfmJsonError.status === 504) {
+        throw new Error("TFM timed out");
+      }
 
       if (tfmJsonError?.data?.error?.code === 500) {
         // consider a no router error

--- a/packages/web/modals/trade-tokens.tsx
+++ b/packages/web/modals/trade-tokens.tsx
@@ -8,6 +8,7 @@ export const TradeTokens: FunctionComponent<
   {
     sendTokenDenom?: string;
     outTokenDenom?: string;
+    forceSwapInPoolId?: string;
   } & ModalBaseProps
 > = (props) => {
   const { showModalBase, accountActionButton, walletConnected } =
@@ -26,6 +27,7 @@ export const TradeTokens: FunctionComponent<
         swapButton={!walletConnected ? accountActionButton : undefined}
         sendTokenDenom={props.sendTokenDenom}
         outTokenDenom={props.outTokenDenom}
+        forceSwapInPoolId={props.forceSwapInPoolId}
       />
     </ModalBase>
   );

--- a/packages/web/pages/pool/[id].tsx
+++ b/packages/web/pages/pool/[id].tsx
@@ -70,7 +70,7 @@ const Pool: FunctionComponent = observer(() => {
       <NextSeo
         title={t("seo.pool.title", { id: poolId ? poolId.toString() : "-" })}
       />
-      {showTradeModal && queryPool && (
+      {showTradeModal && queryPool && poolId && (
         <TradeTokens
           className="md:!p-0"
           isOpen={showTradeModal}
@@ -79,6 +79,7 @@ const Pool: FunctionComponent = observer(() => {
           }}
           sendTokenDenom={queryPool.poolAssetDenoms[0]}
           outTokenDenom={queryPool.poolAssetDenoms[1]}
+          forceSwapInPoolId={poolId}
         />
       )}
       {!queryPool ? (

--- a/packages/web/server/api/edge-routers/swap-router.ts
+++ b/packages/web/server/api/edge-routers/swap-router.ts
@@ -52,8 +52,14 @@ const routers: {
   {
     name: "legacy",
     router: {
-      routeByTokenIn: async (tokenIn, tokenOutDenom) =>
-        (await routeTokenOutGivenIn({ token: tokenIn, tokenOutDenom })).quote,
+      routeByTokenIn: async (tokenIn, tokenOutDenom, forcePoolId) =>
+        (
+          await routeTokenOutGivenIn({
+            token: tokenIn,
+            tokenOutDenom,
+            forcePoolId,
+          })
+        ).quote,
     } as TokenOutGivenInRouter,
   },
 ];
@@ -65,12 +71,19 @@ export const swapRouter = createTRPCRouter({
         tokenInDenom: z.string(),
         tokenInAmount: z.string(),
         tokenOutDenom: z.string(),
-        preferredRouter: zodAvailableRouterKey.optional().default("legacy"),
+        preferredRouter: zodAvailableRouterKey,
+        forcePoolId: z.string().optional(),
       })
     )
     .query(
       async ({
-        input: { tokenInDenom, tokenInAmount, tokenOutDenom, preferredRouter },
+        input: {
+          tokenInDenom,
+          tokenInAmount,
+          tokenOutDenom,
+          preferredRouter,
+          forcePoolId,
+        },
       }) => {
         const { name, router } = routers.find(
           ({ name }) => name === preferredRouter
@@ -83,7 +96,8 @@ export const swapRouter = createTRPCRouter({
             denom: tokenInDenom,
             amount: new Int(tokenInAmount),
           },
-          tokenOutDenom
+          tokenOutDenom,
+          forcePoolId
         );
         const timeMs = Date.now() - startTime;
 

--- a/packages/web/server/queries/complex/route-token-out-given-in.ts
+++ b/packages/web/server/queries/complex/route-token-out-given-in.ts
@@ -35,13 +35,15 @@ import { queryPaginatedPools } from "./pools";
 export async function routeTokenOutGivenIn({
   token,
   tokenOutDenom,
+  forcePoolId,
 }: {
   token: Token;
   tokenOutDenom: string;
+  forcePoolId?: string;
 }) {
   // get quote
   const router = await getRouter();
-  const quote = await router.routeByTokenIn(token, tokenOutDenom);
+  const quote = await router.routeByTokenIn(token, tokenOutDenom, forcePoolId);
   const candidateRoutes = router.getCandidateRoutes(token.denom, tokenOutDenom);
 
   return {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

Restores the prior functionality of the trade tokens modal on the pool detail page of forcing a swap through the pool the user is viewing instead of finding the optimal route through all pools.

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/86a1mq7j8)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->
* Add `forcePoolId` to router interface
* Implement above in sidecar and legacy routers, for TFM, it returns 0 as out amount since their API does not support this
* Add above as parameter to query in pool detail page swap modal
* Hide route visualization if in modal

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

* All pool detail pages should force a swap through that page's pool
* The route visualization should be hidden on pool detail page trade token modals
