### PR TITLE
Fix: `getAssets` tRPC: catch user asset value calculation

### DIFF
--- a/packages/web/server/api/edge-routers/assets.ts
+++ b/packages/web/server/api/edge-routers/assets.ts
@@ -73,6 +73,11 @@ export const assetsRouter = createTRPCRouter({
             const usdValue = await calcAssetValue({
               anyDenom: asset.coinMinimalDenom,
               amount: balance.amount,
+            }).catch(() => {
+              console.error(
+                asset.coinMinimalDenom,
+                "likely missing price config"
+              );
             });
 
             return {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

If the `getAssets` tRPC function is given a user address, it tries to calculate the fiat value of the users balance. But, if it's a new token and the price config is not there yet, it will throw an error. Instead, let's silently fail and return undefined for the fiat value.