### PR TITLE
Animate rewards buttons on hover

### DIFF
--- a/packages/web/components/cards/rewards-card.tsx
+++ b/packages/web/components/cards/rewards-card.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import React from "react";
+import React, { useState } from "react";
 
 import { DynamicLottieAnimation } from "~/components/animation";
 import { Button } from "~/components/buttons";
@@ -34,6 +34,8 @@ export const RewardsCard: React.FC<{
       ? `[mask-image:url('/images/folder-right-tab.svg')] bg-[url('/images/grid-right-tab.svg')]`
       : `[mask-image:url('/images/folder-left-tab.svg')] bg-[url('/images/grid-left-tab.svg')]`;
 
+  const [hover, setHover] = useState(false);
+
   return (
     <Button
       disabled={disabled}
@@ -49,6 +51,8 @@ export const RewardsCard: React.FC<{
           )}
         ></div>
         <DynamicLottieAnimation
+          onMouseEnter={() => setHover(true)}
+          onMouseLeave={() => setHover(false)}
           className={classNames(
             "absolute left-0 top-0 z-20",
             position === "right" ? "scale-[0.85]" : "scale-1"
@@ -56,6 +60,7 @@ export const RewardsCard: React.FC<{
           globalLottieFileKey={globalLottieFileKey}
           importFn={() => import(`./${globalLottieFileKey}.json`)}
           loop={true}
+          autoplay={hover}
         />
         <div
           className={classNames(


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

- animate buttons only on hover

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/86a1xazcx)

## Brief Changelog

add onMouseEnter / onMouseLeave for autoplay prop

## Testing and Verifying


https://github.com/osmosis-labs/osmosis-frontend/assets/30577966/91908aff-f03c-488b-8a29-97995877f9bc


## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
