### PR TITLE
Fix sort fiat value descending

### DIFF
--- a/packages/web/server/api/edge-routers/assets.ts
+++ b/packages/web/server/api/edge-routers/assets.ts
@@ -52,6 +52,7 @@ export const assetsRouter = createTRPCRouter({
         const userAssets = await mapGetUserAssetInfos({
           assets,
           userOsmoAddress,
+          sortFiatValueDirection: "desc",
         });
 
         return maybeCursorPaginatedItems(userAssets, cursor, limit);


### PR DESCRIPTION
I forgot that I added a param that's required to specify the fiat value sort, instead of always sorting by default. This is because with the assets info procedure (to be used with new assets table) I want to be able to specify the sort direction and whether I want it sorted in first place.