### PR TITLE
Use tRPC for sidebar OSMO asset price data

### DIFF
--- a/packages/web/server/api/edge-routers/assets-router.ts
+++ b/packages/web/server/api/edge-routers/assets-router.ts
@@ -8,6 +8,7 @@ import {
   AssetFilterSchema,
   getAsset,
   getAssetHistoricalPrice,
+  getAssetMarketInfo,
   getAssetPrice,
   getUserAssetInfo,
   mapGetAssetMarketInfos,
@@ -86,6 +87,26 @@ export const assetsRouter = createTRPCRouter({
 
     return assets.filter((a): a is Asset => !!a);
   }),
+  getAssetInfo: publicProcedure
+    .input(
+      z
+        .object({
+          findMinDenomOrSymbol: z.string(),
+        })
+        .and(UserOsmoAddressSchema)
+    )
+    .query(async ({ input: { findMinDenomOrSymbol, userOsmoAddress } }) => {
+      const asset = await getAsset({ anyDenom: findMinDenomOrSymbol });
+
+      if (!asset) throw new Error("Asset not found " + findMinDenomOrSymbol);
+
+      const userAsset = await getUserAssetInfo({ asset, userOsmoAddress });
+      const userMarketInfoAsset = await getAssetMarketInfo({
+        asset: userAsset,
+      });
+
+      return userMarketInfoAsset;
+    }),
   getAssetInfos: publicProcedure
     .input(
       GetInfiniteAssetsInputSchema.and(


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

* Use tRPC for getting OSMO currency, asset info (price change) and historical price data. This allows us to leverage fine-grained caching on the edge functions thereby reducing direct data queries.
* Remove/reduce dependency on current chain, price, and queries stores
* Remove adding buy OSMO clicked metadata to amplitude, as we currently aren't querying that [event](https://app.amplitude.com/data/osmosis-zone/Osmosis%20%F0%9F%A7%AA/events/main/latest/Sidebar%3A%20Buy%20OSMO%20clicked?view=All&tab=USED%2520BY&propertyValidityFilter=All%2520Properties). We can re-add metadata if we want in the future, at a time where our tRPC query infra is more mature.
