### PR TITLE
fix: No Keyword Assets and Get Unlisted Assets from TRPC

### DIFF
--- a/packages/web/components/table/asset-info.tsx
+++ b/packages/web/components/table/asset-info.tsx
@@ -24,6 +24,7 @@ import {
 } from "~/hooks";
 import { useSearchQueryInput } from "~/hooks/input/use-search-query-input";
 import { useConst } from "~/hooks/use-const";
+import { useShowUnlistedAssets } from "~/hooks/use-show-unlisted-assets";
 import type { CommonPriceChartTimeFrame } from "~/server/queries/complex/assets";
 import { useStore } from "~/stores";
 import { UnverifiedAssetsState } from "~/stores/user-settings";
@@ -51,7 +52,7 @@ export const AssetsInfoTable: FunctionComponent<{
   onDeposit: (coinMinimalDenom: string) => void;
   onWithdraw: (coinMinimalDenom: string) => void;
 }> = observer(({ tableTopPadding = 0, onDeposit, onWithdraw }) => {
-  const { chainStore, accountStore, userSettings } = useStore();
+  const { chainStore, accountStore, userSettings, assetsStore } = useStore();
   const account = accountStore.getWallet(chainStore.osmosis.chainId);
   const { isLoading: isLoadingWallet } = useWalletSelect();
 
@@ -76,6 +77,8 @@ export const AssetsInfoTable: FunctionComponent<{
   const showUnverifiedAssets =
     showUnverifiedAssetsSetting?.state.showUnverifiedAssets;
 
+  const { showUnlistedAssets } = useShowUnlistedAssets();
+
   // Query
   const {
     data: assetPagesData,
@@ -90,6 +93,7 @@ export const AssetsInfoTable: FunctionComponent<{
       limit: 20,
       search: searchQuery,
       onlyVerified: showUnverifiedAssets === false,
+      includeUnlisted: showUnlistedAssets,
       sort: sortKey
         ? {
             keyPath: sortKey,

--- a/packages/web/components/table/asset-info.tsx
+++ b/packages/web/components/table/asset-info.tsx
@@ -52,7 +52,7 @@ export const AssetsInfoTable: FunctionComponent<{
   onDeposit: (coinMinimalDenom: string) => void;
   onWithdraw: (coinMinimalDenom: string) => void;
 }> = observer(({ tableTopPadding = 0, onDeposit, onWithdraw }) => {
-  const { chainStore, accountStore, userSettings, assetsStore } = useStore();
+  const { chainStore, accountStore, userSettings } = useStore();
   const account = accountStore.getWallet(chainStore.osmosis.chainId);
   const { isLoading: isLoadingWallet } = useWalletSelect();
 

--- a/packages/web/hooks/use-show-unlisted-assets.ts
+++ b/packages/web/hooks/use-show-unlisted-assets.ts
@@ -1,0 +1,14 @@
+import { useSessionStorage } from "react-use";
+
+export const UnlistedAssetsKey = "show_unlisted_assets";
+
+export const useShowUnlistedAssets = () => {
+  const [showUnlistedAssets] = useSessionStorage<boolean>(
+    UnlistedAssetsKey,
+    false
+  );
+
+  return {
+    showUnlistedAssets,
+  };
+};

--- a/packages/web/hooks/use-swap.ts
+++ b/packages/web/hooks/use-swap.ts
@@ -14,6 +14,7 @@ import { useMemo } from "react";
 import { useCallback } from "react";
 import { useEffect } from "react";
 
+import { useShowUnlistedAssets } from "~/hooks/use-show-unlisted-assets";
 import type { RouterKey } from "~/server/api/edge-routers/swap-router";
 import type { AppRouter } from "~/server/api/root";
 import type { Asset } from "~/server/queries/complex/assets";
@@ -334,6 +335,8 @@ export function useSwapAssets({
     [debouncedSearchInput]
   );
 
+  const { showUnlistedAssets } = useShowUnlistedAssets();
+
   const canLoadAssets =
     !isLoadingWallet &&
     Boolean(fromAssetDenom) &&
@@ -350,6 +353,7 @@ export function useSwapAssets({
     {
       search: queryInput,
       userOsmoAddress: account?.address,
+      includeUnlisted: showUnlistedAssets,
       limit: 50, // items per page
     },
     {

--- a/packages/web/server/api/edge-routers/assets-router.ts
+++ b/packages/web/server/api/edge-routers/assets-router.ts
@@ -26,9 +26,9 @@ import { createSortSchema, sort } from "~/utils/sort";
 import { maybeCachePaginatedItems } from "../pagination";
 import { InfiniteQuerySchema } from "../zod-types";
 
-const GetInfiniteAssetsInputSchema = InfiniteQuerySchema.and(
+const GetInfiniteAssetsInputSchema = InfiniteQuerySchema.merge(
   AssetFilterSchema
-).and(UserOsmoAddressSchema);
+).merge(UserOsmoAddressSchema);
 
 export const assetsRouter = createTRPCRouter({
   getAsset: publicProcedure
@@ -37,7 +37,7 @@ export const assetsRouter = createTRPCRouter({
         .object({
           findMinDenomOrSymbol: z.string(),
         })
-        .and(UserOsmoAddressSchema)
+        .merge(UserOsmoAddressSchema)
     )
     .query(async ({ input: { findMinDenomOrSymbol, userOsmoAddress } }) => {
       const asset = await getAsset({ anyDenom: findMinDenomOrSymbol });
@@ -53,7 +53,14 @@ export const assetsRouter = createTRPCRouter({
     .input(GetInfiniteAssetsInputSchema)
     .query(
       async ({
-        input: { search, userOsmoAddress, limit, cursor, onlyVerified },
+        input: {
+          search,
+          userOsmoAddress,
+          limit,
+          cursor,
+          onlyVerified,
+          includeUnlisted,
+        },
       }) =>
         maybeCachePaginatedItems({
           getFreshItems: () =>
@@ -62,6 +69,7 @@ export const assetsRouter = createTRPCRouter({
               userOsmoAddress,
               onlyVerified,
               sortFiatValueDirection: "desc",
+              includeUnlisted,
             }),
           cacheKey: JSON.stringify({ search, userOsmoAddress, onlyVerified }),
           cursor,
@@ -96,7 +104,7 @@ export const assetsRouter = createTRPCRouter({
         .object({
           findMinDenomOrSymbol: z.string(),
         })
-        .and(UserOsmoAddressSchema)
+        .merge(UserOsmoAddressSchema)
     )
     .query(async ({ input: { findMinDenomOrSymbol, userOsmoAddress } }) => {
       const asset = await getAsset({ anyDenom: findMinDenomOrSymbol });
@@ -115,7 +123,7 @@ export const assetsRouter = createTRPCRouter({
     }),
   getAssetInfos: publicProcedure
     .input(
-      GetInfiniteAssetsInputSchema.and(
+      GetInfiniteAssetsInputSchema.merge(
         z.object({
           /** List of symbols or min denoms to be lifted to front of results if not searching or sorting. */
           preferredDenoms: z.array(z.string()).optional(),
@@ -141,6 +149,7 @@ export const assetsRouter = createTRPCRouter({
           onlyPositiveBalances,
           cursor,
           limit,
+          includeUnlisted,
         },
       }) =>
         maybeCachePaginatedItems({
@@ -151,11 +160,13 @@ export const assetsRouter = createTRPCRouter({
             assets = await mapGetAssetMarketInfos({
               search,
               onlyVerified,
+              includeUnlisted,
             });
 
             assets = await mapGetUserAssetInfos({
               assets,
               userOsmoAddress,
+              includeUnlisted,
               sortFiatValueDirection: isDefaultSort
                 ? "desc"
                 : !search && sortInput && sortInput.keyPath === "usdValue"
@@ -227,6 +238,7 @@ export const assetsRouter = createTRPCRouter({
             preferredDenoms,
             sort: sortInput,
             onlyPositiveBalances,
+            includeUnlisted,
           }),
           cursor,
           limit,

--- a/packages/web/server/queries/complex/assets/index.ts
+++ b/packages/web/server/queries/complex/assets/index.ts
@@ -94,7 +94,7 @@ function simplifyAssetListForDisplay(
     .filter((asset) =>
       params.includeUnlisted
         ? true // Do not filter the unlisted assets
-        : asset.keywords && !asset.keywords.includes("osmosis-unlisted")
+        : !asset.keywords?.includes("osmosis-unlisted")
     );
 
   let assetListAssets = listedAssets.filter((asset) => {

--- a/packages/web/server/queries/complex/assets/index.ts
+++ b/packages/web/server/queries/complex/assets/index.ts
@@ -23,6 +23,7 @@ export type Asset = {
 export const AssetFilterSchema = z.object({
   search: SearchSchema.optional(),
   onlyVerified: z.boolean().default(false).optional(),
+  includeUnlisted: z.boolean().default(false).optional(),
 });
 /** Params for filtering assets. */
 export type AssetFilter = z.infer<typeof AssetFilterSchema>;
@@ -33,11 +34,17 @@ const searchableAssetListAssetKeys = ["symbol", "base", "name", "display"];
 export async function getAsset({
   assetList = AssetLists,
   anyDenom,
+  ...params
 }: {
   assetList?: AssetList[];
   anyDenom: string;
-}): Promise<Asset | undefined> {
-  const assets = await getAssets({ assetList, findMinDenomOrSymbol: anyDenom });
+} & AssetFilter): Promise<Asset | undefined> {
+  const assets = await getAssets({
+    assetList,
+    findMinDenomOrSymbol: anyDenom,
+    includeUnlisted: true,
+    ...params,
+  });
   return assets[0];
 }
 
@@ -75,15 +82,19 @@ export async function getAssets({
 /** Transform given asset list into an array of minimal asset types for user in frontend. */
 function simplifyAssetListForDisplay(
   assetList: AssetList[],
-  params: { findMinDenomOrSymbol?: string } & AssetFilter = {}
+  params: {
+    findMinDenomOrSymbol?: string;
+  } & AssetFilter = {}
 ): Asset[] {
   // Create new array with just assets
   const coinMinimalDenomSet = new Set<string>();
 
   const listedAssets = assetList
     .flatMap(({ assets }) => assets)
-    .filter(
-      (asset) => asset.keywords && !asset.keywords.includes("osmosis-unlisted")
+    .filter((asset) =>
+      params.includeUnlisted
+        ? true // Do not filter the unlisted assets
+        : asset.keywords && !asset.keywords.includes("osmosis-unlisted")
     );
 
   let assetListAssets = listedAssets.filter((asset) => {

--- a/packages/web/server/queries/complex/assets/user.ts
+++ b/packages/web/server/queries/complex/assets/user.ts
@@ -30,6 +30,7 @@ export async function getUserAssetInfo<TAsset extends Asset>({
     assetList,
     assets: [asset],
     userOsmoAddress,
+    includeUnlisted: true,
   });
   return userAssets[0];
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

#### No Keyword assets

Assets that don't have a keyword should still be visible when the 'unverified assets' flag is activated because they are not unlisted, and also not verified.

#### Unlisted Assets
 Users who enable the 'unlisted asset preference' should be able to view these assets in both the swap tool and the asset table.

From a technical standpoint, we will introduce a new filter to the map trpc queries, specifically `getAssets` and `getAssetInfos`. However, we won't apply this filter to `getAsset` or `getAssetInfo`, as these more detailed queries are not directly visible to users unless they specifically choose the asset. Thus, it's acceptable to always retrieve unlisted assets for these queries. This approach ensures backward compatibility with other modules, like swap.

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/86a1ym43w)

## Brief Changelog

- Add `includeUnlistedAssets` to the map assets queries 

## Testing and Verifying

- [ ] Should see unlisted assets in the swap and assets table when enabled. To enable add the `show_unlisted_assets=true` query key to the URL.
