### PR TITLE
[Notifi V5.1] fix jwt expiry login issue

### DIFF
--- a/packages/web/integrations/notifi/notifi-subscription-card/fetched-card/fetched-card.tsx
+++ b/packages/web/integrations/notifi/notifi-subscription-card/fetched-card/fetched-card.tsx
@@ -3,6 +3,7 @@ import { useNotifiSubscriptionContext } from "@notifi-network/notifi-react-card"
 import { FunctionComponent } from "react";
 
 import { useNotifiModalContext } from "~/integrations/notifi/notifi-modal-context";
+import { ExpiredCard } from "~/integrations/notifi/notifi-subscription-card/expired-card";
 import { EditView } from "~/integrations/notifi/notifi-subscription-card/fetched-card/edit-view";
 import { HistoryDetailView } from "~/integrations/notifi/notifi-subscription-card/fetched-card/history-detail-view";
 import { HistoryView } from "~/integrations/notifi/notifi-subscription-card/fetched-card/history-view";
@@ -23,6 +24,8 @@ export const FetchedCard: FunctionComponent<{
     return <SignupView />;
   } else if (cardView.state === "edit") {
     return <EditView />;
+  } else if (cardView.state === "expired") {
+    return <ExpiredCard />;
   } else {
     return null;
   }

--- a/packages/web/integrations/notifi/notifi-subscription-card/notifi-subscription-card.tsx
+++ b/packages/web/integrations/notifi/notifi-subscription-card/notifi-subscription-card.tsx
@@ -7,7 +7,6 @@ import { FunctionComponent, useEffect, useRef } from "react";
 import { useNotifiConfig } from "~/integrations/notifi/notifi-config-context";
 import { useNotifiModalContext } from "~/integrations/notifi/notifi-modal-context";
 import { ErrorCard } from "~/integrations/notifi/notifi-subscription-card/error-card";
-import { ExpiredCard } from "~/integrations/notifi/notifi-subscription-card/expired-card";
 import { FetchedCard } from "~/integrations/notifi/notifi-subscription-card/fetched-card";
 import { LoadingCard } from "~/integrations/notifi/notifi-subscription-card/loading-card";
 
@@ -61,8 +60,6 @@ export const NotifiSubscriptionCard: FunctionComponent<Props> = ({
 
   if (!client.isInitialized || config.state === "loading") {
     return <LoadingCard />;
-  } else if (client.isTokenExpired || cardView.state === "expired") {
-    return <ExpiredCard />;
   } else if (config.state === "error") {
     return <ErrorCard error={config.reason} />;
   } else if (cardView.state === "error") {


### PR DESCRIPTION
## Background

We found the issue that the login process will be blocked until the users refresh the dapp if the jwt token in browser is expired. 
This only happens when the users have not login visit dapp for long (> two weeks). 

This PR is to fix the issue above.


