### PR TITLE
Feat: add target blank for external links

### DIFF
--- a/packages/web/components/token-details/token-details.tsx
+++ b/packages/web/components/token-details/token-details.tsx
@@ -165,6 +165,7 @@ const TokenDetails = ({
                 {twitterUrl && (
                   <LinkIconButton
                     href={twitterUrl}
+                    target="_blank"
                     mode="icon-social"
                     size="md-icon-social"
                     aria-label={t("tokenInfos.ariaViewOn", { name: "X" })}
@@ -176,6 +177,7 @@ const TokenDetails = ({
                 {websiteURL && (
                   <LinkIconButton
                     href={websiteURL}
+                    target="_blank"
                     mode="icon-social"
                     size="md-icon-social"
                     aria-label={t("tokenInfos.ariaView", { name: "website" })}
@@ -187,6 +189,7 @@ const TokenDetails = ({
                 {coingeckoURL && (
                   <LinkIconButton
                     href={coingeckoURL}
+                    target="_blank"
                     mode="icon-social"
                     size="md-icon-social"
                     aria-label={t("tokenInfos.ariaViewOn", {


### PR DESCRIPTION
## What is the purpose of the change

Add target blank for social link inside token details page.

### ClickUp Task

[ClickUp Task URL](PASTE_CLICKUP_TASK_URL_HERE)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
