### PR TITLE
fix: Link Text When It's Not Translated

### DIFF
--- a/packages/web/components/navbar/index.tsx
+++ b/packages/web/components/navbar/index.tsx
@@ -597,7 +597,7 @@ const AnnouncementBanner: FunctionComponent<{
     getDeepValue<string>(
       currentLanguageTranslations,
       link?.enTextOrLocalizationKey
-    ) ?? "Click here to learn more";
+    ) ?? link?.enTextOrLocalizationKey;
 
   const handleLeaveClick = () =>
     handleExternalLink({

--- a/packages/web/components/navbar/index.tsx
+++ b/packages/web/components/navbar/index.tsx
@@ -597,7 +597,9 @@ const AnnouncementBanner: FunctionComponent<{
     getDeepValue<string>(
       currentLanguageTranslations,
       link?.enTextOrLocalizationKey
-    ) ?? link?.enTextOrLocalizationKey;
+    ) ??
+    link?.enTextOrLocalizationKey ??
+    "Click here to learn more";
 
   const handleLeaveClick = () =>
     handleExternalLink({


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

If the link text is not translated, the FE displays the default "Click here to learn more". This PR will display the property regardless of its translation.

