### PR TITLE
fix: Announcement banner flicker (#2565)

### DIFF
--- a/packages/web/components/navbar/announcement.tsx
+++ b/packages/web/components/navbar/announcement.tsx
@@ -1,0 +1,156 @@
+import classNames from "classnames";
+import { useRouter } from "next/router";
+import { FunctionComponent, useEffect, useState } from "react";
+
+import { Icon } from "~/components/assets";
+import IconButton from "~/components/buttons/icon-button";
+import { Announcement, AnnouncementInterface } from "~/config";
+import { useDisclosure, useTranslation } from "~/hooks";
+import { ExternalLinkModal, handleExternalLink } from "~/modals";
+import { noop } from "~/utils/function";
+
+// We need to use a localstorage solution that gets the value on first call, as opposed to useLocalStorageState, that uses `useEffect`
+const useLocalStorage = (key: string, initialValue: any) => {
+  const storedValue =
+    typeof window !== "undefined" ? localStorage?.getItem(key) : null;
+  const initial = storedValue ? JSON.parse(storedValue) : initialValue;
+
+  const [value, setValue] = useState(initial);
+
+  const updateValue = (newValue: any) => {
+    setValue(newValue);
+    localStorage.setItem(key, JSON.stringify(newValue));
+  };
+
+  return [value, updateValue];
+};
+
+const useAnnouncement = (): [AnnouncementInterface | undefined, () => void] => {
+  const router = useRouter();
+
+  // prevent SSR to render an Announcement
+  const [csr, setCsr] = useState(false);
+
+  const [announcementState, setAnnouncementState] = useLocalStorage(
+    Announcement?.localStorageKey || "announcement.warning",
+    true
+  );
+
+  useEffect(() => {
+    setCsr(true);
+  }, [setCsr]);
+
+  if (Announcement === undefined || csr === false) {
+    return [undefined, noop];
+  }
+
+  const matchesRoute =
+    !Announcement.pageRoute || router.pathname === Announcement.pageRoute;
+  return [
+    matchesRoute && announcementState ? Announcement : undefined,
+    () => {
+      setAnnouncementState(false);
+    },
+  ];
+};
+
+export const AnnouncementBanner: FunctionComponent<{
+  backElementClassNames?: string;
+}> = ({ backElementClassNames }) => {
+  const [announcement, closeBanner] = useAnnouncement();
+  const { t } = useTranslation();
+  const {
+    isOpen: isLeavingOsmosisOpen,
+    onClose: onCloseLeavingOsmosis,
+    onOpen: onOpenLeavingOsmosis,
+  } = useDisclosure();
+
+  if (!announcement) {
+    return (
+      <div
+        className={classNames(
+          "bg-osmoverse-900",
+          "h-navbar md:h-navbar-mobile",
+          backElementClassNames
+        )}
+      />
+    );
+  }
+
+  const { link, enTextOrLocalizationPath, isWarning, persistent, bg } =
+    announcement;
+
+  const linkText = t(
+    link?.enTextOrLocalizationKey ?? "Click here to learn more"
+  );
+
+  const handleLeaveClick = () =>
+    handleExternalLink({
+      url: link?.url ?? "",
+      openModal: onOpenLeavingOsmosis,
+    });
+
+  return (
+    <>
+      <div
+        className={classNames(
+          "bg-osmoverse-900",
+          "h-[124px]",
+          backElementClassNames
+        )}
+      />
+      <div
+        className={classNames(
+          "fixed top-[71px] z-[51] float-right my-auto ml-sidebar flex w-[calc(100vw_-_14.58rem)] items-center px-8 py-[14px] md:top-[57px] md:ml-0 md:w-full sm:gap-3 sm:px-2",
+          {
+            "bg-gradient-negative": isWarning,
+            "bg-gradient-neutral": !isWarning,
+          },
+          bg
+        )}
+      >
+        <div className="flex w-full place-content-center items-center gap-1.5 text-center text-subtitle1 lg:gap-1 lg:text-xs lg:tracking-normal md:text-left md:text-xxs sm:items-start">
+          <span>{t(enTextOrLocalizationPath)}</span>
+          {Boolean(link) && (
+            <div className="flex cursor-pointer items-center gap-2">
+              {link?.isExternal ? (
+                <button className="underline" onClick={handleLeaveClick}>
+                  {linkText}
+                </button>
+              ) : (
+                <a
+                  className="underline"
+                  href={link?.url}
+                  rel="noreferrer"
+                  // target="_blank"
+                >
+                  {linkText}
+                </a>
+              )}
+              <Icon id="arrow-right" height={24} width={24} />
+            </div>
+          )}
+        </div>
+        {!persistent && !isWarning && (
+          <IconButton
+            className="flex w-fit cursor-pointer items-center py-0 text-white-full"
+            onClick={closeBanner}
+            aria-label="Close"
+            icon={<Icon id="close-small" height={24} width={24} />}
+            size="unstyled"
+            mode="unstyled"
+          />
+        )}
+        {link?.isExternal && (
+          <ExternalLinkModal
+            url={link.url}
+            onRequestClose={onCloseLeavingOsmosis}
+            isOpen={isLeavingOsmosisOpen}
+          />
+        )}
+      </div>
+    </>
+  );
+};
+
+export default AnnouncementBanner;

--- a/packages/web/components/navbar/index.tsx
+++ b/packages/web/components/navbar/index.tsx
@@ -18,9 +18,10 @@ import { Button } from "~/components/buttons";
 import IconButton from "~/components/buttons/icon-button";
 import ClientOnly from "~/components/client-only";
 import { MainMenu } from "~/components/main-menu";
+import AnnouncementBanner from "~/components/navbar/announcement";
 import SkeletonLoader from "~/components/skeleton-loader";
 import { CustomClasses, MainLayoutMenu } from "~/components/types";
-import { Announcement, EventName } from "~/config";
+import { EventName } from "~/config";
 import { useTranslation } from "~/hooks";
 import {
   useAmplitudeAnalytics,
@@ -35,10 +36,6 @@ import {
   NotifiPopover,
 } from "~/integrations/notifi";
 import { ModalBase, ModalBaseProps, SettingsModal } from "~/modals";
-import {
-  ExternalLinkModal,
-  handleExternalLink,
-} from "~/modals/external-links-modal";
 import { ProfileModal } from "~/modals/profile";
 import { UserUpgradesModal } from "~/modals/user-upgrades";
 import { useStore } from "~/stores";
@@ -152,17 +149,6 @@ export const NavBar: FunctionComponent<
     const icnsQuery = queriesExternalStore.queryICNSNames.getQueryContract(
       account?.address ?? ""
     );
-
-    // announcement banner
-    const [_showBanner, setShowBanner] = useLocalStorageState(
-      Announcement ? Announcement?.localStorageKey ?? "" : "",
-      true
-    );
-
-    const showBanner =
-      _showBanner &&
-      Announcement &&
-      (!Announcement.pageRoute || router.pathname === Announcement.pageRoute);
 
     const handleTradeClicked = () => {
       logEvent(EventName.Topnav.tradeClicked);
@@ -384,19 +370,7 @@ export const NavBar: FunctionComponent<
           </div>
         </div>
         {/* Back-layer element to occupy space for the caller */}
-        <div
-          className={classNames(
-            "bg-osmoverse-900",
-            showBanner ? "h-[124px]" : "h-navbar md:h-navbar-mobile",
-            backElementClassNames
-          )}
-        />
-        {showBanner && (
-          <AnnouncementBanner
-            {...Announcement!}
-            closeBanner={() => setShowBanner(false)}
-          />
-        )}
+        <AnnouncementBanner backElementClassNames={backElementClassNames} />
         <FrontierMigrationModal
           isOpen={isFrontierMigrationOpen}
           onRequestClose={onCloseFrontierMigration}
@@ -485,87 +459,6 @@ const WalletInfo: FunctionComponent<
     </div>
   );
 });
