### PR TITLE
fix: Assets That do not Have an IBC Trace

### DIFF
--- a/packages/stores/src/currency-registrar/unsafe-ibc.ts
+++ b/packages/stores/src/currency-registrar/unsafe-ibc.ts
@@ -1,7 +1,7 @@
 import { Currency, IBCCurrency } from "@keplr-wallet/types";
 import { ChainStore } from "@osmosis-labs/keplr-stores";
 import type { AppCurrency, Asset, ChainInfo } from "@osmosis-labs/types";
-import { getSourceDenomFromAssetList } from "@osmosis-labs/utils";
+import { getIbcTrace, getSourceDenomFromAssetList } from "@osmosis-labs/utils";
 
 type OriginChainCurrencyInfo = [
   string, // chain ID
@@ -36,24 +36,28 @@ export class UnsafeIbcCurrencyRegistrar<C extends ChainInfo = ChainInfo> {
     // tutorial: https://tutorials.cosmos.network/tutorials/6-ibc-dev/
     const ibcCache = new Map<string, OriginChainCurrencyInfo>();
     assets
-      .filter((asset) => asset.traces.length > 0) // Filter Osmosis assets
+      .filter((asset) =>
+        asset.traces.some(
+          (trace) => trace.type === "ibc" || trace.type === "ibc-cw20"
+        )
+      ) // Filter Osmosis assets
       .forEach((ibcAsset) => {
-        const lastTrace = ibcAsset.traces[ibcAsset.traces.length - 1];
+        const ibcTrace = getIbcTrace(ibcAsset.traces);
         const ibcDenom = ibcAsset.base; // The IBC denom will also be the multihop hash when needed
 
-        if (lastTrace?.type !== "ibc-cw20" && lastTrace?.type !== "ibc") {
+        if (!ibcTrace) {
           throw new Error(
-            `Unknown trace type ${lastTrace?.type}. Asset ${ibcAsset.symbol}`
+            `Invalid IBC asset config: ${JSON.stringify(ibcAsset)}`
           );
         }
 
         const sourceDenom = getSourceDenomFromAssetList(ibcAsset);
 
-        const channels = lastTrace.chain.path.match(/channel-(\d+)/g);
+        const channels = ibcTrace.chain.path.match(/channel-(\d+)/g);
         const paths = [];
 
         if (!channels) {
-          throw new Error(`Invalid IBC path ${lastTrace.chain.path}`);
+          throw new Error(`Invalid IBC path ${ibcTrace.chain.path}`);
         }
 
         for (const channel of channels) {

--- a/packages/stores/src/currency-registrar/unsafe-ibc.ts
+++ b/packages/stores/src/currency-registrar/unsafe-ibc.ts
@@ -1,7 +1,10 @@
 import { Currency, IBCCurrency } from "@keplr-wallet/types";
 import { ChainStore } from "@osmosis-labs/keplr-stores";
 import type { AppCurrency, Asset, ChainInfo } from "@osmosis-labs/types";
-import { getIbcTrace, getSourceDenomFromAssetList } from "@osmosis-labs/utils";
+import {
+  getLastIbcTrace,
+  getSourceDenomFromAssetList,
+} from "@osmosis-labs/utils";
 
 type OriginChainCurrencyInfo = [
   string, // chain ID
@@ -42,7 +45,7 @@ export class UnsafeIbcCurrencyRegistrar<C extends ChainInfo = ChainInfo> {
         )
       ) // Filter Osmosis assets
       .forEach((ibcAsset) => {
-        const ibcTrace = getIbcTrace(ibcAsset.traces);
+        const ibcTrace = getLastIbcTrace(ibcAsset.traces);
         const ibcDenom = ibcAsset.base; // The IBC denom will also be the multihop hash when needed
 
         if (!ibcTrace) {

--- a/packages/types/src/asset-types.ts
+++ b/packages/types/src/asset-types.ts
@@ -93,7 +93,7 @@ interface TraceChain {
   path: string;
 }
 
-interface IBCTrace {
+export interface IBCTrace {
   type: "ibc";
   counterparty: TraceCounterpartyChain & {
     channel_id: string;
@@ -101,7 +101,7 @@ interface IBCTrace {
   chain: TraceChain;
 }
 
-interface IbcCW20Trace {
+export interface IbcCW20Trace {
   type: "ibc-cw20";
   counterparty: TraceCounterpartyChain & {
     port: string;

--- a/packages/utils/src/asset-utils.ts
+++ b/packages/utils/src/asset-utils.ts
@@ -5,13 +5,14 @@ import type {
   IBCTrace,
 } from "@osmosis-labs/types";
 
-export function getIbcTrace(
+export function getLastIbcTrace(
   traces: Asset["traces"]
 ): IbcCW20Trace | IBCTrace | undefined {
-  return traces.find(
+  const ibcTraces = traces.filter(
     (trace): trace is IBCTrace | IbcCW20Trace =>
       trace.type === "ibc-cw20" || trace.type === "ibc"
   );
+  return ibcTraces[ibcTraces.length - 1];
 }
 
 export function getSourceDenomFromAssetList({
@@ -23,7 +24,7 @@ export function getSourceDenomFromAssetList({
     return base;
   }
 
-  const ibcTrace = getIbcTrace(traces);
+  const ibcTrace = getLastIbcTrace(traces);
 
   /** It's an Osmosis Asset, since there's no IBC traces from other chains. */
   if (!ibcTrace) {
@@ -105,7 +106,7 @@ export const hasMatchingSourceDenom = (
 export function getChannelInfoFromAsset(
   asset: Pick<Asset, "traces" | "symbol">
 ) {
-  const ibcTrace = getIbcTrace(asset.traces);
+  const ibcTrace = getLastIbcTrace(asset.traces);
 
   if (!ibcTrace) {
     throw new Error(`Asset ${asset.symbol} does not have an IBC trace.`);

--- a/packages/web/modals/wallet-select.tsx
+++ b/packages/web/modals/wallet-select.tsx
@@ -246,7 +246,12 @@ export const WalletSelectModal: FunctionComponent<
       hideCloseButton
       className="max-h-[90vh] w-full max-w-[800px] overflow-hidden !px-0 py-0 sm:max-h-[80vh]"
     >
-      <div className="flex max-h-[530px] min-h-[50vh] overflow-auto sm:max-h-full sm:flex-col">
+      <div
+        className={classNames(
+          "flex min-h-[50vh] overflow-auto sm:max-h-full sm:flex-col",
+          modalView === "qrCode" ? "max-h-[600px]" : "max-h-[530px]"
+        )}
+      >
         <ClientOnly
           className={classNames(
             "w-full max-w-[284px] overflow-auto sm:max-w-none sm:shrink-0 sm:bg-[rgba(20,15,52,0.2)]",

--- a/packages/web/stores/assets/assets-store.ts
+++ b/packages/web/stores/assets/assets-store.ts
@@ -11,7 +11,7 @@ import {
   OsmosisQueries,
 } from "@osmosis-labs/stores";
 import { Asset } from "@osmosis-labs/types";
-import { getSourceDenomFromAssetList } from "@osmosis-labs/utils";
+import { getIbcTrace, getSourceDenomFromAssetList } from "@osmosis-labs/utils";
 import { autorun, computed, makeObservable } from "mobx";
 
 import { displayToast, ToastType } from "~/components/alert";
@@ -181,16 +181,16 @@ export class ObservableAssets {
           );
         }
 
-        const lastTrace = ibcAsset.traces[ibcAsset.traces.length - 1];
+        const ibcTrace = getIbcTrace(ibcAsset.traces);
 
-        if (lastTrace?.type !== "ibc-cw20" && lastTrace?.type !== "ibc") {
+        if (!ibcTrace) {
           throw new Error(
-            `Unknown trace type ${lastTrace?.type}. Asset ${ibcAsset.symbol}`
+            `Invalid IBC asset config: ${JSON.stringify(ibcAsset)}`
           );
         }
 
-        const sourceChannelId = lastTrace.chain.channel_id;
-        const destChannelId = lastTrace.counterparty.channel_id;
+        const sourceChannelId = ibcTrace.chain.channel_id;
+        const destChannelId = ibcTrace.counterparty.channel_id;
         const isVerified = ibcAsset.keywords?.includes("osmosis-main");
         const isUnstable = ibcAsset.keywords?.includes("osmosis-unstable");
 
@@ -202,7 +202,7 @@ export class ObservableAssets {
          * to send the source denom for deposits.
          */
         let sourceDenom: string | undefined;
-        if ((lastTrace.chain.path.match(/transfer/gi)?.length ?? 0) >= 2) {
+        if ((ibcTrace.chain.path.match(/transfer/gi)?.length ?? 0) >= 2) {
           sourceDenom = minimalDenom;
         }
 
@@ -254,10 +254,10 @@ export class ObservableAssets {
           this._verifiedAssets.add(balance.currency.coinDenom);
         }
 
-        if (lastTrace.type === "ibc-cw20") {
+        if (ibcTrace.type === "ibc-cw20") {
           return {
             ...ibcBalance,
-            ics20ContractAddress: lastTrace.counterparty.port.split(".")[1],
+            ics20ContractAddress: ibcTrace.counterparty.port.split(".")[1],
           } as IBCCW20ContractBalance;
         } else {
           return ibcBalance;

--- a/packages/web/stores/assets/assets-store.ts
+++ b/packages/web/stores/assets/assets-store.ts
@@ -11,7 +11,10 @@ import {
   OsmosisQueries,
 } from "@osmosis-labs/stores";
 import { Asset } from "@osmosis-labs/types";
-import { getIbcTrace, getSourceDenomFromAssetList } from "@osmosis-labs/utils";
+import {
+  getLastIbcTrace,
+  getSourceDenomFromAssetList,
+} from "@osmosis-labs/utils";
 import { autorun, computed, makeObservable } from "mobx";
 
 import { displayToast, ToastType } from "~/components/alert";
@@ -181,7 +184,7 @@ export class ObservableAssets {
           );
         }
 
-        const ibcTrace = getIbcTrace(ibcAsset.traces);
+        const ibcTrace = getLastIbcTrace(ibcAsset.traces);
 
         if (!ibcTrace) {
           throw new Error(


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Previously, we considered an empty `traces` array a native Osmosis token. Unfortunately, there will be assets that are native to Osmosis and also have a trace like `liquid-stake`. This PR finds the last ibc denom instead of assuming it's the last entry.

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/86a1raryg)

## Testing and Verifying

- [ ] Should be able to do IBC transfers
- [ ] Balances should be computed correctly
- [ ] All listed assets should be visible