### PR TITLE
Squad "View or edit" button disabled - update

### DIFF
--- a/packages/web/components/cards/validator-squad-card.tsx
+++ b/packages/web/components/cards/validator-squad-card.tsx
@@ -129,6 +129,9 @@ export const ValidatorSquadCard: React.FC<{
       );
     }
 
+    const viewOrEditButtonDisabled =
+      hasInsufficientBalance && validators?.length === 0;
+
     return (
       <>
         <div className="mx-2 flex items-center">
@@ -141,13 +144,11 @@ export const ValidatorSquadCard: React.FC<{
             {validatorBlock}
             <div className="flex items-center">
               <Button
-                disabled={hasInsufficientBalance}
+                disabled={viewOrEditButtonDisabled}
                 mode="bullish-special"
                 size="normal"
                 className="rounded-[19px]"
-                onClick={() => {
-                  setShowValidatorModal(true);
-                }}
+                onClick={() => setShowValidatorModal(true)}
               >
                 {t("stake.viewOrEdit")}
               </Button>


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

The "View or edit" button has a disabled state when you have insufficient funds for the value entered in the stake/unstake amount fields - basically the same behavior as the Stake and Unstake buttons.

This button should never be disabled if you are actively staking – i.e. you have at least one validator in your squad.


### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/86a1vg6rg)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
