### PR TITLE
Include superfluid in APR breakdown

### DIFF
--- a/packages/web/components/cards/apr-breakdown.tsx
+++ b/packages/web/components/cards/apr-breakdown.tsx
@@ -35,6 +35,12 @@ export const AprBreakdown: FunctionComponent<
             <p>{poolAprs.osmosis.maxDecimals(1).toString()}</p>
           </div>
         )}
+        {poolAprs?.superfluid && (
+          <BreakdownRow
+            label={t("pools.aprBreakdown.superfluid")}
+            value={poolAprs.superfluid}
+          />
+        )}
         {poolAprs?.boost && (
           <div className="body2 flex w-full place-content-between items-center px-3 text-bullish-500">
             <div className="flex place-content-between items-center gap-1">
@@ -43,12 +49,6 @@ export const AprBreakdown: FunctionComponent<
             </div>
             <p>{poolAprs.boost.maxDecimals(1).toString()}</p>
           </div>
-        )}
-        {poolAprs?.superfluid && (
-          <BreakdownRow
-            label={t("pools.aprBreakdown.superfluid")}
-            value={poolAprs.superfluid}
-          />
         )}
       </div>
 

--- a/packages/web/components/cards/apr-breakdown.tsx
+++ b/packages/web/components/cards/apr-breakdown.tsx
@@ -19,7 +19,7 @@ export const AprBreakdown: FunctionComponent<
 
   return (
     <div className={classNames("flex w-60 flex-col gap-4 p-5", className)}>
-      <div className="my-auto flex flex-col gap-2">
+      <div className="flex flex-col gap-2">
         {poolAprs?.swapFees && (
           <BreakdownRow
             label={t("pools.aprBreakdown.swapFees")}
@@ -43,6 +43,12 @@ export const AprBreakdown: FunctionComponent<
             </div>
             <p>{poolAprs.boost.maxDecimals(1).toString()}</p>
           </div>
+        )}
+        {poolAprs?.superfluid && (
+          <BreakdownRow
+            label={t("pools.aprBreakdown.superfluid")}
+            value={poolAprs.superfluid}
+          />
         )}
       </div>
 

--- a/packages/web/components/pool-detail/concentrated.tsx
+++ b/packages/web/components/pool-detail/concentrated.tsx
@@ -18,7 +18,7 @@ import { MyPositionsSection } from "~/components/complex/my-positions-section";
 import { SuperchargePool } from "~/components/funnels/concentrated-liquidity";
 import Spinner from "~/components/spinner";
 import { EventName } from "~/config";
-import { useTranslation } from "~/hooks";
+import { useFeatureFlags, useTranslation } from "~/hooks";
 import { useAmplitudeAnalytics } from "~/hooks";
 import { useHistoricalAndLiquidityData } from "~/hooks/ui-config/use-historical-and-depth-data";
 import { AddLiquidityModal } from "~/modals";
@@ -465,6 +465,7 @@ const UserAssetsAndExternalIncentives: FunctionComponent<{ poolId: string }> =
   observer(({ poolId }) => {
     const { derivedDataStore } = useStore();
     const { t } = useTranslation();
+    const featureFlags = useFeatureFlags();
 
     const concentratedPoolDetail =
       derivedDataStore.concentratedPoolDetails.get(poolId);
@@ -511,10 +512,12 @@ const UserAssetsAndExternalIncentives: FunctionComponent<{ poolId: string }> =
             ))}
           </div>
         </div>
