### PR TITLE
Astroport PCL pool

### DIFF
--- a/packages/pools/src/cosmwasm/astroport-pcl.ts
+++ b/packages/pools/src/cosmwasm/astroport-pcl.ts
@@ -1,0 +1,158 @@
+import { Dec, Int } from "@keplr-wallet/unit";
+
+import { validateDenoms } from "../errors";
+import { BasePool } from "../interface";
+import { Quote, RoutablePool, Token } from "../router";
+import { querySmartContract } from "../utils";
+import { CosmwasmPoolRaw } from "./types";
+
+export class AstroportPclPool implements BasePool, RoutablePool {
+  get type() {
+    return "astroport-pcl" as const;
+  }
+
+  get id(): string {
+    return this.raw.pool_id;
+  }
+
+  get swapFee(): Dec {
+    return new Dec(0);
+  }
+
+  get exitFee(): Dec {
+    return new Dec(0);
+  }
+
+  get takerFee(): Dec {
+    return new Dec(this.raw.taker_fee);
+  }
+
+  get poolAssetDenoms(): string[] {
+    return this.raw.tokens.map(({ denom }) => denom);
+  }
+
+  get poolAssets(): { denom: string; amount: Int }[] {
+    return this.raw.tokens.map(({ denom, amount }) => ({
+      denom,
+      amount: new Int(amount),
+    }));
+  }
+
+  constructor(readonly raw: CosmwasmPoolRaw, readonly restBaseUrl: string) {}
+
+  // Interface: BasePool
+
+  hasPoolAsset(denom: string): boolean {
+    return this.raw.tokens.some(
+      ({ denom: tokenDenom }) => tokenDenom === denom
+    );
+  }
+
+  getSpotPriceInOverOut(tokenInDenom: string, tokenOutDenom: string): Dec {
+    validateDenoms(this, tokenInDenom, tokenOutDenom);
+    return new Dec(1);
+  }
+  getSpotPriceOutOverIn(tokenInDenom: string, tokenOutDenom: string): Dec {
+    validateDenoms(this, tokenInDenom, tokenOutDenom);
+    return new Dec(1);
+  }
+  getSpotPriceInOverOutWithoutSwapFee(
+    tokenInDenom: string,
+    tokenOutDenom: string
+  ): Dec {
+    validateDenoms(this, tokenInDenom, tokenOutDenom);
+    return new Dec(1);
+  }
+  getSpotPriceOutOverInWithoutSwapFee(
+    tokenInDenom: string,
+    tokenOutDenom: string
+  ): Dec {
+    validateDenoms(this, tokenInDenom, tokenOutDenom);
+    return new Dec(1);
+  }
+
+  /** Find the min other token that could be swapped out, since ratio is 1:1. */
+  getLimitAmountByTokenIn(denom: string): Int {
+    const outAmounts = this.raw.tokens
+      .filter(({ denom: tokenDenom }) => tokenDenom !== denom)
+      .map(({ amount }) => new Int(amount));
+    return outAmounts.reduce(
+      (min, amount) => (amount.lt(min) ? amount : min),
+      new Int(Number.MAX_SAFE_INTEGER)
+    );
+  }
+
+  async getTokenOutByTokenIn(
+    tokenIn: Token,
+    tokenOutDenom: string
+  ): Promise<Quote> {
+    validateDenoms(this, tokenIn.denom, tokenOutDenom);
+
+    try {
+      const simulateResponse = await querySmartContract<{
+        token_out: {
+          amount: string;
+          denom: string;
+        };
+      }>(this.restBaseUrl, this.raw.contract_address, {
+        calc_out_amt_given_in: {
+          token_in: {
+            denom: tokenIn.denom,
+            amount: tokenIn.amount.toString(),
+          },
+          token_out_denom: tokenOutDenom,
+          swap_fee: this.swapFee.toString(),
+        },
+      });
+
+      return {
+        ...defaultQuoteOptions,
+        amount: new Int(simulateResponse.token_out.amount),
+      };
+    } catch {
+      throw new Error("Contract quote simulation failed.");
+    }
+  }
+
+  async getTokenInByTokenOut(
+    tokenOut: Token,
+    tokenInDenom: string
+  ): Promise<Quote> {
+    validateDenoms(this, tokenOut.denom, tokenInDenom);
+
+    try {
+      const simulateResponse = await querySmartContract<{
+        token_in: {
+          amount: string;
+          denom: string;
+        };
+      }>(this.restBaseUrl, this.raw.contract_address, {
+        calc_in_amt_given_out: {
+          token_out: {
+            denom: tokenOut.denom,
+            amount: tokenOut.amount.toString(),
+          },
+          token_in_denom: tokenInDenom,
+          swap_fee: this.swapFee.toString(),
+        },
+      });
+
+      return {
+        ...defaultQuoteOptions,
+        amount: new Int(simulateResponse.token_in.amount),
+      };
+    } catch {
+      throw new Error("Contract quote simulation failed.");
+    }
+  }
+}
+
+const defaultQuoteOptions = {
+  beforeSpotPriceInOverOut: new Dec(1),
+  beforeSpotPriceOutOverIn: new Dec(1),
+  afterSpotPriceInOverOut: new Dec(1),
+  afterSpotPriceOutOverIn: new Dec(1),
+  effectivePriceInOverOut: new Dec(1),
+  effectivePriceOutOverIn: new Dec(1),
+  priceImpactTokenOut: new Dec(0),
+};

