### PR TITLE
CL: add APR breakdown to pool detail page

### DIFF
--- a/packages/stores/src/derived-data/pool/concentrated.ts
+++ b/packages/stores/src/derived-data/pool/concentrated.ts
@@ -15,6 +15,7 @@ import { OsmosisQueries } from "../../queries/store";
 import {
   ObservableQueryActiveGauges,
   ObservableQueryClPoolAvgAprs,
+  ObservableQueryPoolAprs,
   ObservableQueryPoolFeesMetrics,
   ObservableQueryPriceRangeAprs,
 } from "../../queries-external";
@@ -31,7 +32,7 @@ export class ObservableConcentratedPoolDetail {
       queryPoolFeeMetrics: ObservableQueryPoolFeesMetrics;
       queryActiveGauges: ObservableQueryActiveGauges;
       queryPriceRangeAprs: ObservableQueryPriceRangeAprs;
-      queryClPoolAvgAprs: ObservableQueryClPoolAvgAprs;
+      queryPoolAprs: ObservableQueryPoolAprs;
     },
     protected readonly accountStore: AccountStore,
     protected readonly priceStore: IPriceStore
@@ -82,12 +83,17 @@ export class ObservableConcentratedPoolDetail {
 
   @computed
   get swapFeeApr(): RatePretty {
-    const queryPool = this.osmosisQueries.queryPools.getPool(this.poolId);
-    if (!queryPool) return new RatePretty(0);
+    return (
+      this.externalQueries.queryPoolAprs.getForPool(this.poolId)?.swapFees ??
+      new RatePretty(0).ready(false)
+    );
+  }
 
-    return this.externalQueries.queryPoolFeeMetrics.get7dPoolFeeApr(
-      queryPool,
-      this.priceStore
+  @computed
+  get totalApr(): RatePretty {
+    return (
+      this.externalQueries.queryPoolAprs.getForPool(this.poolId)?.totalApr ??
+      new RatePretty(0).ready(false)
     );
   }
 
@@ -96,13 +102,6 @@ export class ObservableConcentratedPoolDetail {
       this.externalQueries.queryPriceRangeAprs
         .get(this.poolId)
         .apr?.inequalitySymbol(true) ?? new RatePretty(0).ready(false)
-    );
-  }
-
-  get avgApr(): RatePretty {
-    return (
-      this.externalQueries.queryClPoolAvgAprs.get(this.poolId).apr ??
-      new RatePretty(0).ready(false)
     );
   }
 
@@ -206,6 +205,7 @@ export class ObservableConcentratedPoolDetails extends HasMapStore<ObservableCon
       queryActiveGauges: ObservableQueryActiveGauges;
       queryPriceRangeAprs: ObservableQueryPriceRangeAprs;
       queryClPoolAvgAprs: ObservableQueryClPoolAvgAprs;
+      queryPoolAprs: ObservableQueryPoolAprs;
     },
     protected readonly accountStore: AccountStore,
     protected readonly priceStore: IPriceStore

