### PR TITLE
Update Pool Creation Fee to 100 USDC

### DIFF
--- a/packages/web/components/complex/pool/create/index.ts
+++ b/packages/web/components/complex/pool/create/index.ts
@@ -4,4 +4,4 @@ export * from "./step2-add-liquidity";
 export * from "./step3-confirm";
 export * from "./types";
 
-export const POOL_CREATION_FEE = "400 OSMO";
+export const POOL_CREATION_FEE = "100 USDC";


### PR DESCRIPTION
## What is the purpose of the change

Adjusts pool creation fee warning to 100 USDC
According to https://www.mintscan.io/osmosis/proposals/699


### ClickUp Task

N/A

## Brief Changelog

Adjusts pool creation fee warning to 100 USDC

## Testing and Verifying

This change has not been tested locally

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes)
- How is the feature or change documented? (Docs site adjusted) -->