-        <AprBreakdown
-          className="shrink-0 rounded-[28px] bg-osmoverse-1000"
-          poolId={poolId}
-        />
+        {featureFlags.aprBreakdown && (
+          <AprBreakdown
+            className="shrink-0 rounded-[28px] bg-osmoverse-1000"
+            poolId={poolId}
+          />
+        )}
 
         {hasIncentives && (
           <div className="flex h-full w-full flex-col place-content-between items-center rounded-[28px] bg-osmoverse-1000 px-8 py-7">

--- a/packages/web/localizations/en.json
+++ b/packages/web/localizations/en.json
@@ -553,6 +553,7 @@
     "aprBreakdown": {
       "swapFees": "Swap fees",
       "boost": "Boost",
+      "superfluid": "Superfluid",
       "externalBoost": "External Boost",
       "total": "Total APR"
     }

--- a/packages/web/localizations/es.json
+++ b/packages/web/localizations/es.json
@@ -553,6 +553,7 @@
     "aprBreakdown": {
       "swapFees": "Tarifas de intercambio",
       "boost": "Aumentar",
+      "superfluid": "superfluido",
       "externalBoost": "Impulso externo",
       "total": "TAE total"
     }

--- a/packages/web/localizations/fa.json
+++ b/packages/web/localizations/fa.json
@@ -553,6 +553,7 @@
     "aprBreakdown": {
       "swapFees": "کارمزد تعویض",
       "boost": "تقویت کنید",
+      "superfluid": "ابر سیال",
       "externalBoost": "تقویت خارجی",
       "total": "کل آوریل"
     }

--- a/packages/web/localizations/fr.json
+++ b/packages/web/localizations/fr.json
@@ -553,6 +553,7 @@
     "aprBreakdown": {
       "swapFees": "Frais de swap",
       "boost": "Booster",
+      "superfluid": "Superfluide",
       "externalBoost": "Boost externe",
       "total": "TAEG total"
     }

--- a/packages/web/localizations/ko.json
+++ b/packages/web/localizations/ko.json
@@ -553,6 +553,7 @@
     "aprBreakdown": {
       "swapFees": "스왑 수수료",
       "boost": "후원",
+      "superfluid": "초유체",
       "externalBoost": "외부 부스트",
       "total": "총 연이율"
     }

--- a/packages/web/localizations/pl.json
+++ b/packages/web/localizations/pl.json
@@ -553,6 +553,7 @@
     "aprBreakdown": {
       "swapFees": "Opłaty za zamianę",
       "boost": "Zwiększyć",
+      "superfluid": "Nadciekły",
       "externalBoost": "Zewnętrzne wzmocnienie",
       "total": "Całkowita RRSO"
     }

--- a/packages/web/localizations/pt-br.json
+++ b/packages/web/localizations/pt-br.json
@@ -553,6 +553,7 @@
     "aprBreakdown": {
       "swapFees": "Taxas de troca",
       "boost": "Impulsionar",
+      "superfluid": "Superfluido",
       "externalBoost": "Impulso externo",
       "total": "TAEG total"
     }

--- a/packages/web/localizations/ro.json
+++ b/packages/web/localizations/ro.json
@@ -553,6 +553,7 @@
     "aprBreakdown": {
       "swapFees": "Taxe de schimb",
       "boost": "Boost",
+      "superfluid": "Superfluid",
       "externalBoost": "Boost extern",
       "total": "DAE totală"
     }

--- a/packages/web/localizations/tr.json
+++ b/packages/web/localizations/tr.json
@@ -553,6 +553,7 @@
     "aprBreakdown": {
       "swapFees": "Takas ücretleri",
       "boost": "Artırmak",
+      "superfluid": "Süperakışkan",
       "externalBoost": "Harici Güçlendirme",
       "total": "Toplam Nisan"
     }

--- a/packages/web/localizations/zh-cn.json
+++ b/packages/web/localizations/zh-cn.json
@@ -553,6 +553,7 @@
     "aprBreakdown": {
       "swapFees": "掉期费用",
       "boost": "促进",
+      "superfluid": "超流体",
       "externalBoost": "外部升压",
       "total": "总年利率"
     }

--- a/packages/web/localizations/zh-hk.json
+++ b/packages/web/localizations/zh-hk.json
@@ -553,6 +553,7 @@
     "aprBreakdown": {
       "swapFees": "掉期費用",
       "boost": "促進",
+      "superfluid": "超流體",
       "externalBoost": "外部升壓",
       "total": "總年利率"
     }

--- a/packages/web/localizations/zh-tw.json
+++ b/packages/web/localizations/zh-tw.json
@@ -553,6 +553,7 @@
     "aprBreakdown": {
       "swapFees": "掉期費用",
       "boost": "促進",
+      "superfluid": "超流體",
       "externalBoost": "外部升壓",
       "total": "總年利率"
     }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

Numia includes superfluid APRs in the total APR. Was added shortly after release of our UI. This includes superfluid staking returns in the breakdown.

![Screenshot 2024-01-02 at 9 01 19 PM](https://github.com/osmosis-labs/osmosis-frontend/assets/4606373/82125128-716c-42de-991e-1e9b7312a4a6)
