### PR TITLE
Remove unlisted keyword filter of asset list

### DIFF
--- a/packages/web/server/queries/complex/assets/__tests__/assets.spec.ts
+++ b/packages/web/server/queries/complex/assets/__tests__/assets.spec.ts
@@ -29,15 +29,6 @@ describe("getAssets", () => {
       expect(assets[0].coinDenom).toEqual("stLUNA");
     });
 
-    it("should not return unlisted assets", async () => {
-      const assets = await getAssets({
-        search: { query: "PYTH" },
-        assetList: AssetLists,
-      });
-
-      expect(assets).toEqual([]);
-    });
-
     it("should filter unverified assets if specified", async () => {
       const assets = await getAssets({
         assetList: AssetLists,

--- a/packages/web/server/queries/complex/assets/index.ts
+++ b/packages/web/server/queries/complex/assets/index.ts
@@ -79,30 +79,27 @@ function simplifyAssetListForDisplay(
   // Create new array with just assets
   const coinMinimalDenomSet = new Set<string>();
 
-  const listedAssets = assetList
+  let assetListAssets = assetList
     .flatMap(({ assets }) => assets)
-    .filter(
-      (asset) => asset.keywords && !asset.keywords.includes("osmosis-unlisted")
-    );
+    .filter((asset) => {
+      if (params.findMinDenomOrSymbol) {
+        return (
+          params.findMinDenomOrSymbol.toUpperCase() ===
+            asset.base.toUpperCase() ||
+          params.findMinDenomOrSymbol.toUpperCase() ===
+            asset.symbol.toUpperCase()
+        );
+      }
 
-  let assetListAssets = listedAssets.filter((asset) => {
-    if (params.findMinDenomOrSymbol) {
-      return (
-        params.findMinDenomOrSymbol.toUpperCase() ===
-          asset.base.toUpperCase() ||
-        params.findMinDenomOrSymbol.toUpperCase() === asset.symbol.toUpperCase()
-      );
-    }
-
-    // Ensure denoms are unique on Osmosis chain
-    // In the case the asset list has the same asset twice
-    if (coinMinimalDenomSet.has(asset.base)) {
-      return false;
-    } else {
-      coinMinimalDenomSet.add(asset.base);
-      return true;
-    }
-  });
+      // Ensure denoms are unique on Osmosis chain
+      // In the case the asset list has the same asset twice
+      if (coinMinimalDenomSet.has(asset.base)) {
+        return false;
+      } else {
+        coinMinimalDenomSet.add(asset.base);
+        return true;
+      }
+    });
 
   // Search raw asset list before reducing type to minimal Asset type
   if (params.search) {

--- a/packages/web/server/queries/complex/pools/route-token-out-given-in.ts
+++ b/packages/web/server/queries/complex/pools/route-token-out-given-in.ts
@@ -44,7 +44,9 @@ export async function routeTokenOutGivenIn({
   // get quote
   const router = await getRouter(forcePoolId ? 0 : undefined);
   const quote = await router.routeByTokenIn(token, tokenOutDenom, forcePoolId);
-  const candidateRoutes = router.getCandidateRoutes(token.denom, tokenOutDenom);
+  const candidateRoutes = forcePoolId
+    ? []
+    : router.getCandidateRoutes(token.denom, tokenOutDenom);
 
   return {
     quote: {


### PR DESCRIPTION
When creating asset tRPC procedure, I was under the impression that the "osmosis-unlisted" keyword meant that it should be filtered. This caused confusion when unlisted assets were not appearing in the frontend.

I removed the filter, and will consider adding a flag later that can be used to treat that keyword as a filter of the assets page.

Also fixed direct swap hanging issue in legacy router.