### PR TITLE
fix: Withdraw UI on Mobile

### DIFF
--- a/packages/web/components/animation/bridge/index.tsx
+++ b/packages/web/components/animation/bridge/index.tsx
@@ -21,7 +21,7 @@ export const BridgeAnimation = (props: CustomClasses) => {
   return (
     <div
       className={classNames(
-        "absolute left-1/2 top-[22px] -translate-x-1/2 transform transition-opacity duration-300 md:top-[8px] sm:left-[45%]",
+        "absolute left-1/2 top-[22px] -translate-x-1/2 transform transition-opacity duration-300 md:top-[18px] sm:left-[45%]",
         className
       )}
     >

--- a/packages/web/components/animation/bridge/index.tsx
+++ b/packages/web/components/animation/bridge/index.tsx
@@ -21,7 +21,7 @@ export const BridgeAnimation = (props: CustomClasses) => {
   return (
     <div
       className={classNames(
-        "absolute left-1/2 top-[22px]  -translate-x-1/2 transform transition-opacity duration-300 md:h-[50px]",
+        "absolute left-1/2 top-[22px] -translate-x-1/2 transform transition-opacity duration-300 md:top-[8px] sm:left-[45%]",
         className
       )}
     >
@@ -29,7 +29,7 @@ export const BridgeAnimation = (props: CustomClasses) => {
         animationData={animData}
         autoplay
         loop
-        className="h-[85px] w-[400px] md:h-[80px] md:w-[500px]"
+        className="h-[85px] w-[400px] md:w-[400px] sm:w-[120%]"
       />
     </div>
   );

--- a/packages/web/components/animation/bridge/index.tsx
+++ b/packages/web/components/animation/bridge/index.tsx
@@ -1,56 +1,14 @@
-import { Menu } from "@headlessui/react";
 import classNames from "classnames";
 import dynamic from "next/dynamic";
-import Image from "next/image";
 import { useEffect, useState } from "react";
 
-import { Icon } from "~/components/assets";
-import {
-  BaseBridgeProviderOption,
-  TransferProps,
-} from "~/components/complex/transfer";
 import { CustomClasses } from "~/components/types";
-import { useTranslation } from "~/hooks";
-import { useWindowSize } from "~/hooks";
-import { truncateString } from "~/utils/string";
 
 const Lottie = dynamic(() => import("lottie-react"), { ssr: false });
 
-interface BridgeAnimationProps<
-  BridgeProviderOption extends BaseBridgeProviderOption
-> extends CustomClasses {
-  transferPath: [
-    { address: string; networkName: string; iconUrl?: string },
-    { address: string; networkName: string; iconUrl?: string }
-  ];
-  bridgeProviders?: TransferProps<BridgeProviderOption>["bridgeProviders"];
-  selectedBridgeProvidersId?: TransferProps<BridgeProviderOption>["selectedBridgeProvidersId"];
-  onSelectBridgeProvider?: TransferProps<BridgeProviderOption>["onSelectBridgeProvider"];
-}
-
 /** Illustrates a bespoke or IBC bridge transfer for user info. */
-export const BridgeAnimation = <
-  BridgeProviderOption extends BaseBridgeProviderOption
->(
-  props: BridgeAnimationProps<BridgeProviderOption>
-) => {
-  const {
-    transferPath: [from, to],
-    className,
-    selectedBridgeProvidersId,
-    bridgeProviders,
-    onSelectBridgeProvider,
-  } = props;
-  const { isMobile } = useWindowSize();
-  const { t } = useTranslation();
-
-  const longFromName = from.networkName.length > 7;
-  const longToName = to.networkName.length > 7;
-
-  // constants
-  const overlayedIconSize = isMobile
-    ? { height: 36, width: 36 }
-    : { height: 45, width: 45 };
+export const BridgeAnimation = (props: CustomClasses) => {
+  const { className } = props;
 
   // dynamic load JSON animation data - keep base bundle small
   const [animData, setAnimData] = useState<object | null>(null);
@@ -60,146 +18,19 @@ export const BridgeAnimation = <
     }
   }, [animData]);
 
-  const selectedProvider = bridgeProviders?.find(
-    (provider) => provider.id === selectedBridgeProvidersId
-  );
-  const filteredBridgeProviders = bridgeProviders?.filter(
-    (provider) => provider.id !== selectedBridgeProvidersId
-  );
-
   return (
     <div
       className={classNames(
-        "relative h-[110px] w-[600px] md:w-[300px]",
+        "absolute left-1/2 top-[22px]  -translate-x-1/2 transform transition-opacity duration-300 md:h-[50px]",
         className
       )}
     >
-      <div className="absolute left-[10%] h-full w-1/3 text-center md:left-[2.5%]">
-        <span
-          className={classNames(
-            "whitespace-nowrap transition-opacity duration-300",
-            longFromName || longToName
-              ? isMobile
-                ? "caption"
-                : "subtitle1"
-              : "md:subtitle2",
-            longFromName
-              ? "left-[90px] md:-left-[4px]"
-              : "left-[122px] md:left-[10px]"
-          )}
-        >
-          {t("assets.transfer.from")} {truncateString(from.networkName, 22)}
-        </span>
-      </div>
-
-      <div className="absolute right-[10%] h-full w-1/3 text-center md:-right-[1%]">
-        <span
-          className={classNames(
-            "w-fit whitespace-nowrap transition-opacity duration-300",
-            longFromName || longToName
-              ? isMobile
-                ? "caption"
-                : "subtitle1"
-              : "md:subtitle2",
-            "left-[405px] md:left-[210px]"
-          )}
-        >
-          {t("assets.transfer.to")} {truncateString(to.networkName, 22)}
-        </span>
-      </div>
-
-      <div className="absolute left-[105px] top-[20px] md:left-[30px]">
-        <div className="transition-opacity duration-300">
-          <Lottie
-            style={{ height: isMobile ? 80 : 85, width: isMobile ? 255 : 400 }}
-            animationData={animData}
-            autoplay
-            loop
-          />
-        </div>
-      </div>
-      {from.iconUrl && (
-        <div className="absolute left-[139px] top-[40px] transition-opacity duration-300 md:left-[40px] md:top-[42px]">
-          <Image alt="token icon" src={from.iconUrl} {...overlayedIconSize} />
-        </div>
-      )}
-      {to.iconUrl && (
-        <div className="absolute left-[424px] top-[40px] transition-opacity duration-300 md:left-[237px] md:top-[42px]">
-          <Image alt="token icon" src={to.iconUrl} {...overlayedIconSize} />
-        </div>
-      )}
-      {filteredBridgeProviders && selectedProvider && (
-        <div
-          className="absolute left-1/2 flex -translate-x-[33%] transform place-content-between items-center"
-          title={t("assets.ibcTransfer.provider")}
-        >
-          {filteredBridgeProviders?.length === 0 ? (
-            <p className="subtitle-2 flex flex-col items-center gap-4">
-              <span className="rounded-lg bg-osmoverse-700 px-2 text-osmoverse-200">
-                {selectedProvider.name}
-              </span>
-              <Image
-                src={selectedProvider.logo}
-                alt={`${selectedProvider.name} logo`}
-                {...overlayedIconSize}
-              />
-            </p>
-          ) : (
-            <Menu>
-              {({ open }) => (
-                <div className="relative">
-                  <Menu.Button className="flex flex-col items-center gap-4">
-                    <div className="subtitle-2 flex items-center gap-1.5 rounded-lg bg-osmoverse-700 px-2 text-osmoverse-200">
-                      {selectedProvider.name}
-                      <Icon
-                        className="flex shrink-0 items-center"
-                        id={open ? "chevron-up" : "chevron-down"}
-                        height={10}
-                        width={10}
-                      />
-                    </div>
-                    <Image
-                      src={selectedProvider.logo}
-                      alt={`${selectedProvider.name} logo`}
-                      {...overlayedIconSize}
-                    />
-                  </Menu.Button>
-
-                  <Menu.Items className="absolute top-1/3 -right-px mb-2 flex w-max select-none flex-col overflow-hidden rounded-xl border border-osmoverse-700 bg-osmoverse-700">
-                    {filteredBridgeProviders.map((provider, index) => (
-                      <Menu.Item key={provider.id}>
-                        {({ active }) => (
-                          <button
-                            onClick={() => onSelectBridgeProvider?.(provider)}
-                            className={classNames(
-                              "flex cursor-pointer items-center gap-2 py-1 pl-2  pr-4 transition-colors",
-                              {
-                                "bg-osmoverse-600": active,
-                                "rounded-b-xlinset":
-                                  index === filteredBridgeProviders.length - 1,
-                              }
-                            )}
-                          >
-                            <div className="flex flex-shrink-0">
-                              <Image
-                                src={provider.logo}
-                                alt={`${provider.name} logo`}
-                                width={16}
-                                height={16}
-                              />
-                            </div>
-                            {provider.name}
-                          </button>
-                        )}
-                      </Menu.Item>
-                    ))}
-                  </Menu.Items>
-                </div>
-              )}
-            </Menu>
-          )}
-        </div>
-      )}
+      <Lottie
+        animationData={animData}
+        autoplay
+        loop
+        className="h-[85px] w-[400px] md:h-[80px] md:w-[500px]"
+      />
     </div>
   );
 };

--- a/packages/web/components/complex/bridge-from-to-network.tsx
+++ b/packages/web/components/complex/bridge-from-to-network.tsx
@@ -1,0 +1,187 @@
+import { Menu } from "@headlessui/react";
+import classNames from "classnames";
+import Image from "next/image";
+
+import { BridgeAnimation } from "~/components/animation/bridge";
+import { Icon } from "~/components/assets";
+import {
+  BaseBridgeProviderOption,
+  TransferProps,
+} from "~/components/complex/transfer";
+import { CustomClasses } from "~/components/types";
+import { useTranslation } from "~/hooks";
+import { useWindowSize } from "~/hooks";
+import { truncateString } from "~/utils/string";
+
+interface BridgeFromToNetworkProps<
+  BridgeProviderOption extends BaseBridgeProviderOption
+> extends CustomClasses {
+  transferPath: [
+    { address: string; networkName: string; iconUrl?: string },
+    { address: string; networkName: string; iconUrl?: string }
+  ];
+  bridgeProviders?: TransferProps<BridgeProviderOption>["bridgeProviders"];
+  selectedBridgeProvidersId?: TransferProps<BridgeProviderOption>["selectedBridgeProvidersId"];
+  onSelectBridgeProvider?: TransferProps<BridgeProviderOption>["onSelectBridgeProvider"];
+}
+
+export const BridgeFromToNetwork = <
+  BridgeProviderOption extends BaseBridgeProviderOption
+>(
+  props: BridgeFromToNetworkProps<BridgeProviderOption>
+) => {
+  const {
+    transferPath: [from, to],
+    className,
+    selectedBridgeProvidersId,
+    bridgeProviders,
+    onSelectBridgeProvider,
+  } = props;
+  const { isMobile } = useWindowSize();
+  const { t } = useTranslation();
+
+  // constants
+  const overlayedIconSize = isMobile
+    ? { height: 36, width: 36 }
+    : { height: 45, width: 45 };
+
+  const selectedProvider = bridgeProviders?.find(
+    (provider) => provider.id === selectedBridgeProvidersId
+  );
+  const filteredBridgeProviders = bridgeProviders?.filter(
+    (provider) => provider.id !== selectedBridgeProvidersId
+  );
+
+  return (
+    <div
+      className={classNames(
+        "relative flex w-full flex-col text-osmoverse-400",
+        className
+      )}
+    >
+      <BridgeAnimation />
+
+      <div className="flex flex-1 text-center">
+        {/* From Network */}
+        <div className="z-10 flex flex-1 flex-col items-center gap-4 pl-4 md:pl-8 sm:pl-0">
+          <span
+            className={classNames(
+              "whitespace-nowrap text-osmoverse-100 transition-opacity duration-300",
+              "md:subtitle2"
+            )}
+          >
+            {t("assets.transfer.from")} {truncateString(from.networkName, 22)}
+          </span>
+
+          {from.iconUrl && (
+            <div
+              className="transition-opacity duration-300"
+              style={overlayedIconSize}
+            >
+              <Image
+                alt="token icon"
+                src={from.iconUrl}
+                {...overlayedIconSize}
+              />
+            </div>
+          )}
+        </div>
+
+        {/* Provider select */}
+        {filteredBridgeProviders && selectedProvider && (
+          <div
+            className="absolute left-1/2 z-20 flex -translate-x-[33%] transform place-content-between items-center"
+            title={t("assets.ibcTransfer.provider")}
+          >
+            {filteredBridgeProviders?.length === 0 ? (
+              <p className="subtitle-2 flex flex-col items-center gap-4">
+                <span className="rounded-lg bg-osmoverse-700 px-2 text-osmoverse-200">
+                  {selectedProvider.name}
+                </span>
+                <Image
+                  src={selectedProvider.logo}
+                  alt={`${selectedProvider.name} logo`}
+                  {...overlayedIconSize}
+                />
+              </p>
+            ) : (
+              <Menu>
+                {({ open }) => (
+                  <div className="relative">
+                    <Menu.Button className="flex flex-col items-center gap-4">
+                      <div className="subtitle-2 flex items-center gap-1.5 rounded-lg bg-osmoverse-700 px-2 text-osmoverse-200">
+                        {selectedProvider.name}
+                        <Icon
+                          className="flex shrink-0 items-center"
+                          id={open ? "chevron-up" : "chevron-down"}
+                          height={10}
+                          width={10}
+                        />
+                      </div>
+                      <Image
+                        src={selectedProvider.logo}
+                        alt={`${selectedProvider.name} logo`}
+                        {...overlayedIconSize}
+                      />
+                    </Menu.Button>
+
+                    <Menu.Items className="absolute top-1/3 -right-px mb-2 flex w-max select-none flex-col overflow-hidden rounded-xl border border-osmoverse-700 bg-osmoverse-700">
+                      {filteredBridgeProviders.map((provider, index) => (
+                        <Menu.Item key={provider.id}>
+                          {({ active }) => (
+                            <button
+                              onClick={() => onSelectBridgeProvider?.(provider)}
+                              className={classNames(
+                                "flex cursor-pointer items-center gap-2 py-1 pl-2  pr-4 transition-colors",
+                                {
+                                  "bg-osmoverse-600": active,
+                                  "rounded-b-xlinset":
+                                    index ===
+                                    filteredBridgeProviders.length - 1,
+                                }
+                              )}
+                            >
+                              <div className="flex flex-shrink-0">
+                                <Image
+                                  src={provider.logo}
+                                  alt={`${provider.name} logo`}
+                                  width={16}
+                                  height={16}
+                                />
+                              </div>
+                              {provider.name}
+                            </button>
+                          )}
+                        </Menu.Item>
+                      ))}
+                    </Menu.Items>
+                  </div>
+                )}
+              </Menu>
+            )}
+          </div>
+        )}
+
+        {/* To Network */}
+        <div className="z-10 flex flex-1 flex-col items-center gap-4 pr-5 text-center md:pr-8 sm:pr-0">
+          <span
+            className={classNames(
+              "w-fit whitespace-nowrap text-osmoverse-100 transition-opacity duration-300",
+              "md:subtitle2"
+            )}
+          >
+            {t("assets.transfer.to")} {truncateString(to.networkName, 22)}
+          </span>
+          {to.iconUrl && (
+            <div
+              className="transition-opacity duration-300"
+              style={overlayedIconSize}
+            >
+              <Image alt="token icon" src={to.iconUrl} {...overlayedIconSize} />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/web/components/complex/transfer.tsx
+++ b/packages/web/components/complex/transfer.tsx
@@ -198,8 +198,6 @@ export const Transfer = observer(
     const overlayedIconSize = isMobile
       ? { height: 36, width: 36 }
       : { height: 45, width: 45 };
-    const longFromName = from.networkName.length > 7;
-    const longToName = to.networkName.length > 7;
 
     const selectedProvider = bridgeProviders?.find(
       (provider) => provider.id === selectedBridgeProvidersId

--- a/packages/web/components/complex/transfer.tsx
+++ b/packages/web/components/complex/transfer.tsx
@@ -194,17 +194,6 @@ export const Transfer = observer(
     const isAddButtonVisible =
       isWithdraw && addWithdrawAddrConfig && !disabled && !isAddingWithdrawAddr;
 
-    const overlayedIconSize = isMobile
-      ? { height: 36, width: 36 }
-      : { height: 45, width: 45 };
-
-    const selectedProvider = bridgeProviders?.find(
-      (provider) => provider.id === selectedBridgeProvidersId
-    );
-    const filteredBridgeProviders = bridgeProviders?.filter(
-      (provider) => provider.id !== selectedBridgeProvidersId
-    );
-
     let displayFromAddress: ReactNode | undefined;
     if (!from.address.startsWith("0x") || from.address.length === 0) {
       if (isOsmosisAccountLoaded) {

--- a/packages/web/components/complex/transfer.tsx
+++ b/packages/web/components/complex/transfer.tsx
@@ -262,7 +262,7 @@ export const Transfer = observer(
           <div
             className={classNames(
               "z-10 flex w-full flex-col gap-12 transition-width",
-              !isEditingWithdrawAddr && "flex pl-6",
+              !isEditingWithdrawAddr && "flex pl-6 sm:pl-0",
               {
                 "w-1/4 text-osmoverse-400/30": isEditingWithdrawAddr,
               }
@@ -408,7 +408,7 @@ export const Transfer = observer(
           <div
             className={classNames(
               "z-10 flex w-full flex-col gap-12 transition-width",
-              isEditingWithdrawAddr ? "p-[7px]" : "flex pr-7",
+              isEditingWithdrawAddr ? "p-[7px]" : "flex pr-7 md:pr-9 sm:pr-0",
               {
                 "w-3/4": isEditingWithdrawAddr,
               }

--- a/packages/web/components/complex/transfer.tsx
+++ b/packages/web/components/complex/transfer.tsx
@@ -305,7 +305,7 @@ export const Transfer = observer(
             {/* Provider select */}
             {filteredBridgeProviders && selectedProvider && (
               <div
-                className="absolute left-1/2 flex -translate-x-[33%] transform place-content-between items-center"
+                className="absolute left-1/2 z-20 flex -translate-x-[33%] transform place-content-between items-center"
                 title={t("assets.ibcTransfer.provider")}
               >
                 {filteredBridgeProviders?.length === 0 ? (

--- a/packages/web/components/complex/transfer.tsx
+++ b/packages/web/components/complex/transfer.tsx
@@ -1,4 +1,3 @@
-import { Menu } from "@headlessui/react";
 import { Bech32Address } from "@keplr-wallet/cosmos";
 import { CoinPretty, PricePretty, RatePretty } from "@keplr-wallet/unit";
 import classNames from "classnames";
@@ -9,12 +8,12 @@ import { ReactNode } from "react";
 import { useRef, useState } from "react";
 import { useClickAway } from "react-use";
 
-import { BridgeAnimation } from "~/components/animation/bridge";
 import { Icon } from "~/components/assets";
 import { GradientView } from "~/components/assets/gradient-view";
 import { Button } from "~/components/buttons";
 import IconButton from "~/components/buttons/icon-button";
 import { SwitchWalletButton } from "~/components/buttons/switch-wallet";
+import { BridgeFromToNetwork } from "~/components/complex/bridge-from-to-network";
 import { CheckBox, MenuDropdown, MenuToggle } from "~/components/control";
 import { InputBox } from "~/components/input";
 import SkeletonLoader from "~/components/skeleton-loader";
@@ -25,7 +24,7 @@ import { useWindowSize } from "~/hooks";
 import { truncateEthAddress } from "~/integrations/ethereum/metamask-utils";
 import { WalletDisplay } from "~/integrations/wallets";
 import { useStore } from "~/stores";
-import { formatICNSName, truncateString } from "~/utils/string";
+import { formatICNSName } from "~/utils/string";
 
 type PathSource = "counterpartyAccount" | "account";
 
@@ -273,136 +272,12 @@ export const Transfer = observer(
         )}
 
         <div className="body1 relative flex w-full flex-col gap-12 text-osmoverse-400 transition-opacity duration-300">
-          <BridgeAnimation />
-
-          <div className="flex w-full overflow-hidden text-center">
-            {/* From Network */}
-            <div className="z-10 flex flex-1 flex-col items-center gap-4 pl-4 md:pl-8 sm:pl-0">
-              <span
-                className={classNames(
-                  "whitespace-nowrap text-osmoverse-100 transition-opacity duration-300",
-                  "md:subtitle2"
-                )}
-              >
-                {t("assets.transfer.from")}{" "}
-                {truncateString(from.networkName, 22)}
-              </span>
-
-              {from.iconUrl && (
-                <div
-                  className="transition-opacity duration-300"
-                  style={overlayedIconSize}
-                >
-                  <Image
-                    alt="token icon"
-                    src={from.iconUrl}
-                    {...overlayedIconSize}
-                  />
-                </div>
-              )}
-            </div>
-
-            {/* Provider select */}
-            {filteredBridgeProviders && selectedProvider && (
-              <div
-                className="absolute left-1/2 z-20 flex -translate-x-[33%] transform place-content-between items-center"
-                title={t("assets.ibcTransfer.provider")}
-              >
-                {filteredBridgeProviders?.length === 0 ? (
-                  <p className="subtitle-2 flex flex-col items-center gap-4">
-                    <span className="rounded-lg bg-osmoverse-700 px-2 text-osmoverse-200">
-                      {selectedProvider.name}
-                    </span>
-                    <Image
-                      src={selectedProvider.logo}
-                      alt={`${selectedProvider.name} logo`}
-                      {...overlayedIconSize}
-                    />
-                  </p>
-                ) : (
-                  <Menu>
-                    {({ open }) => (
-                      <div className="relative">
-                        <Menu.Button className="flex flex-col items-center gap-4">
-                          <div className="subtitle-2 flex items-center gap-1.5 rounded-lg bg-osmoverse-700 px-2 text-osmoverse-200">
-                            {selectedProvider.name}
-                            <Icon
-                              className="flex shrink-0 items-center"
-                              id={open ? "chevron-up" : "chevron-down"}
-                              height={10}
-                              width={10}
-                            />
-                          </div>
-                          <Image
-                            src={selectedProvider.logo}
-                            alt={`${selectedProvider.name} logo`}
-                            {...overlayedIconSize}
-                          />
-                        </Menu.Button>
-
-                        <Menu.Items className="absolute top-1/3 -right-px mb-2 flex w-max select-none flex-col overflow-hidden rounded-xl border border-osmoverse-700 bg-osmoverse-700">
-                          {filteredBridgeProviders.map((provider, index) => (
-                            <Menu.Item key={provider.id}>
-                              {({ active }) => (
-                                <button
-                                  onClick={() =>
-                                    onSelectBridgeProvider?.(provider)
-                                  }
-                                  className={classNames(
-                                    "flex cursor-pointer items-center gap-2 py-1 pl-2  pr-4 transition-colors",
-                                    {
-                                      "bg-osmoverse-600": active,
-                                      "rounded-b-xlinset":
-                                        index ===
-                                        filteredBridgeProviders.length - 1,
-                                    }
-                                  )}
-                                >
-                                  <div className="flex flex-shrink-0">
-                                    <Image
-                                      src={provider.logo}
-                                      alt={`${provider.name} logo`}
-                                      width={16}
-                                      height={16}
-                                    />
-                                  </div>
-                                  {provider.name}
-                                </button>
-                              )}
-                            </Menu.Item>
-                          ))}
-                        </Menu.Items>
-                      </div>
-                    )}
-                  </Menu>
-                )}
-              </div>
-            )}
-
-            {/* To Network */}
-            <div className="z-10 flex flex-1 flex-col items-center gap-4 pr-5 text-center md:pr-8 sm:-mr-1 sm:pr-0">
-              <span
-                className={classNames(
-                  "w-fit whitespace-nowrap text-osmoverse-100 transition-opacity duration-300",
-                  "md:subtitle2"
-                )}
-              >
-                {t("assets.transfer.to")} {truncateString(to.networkName, 22)}
-              </span>
-              {to.iconUrl && (
-                <div
-                  className="transition-opacity duration-300"
-                  style={overlayedIconSize}
-                >
-                  <Image
-                    alt="token icon"
-                    src={to.iconUrl}
-                    {...overlayedIconSize}
-                  />
-                </div>
-              )}
-            </div>
-          </div>
+          <BridgeFromToNetwork
+            transferPath={[from, to]}
+            bridgeProviders={bridgeProviders}
+            onSelectBridgeProvider={onSelectBridgeProvider}
+            selectedBridgeProvidersId={selectedBridgeProvidersId}
+          />
 
           <div className="z-10 flex w-full gap-4 pr-7 pl-6 text-center md:pr-9 sm:pr-0 sm:pl-0">
             {/* From Address */}
@@ -437,7 +312,7 @@ export const Transfer = observer(
             {/* To Address */}
             <div
               className={classNames(
-                "flex h-full w-full rounded-2xl border border-white-faint py-2.5 text-center transition-width",
+                "flex w-full rounded-2xl border border-white-faint py-2.5 text-center transition-width",
                 {
                   "w-3/4": isEditingWithdrawAddr,
                 }

--- a/packages/web/components/control/token-select.tsx
+++ b/packages/web/components/control/token-select.tsx
@@ -143,7 +143,7 @@ export const TokenSelect: FunctionComponent<{
             }}
           >
             {selectedCurrency.coinImageUrl && (
-              <div className="mr-1 h-[50px] w-[50px] shrink-0 overflow-hidden rounded-full md:h-7 md:w-7">
+              <div className="mr-1 h-[50px] w-[50px] shrink-0 overflow-hidden rounded-full md:h-[30px] md:w-[30px]">
                 <Image
                   src={selectedCurrency.coinImageUrl}
                   alt="token icon"

--- a/packages/web/integrations/axelar/transfer.tsx
+++ b/packages/web/integrations/axelar/transfer.tsx
@@ -300,7 +300,7 @@ const AxelarTransfer: FunctionComponent<
     }, [ethWalletClient.isConnected, userDisconnectedEthWallet]);
 
     const correctChainSelected =
-      (EthClientChainIds_SourceChainMap[ethWalletClient.chainId as string] ??
+      (EthClientChainIds_SourceChainMap[ethWalletClient?.chainId ?? ""] ??
         ethWalletClient.chainId) ===
       (AxelarChainIds_SourceChainMap[selectedSourceChainAxelarKey] ??
         selectedSourceChainAxelarKey);

--- a/packages/web/integrations/ethereum/hooks/use-amount-config.ts
+++ b/packages/web/integrations/ethereum/hooks/use-amount-config.ts
@@ -16,7 +16,7 @@ export function useAmountConfig({
   address,
   gasCurrency,
 }: {
-  sendFn: SendFn;
+  sendFn?: SendFn;
   balance?: CoinPretty;
   address?: string;
   gasCurrency?: Currency;

--- a/packages/web/integrations/ethereum/hooks/use-erc20-balance.ts
+++ b/packages/web/integrations/ethereum/hooks/use-erc20-balance.ts
@@ -6,17 +6,19 @@ import { EthWallet } from "~/integrations/ethereum/types";
 
 /** Use balance of arbitrary ERC20 EVM contract. */
 export function useErc20Balance(
-  ethWallet: EthWallet,
+  ethWallet: EthWallet | undefined,
   erc20ContractAddress?: string
 ) {
   const [erc20Balance, setErc20Balance] = useState<Awaited<
     ReturnType<typeof queryErc20Balance>
   > | null>(null);
 
-  const address = ethWallet.accountAddress;
-  const sendFn = ethWallet.send;
+  const address = ethWallet?.accountAddress;
+  const sendFn = ethWallet?.send;
 
   useEffect(() => {
+    if (!ethWallet || !sendFn) return;
+
     if (address && erc20ContractAddress) {
       queryErc20Balance(sendFn, erc20ContractAddress, address).then(
         (balance) => {
@@ -24,7 +26,7 @@ export function useErc20Balance(
         }
       );
     }
-  }, [ethWallet.chainId, address, erc20ContractAddress, sendFn]);
+  }, [ethWallet?.chainId, address, erc20ContractAddress, sendFn, ethWallet]);
 
   if (!erc20Balance) return;
   return new CoinPretty(

--- a/packages/web/integrations/ethereum/hooks/use-native-balance.ts
+++ b/packages/web/integrations/ethereum/hooks/use-native-balance.ts
@@ -7,19 +7,18 @@ import { EthWallet } from "~/integrations/ethereum/types";
 
 /** Use native EVM balance. */
 export function useNativeBalance(
-  ethWallet: EthWallet,
+  ethWallet: EthWallet | undefined,
   originCurrency?: Currency
 ) {
   const [nativeBalance, setNativeBalance] = useState<Int | null>(null);
 
-  const address = ethWallet.accountAddress;
-  const sendFn = ethWallet.send;
+  const address = ethWallet?.accountAddress;
+  const sendFn = ethWallet?.send;
 
   useEffect(() => {
-    if (address) {
-      queryAccountBalance(sendFn, address).then(setNativeBalance);
-    }
-  }, [ethWallet.chainId, address, sendFn]);
+    if (!ethWallet || !sendFn || !address) return;
+    queryAccountBalance(sendFn, address).then(setNativeBalance);
+  }, [ethWallet?.chainId, address, sendFn, ethWallet]);
 
   if (!originCurrency || !nativeBalance) return;
   return new CoinPretty(originCurrency, nativeBalance);

--- a/packages/web/integrations/ethereum/hooks/use-tx-gas-estimate.ts
+++ b/packages/web/integrations/ethereum/hooks/use-tx-gas-estimate.ts
@@ -12,7 +12,7 @@ import { SendFn } from "~/integrations/ethereum/types";
  * @param costMultiplier Buffer to add to gas cost to handle high gas cost case (gas slippage).
  */
 export function useTxGasEstimate(
-  sendFn: SendFn,
+  sendFn?: SendFn,
   memoedParams?: unknown[],
   memoedCurrency?: Currency,
   costMultiplier = 5.4
@@ -22,7 +22,7 @@ export function useTxGasEstimate(
   const gasCostCache = useRef<Map<string, string>>(new Map());
 
   useEffect(() => {
-    if (memoedParams && memoedCurrency) {
+    if (memoedParams && memoedCurrency && sendFn) {
       const cacheKey = `${JSON.stringify(memoedParams)}${JSON.stringify(
         memoedCurrency
       )}`;

--- a/packages/web/integrations/ethereum/use-tx-receipt-state.ts
+++ b/packages/web/integrations/ethereum/use-tx-receipt-state.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 
 import { EthWallet } from "./types";
 
-export function useTxReceiptState(client: EthWallet): {
+export function useTxReceiptState(client?: EthWallet): {
   isEthTxPending: boolean;
 } {
   const [isEthTxPending, setIsEthTxPending] = useState(false);
@@ -10,14 +10,14 @@ export function useTxReceiptState(client: EthWallet): {
   useEffect(() => {
     const handlePending = () => setIsEthTxPending(true);
     const handleResolved = () => setIsEthTxPending(false);
-    client.txStatusEventEmitter?.on("pending", handlePending);
-    client.txStatusEventEmitter?.on("confirmed", handleResolved);
-    client.txStatusEventEmitter?.on("failed", handleResolved);
+    client?.txStatusEventEmitter?.on("pending", handlePending);
+    client?.txStatusEventEmitter?.on("confirmed", handleResolved);
+    client?.txStatusEventEmitter?.on("failed", handleResolved);
 
     return () => {
-      client.txStatusEventEmitter?.removeListener("pending", handlePending);
-      client.txStatusEventEmitter?.removeListener("confirmed", handleResolved);
-      client.txStatusEventEmitter?.removeListener("failed", handleResolved);
+      client?.txStatusEventEmitter?.removeListener("pending", handlePending);
+      client?.txStatusEventEmitter?.removeListener("confirmed", handleResolved);
+      client?.txStatusEventEmitter?.removeListener("failed", handleResolved);
     };
   }, [client]);
 

--- a/packages/web/integrations/nomic/transfer.tsx
+++ b/packages/web/integrations/nomic/transfer.tsx
@@ -12,9 +12,9 @@ import { useEffect, useState } from "react";
 import { FunctionComponent } from "react";
 
 import { displayToast, ToastType } from "~/components/alert";
-import { BridgeAnimation } from "~/components/animation";
 import { GradientView } from "~/components/assets/gradient-view";
 import { Button } from "~/components/buttons";
+import { BridgeFromToNetwork } from "~/components/complex/bridge-from-to-network";
 import { InputBox } from "~/components/input";
 import SkeletonLoader from "~/components/skeleton-loader";
 import { IS_TESTNET } from "~/config";
@@ -277,10 +277,11 @@ const NomicTransfer: FunctionComponent<
           </div>
         ) : (
           <>
-            <BridgeAnimation
-              className={`mx-auto mt-6 -mb-4`}
+            <BridgeFromToNetwork
+              className={`mx-auto mt-6`}
               transferPath={[from, to]}
             />
+
             {isWithdraw ? (
               <>
                 <div

--- a/packages/web/localizations/en.json
+++ b/packages/web/localizations/en.json
@@ -242,8 +242,8 @@
         "noQuotesAvailable": "No Quotes Available",
         "unexpectedError": "Unexpected Error. Please try again.",
         "transactionError": "Error getting transaction. Please try again.",
-        "missingAddress": "Missing Address",
-        "invalidAddress": "Invalid Address"
+        "invalidAddress": "Invalid Address",
+        "missingAddress": "Missing Address"
       },
       "from": "From",
       "loading": "Loading",

--- a/packages/web/localizations/en.json
+++ b/packages/web/localizations/en.json
@@ -172,6 +172,7 @@
       "title": "Transfer History"
     },
     "ibcTransfer": {
+      "buttonAdd": "Add",
       "buttonEdit": "Edit",
       "buttonEnter": "Enter",
       "channelCongestedDeposit": "Deposit (Channel congested)",
@@ -231,6 +232,7 @@
       "availableOn": "Available on {network}",
       "approving": "Approving...",
       "givePermission": "Give permissions to use tokens",
+      "enterEthAddress": "EVM address",
       "errors": {
         "insufficientBal": "Insufficient Balance",
         "insufficientFee": "Insufficient Fee",
@@ -239,7 +241,8 @@
         "seeRequest": "See request in {walletName}",
         "noQuotesAvailable": "No Quotes Available",
         "unexpectedError": "Unexpected Error. Please try again.",
-        "transactionError": "Error getting transaction. Please try again."
+        "transactionError": "Error getting transaction. Please try again.",
+        "missingAddress": "Missing Address"
       },
       "from": "From",
       "loading": "Loading",

--- a/packages/web/localizations/en.json
+++ b/packages/web/localizations/en.json
@@ -242,7 +242,8 @@
         "noQuotesAvailable": "No Quotes Available",
         "unexpectedError": "Unexpected Error. Please try again.",
         "transactionError": "Error getting transaction. Please try again.",
-        "missingAddress": "Missing Address"
+        "missingAddress": "Missing Address",
+        "invalidAddress": "Invalid Address"
       },
       "from": "From",
       "loading": "Loading",

--- a/packages/web/localizations/es.json
+++ b/packages/web/localizations/es.json
@@ -172,6 +172,7 @@
       "title": "Historial de transferencias"
     },
     "ibcTransfer": {
+      "buttonAdd": "Agregar",
       "buttonEdit": "Editar",
       "buttonEnter": "Ingresar",
       "channelCongestedDeposit": "Depositar (Canal impugnado)",

--- a/packages/web/localizations/es.json
+++ b/packages/web/localizations/es.json
@@ -242,7 +242,8 @@
         "noQuotesAvailable": "No hay cotizaciones disponibles",
         "unexpectedError": "Error inesperado. Inténtalo de nuevo.",
         "transactionError": "Error al obtener la transacción. Inténtalo de nuevo.",
-        "invalidAddress": "Dirección inválida"
+        "invalidAddress": "Dirección inválida",
+        "missingAddress": "Dirección faltante"
       },
       "from": "De",
       "loading": "Cargando",

--- a/packages/web/localizations/es.json
+++ b/packages/web/localizations/es.json
@@ -232,6 +232,7 @@
       "availableOn": "Disponible en {network}",
       "approving": "Aprobando...",
       "givePermission": "Dar permisos para usar tokens",
+      "enterEthAddress": "dirección EVM",
       "errors": {
         "insufficientBal": "Saldo insuficiente",
         "insufficientFee": "Cuota insuficiente",
@@ -240,7 +241,8 @@
         "seeRequest": "Ver solicitud en {walletName}",
         "noQuotesAvailable": "No hay cotizaciones disponibles",
         "unexpectedError": "Error inesperado. Inténtalo de nuevo.",
-        "transactionError": "Error al obtener la transacción. Inténtalo de nuevo."
+        "transactionError": "Error al obtener la transacción. Inténtalo de nuevo.",
+        "invalidAddress": "Dirección inválida"
       },
       "from": "De",
       "loading": "Cargando",

--- a/packages/web/localizations/fa.json
+++ b/packages/web/localizations/fa.json
@@ -172,6 +172,7 @@
       "title": "تاریخ چه انتقال"
     },
     "ibcTransfer": {
+      "buttonAdd": "اضافه کردن",
       "buttonEdit": "ویرایش",
       "buttonEnter": "ورود",
       "channelCongestedDeposit": "واریز وجه(کانال شلوغ)",

--- a/packages/web/localizations/fa.json
+++ b/packages/web/localizations/fa.json
@@ -242,7 +242,8 @@
         "noQuotesAvailable": "هیچ نقل قولی در دسترس نیست",
         "unexpectedError": "خطای غیرمنتظره لطفا دوباره تلاش کنید.",
         "transactionError": "خطا در دریافت تراکنش. لطفا دوباره تلاش کنید.",
-        "invalidAddress": "آدرس نامعتبر"
+        "invalidAddress": "آدرس نامعتبر",
+        "missingAddress": "آدرس گم شده"
       },
       "from": "از",
       "loading": "در حال بارگذاری",

--- a/packages/web/localizations/fa.json
+++ b/packages/web/localizations/fa.json
@@ -232,6 +232,7 @@
       "availableOn": "دارایی در شبکه {network}",
       "approving": "تایید...",
       "givePermission": "اجازه استفاده از توکن ها را بدهید",
+      "enterEthAddress": "آدرس EVM",
       "errors": {
         "insufficientBal": "موجودی نا کافی",
         "insufficientFee": "کارمزد ناکافی",
@@ -240,7 +241,8 @@
         "seeRequest": "درخواست را در {walletName} ببینید",
         "noQuotesAvailable": "هیچ نقل قولی در دسترس نیست",
         "unexpectedError": "خطای غیرمنتظره لطفا دوباره تلاش کنید.",
-        "transactionError": "خطا در دریافت تراکنش. لطفا دوباره تلاش کنید."
+        "transactionError": "خطا در دریافت تراکنش. لطفا دوباره تلاش کنید.",
+        "invalidAddress": "آدرس نامعتبر"
       },
       "from": "از",
       "loading": "در حال بارگذاری",

--- a/packages/web/localizations/fr.json
+++ b/packages/web/localizations/fr.json
@@ -232,6 +232,7 @@
       "availableOn": "Disponible sur {network}",
       "approving": "Approuvant...",
       "givePermission": "Accorder les autorisations pour utiliser des jetons",
+      "enterEthAddress": "Adresse EVM",
       "errors": {
         "insufficientBal": "Solde insuffisant",
         "insufficientFee": "Frais insuffisants",
@@ -240,7 +241,8 @@
         "seeRequest": "Voir la demande dans {walletName}",
         "noQuotesAvailable": "Aucun devis disponible",
         "unexpectedError": "Erreur inattendue. Veuillez réessayer.",
-        "transactionError": "Erreur lors de la transaction. Veuillez réessayer."
+        "transactionError": "Erreur lors de la transaction. Veuillez réessayer.",
+        "invalidAddress": "Adresse invalide"
       },
       "from": "De",
       "loading": "Chargement",

--- a/packages/web/localizations/fr.json
+++ b/packages/web/localizations/fr.json
@@ -242,7 +242,8 @@
         "noQuotesAvailable": "Aucun devis disponible",
         "unexpectedError": "Erreur inattendue. Veuillez réessayer.",
         "transactionError": "Erreur lors de la transaction. Veuillez réessayer.",
-        "invalidAddress": "Adresse invalide"
+        "invalidAddress": "Adresse invalide",
+        "missingAddress": "Adresse manquante"
       },
       "from": "De",
       "loading": "Chargement",

--- a/packages/web/localizations/fr.json
+++ b/packages/web/localizations/fr.json
@@ -172,6 +172,7 @@
       "title": "Historique des transferts"
     },
     "ibcTransfer": {
+      "buttonAdd": "Ajouter",
       "buttonEdit": "Éditer",
       "buttonEnter": "Entrer",
       "channelCongestedDeposit": "Déposer (Canal conjecturé)",

--- a/packages/web/localizations/ko.json
+++ b/packages/web/localizations/ko.json
@@ -232,6 +232,7 @@
       "availableOn": "{network} 잔고",
       "approving": "승인 중...",
       "givePermission": "토큰 사용 권한 부여",
+      "enterEthAddress": "EVM 주소",
       "errors": {
         "insufficientBal": "잔액이 부족합니다",
         "insufficientFee": "수수료가 부족합니다",
@@ -240,7 +241,8 @@
         "seeRequest": "{walletName}에서 요청 사항 확인하기",
         "noQuotesAvailable": "이용 가능한 견적이 없습니다.",
         "unexpectedError": "예기치 않은 오류. 다시 시도해 주세요.",
-        "transactionError": "거래를 가져오는 중에 오류가 발생했습니다. 다시 시도해 주세요."
+        "transactionError": "거래를 가져오는 중에 오류가 발생했습니다. 다시 시도해 주세요.",
+        "invalidAddress": "잘못된 주소"
       },
       "from": "발신 체인",
       "loading": "로딩",

--- a/packages/web/localizations/ko.json
+++ b/packages/web/localizations/ko.json
@@ -242,7 +242,8 @@
         "noQuotesAvailable": "이용 가능한 견적이 없습니다.",
         "unexpectedError": "예기치 않은 오류. 다시 시도해 주세요.",
         "transactionError": "거래를 가져오는 중에 오류가 발생했습니다. 다시 시도해 주세요.",
-        "invalidAddress": "잘못된 주소"
+        "invalidAddress": "잘못된 주소",
+        "missingAddress": "누락된 주소"
       },
       "from": "발신 체인",
       "loading": "로딩",

--- a/packages/web/localizations/ko.json
+++ b/packages/web/localizations/ko.json
@@ -172,6 +172,7 @@
       "title": "전송 내역"
     },
     "ibcTransfer": {
+      "buttonAdd": "추가하다",
       "buttonEdit": "수정",
       "buttonEnter": "입력",
       "channelCongestedDeposit": "입금 (채널 혼잡)",

--- a/packages/web/localizations/pl.json
+++ b/packages/web/localizations/pl.json
@@ -242,7 +242,8 @@
         "noQuotesAvailable": "Brak dostępnych cytatów",
         "unexpectedError": "Niespodziewany błąd. Proszę spróbuj ponownie.",
         "transactionError": "Błąd podczas uzyskiwania transakcji. Proszę spróbuj ponownie.",
-        "invalidAddress": "Błędny adres"
+        "invalidAddress": "Błędny adres",
+        "missingAddress": "Brak adresu"
       },
       "from": "Od",
       "loading": "Ładowanie",

--- a/packages/web/localizations/pl.json
+++ b/packages/web/localizations/pl.json
@@ -232,6 +232,7 @@
       "availableOn": "Dostępne na {network}",
       "approving": "Pochlebny...",
       "givePermission": "Nadaj uprawnienia do używania tokenów",
+      "enterEthAddress": "Adres EVM",
       "errors": {
         "insufficientBal": "Niewystarczająca Ilość Środków",
         "insufficientFee": "Niewystarczająca Prowizja",
@@ -240,7 +241,8 @@
         "seeRequest": "Zobacz żądanie w {walletName}",
         "noQuotesAvailable": "Brak dostępnych cytatów",
         "unexpectedError": "Niespodziewany błąd. Proszę spróbuj ponownie.",
-        "transactionError": "Błąd podczas uzyskiwania transakcji. Proszę spróbuj ponownie."
+        "transactionError": "Błąd podczas uzyskiwania transakcji. Proszę spróbuj ponownie.",
+        "invalidAddress": "Błędny adres"
       },
       "from": "Od",
       "loading": "Ładowanie",

--- a/packages/web/localizations/pl.json
+++ b/packages/web/localizations/pl.json
@@ -172,6 +172,7 @@
       "title": "Historia Transferów"
     },
     "ibcTransfer": {
+      "buttonAdd": "Dodać",
       "buttonEdit": "Edytuj",
       "buttonEnter": "Ok",
       "channelCongestedDeposit": "Wpłać (Kanał zmyślony)",

--- a/packages/web/localizations/pt-br.json
+++ b/packages/web/localizations/pt-br.json
@@ -172,6 +172,7 @@
       "title": "Histórico de Transferências"
     },
     "ibcTransfer": {
+      "buttonAdd": "Adicionar",
       "buttonEdit": "Editar",
       "buttonEnter": "Entrar",
       "channelCongestedDeposit": "Depositar (Canal congestionada)",

--- a/packages/web/localizations/pt-br.json
+++ b/packages/web/localizations/pt-br.json
@@ -242,7 +242,8 @@
         "noQuotesAvailable": "Nenhuma cotação disponível",
         "unexpectedError": "Erro inesperado. Por favor, tente novamente.",
         "transactionError": "Erro ao obter transação. Por favor, tente novamente.",
-        "invalidAddress": "Endereço inválido"
+        "invalidAddress": "Endereço inválido",
+        "missingAddress": "Endereço ausente"
       },
       "from": "De",
       "loading": "Carregando",

--- a/packages/web/localizations/pt-br.json
+++ b/packages/web/localizations/pt-br.json
@@ -232,6 +232,7 @@
       "availableOn": "Disponível em {network}",
       "approving": "Aprovando...",
       "givePermission": "Dê permissões para usar tokens",
+      "enterEthAddress": "Endereço EVM",
       "errors": {
         "insufficientBal": "Saldo Insuficiente",
         "insufficientFee": "Taxa Insuficiente",
@@ -240,7 +241,8 @@
         "seeRequest": "Ver solicitação em {walletName}",
         "noQuotesAvailable": "Nenhuma cotação disponível",
         "unexpectedError": "Erro inesperado. Por favor, tente novamente.",
-        "transactionError": "Erro ao obter transação. Por favor, tente novamente."
+        "transactionError": "Erro ao obter transação. Por favor, tente novamente.",
+        "invalidAddress": "Endereço inválido"
       },
       "from": "De",
       "loading": "Carregando",

--- a/packages/web/localizations/ro.json
+++ b/packages/web/localizations/ro.json
@@ -232,6 +232,7 @@
       "availableOn": "Disponibil pe {network}",
       "approving": "Se aprobă...",
       "givePermission": "Acordați permisiunea de a folosi jetoane",
+      "enterEthAddress": "adresa EVM",
       "errors": {
         "insufficientBal": "Balanta Insuficienta",
         "insufficientFee": "Taxa Insuficienta",
@@ -240,7 +241,8 @@
         "seeRequest": "Vezi solicitarea în {walletName}",
         "noQuotesAvailable": "Nu există oferte disponibile",
         "unexpectedError": "Eroare neașteptată. Vă rugăm să încercați din nou.",
-        "transactionError": "Eroare la obținerea tranzacției. Vă rugăm să încercați din nou."
+        "transactionError": "Eroare la obținerea tranzacției. Vă rugăm să încercați din nou.",
+        "invalidAddress": "Adresă invalidă"
       },
       "from": "De la",
       "loading": "Se incarca",

--- a/packages/web/localizations/ro.json
+++ b/packages/web/localizations/ro.json
@@ -172,6 +172,7 @@
       "title": "Istoric Transferuri"
     },
     "ibcTransfer": {
+      "buttonAdd": "Adăuga",
       "buttonEdit": "Modifica",
       "buttonEnter": "Intra",
       "channelCongestedDeposit": "Depoziteaza (Channel congested)",

--- a/packages/web/localizations/ro.json
+++ b/packages/web/localizations/ro.json
@@ -242,7 +242,8 @@
         "noQuotesAvailable": "Nu există oferte disponibile",
         "unexpectedError": "Eroare neașteptată. Vă rugăm să încercați din nou.",
         "transactionError": "Eroare la obținerea tranzacției. Vă rugăm să încercați din nou.",
-        "invalidAddress": "Adresă invalidă"
+        "invalidAddress": "Adresă invalidă",
+        "missingAddress": "Adresa lipsă"
       },
       "from": "De la",
       "loading": "Se incarca",

--- a/packages/web/localizations/tr.json
+++ b/packages/web/localizations/tr.json
@@ -172,6 +172,7 @@
       "title": "Transfer Geçmişi"
     },
     "ibcTransfer": {
+      "buttonAdd": "Eklemek",
       "buttonEdit": "Düzenle",
       "buttonEnter": "Onay",
       "channelCongestedDeposit": "Yatır (Kanal çağrıldı)",

--- a/packages/web/localizations/tr.json
+++ b/packages/web/localizations/tr.json
@@ -242,7 +242,8 @@
         "noQuotesAvailable": "Mevcut Fiyat Teklifi Yok",
         "unexpectedError": "Beklenmeyen hata. Lütfen tekrar deneyin.",
         "transactionError": "İşlem alınırken hata oluştu. Lütfen tekrar deneyin.",
-        "invalidAddress": "Geçersiz adres"
+        "invalidAddress": "Geçersiz adres",
+        "missingAddress": "Eksik Adres"
       },
       "from": "Ağından",
       "loading": "Yükleniyor",

--- a/packages/web/localizations/tr.json
+++ b/packages/web/localizations/tr.json
@@ -232,6 +232,7 @@
       "availableOn": "{network} ağında mevcut",
       "approving": "Onaylanıyor...",
       "givePermission": "Belirteçleri kullanma izinleri verin",
+      "enterEthAddress": "EVM adresi",
       "errors": {
         "insufficientBal": "Yetersiz Bakiye",
         "insufficientFee": "Yetersiz Ücret",
@@ -240,7 +241,8 @@
         "seeRequest": "{walletName}'deki talebi gör",
         "noQuotesAvailable": "Mevcut Fiyat Teklifi Yok",
         "unexpectedError": "Beklenmeyen hata. Lütfen tekrar deneyin.",
-        "transactionError": "İşlem alınırken hata oluştu. Lütfen tekrar deneyin."
+        "transactionError": "İşlem alınırken hata oluştu. Lütfen tekrar deneyin.",
+        "invalidAddress": "Geçersiz adres"
       },
       "from": "Ağından",
       "loading": "Yükleniyor",

--- a/packages/web/localizations/zh-cn.json
+++ b/packages/web/localizations/zh-cn.json
@@ -172,6 +172,7 @@
       "title": "转账记录"
     },
     "ibcTransfer": {
+      "buttonAdd": "添加",
       "buttonEdit": "编辑",
       "buttonEnter": "确定",
       "channelCongestedDeposit": "存入 (频道争抢)",

--- a/packages/web/localizations/zh-cn.json
+++ b/packages/web/localizations/zh-cn.json
@@ -232,6 +232,7 @@
       "availableOn": "在 {network} 网络上可用",
       "approving": "正在批准...",
       "givePermission": "授予使用令牌的权限",
+      "enterEthAddress": "评估板地址",
       "errors": {
         "insufficientBal": "余额不足",
         "insufficientFee": "费用不足",
@@ -240,7 +241,8 @@
         "seeRequest": "在{walletName}中查看请求",
         "noQuotesAvailable": "无可用报价",
         "unexpectedError": "意外的错误。请再试一次。",
-        "transactionError": "获取交易时出错。请再试一次。"
+        "transactionError": "获取交易时出错。请再试一次。",
+        "invalidAddress": "无效地址"
       },
       "from": "从",
       "loading": "加载中",

--- a/packages/web/localizations/zh-cn.json
+++ b/packages/web/localizations/zh-cn.json
@@ -242,7 +242,8 @@
         "noQuotesAvailable": "无可用报价",
         "unexpectedError": "意外的错误。请再试一次。",
         "transactionError": "获取交易时出错。请再试一次。",
-        "invalidAddress": "无效地址"
+        "invalidAddress": "无效地址",
+        "missingAddress": "缺少地址"
       },
       "from": "从",
       "loading": "加载中",

--- a/packages/web/localizations/zh-hk.json
+++ b/packages/web/localizations/zh-hk.json
@@ -172,6 +172,7 @@
       "title": "轉移歷史"
     },
     "ibcTransfer": {
+      "buttonAdd": "添加",
       "buttonEdit": "編輯",
       "buttonEnter": "輸入",
       "channelCongestedDeposit": "存入 (通道擁擠緊)",

--- a/packages/web/localizations/zh-hk.json
+++ b/packages/web/localizations/zh-hk.json
@@ -242,7 +242,8 @@
         "noQuotesAvailable": "無可用報價",
         "unexpectedError": "意外的錯誤。請再試一次。",
         "transactionError": "獲取交易時出錯。請再試一次。",
-        "invalidAddress": "無效地址"
+        "invalidAddress": "無效地址",
+        "missingAddress": "缺少地址"
       },
       "from": "從",
       "loading": "載入中",

--- a/packages/web/localizations/zh-hk.json
+++ b/packages/web/localizations/zh-hk.json
@@ -232,6 +232,7 @@
       "availableOn": "{network}上可用",
       "approving": "正在批准...",
       "givePermission": "授予使用令牌的權限",
+      "enterEthAddress": "評估板地址",
       "errors": {
         "insufficientBal": "結餘唔夠喎",
         "insufficientFee": "交易費唔夠喎",
@@ -240,7 +241,8 @@
         "seeRequest": "在{walletName}中查看請求",
         "noQuotesAvailable": "無可用報價",
         "unexpectedError": "意外的錯誤。請再試一次。",
-        "transactionError": "獲取交易時出錯。請再試一次。"
+        "transactionError": "獲取交易時出錯。請再試一次。",
+        "invalidAddress": "無效地址"
       },
       "from": "從",
       "loading": "載入中",

--- a/packages/web/localizations/zh-tw.json
+++ b/packages/web/localizations/zh-tw.json
@@ -232,6 +232,7 @@
       "availableOn": "{network}上可用",
       "approving": "正在批准...",
       "givePermission": "授予使用令牌的權限",
+      "enterEthAddress": "評估板地址",
       "errors": {
         "insufficientBal": "結餘不足",
         "insufficientFee": "交易費不足",
@@ -240,7 +241,8 @@
         "seeRequest": "在{walletName}中檢視請求",
         "noQuotesAvailable": "無可用報價",
         "unexpectedError": "意外的錯誤。請再試一次。",
-        "transactionError": "獲取交易時出錯。請再試一次。"
+        "transactionError": "獲取交易時出錯。請再試一次。",
+        "invalidAddress": "無效地址"
       },
       "from": "從",
       "loading": "載入中",

--- a/packages/web/localizations/zh-tw.json
+++ b/packages/web/localizations/zh-tw.json
@@ -242,7 +242,8 @@
         "noQuotesAvailable": "無可用報價",
         "unexpectedError": "意外的錯誤。請再試一次。",
         "transactionError": "獲取交易時出錯。請再試一次。",
-        "invalidAddress": "無效地址"
+        "invalidAddress": "無效地址",
+        "missingAddress": "缺少地址"
       },
       "from": "從",
       "loading": "載入中",

--- a/packages/web/localizations/zh-tw.json
+++ b/packages/web/localizations/zh-tw.json
@@ -172,6 +172,7 @@
       "title": "轉移歷史"
     },
     "ibcTransfer": {
+      "buttonAdd": "添加",
       "buttonEdit": "編輯",
       "buttonEnter": "輸入",
       "channelCongestedDeposit": "存入 (通道擁擠中)",

--- a/packages/web/modals/bridge-transfer-v2.tsx
+++ b/packages/web/modals/bridge-transfer-v2.tsx
@@ -316,6 +316,7 @@ const ManualTransfer: FunctionComponent<
         !addressConfig.isValid ||
         !didAckWithdrawRisk
       }
+      isCounterpartyAddressValid={addressConfig.isValid}
     />
   );
 });
@@ -329,6 +330,7 @@ export const TransferContent: FunctionComponent<
     sourceChainKey: SourceChainKey;
     onRequestSwitchWallet: () => void;
     counterpartyAddress: string;
+    isCounterpartyAddressValid?: boolean;
 
     // Deposit
     isCorrectChainSelected?: boolean;
@@ -366,6 +368,7 @@ export const TransferContent: FunctionComponent<
     ethWalletClient,
     addWithdrawAddrConfig,
     isDisabled: isDisabledProp,
+    isCounterpartyAddressValid = true,
   } = props;
   const { t } = useTranslation();
   const { logEvent } = useAmplitudeAnalytics();
@@ -547,7 +550,10 @@ export const TransferContent: FunctionComponent<
       fromAmount: inputAmount.truncate().toString(),
     },
     {
-      enabled: inputAmount.gt(new Dec(0)),
+      enabled:
+        inputAmount.gt(new Dec(0)) &&
+        counterpartyAddress !== "" &&
+        isCounterpartyAddressValid,
       refetchInterval: 30 * 1000, // 30 seconds
       retry(failureCount, error) {
         if (failureCount > 3) return false;
@@ -1034,6 +1040,8 @@ export const TransferContent: FunctionComponent<
   let buttonErrorMessage: string | undefined;
   if (!counterpartyAddress) {
     buttonErrorMessage = t("assets.transfer.errors.missingAddress");
+  } else if (!isCounterpartyAddressValid) {
+    buttonErrorMessage = t("assets.transfer.errors.invalidAddress");
   } else if (hasNoQuotes) {
     buttonErrorMessage = t("assets.transfer.errors.noQuotesAvailable");
   } else if (userDisconnectedEthWallet) {

--- a/packages/web/modals/pre-transfer.tsx
+++ b/packages/web/modals/pre-transfer.tsx
@@ -10,8 +10,8 @@ import { TokenSelect } from "~/components/control";
 import { UNSTABLE_MSG } from "~/config";
 import { useTranslation } from "~/hooks";
 import { useWindowSize } from "~/hooks";
+import { useCoinFiatValue } from "~/hooks/queries/assets/use-coin-fiat-value";
 import { ModalBase, ModalBaseProps } from "~/modals";
-import { useStore } from "~/stores";
 import { ObservableAssets } from "~/stores/assets/assets-store";
 
 /** MOBILE: Pre transfer to select whether to deposit/withdraw */
@@ -37,14 +37,10 @@ export const PreTransferModal: FunctionComponent<
     onWithdraw,
     onDeposit,
   } = props;
-  const { priceStore } = useStore();
   const { isMobile } = useWindowSize();
   const { t } = useTranslation();
 
-  const tokenValue = priceStore.calculatePrice(
-    selectedToken.balance,
-    priceStore.defaultVsCurrency
-  );
+  const tokenValue = useCoinFiatValue(selectedToken.balance);
 
   const isEthAsset = selectedToken.originBridgeInfo?.bridge === "axelar";
 

--- a/packages/web/modals/pre-transfer.tsx
+++ b/packages/web/modals/pre-transfer.tsx
@@ -5,18 +5,19 @@ import Image from "next/image";
 import { FunctionComponent } from "react";
 
 import { Info } from "~/components/alert";
-import { Button } from "~/components/buttons";
+import { Button, buttonCVA } from "~/components/buttons";
 import { TokenSelect } from "~/components/control";
 import { UNSTABLE_MSG } from "~/config";
 import { useTranslation } from "~/hooks";
 import { useWindowSize } from "~/hooks";
 import { ModalBase, ModalBaseProps } from "~/modals";
 import { useStore } from "~/stores";
+import { ObservableAssets } from "~/stores/assets/assets-store";
 
 /** MOBILE: Pre transfer to select whether to deposit/withdraw */
 export const PreTransferModal: FunctionComponent<
   ModalBaseProps & {
-    selectedToken: CoinPretty;
+    selectedToken: ObservableAssets["unverifiedIbcBalances"][number];
     tokens: CoinPretty[];
     externalDepositUrl?: string;
     externalWithdrawUrl?: string;
@@ -41,16 +42,18 @@ export const PreTransferModal: FunctionComponent<
   const { t } = useTranslation();
 
   const tokenValue = priceStore.calculatePrice(
-    selectedToken,
+    selectedToken.balance,
     priceStore.defaultVsCurrency
   );
+
+  const isEthAsset = selectedToken.originBridgeInfo?.bridge === "axelar";
 
   return (
     <ModalBase
       {...props}
       title={
         <TokenSelect
-          selectedTokenDenom={selectedToken.denom}
+          selectedTokenDenom={selectedToken.balance.denom}
           tokens={tokens}
           onSelect={(coinDenom) => onSelectToken(coinDenom)}
           sortByBalances
@@ -62,7 +65,7 @@ export const PreTransferModal: FunctionComponent<
           <span className="caption text-osmoverse-400">
             {t("assets.table.preTransfer.currentBal")}
           </span>
-          <h6>{selectedToken.trim(true).toString()}</h6>
+          <h6>{selectedToken.balance.trim(true).toString()}</h6>
           {tokenValue && (
             <span className="subtitle2 text-osmoverse-400">
               {tokenValue?.toString()}
@@ -104,13 +107,17 @@ export const PreTransferModal: FunctionComponent<
               {t("assets.table.preTransfer.withdraw")}
             </Button>
           )}
-          {externalDepositUrl ? (
+          {Boolean(externalDepositUrl) && (
             <a
               className={classNames(
-                "flex h-10 w-full items-center justify-center gap-1 rounded-lg bg-wosmongton-200 text-button font-button",
+                buttonCVA({
+                  className:
+                    "h-10 w-full gap-2 border-wosmongton-300 bg-wosmongton-300",
+                  mode: "primary",
+                }),
                 { "opacity-30": isUnstable }
               )}
-              href={externalDepositUrl}
+              href={isUnstable ? "" : externalDepositUrl}
               rel="noreferrer"
               target="_blank"
               style={
@@ -119,15 +126,16 @@ export const PreTransferModal: FunctionComponent<
                   : undefined
               }
             >
-              {t("assets.table.preTransfer.deposit")}
+              <span>{t("assets.table.preTransfer.deposit")}</span>
               <Image
                 alt="external transfer link"
                 src="/icons/external-link-white.svg"
-                height={8}
-                width={8}
+                height={12}
+                width={12}
               />
             </a>
-          ) : (
+          )}
+          {!isEthAsset && !externalDepositUrl && (
             <Button
               className="h-10 w-full"
               disabled={isUnstable}

--- a/packages/web/pages/assets/index.tsx
+++ b/packages/web/pages/assets/index.tsx
@@ -77,7 +77,7 @@ const Assets: NextPage = observer(() => {
 
       setPreTransferModalProps({
         isOpen: true,
-        selectedToken: ibcBalance.balance,
+        selectedToken: ibcBalance,
         tokens: ibcBalances.map(({ balance }) => balance),
         externalDepositUrl: ibcBalance.depositUrlOverride,
         externalWithdrawUrl: ibcBalance.withdrawUrlOverride,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

For mobile users who cannot use Metamask, provide an option to manually enter their wallet address, enabling them to transfer assets directly to this address.

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/86a1g2bf8)

## Testing and Verifying

- [ ] Can transfer to manually input evm address
- [ ] Deposit button should be hidden in mobile
- [ ] Can still transfer on desktop