-
-const AnnouncementBanner: FunctionComponent<
-  typeof Announcement & { closeBanner: () => void }
-> = ({
-  enTextOrLocalizationPath,
-  link,
-  isWarning,
-  persistent,
-  closeBanner,
-  bg,
-}) => {
-  const { t } = useTranslation();
-  const {
-    isOpen: isLeavingOsmosisOpen,
-    onClose: onCloseLeavingOsmosis,
-    onOpen: onOpenLeavingOsmosis,
-  } = useDisclosure();
-
-  const linkText = t(
-    link?.enTextOrLocalizationKey ?? "Click here to learn more"
-  );
-
-  const handleLeaveClick = () =>
-    handleExternalLink({
-      url: link?.url ?? "",
-      openModal: onOpenLeavingOsmosis,
-    });
-
-  return (
-    <div
-      className={classNames(
-        "fixed top-[71px] z-[51] float-right my-auto ml-sidebar flex w-[calc(100vw_-_14.58rem)] items-center px-8 py-[14px] md:top-[57px] md:ml-0 md:w-full sm:gap-3 sm:px-2",
-        {
-          "bg-gradient-negative": isWarning,
-          "bg-gradient-neutral": !isWarning,
-        },
-        bg
-      )}
-    >
-      <div className="flex w-full place-content-center items-center gap-1.5 text-center text-subtitle1 lg:gap-1 lg:text-xs lg:tracking-normal md:text-left md:text-xxs sm:items-start">
-        <span>{t(enTextOrLocalizationPath)}</span>
-        {Boolean(link) && (
-          <div className="flex cursor-pointer items-center gap-2">
-            {link?.isExternal ? (
-              <button className="underline" onClick={handleLeaveClick}>
-                {linkText}
-              </button>
-            ) : (
-              <a
-                className="underline"
-                href={link?.url}
-                rel="noreferrer"
-                // target="_blank"
-              >
-                {linkText}
-              </a>
-            )}
-            <Icon id="arrow-right" height={24} width={24} />
-          </div>
-        )}
-      </div>
-      {!persistent && !isWarning && (
-        <IconButton
-          className="flex w-fit cursor-pointer items-center py-0 text-white-full"
-          onClick={closeBanner}
-          aria-label="Close"
-          icon={<Icon id="close-small" height={24} width={24} />}
-          size="unstyled"
-          mode="unstyled"
-        />
-      )}
-      {link?.isExternal && (
-        <ExternalLinkModal
-          url={link.url}
-          onRequestClose={onCloseLeavingOsmosis}
-          isOpen={isLeavingOsmosisOpen}
-        />
-      )}
-    </div>
-  );
-};
 
 const FrontierMigrationModal: FunctionComponent<
   ModalBaseProps & { onOpenSettings: () => void }