--- a/packages/pools/src/cosmwasm/index.ts
+++ b/packages/pools/src/cosmwasm/index.ts
@@ -1,2 +1,3 @@
+export * from "./astroport-pcl";
 export * from "./transmuter";
 export * from "./types";

--- a/packages/pools/src/types.ts
+++ b/packages/pools/src/types.ts
@@ -25,7 +25,8 @@ export type PoolType =
   | "weighted"
   | "stable"
   | "transmuter"
-  | "cosmwasm";
+  | "cosmwasm"
+  | "astroport-pcl";
 
 /**
  * Returns corresponding pool class instance from raw pool data.

--- a/packages/pools/src/utils.ts
+++ b/packages/pools/src/utils.ts
@@ -1,0 +1,25 @@
+export async function querySmartContract<T = unknown>(
+  baseUrl: string,
+  address: string,
+  query: object
+): Promise<T> {
+  const encodedQuery = Buffer.from(JSON.stringify(query)).toString("base64");
+
+  const res = await fetch(
+    `${baseUrl}/cosmwasm/wasm/v1/contract/${address}/smart/${encodedQuery}`,
+    {
+      headers: {
+        accept: "application/json",
+        "content-type": "application/json",
+      },
+    }
+  );
+
+  if (!res.ok) {
+    throw new Error(`failed to query smart contract: ${address}`);
+  }
+
+  const json = await res.json();
+
+  return json.data;
+}

--- a/packages/web/config/feature-flag.ts
+++ b/packages/web/config/feature-flag.ts
@@ -1,5 +1,3 @@
-import { IS_TESTNET } from "./env";
-
 /** UI will go into "halt mode" if `true`. */
 export const IS_HALTED = false;
 
@@ -46,9 +44,6 @@ export const BUY_OSMO_TRANSAK = true;
 
 /** Blacklists pools out at the query level. Marks them as non existant. */
 export const BlacklistedPoolIds: string[] = ["895"];
