### PR TITLE
Add stake learn more modal via button

### DIFF
--- a/packages/web/modals/validator-next-step.tsx
+++ b/packages/web/modals/validator-next-step.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link";
 import { useCallback } from "react";
 import { FunctionComponent } from "react";
 
@@ -12,6 +11,7 @@ interface ExtendedModalBaseProps extends ModalBaseProps {
   setShowValidatorModal: () => void;
   isNewUser: boolean;
   stakeCall: () => void;
+  setShowStakeLearnMoreModal: () => void;
 }
 
 export const ValidatorNextStepModal: FunctionComponent<
@@ -22,6 +22,7 @@ export const ValidatorNextStepModal: FunctionComponent<
   setShowValidatorModal,
   isNewUser,
   stakeCall,
+  setShowStakeLearnMoreModal,
 }) => {
   const { t } = useTranslation();
 
@@ -62,13 +63,16 @@ export const ValidatorNextStepModal: FunctionComponent<
         <>
           <p className="text-base font-thin">
             {t("stake.validatorNextStep.newUser.description")}{" "}
-            <Link
-              href=""
-              className="text-bullish-200 whitespace-nowrap underline"
+            <Button
+              mode="unstyled"
+              className="!inline !w-max whitespace-nowrap !p-0 !text-bullish-300 underline"
+              onClick={() => {
+                onRequestClose();
+                setShowStakeLearnMoreModal();
+              }}
             >
-              {/* TODO - add link to learn here */}
               {t("stake.validatorNextStep.newUser.learnMore")} {"->"}
-            </Link>
+            </Button>
           </p>
           <Button
             mode="primary-bullish"

--- a/packages/web/pages/stake.tsx
+++ b/packages/web/pages/stake.tsx
@@ -427,6 +427,7 @@ export const Staking: React.FC = observer(() => {
         queryValidators={queryValidators}
       />
       <ValidatorNextStepModal
+        setShowStakeLearnMoreModal={() => setShowStakeLearnMoreModal(true)}
         isNewUser={isNewUser}
         isOpen={showValidatorNextStepModal}
         onRequestClose={() => setShowValidatorNextStepModal(false)}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

"link" should point to stake learn more modal

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/86a1qpbpz)

## Brief Changelog

- convert to unstyled button, link up to stake learn more modal

## Testing and Verifying

https://github.com/osmosis-labs/osmosis-frontend/assets/30577966/efff2ffa-f3cd-42ec-b9b7-a99c910b5a3d

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