--- a/packages/web/config/feature-flag.ts
+++ b/packages/web/config/feature-flag.ts
@@ -7,30 +7,30 @@ export const UserAction: { [key: string]: boolean } = {
   CreateNewPool: true,
 };
 
+export interface AnnouncementInterface {
+  localStorageKey?: string;
+  /** Leave undefined to include all pages. */
+  pageRoute?: string;
+  /** English text or key into localization jsons. */
+  enTextOrLocalizationPath: string;
+  /** Link to external page. */
+  link?: {
+    /** Default: "Click here to learn more" in english-us */
+    enTextOrLocalizationKey?: string;
+    url: string;
+    /** External to Osmosis. Show disclaimer before linking out of app. */
+    isExternal?: boolean;
+  };
+  /** Use orange styling, persist on page reloads. */
+  isWarning?: boolean;
+  /** Will always show on page reload. Use with caution. (Warnings persist) */
+  persistent?: boolean;
+  /** Custom Background color. */
+  bg?: string;
+}
+
 /** Banner below nav bar: mapping of inclusion (.includes()) in page routes to message in banner. */
-export const Announcement:
-  | {
-      localStorageKey?: string;
-      /** Leave undefined to include all pages. */
-      pageRoute?: string;
-      /** English text or key into localization jsons. */
-      enTextOrLocalizationPath: string;
-      /** Link to external page. */
-      link?: {
-        /** Default: "Click here to learn more" in english-us */
-        enTextOrLocalizationKey?: string;
-        url: string;
-        /** External to Osmosis. Show disclaimer before linking out of app. */
-        isExternal?: boolean;
-      };
-      /** Use orange styling, persist on page reloads. */
-      isWarning?: boolean;
-      /** Will always show on page reload. Use with caution. (Warnings persist) */
-      persistent?: boolean;
-      /** Custom Background color. */
-      bg?: string;
-    }
-  | undefined = IS_HALTED
+export const Announcement: AnnouncementInterface | undefined = IS_HALTED
   ? {
       enTextOrLocalizationPath:
         "Chain is halted, transactions are temporarily disabled",


### PR DESCRIPTION
## What is the purpose of the change

Fix the Announcement banner flicker, when the Banner has already been closed, it doesn't show on refresh.

## Brief Changelog

- Moved Banner implementation to `announcement.tsx`.
- show announcements only on client side.
- changed the utilization of `useLocalStorageState` for `useLocalStorage` for preventing a one-frame flicker.

## Testing and Verifying

This change has been tested locally , and is verified by screen recording.

https://github.com/osmosis-labs/osmosis-frontend/assets/4956754/d4e903dc-f129-41f0-bc54-b8f42ecf4739

Closes: #2565
