### PR TITLE
Cosmwasm pools opening in new tab (#2564)

### DIFF
--- a/packages/web/components/complex/all-pools-table.tsx
+++ b/packages/web/components/complex/all-pools-table.tsx
@@ -1,7 +1,6 @@
 import { Menu } from "@headlessui/react";
 import { Dec, PricePretty, RatePretty } from "@keplr-wallet/unit";
 import type { BasePool } from "@osmosis-labs/pools";
-import { ObservableQueryPool } from "@osmosis-labs/stores";
 import {
   CellContext,
   createColumnHelper,
@@ -109,14 +108,6 @@ function getIncentiveFilters(
     superfluid: t("components.table.superfluid"),
     noIncentives: t("components.table.noIncentives"),
   };
-}
-
-export function getPoolLink(queryPool: ObservableQueryPool): string {
-  if (queryPool.type === "transmuter") {
-    return `https://celatone.osmosis.zone/osmosis-1/pools/${queryPool.id}`;
-  }
-
-  return `/pool/${queryPool.id}`;
 }
 
 export const AllPoolsTable: FunctionComponent<{


### PR DESCRIPTION
## What is the purpose of the change

This pull request addresses the bug bounty issue related to #2564. The fix ensures that when users click on a Cosmwasm pool, it will open in a new tab as expected, linking to Celatone.

## Brief Changelog

- Updated the relevant code to enforce opening links in a separate tab.

## Testing and Verifying

**Method:**
1. Clicked on non-Cosmwasm pools on mobile and desktop, to check that it doesn't break existing functionality.
1. Clicked on Cosmwasm pools on mobile and desktop, observing that opens on a new tab.

### Video Record Proof:

https://github.com/osmosis-labs/osmosis-frontend/assets/4956754/cdd789f5-af2b-4b13-b564-1574406006a8

Closes: #2564