--- a/packages/web/components/cards/apr-breakdown.tsx
+++ b/packages/web/components/cards/apr-breakdown.tsx
@@ -1,0 +1,74 @@
+import { RatePretty } from "@keplr-wallet/unit";
+import classNames from "classnames";
+import { observer } from "mobx-react-lite";
+import { FunctionComponent } from "react";
+
+import { useTranslation } from "~/hooks";
+import { useStore } from "~/stores";
+import { theme } from "~/tailwind.config";
+
+import { Icon } from "../assets";
+import { CustomClasses } from "../types";
+
+export const AprBreakdown: FunctionComponent<
+  { poolId: string } & CustomClasses
+> = observer(({ poolId, className }) => {
+  const { queriesExternalStore } = useStore();
+  const poolAprs = queriesExternalStore.queryPoolAprs.getForPool(poolId);
+  const { t } = useTranslation();
+
+  return (
+    <div className={classNames("flex w-60 flex-col gap-4 p-5", className)}>
+      <div className="my-auto flex flex-col gap-2">
+        {poolAprs?.swapFees && (
+          <BreakdownRow
+            label={t("pools.aprBreakdown.swapFees")}
+            value={poolAprs.swapFees}
+          />
+        )}
+        {poolAprs?.osmosis && (
+          <div className="body2 flex w-full place-content-between items-center px-3 text-bullish-500">
+            <div className="flex place-content-between items-center gap-1">
+              <p>OSMO {t("pools.aprBreakdown.boost")}</p>
+              <Icon id="boost" color={theme.colors.bullish[500]} />
+            </div>
+            <p>{poolAprs.osmosis.maxDecimals(1).toString()}</p>
+          </div>
+        )}
+        {poolAprs?.boost && (
+          <div className="body2 flex w-full place-content-between items-center px-3 text-bullish-500">
+            <div className="flex place-content-between items-center gap-1">
+              <p>{t("pools.aprBreakdown.externalBoost")}</p>
+              <Icon id="boost" color={theme.colors.bullish[500]} />
+            </div>
+            <p>{poolAprs.boost.maxDecimals(1).toString()}</p>
+          </div>
+        )}
+      </div>
+
+      {poolAprs?.totalApr && (
+        <div
+          className={classNames(
+            "subtitle1 flex w-full place-content-between items-center rounded-lg bg-osmoverse-825 py-1 px-3",
+            {
+              "text-bullish-500": Boolean(poolAprs?.boost),
+            }
+          )}
+        >
+          <p>{t("pools.aprBreakdown.total")}</p>
+          <p>{poolAprs.totalApr.maxDecimals(1).toString()}</p>
+        </div>
+      )}
+    </div>
+  );
+});
+
+const BreakdownRow: FunctionComponent<{
+  label: string;
+  value: RatePretty;
+}> = ({ label, value }) => (
+  <div className="body2 flex w-full place-content-between items-center px-3">
+    <p className="text-white-full">{label}</p>
+    <p className="text-osmoverse-200">{value.maxDecimals(1).toString()}</p>
+  </div>
+);

--- a/packages/web/components/pool-detail/concentrated.tsx
+++ b/packages/web/components/pool-detail/concentrated.tsx
@@ -472,7 +472,7 @@ const UserAssetsAndExternalIncentives: FunctionComponent<{ poolId: string }> =
     const hasIncentives = concentratedPoolDetail.incentiveGauges.length > 0;
 
     return (
-      <div className="flex h-40 gap-4">
+      <div className="flex flex-wrap gap-4">
         <div className="flex shrink-0 items-center gap-8 rounded-[28px] bg-osmoverse-1000 px-8 py-7">
           <div className="flex h-full flex-col place-content-between">
             <span className="body2 text-osmoverse-300">
@@ -512,7 +512,7 @@ const UserAssetsAndExternalIncentives: FunctionComponent<{ poolId: string }> =
           </div>
         </div>
         <AprBreakdown
-          className="rounded-[28px] bg-osmoverse-1000"
+          className="shrink-0 rounded-[28px] bg-osmoverse-1000"
           poolId={poolId}
         />
 

--- a/packages/web/components/pool-detail/concentrated.tsx
+++ b/packages/web/components/pool-detail/concentrated.tsx
@@ -29,6 +29,8 @@ import { formatPretty } from "~/utils/formatter";
 import { getNumberMagnitude } from "~/utils/number";
 import { removeQueryParam } from "~/utils/url";
 
+import { AprBreakdown } from "../cards/apr-breakdown";
+
 const ConcentratedLiquidityDepthChart = dynamic(
   () => import("~/components/chart/concentrated-liquidity-depth"),
   { ssr: false }
@@ -509,6 +511,11 @@ const UserAssetsAndExternalIncentives: FunctionComponent<{ poolId: string }> =
             ))}
           </div>
         </div>