-
-/** Cosmwasm Code Ids confirmed to be transmuter pools in current env. */
-export const TransmuterPoolCodeIds = IS_TESTNET ? ["3084"] : ["148"];
 
 export const RecommendedSwapDenoms = [
   "OSMO",

--- a/packages/web/config/feature-flag.ts
+++ b/packages/web/config/feature-flag.ts
@@ -51,9 +51,6 @@ export const BlacklistedPoolIds: string[] = ["895"];
  *  NOTE: this is only used in the pools query for pools page and pool detail page. */
 export const TransmuterPoolCodeIds = IS_TESTNET ? ["3084"] : ["148"];
 
-/** Cosmwasm Code Ids confirmed to be transmuter pools in current env. */
-export const AstroportPoolCodeIds = IS_TESTNET ? ["5005"] : [""];
-
 export const RecommendedSwapDenoms = [
   "OSMO",
   "USDC.axl",

--- a/packages/web/config/feature-flag.ts
+++ b/packages/web/config/feature-flag.ts
@@ -47,7 +47,8 @@ export const BUY_OSMO_TRANSAK = true;
 /** Blacklists pools out at the query level. Marks them as non existant. */
 export const BlacklistedPoolIds: string[] = ["895"];
 
-/** Cosmwasm Code Ids confirmed to be transmuter pools in current env. */
+/** Cosmwasm Code Ids confirmed to be transmuter pools in current env.
+ *  NOTE: this is only used in the pools query for pools page and pool detail page. */
 export const TransmuterPoolCodeIds = IS_TESTNET ? ["3084"] : ["148"];
 
 export const RecommendedSwapDenoms = [

--- a/packages/web/config/feature-flag.ts
+++ b/packages/web/config/feature-flag.ts
@@ -51,6 +51,9 @@ export const BlacklistedPoolIds: string[] = ["895"];
  *  NOTE: this is only used in the pools query for pools page and pool detail page. */
 export const TransmuterPoolCodeIds = IS_TESTNET ? ["3084"] : ["148"];
 
+/** Cosmwasm Code Ids confirmed to be transmuter pools in current env. */
+export const AstroportPoolCodeIds = IS_TESTNET ? ["5005"] : [""];
+
 export const RecommendedSwapDenoms = [
   "OSMO",
   "USDC.axl",

--- a/packages/web/config/feature-flag.ts
+++ b/packages/web/config/feature-flag.ts
@@ -1,3 +1,5 @@
+import { IS_TESTNET } from "./env";
+
 /** UI will go into "halt mode" if `true`. */
 export const IS_HALTED = false;
 
@@ -44,6 +46,9 @@ export const BUY_OSMO_TRANSAK = true;
 
 /** Blacklists pools out at the query level. Marks them as non existant. */
 export const BlacklistedPoolIds: string[] = ["895"];
+
+/** Cosmwasm Code Ids confirmed to be transmuter pools in current env. */
+export const TransmuterPoolCodeIds = IS_TESTNET ? ["3084"] : ["148"];
 
 export const RecommendedSwapDenoms = [
   "OSMO",

--- a/packages/web/server/queries/complex/route-token-out-given-in.ts
+++ b/packages/web/server/queries/complex/route-token-out-given-in.ts
@@ -20,10 +20,15 @@ import cachified, { CacheEntry } from "cachified";
 import { LRUCache } from "lru-cache";
 
 import { DEFAULT_LRU_OPTIONS } from "~/config/cache";
+import { IS_TESTNET } from "~/config/env";
 import { ChainList } from "~/config/generated/chain-list";
 
 import { queryNumPools } from "../osmosis";
 import { queryPaginatedPools } from "./pools";
+
+// specify the code IDs of the various types of cosmwasm pools
+// so we can switch on the specific cosmwasm implementation
+export const TransmuterPoolCodeIds = IS_TESTNET ? ["3084"] : ["148"];
 
 /**
  * This function routes a given token to a specified output token denomination.
@@ -100,7 +105,10 @@ export async function getRouter(
           }
 
           if (pool["@type"] === COSMWASM_POOL_TYPE) {
-            return new TransmuterPool(pool as CosmwasmPoolRaw);
+            pool = pool as CosmwasmPoolRaw;
+            if (TransmuterPoolCodeIds.includes(pool.code_id)) {
+              return new TransmuterPool(pool as CosmwasmPoolRaw);
+            }
           }
         })
         .filter(

--- a/packages/web/server/queries/complex/route-token-out-given-in.ts
+++ b/packages/web/server/queries/complex/route-token-out-given-in.ts
@@ -1,5 +1,6 @@
 import { Dec } from "@keplr-wallet/unit";
 import {
+  AstroportPclPool,
   CONCENTRATED_LIQ_POOL_TYPE,
   ConcentratedLiquidityPool,
   ConcentratedLiquidityPoolRaw,
@@ -19,6 +20,7 @@ import {
 import cachified, { CacheEntry } from "cachified";
 import { LRUCache } from "lru-cache";
 
+import { AstroportPoolCodeIds } from "~/config";
 import { DEFAULT_LRU_OPTIONS } from "~/config/cache";
 import { IS_TESTNET } from "~/config/env";
 import { ChainList } from "~/config/generated/chain-list";
@@ -107,7 +109,14 @@ export async function getRouter(
           if (pool["@type"] === COSMWASM_POOL_TYPE) {
             pool = pool as CosmwasmPoolRaw;
             if (TransmuterPoolCodeIds.includes(pool.code_id)) {
-              return new TransmuterPool(pool as CosmwasmPoolRaw);
+              return new TransmuterPool(pool);
+            }
+
+            if (AstroportPoolCodeIds.includes(pool.code_id)) {
+              return new AstroportPclPool(
+                pool,
+                ChainList[0].apis.rest[0].address
+              );
             }
           }
         })

--- a/packages/web/server/queries/complex/route-token-out-given-in.ts
+++ b/packages/web/server/queries/complex/route-token-out-given-in.ts
@@ -20,7 +20,6 @@ import {
 import cachified, { CacheEntry } from "cachified";
 import { LRUCache } from "lru-cache";
 
-import { AstroportPoolCodeIds } from "~/config";
 import { DEFAULT_LRU_OPTIONS } from "~/config/cache";
 import { IS_TESTNET } from "~/config/env";
 import { ChainList } from "~/config/generated/chain-list";
@@ -29,8 +28,9 @@ import { queryNumPools } from "../osmosis";
 import { queryPaginatedPools } from "./pools";
 
 // specify the code IDs of the various types of cosmwasm pools
-// so we can switch on the specific cosmwasm implementation
+// so we can switch on the specific cosmwasm implementation for simulation
 export const TransmuterPoolCodeIds = IS_TESTNET ? ["3084"] : ["148"];
+export const AstroportPoolCodeIds = IS_TESTNET ? ["5005"] : [""];
 
 /**
  * This function routes a given token to a specified output token denomination.
@@ -127,7 +127,8 @@ export async function getRouter(
             | ConcentratedLiquidityPool
             | WeightedPool
             | StablePool
-            | TransmuterPool => pool !== undefined
+            | TransmuterPool
+            | AstroportPclPool => pool !== undefined
         );
 
       // prep router params
@@ -136,7 +137,7 @@ export async function getRouter(
           if (pool.type === "concentrated") {
             preferredPoolIds.push(pool.id);
           }
-          if (pool.type === "transmuter") {
+          if (pool.type === "transmuter" || pool.type === "astroport-pcl") {
             preferredPoolIds.unshift(pool.id);
           }
 

--- a/packages/web/stores/root.ts
+++ b/packages/web/stores/root.ts
@@ -28,7 +28,6 @@ import {
   BlacklistedPoolIds,
   INDEXER_DATA_URL,
   TIMESERIES_DATA_URL,
-  TransmuterPoolCodeIds,
   WALLETCONNECT_PROJECT_KEY,
   WALLETCONNECT_RELAY_URL,
 } from "~/config";
@@ -106,8 +105,7 @@ export class RootStore {
       OsmosisQueries.use(
         this.chainStore.osmosis.chainId,
         webApiBaseUrl,
-        BlacklistedPoolIds,
-        TransmuterPoolCodeIds
+        BlacklistedPoolIds
       )
     );
 


### PR DESCRIPTION
This PR improves transmuter handling and serves as a reference for Astroport adding their custom cosmwasm pool.

For now, Astroport's pool will only be included in router but not in pools query.

Their code ID will need to be added once they deploy their contract to mainnet.