### PR TITLE
Add default feature flags for development mode

### DIFF
--- a/packages/web/hooks/use-feature-flags.ts
+++ b/packages/web/hooks/use-feature-flags.ts
@@ -69,7 +69,7 @@ export const useFeatureFlags = () => {
     notifications: isMobile
       ? launchdarklyFlags.mobileNotifications
       : launchdarklyFlags.notifications,
-    _isInitialized: process.env.NODE_ENV === "development",
+    _isInitialized: process.env.NODE_ENV === "development" || isInitialized,
     _isClientIDPresent: !!process.env.NEXT_PUBLIC_LAUNCH_DARKLY_CLIENT_SIDE_ID,
   } as Record<ModifiedFlags, boolean>;
 };

--- a/packages/web/hooks/use-feature-flags.ts
+++ b/packages/web/hooks/use-feature-flags.ts
@@ -28,6 +28,29 @@ type ModifiedFlags =
   | "_isInitialized"
   | "_isClientIDPresent";
 
+// These default flags will be passed to the app if the app is running in development mode
+const defaultFlags: Record<ModifiedFlags, boolean> = {
+  concentratedLiquidity: true,
+  staking: false,
+  swapsAdBanner: true,
+  notifications: true,
+  convertToStake: true,
+  upgrades: true,
+  tokenInfo: true,
+  newAssetsTable: false,
+  sidebarOsmoChangeAndChart: true,
+  multiBridgeProviders: true,
+  unlistedAssets: false,
+  earnPage: false,
+  sidecarRouter: true,
+  legacyRouter: true,
+  tfmRouter: true,
+  osmosisUpdatesPopUp: false,
+  aprBreakdown: true,
+  _isInitialized: false,
+  _isClientIDPresent: false,
+};
+
 export const useFeatureFlags = () => {
   const launchdarklyFlags: Record<AvailableFlags, boolean> = useFlags();
   const { isMobile } = useWindowSize();
@@ -42,10 +65,11 @@ export const useFeatureFlags = () => {
 
   return {
     ...launchdarklyFlags,
+    ...(process.env.NODE_ENV === "development" ? defaultFlags : {}),
     notifications: isMobile
       ? launchdarklyFlags.mobileNotifications
       : launchdarklyFlags.notifications,
-    _isInitialized: isInitialized,
+    _isInitialized: process.env.NODE_ENV === "development",
     _isClientIDPresent: !!process.env.NEXT_PUBLIC_LAUNCH_DARKLY_CLIENT_SIDE_ID,
   } as Record<ModifiedFlags, boolean>;
 };


### PR DESCRIPTION
## What is the purpose of the change

This pull request modifies the `useFeatureFlags` hook to only enable certain feature flags and set `_isInitialized` to `true` when running in a development environment.

### ClickUp Task

[ClickUp Task URL](PASTE_CLICKUP_TASK_URL_HERE)

## Brief Changelog

- Modified the `useFeatureFlags` hook to conditionally spread `defaultFlags` and set `_isInitialized` based on the `NODE_ENV` environment variable.

## Testing and Verifying

This change has been tested locally by running the application in both development and production environments and verifying that the feature flags and `_isInitialized` are set as expected. It has not been tested on stage.

## Documentation and Release Note

- Does this pull request introduce a new feature or user-facing behavior changes? No