### PR TITLE
Add cached cursor-based pagination

### DIFF
--- a/packages/web/server/api/__tests__/pagination.spec.ts
+++ b/packages/web/server/api/__tests__/pagination.spec.ts
@@ -1,4 +1,4 @@
-import { maybeCursorPaginatedItems } from "../utils";
+import { maybeCursorPaginatedItems } from "../pagination";
 
 describe("maybeCursorPaginatedItems", () => {
   const items = Array.from({ length: 100 }, (_, i) => i); // Create an array of 100 items

--- a/packages/web/server/api/edge-routers/assets-router.ts
+++ b/packages/web/server/api/edge-routers/assets-router.ts
@@ -55,18 +55,18 @@ export const assetsRouter = createTRPCRouter({
       async ({
         input: { search, userOsmoAddress, limit, cursor, onlyVerified },
       }) =>
-        maybeCachePaginatedItems(
-          () =>
+        maybeCachePaginatedItems({
+          getFreshItems: () =>
             mapGetUserAssetInfos({
               search,
               userOsmoAddress,
               onlyVerified,
               sortFiatValueDirection: "desc",
             }),
-          JSON.stringify({ search, userOsmoAddress, onlyVerified }),
+          cacheKey: JSON.stringify({ search, userOsmoAddress, onlyVerified }),
           cursor,
-          limit
-        )
+          limit,
+        })
     ),
   getAssetPrice: publicProcedure
     .input(
@@ -140,8 +140,8 @@ export const assetsRouter = createTRPCRouter({
           limit,
         },
       }) =>
-        maybeCachePaginatedItems(
-          async () => {
+        maybeCachePaginatedItems({
+          getFreshItems: async () => {
             const isDefaultSort = !sortInput && !search;
 
             let assets;
@@ -217,7 +217,7 @@ export const assetsRouter = createTRPCRouter({
             // Can be searching and/or sorting
             return assets;
           },
-          JSON.stringify({
+          cacheKey: JSON.stringify({
             search,
             onlyVerified,
             userOsmoAddress,
@@ -226,8 +226,8 @@ export const assetsRouter = createTRPCRouter({
             onlyPositiveBalances,
           }),
           cursor,
-          limit
-        )
+          limit,
+        })
     ),
   getAssetHistoricalPrice: publicProcedure
     .input(

--- a/packages/web/server/api/pagination.ts
+++ b/packages/web/server/api/pagination.ts
@@ -1,3 +1,8 @@
+import cachified, { CacheEntry } from "cachified";
+import { LRUCache } from "lru-cache";
+
+import { DEFAULT_LRU_OPTIONS } from "~/config/cache";
+
 /** Uses numerical cursor-based pagination that is compatible with and similar to offest pagination.
  *  This means if you have a cursor of 50 and a limit of 20, you will get items 50-69.
  *  Also, you should rerequest all data if it changes, as the cursor is not a pointer to a page, but to an item index.
@@ -34,4 +39,39 @@ export function maybeCursorPaginatedItems<TItem>(
     items: page,
     nextCursor: cursor + limit > items.length - 1 ? null : cursor + limit,
   };
+}
+
+const paginationCache = new LRUCache<string, CacheEntry>(DEFAULT_LRU_OPTIONS);
+/** Returns cached items while the user is paginating the list.
+ *  If the input changes or the cursor is reset, the cache is invalidated.
+ *  With useInfiniteQuery, the cursor will be reset to 0 when input to the query changes or the query is invalidated. */
+export async function maybeCachePaginatedItems<TItem>(
+  getFreshItems: () => Promise<TItem[]>,
+  cacheKey: string,
+  cursor: number | null | undefined,
+  limit: number | null | undefined
+): Promise<{
+  items: TItem[];
+  nextCursor: number | null;
+}> {
+  // if pagination is not used, return items
+  if (!cursor && !limit)
+    return { items: await getFreshItems(), nextCursor: null };
+
+  // If cursor is 0, delete the cache entry for the given key
+  if (cursor === 0) {
+    paginationCache.delete(cacheKey);
+  }
+
+  const items = await cachified({
+    key: cacheKey,
+    cache: paginationCache,
+    ttl: 30 * 1000, // 30 seconds
+    getFreshValue: () => {
+      console.log("Get fresh items", cacheKey);
+      return getFreshItems();
+    },
+  });
+
+  return maybeCursorPaginatedItems(items, cursor, limit);
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

This is in prep for assets table.

Currently, each time the next page of a list is requested by useInfiniteQuery, the entire list of items is refetched. Often, this isn't bad as usually that underlying data is pulled from the cache. But, in the case of user balances of assets, each requested page triggers a balances query.

These changes wrap the list of items in a cache, and invalidate that list of items if any of the input changes or the cursor is reset to 0. With useInfiniteQuery, the cursor will be set to 0 when the query is invalidated.

This allows us to cache user balances while paginating.

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/86a0vf1e7)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->
* Add `maybeCachePaginatedItems`
* Rename utils to pagination

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

* Should notice slight perf improvements to swap tool drawer scrolling pagination
* With assets table FF enabled in dev, should notice improvements to assets table pagination performance