### PR TITLE
Validator search + select fix

### DIFF
--- a/packages/web/modals/validator-squad-modal.tsx
+++ b/packages/web/modals/validator-squad-modal.tsx
@@ -470,7 +470,7 @@ export const ValidatorSquadModal: FunctionComponent<ValidatorSquadModalProps> =
         setRowSelection(defaultRowSelection);
       }, [usersValidatorSetPreferenceMap]);
 
-      const setSquadButtonDisabled = !table.getIsSomeRowsSelected();
+      const setSquadButtonDisabled = Object.keys(rowSelection).length === 0;
 
       const handleSetSquadClick = useCallback(async () => {
         // TODO disable cases for button, disable if none selected, if weights and list is same


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

- previously we used `getIsSomeRowsSelected` to determine if the table selection is empty or not, instead derive this directly from the selected state




### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/86a1qputf)

## Brief Changelog

- after filtering, this doesn't seem to be behaving as expected - https://tanstack.com/table/v8/docs/api/features/row-selection#getissomerowsselected
- some github issues potentially related to this https://github.com/TanStack/table/issues/4212

## Testing and Verifying


https://github.com/osmosis-labs/osmosis-frontend/assets/30577966/30df97e7-81c5-45d7-b26e-d52bd457955b


https://github.com/osmosis-labs/osmosis-frontend/assets/30577966/68bd3e42-a438-4dfa-b444-6e1aa56c3bfc



## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