+        <AprBreakdown
+          className="rounded-[28px] bg-osmoverse-1000"
+          poolId={poolId}
+        />
+
         {hasIncentives && (
           <div className="flex h-full w-full flex-col place-content-between items-center rounded-[28px] bg-osmoverse-1000 px-8 py-7">
             <span className="body2 mr-auto text-osmoverse-300">

--- a/packages/web/components/table/cells/apr-breakdown.tsx
+++ b/packages/web/components/table/cells/apr-breakdown.tsx
@@ -1,13 +1,11 @@
-import { RatePretty } from "@keplr-wallet/unit";
 import classNames from "classnames";
 import { observer } from "mobx-react-lite";
 import React, { FunctionComponent } from "react";
 
 import { Icon } from "~/components/assets";
+import { AprBreakdown } from "~/components/cards/apr-breakdown";
 import { Tooltip } from "~/components/tooltip";
-import { useTranslation } from "~/hooks";
 import { useStore } from "~/stores";
-import { theme } from "~/tailwind.config";
 
 export const AprBreakdownCell: FunctionComponent<{
   poolId: string;
@@ -18,7 +16,7 @@ export const AprBreakdownCell: FunctionComponent<{
   return (
     <Tooltip
       rootClassNames="!rounded-[20px] drop-shadow-md"
-      content={<BreakdownPopup poolId={poolId} />}
+      content={<AprBreakdown poolId={poolId} />}
     >
       <p
         className={classNames("ml-auto flex items-center gap-1.5", {
@@ -35,66 +33,3 @@ export const AprBreakdownCell: FunctionComponent<{
     </Tooltip>
   );
 });
-
-const BreakdownPopup: FunctionComponent<{ poolId: string }> = observer(
-  ({ poolId }) => {
-    const { queriesExternalStore } = useStore();
-    const poolAprs = queriesExternalStore.queryPoolAprs.getForPool(poolId);
-    const { t } = useTranslation();
-
-    return (
-      <div className="flex w-60 flex-col gap-4 p-5">
-        <div className="flex flex-col gap-2">
-          {poolAprs?.swapFees && (
-            <BreakdownRow
-              label={t("pools.aprBreakdown.swapFees")}
-              value={poolAprs.swapFees}
-            />
-          )}
-          {poolAprs?.osmosis && (
-            <div className="body2 flex w-full place-content-between items-center px-3 text-bullish-500">
-              <div className="flex place-content-between items-center gap-1">
-                <p>OSMO {t("pools.aprBreakdown.boost")}</p>
-                <Icon id="boost" color={theme.colors.bullish[500]} />
-              </div>
-              <p>{poolAprs.osmosis.maxDecimals(1).toString()}</p>
-            </div>
-          )}
-          {poolAprs?.boost && (
-            <div className="body2 flex w-full place-content-between items-center px-3 text-bullish-500">
-              <div className="flex place-content-between items-center gap-1">
-                <p>{t("pools.aprBreakdown.externalBoost")}</p>
-                <Icon id="boost" color={theme.colors.bullish[500]} />
-              </div>
-              <p>{poolAprs.boost.maxDecimals(1).toString()}</p>
-            </div>
-          )}
-        </div>
-
-        {poolAprs?.totalApr && (
-          <div
-            className={classNames(
-              "subtitle1 flex w-full place-content-between items-center rounded-lg bg-osmoverse-825 py-1 px-3",
-              {
-                "text-bullish-500": Boolean(poolAprs?.boost),
-              }
-            )}
-          >
-            <p>{t("pools.aprBreakdown.total")}</p>
-            <p>{poolAprs.totalApr.maxDecimals(1).toString()}</p>
-          </div>
-        )}
-      </div>
-    );
-  }
-);
-
-const BreakdownRow: FunctionComponent<{
-  label: string;
-  value: RatePretty;
-}> = ({ label, value }) => (
-  <div className="body2 flex w-full place-content-between items-center px-3">
-    <p className="text-white-full">{label}</p>
-    <p className="text-osmoverse-200">{value.maxDecimals(1).toString()}</p>
-  </div>
-);

--- a/packages/web/pages/pools.tsx
+++ b/packages/web/pages/pools.tsx
@@ -494,7 +494,7 @@ const MyPoolsSection = observer(() => {
               poolDetail instanceof ObservableSharePoolDetail
                 ? poolBonding.highestBondDuration?.aggregateApr ??
                   new RatePretty(0)
-                : poolDetail.swapFeeApr;
+                : poolDetail.totalApr;
 
             const poolLiquidity = formatPretty(poolDetail.totalValueLocked, {
               maxDecimals: 0,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

* Add numa's APR breakdown to CL pool detail page

<img width="1066" alt="Screenshot 2023-12-28 at 7 50 33 PM" src="https://github.com/osmosis-labs/osmosis-frontend/assets/4606373/6ef0c6a6-9dd0-4149-9819-99013a35d2f3">

* Use numa's totalAPR in the pool cards for CL pools, instead of imperators 7d swap fee APR
<img width="532" alt="Screenshot 2023-12-28 at 7 54 29 PM" src="https://github.com/osmosis-labs/osmosis-frontend/assets/4606373/9aae4f83-cd41-49ad-8ca0-190961e6b2a3">
<img width="975" alt="Screenshot 2023-12-28 at 7 54 51 PM" src="https://github.com/osmosis-labs/osmosis-frontend/assets/4606373/5383fd9c-e131-4ea9-bef6-3f112bd3d13e">

