### PR TITLE
Fix pagination + search

### DIFF
--- a/packages/web/server/api/__tests__/utils.spec.ts
+++ b/packages/web/server/api/__tests__/utils.spec.ts
@@ -24,6 +24,13 @@ describe("maybeCursorPaginatedItems", () => {
   test("returns last items of page items based on provided cursor and limit", () => {
     const result = maybeCursorPaginatedItems(items, 90, 20);
     expect(result.items).toEqual(items.slice(90, 100));
-    expect(result.nextCursor).toEqual(99);
+    expect(result.nextCursor).toEqual(null);
+  });
+
+  test("returns elements that are less then a single page size", () => {
+    const lessItems = [1, 2, 3];
+    const result = maybeCursorPaginatedItems(lessItems, 0, 20);
+    expect(result.items).toEqual(lessItems);
+    expect(result.nextCursor).toEqual(null);
   });
 });

--- a/packages/web/server/api/utils.ts
+++ b/packages/web/server/api/utils.ts
@@ -24,14 +24,14 @@ export function maybeCursorPaginatedItems<TItem>(
   limit = limit || 50;
   const startIndex = cursor;
 
-  // no more items
-  if (startIndex >= items.length - 1) return { items: [], nextCursor: null };
+  // no more items if given an invalid cursor
+  if (startIndex > items.length - 1) return { items: [], nextCursor: null };
 
   // get the page
   const page = items.slice(startIndex, startIndex + limit);
 
   return {
     items: page,
-    nextCursor: Math.min(cursor + limit, items.length - 1),
+    nextCursor: cursor + limit > items.length - 1 ? null : cursor + limit,
   };
 }

--- a/packages/web/server/queries/complex/assets/index.ts
+++ b/packages/web/server/queries/complex/assets/index.ts
@@ -65,7 +65,7 @@ export async function getAssets({
   assetList?: AssetList[];
   /** Explicitly match the base or symbol denom. */
   findMinDenomOrSymbol?: string;
-} & AssetFilter): Promise<Asset[]> {
+} & AssetFilter = {}): Promise<Asset[]> {
   const makeMinimalAssets = (assetList: AssetList[]) => {
     // Create new array with just assets
     const coinMinimalDenomSet = new Set<string>();

--- a/packages/web/utils/__tests__/search.spec.ts
+++ b/packages/web/utils/__tests__/search.spec.ts
@@ -1,0 +1,45 @@
+import { Search, search } from "../search";
+
+describe("search", () => {
+  it("should return the correct results based on the query", () => {
+    const data = [
+      { name: "John", age: 30 },
+      { name: "Jane", age: 25 },
+      { name: "Doe", age: 35 },
+    ];
+    const keys = ["name", "age"];
+    const searchParams: Search = { query: "John", limit: 2 };
+
+    const result = search(data, keys, searchParams);
+
+    expect(result).toEqual([{ name: "John", age: 30 }]);
+  });
+
+  it("should limit the results based on the limit parameter", () => {
+    const data = [
+      { name: "John", age: 30 },
+      { name: "Jane", age: 25 },
+      { name: "Doe", age: 35 },
+    ];
+    const keys = ["name", "age"];
+    const searchParams: Search = { query: "a", limit: 1 };
+
+    const result = search(data, keys, searchParams);
+
+    expect(result).toEqual([{ name: "Jane", age: 25 }]);
+  });
+
+  it("should return an empty array if no match is found", () => {
+    const data = [
+      { name: "John", age: 30 },
+      { name: "Jane", age: 25 },
+      { name: "Doe", age: 35 },
+    ];
+    const keys = ["name", "age"];
+    const searchParams: Search = { query: "XYZ", limit: 2 };
+
+    const result = search(data, keys, searchParams);
+
+    expect(result).toEqual([]);
+  });
+});


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

I missed a test case for cursor pagination for when the list of items is less then the length of a single page. I added a test to handle that case, and this allows a list filtered to one item (i.e. "dydx" in the issue) to appear with a useInfiniteQuery hook.

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/86a1t4yn4)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->
* Fix returning single page of items that is less in length vs single page size
  * Add test case for this
* Add basic tests for search

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

* As seen in the bug task linked above, you should now be able to search dydx and see just dydx as a result.
