### PR TITLE
fix: Update Picasso Deposit/Withdraw URLs

### DIFF
--- a/packages/web/config/ibc-overrides.ts
+++ b/packages/web/config/ibc-overrides.ts
@@ -119,10 +119,8 @@ const MainnetIBCAdditionalData: Partial<
     withdrawUrlOverride: "https://portalbridge.com/cosmos/",
   },
   DOT: {
-    depositUrlOverride:
-      "https://app.trustless.zone/multihop?from=PICASSO&to=OSMOSIS",
-    withdrawUrlOverride:
-      "https://app.trustless.zone/multihop?from=OSMOSIS&to=PICASSO",
+    depositUrlOverride: "https://app.trustless.zone/?from=PICASSO&to=OSMOSIS",
+    withdrawUrlOverride: "https://app.trustless.zone/?from=OSMOSIS&to=PICASSO",
   },
   MATIC: {
     sourceChainNameOverride: "Polygon",
@@ -314,10 +312,8 @@ const MainnetIBCAdditionalData: Partial<
       "https://tfm.com/bridge?chainFrom=osmosis-1&chainTo=pacific-1&token0=ibc%2F71F11BC0AF8E526B80E44172EBA9D3F0A8E03950BB882325435691EBC9450B1D&token1=usei",
   },
   KSM: {
-    depositUrlOverride:
-      "https://app.trustless.zone/multihop?from=PICASSO&to=OSMOSIS",
-    withdrawUrlOverride:
-      "https://app.trustless.zone/multihop?from=OSMOSIS&to=PICASSO",
+    depositUrlOverride: "https://app.trustless.zone/?from=PICASSO&to=OSMOSIS",
+    withdrawUrlOverride: "https://app.trustless.zone/?from=OSMOSIS&to=PICASSO",
   },
   LUNC: {
     depositUrlOverride: "https://bridge.terra.money",
@@ -442,10 +438,8 @@ const MainnetIBCAdditionalData: Partial<
       "https://tfm.com/bridge?chainTo=osmosis-1&chainFrom=planq_7070-2&token0=aplanq&token1=ibc%2FB1E0166EA0D759FDF4B207D1F5F12210D8BFE36F2345CEFC76948CE2B36DFBAF",
   },
   PICA: {
-    depositUrlOverride:
-      "https://app.trustless.zone/multihop?from=PICASSO&to=OSMOSIS",
-    withdrawUrlOverride:
-      "https://app.trustless.zone/multihop?from=OSMOSIS&to=PICASSO",
+    depositUrlOverride: "https://app.trustless.zone/?from=PICASSO&to=OSMOSIS",
+    withdrawUrlOverride: "https://app.trustless.zone/?from=OSMOSIS&to=PICASSO",
   },
   "WBTC.grv": {
     depositUrlOverride:


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Update Picasso Deposit/Withdraw URLs since the old ones go to 404 now. Updated for PICA, KSM and DOT, all of which use the Trustless app.

<!-- > Add a description of the overall background and high level changes that this PR introduces


## Brief Changelog

Update Picasso Deposit/Withdraw URLs for PICA, KSM, and DOT in config/ibc-overrides.ts

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

This change has been tested locally by rebuilding the website and verified content and links are expected


Validation Successful