### PR TITLE
feat: Only Track Transfer When ETH TX is Successful and Do not Select Whole Input on Click

### DIFF
--- a/packages/web/components/input/input-box.tsx
+++ b/packages/web/components/input/input-box.tsx
@@ -127,7 +127,6 @@ export const InputBox: FunctionComponent<Props> = ({
               onFocus && onFocus(e);
             }}
             onInput={(e: any) => onInput(e.target.value)}
-            onClick={(e: any) => e.target.select()}
             disabled={disabled}
             autoFocus={autoFocus}
           />

--- a/packages/web/modals/bridge-transfer-v2.tsx
+++ b/packages/web/modals/bridge-transfer-v2.tsx
@@ -638,12 +638,21 @@ export const BridgeTransferV2Modal: FunctionComponent<
           },
         ],
       });
-      trackTransferStatus(quote.provider.id, {
-        sendTxHash: txHash as string,
-        fromChainId: quote.fromChain.chainId,
-        toChainId: quote.toChain.chainId,
+
+      await new Promise((resolve, reject) => {
+        ethWalletClient.txStatusEventEmitter!.on("confirmed", () => {
+          resolve(void 0);
+          trackTransferStatus(quote.provider.id, {
+            sendTxHash: txHash as string,
+            fromChainId: quote.fromChain.chainId,
+            toChainId: quote.toChain.chainId,
+          });
+          setLastDepositAccountEvmAddress(ethWalletClient.accountAddress!);
+        });
+        ethWalletClient.txStatusEventEmitter!.on("failed", () => {
+          reject(void 0);
+        });
       });
-      setLastDepositAccountEvmAddress(ethWalletClient.accountAddress!);
 
       if (isWithdraw) {
         withdrawAmountConfig.setAmount("");

--- a/packages/web/modals/bridge-transfer-v2.tsx
+++ b/packages/web/modals/bridge-transfer-v2.tsx
@@ -648,18 +648,18 @@ export const BridgeTransferV2Modal: FunctionComponent<
             toChainId: quote.toChain.chainId,
           });
           setLastDepositAccountEvmAddress(ethWalletClient.accountAddress!);
+
+          if (isWithdraw) {
+            withdrawAmountConfig.setAmount("");
+          } else {
+            setDepositAmount("");
+          }
+          setTransferInitiated(true);
         });
         ethWalletClient.txStatusEventEmitter!.on("failed", () => {
           reject(void 0);
         });
       });
-
-      if (isWithdraw) {
-        withdrawAmountConfig.setAmount("");
-      } else {
-        setDepositAmount("");
-      }
-      setTransferInitiated(true);
     } catch (e) {
       const msg = ethWalletClient.displayError?.(e);
       if (typeof msg === "string") {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

### ClickUp Task

[Only Track Transfer When ETH TX is Successful](https://app.clickup.com/t/86a1np0h7)
[Do not Select Whole Input on Click](https://app.clickup.com/t/86a1nwern)

## Testing and Verifying

- [ ] If Tx fails, does not add the tx to track on the history table
- [ ] Clicking on input does not select the content
- [ ] Can bridge assets
