### PR TITLE
feat: Remember Leaving Osmosis Modal Per Site

### DIFF
--- a/packages/web/components/navbar/index.tsx
+++ b/packages/web/components/navbar/index.tsx
@@ -35,7 +35,10 @@ import {
   NotifiPopover,
 } from "~/integrations/notifi";
 import { ModalBase, ModalBaseProps, SettingsModal } from "~/modals";
-import { ExternalLinkModal } from "~/modals/external-links-modal";
+import {
+  ExternalLinkModal,
+  handleExternalLink,
+} from "~/modals/external-links-modal";
 import { ProfileModal } from "~/modals/profile";
 import { UserUpgradesModal } from "~/modals/user-upgrades";
 import { useStore } from "~/stores";
@@ -504,20 +507,11 @@ const AnnouncementBanner: FunctionComponent<
     link?.enTextOrLocalizationKey ?? "Click here to learn more"
   );
 
-  const handleLeaveClick = () => {
-    // try/catch in case user is in private mode
-    try {
-      const doNotShowModal = localStorage.getItem("doNotShowExternalLinkModal");
-      if (doNotShowModal) {
-        window.open(link?.url, "_blank");
-      } else {
-        onOpenLeavingOsmosis();
-      }
-    } catch (error) {
-      console.error("Error accessing localStorage:", error);
-      onOpenLeavingOsmosis();
-    }
-  };
+  const handleLeaveClick = () =>
+    handleExternalLink({
+      url: link?.url ?? "",
+      openModal: onOpenLeavingOsmosis,
+    });
 
   return (
     <div


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Currently, Leaving Osmosis Modal has a 'don't show again' checkbox that allows users to opt out of seeing the modal every time they click on an external website (e.g. Levana or Mars)

We still want this, except the user should be able to opt for the 'Leaving Osmosis' modal.

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/86a1p9x8e)

## Testing and Verifying

- [ ] Should remember when the user checks 'do not show again' and not display the modal again