### PR TITLE
tRPC: Throw errors more aggressively & fix pool detail page SSR

### DIFF
--- a/packages/web/pages/pool/[id].tsx
+++ b/packages/web/pages/pool/[id].tsx
@@ -1,5 +1,4 @@
 import { observer } from "mobx-react-lite";
-import { GetStaticPaths, GetStaticProps, InferGetStaticPropsType } from "next";
 import { useRouter } from "next/router";
 import { NextSeo } from "next-seo";
 import { FunctionComponent, useEffect, useMemo, useState } from "react";
@@ -14,104 +13,102 @@ import { useTranslation, useWindowSize } from "~/hooks";
 import { useNavBar } from "~/hooks";
 import { useFeatureFlags } from "~/hooks/use-feature-flags";
 import { TradeTokens } from "~/modals";
-import { queryNumPools } from "~/server/queries/osmosis";
 import { useStore } from "~/stores";
 
 interface Props {
   id: string;
 }
 
-const Pool: FunctionComponent<Props> = observer(
-  ({ id: poolId }: InferGetStaticPropsType<typeof getStaticProps>) => {
-    const router = useRouter();
-    const { chainStore, queriesStore } = useStore();
-    const { chainId } = chainStore.osmosis;
-    const { t } = useTranslation();
-    const { isMobile } = useWindowSize();
+const Pool: FunctionComponent<Props> = observer(() => {
+  const router = useRouter();
+  const poolId = router.query.id as string;
+  const { chainStore, queriesStore } = useStore();
+  const { chainId } = chainStore.osmosis;
+  const { t } = useTranslation();
+  const { isMobile } = useWindowSize();
 
-    const queryOsmosis = queriesStore.get(chainId).osmosis!;
+  const queryOsmosis = queriesStore.get(chainId).osmosis!;
 
-    const flags = useFeatureFlags();
+  const flags = useFeatureFlags();
 
-    const [showTradeModal, setShowTradeModal] = useState(false);
+  const [showTradeModal, setShowTradeModal] = useState(false);
 
-    // eject to pools page if pool does not exist
-    const poolExists =
-      poolId && typeof poolId === "string" && Boolean(poolId)
-        ? queryOsmosis.queryPools.poolExists(poolId)
-        : undefined;
-    useEffect(() => {
-      if (poolExists === false) {
-        router.push("/pools");
-      }
-    }, [poolExists, router]);
+  // eject to pools page if pool does not exist
+  const poolExists =
+    poolId && typeof poolId === "string" && Boolean(poolId)
+      ? queryOsmosis.queryPools.poolExists(poolId)
+      : undefined;
+  useEffect(() => {
+    if (poolExists === false) {
+      router.push("/pools");
+    }
+  }, [poolExists, router]);
 
-    const queryPool = queryOsmosis.queryPools.getPool(poolId);
+  const queryPool = queryOsmosis.queryPools.getPool(poolId);
 
-    useNavBar(
-      useMemo(
-        () => ({
-          title: t("pool.title", { id: poolId ?? "" }),
-          ctas: [
-            { label: t("pool.swap"), onClick: () => setShowTradeModal(true) },
-          ],
-        }),
-        [t, poolId]
-      )
-    );
+  useNavBar(
+    useMemo(
+      () => ({
+        title: t("pool.title", { id: poolId ?? "" }),
+        ctas: [
+          { label: t("pool.swap"), onClick: () => setShowTradeModal(true) },
+        ],
+      }),
+      [t, poolId]
+    )
+  );
 
-    useEffect(() => {
-      if (
-        queryPool &&
-        !flags.concentratedLiquidity &&
-        queryPool.type === "concentrated" &&
-        !isMobile
-      ) {
-        router.push(`/pools`);
-      }
-    }, [queryPool, isMobile, flags.concentratedLiquidity, router]);
+  useEffect(() => {
+    if (
+      queryPool &&
+      !flags.concentratedLiquidity &&
+      queryPool.type === "concentrated" &&
+      !isMobile
+    ) {
+      router.push(`/pools`);
+    }
+  }, [queryPool, isMobile, flags.concentratedLiquidity, router]);
 
-    return (
-      <>
-        <NextSeo title={t("seo.pool.title", { id: poolId })} />
-        {queryPool && Boolean(poolId) && (
-          <TradeTokens
-            className="md:!p-0"
-            isOpen={showTradeModal}
-            onRequestClose={() => {
-              setShowTradeModal(false);
-            }}
-            sendTokenDenom={queryPool.poolAssetDenoms[0]}
-            outTokenDenom={queryPool.poolAssetDenoms[1]}
-            forceSwapInPoolId={poolId}
-          />
-        )}
-        {!queryPool ? (
-          <div className="mx-auto flex max-w-container flex-col gap-10 py-6 px-6">
-            <SkeletonLoader className="h-[30rem] !rounded-3xl" />
-            <SkeletonLoader className="h-40 !rounded-3xl" />
-            <SkeletonLoader className="h-8 !rounded-xl" />
-            <SkeletonLoader className="h-40 !rounded-3xl" />
-          </div>
-        ) : (
-          <>
-            {flags.concentratedLiquidity &&
-            queryPool?.type === "concentrated" &&
-            !isMobile ? (
-              <ConcentratedLiquidityPool poolId={poolId} />
-            ) : Boolean(queryPool?.sharePool) ? (
-              queryPool && <SharePool poolId={poolId} />
-            ) : queryPool ? (
-              <BasePoolDetails pool={queryPool!.pool} />
-            ) : null}
-          </>
-        )}
-      </>
-    );
-  }
-);
+  return (
+    <>
+      <NextSeo title={t("seo.pool.title", { id: poolId })} />
+      {queryPool && Boolean(poolId) && (
+        <TradeTokens
+          className="md:!p-0"
+          isOpen={showTradeModal}
+          onRequestClose={() => {
+            setShowTradeModal(false);
+          }}
+          sendTokenDenom={queryPool.poolAssetDenoms[0]}
+          outTokenDenom={queryPool.poolAssetDenoms[1]}
+          forceSwapInPoolId={poolId}
+        />
+      )}
+      {!queryPool ? (
+        <div className="mx-auto flex max-w-container flex-col gap-10 py-6 px-6">
+          <SkeletonLoader className="h-[30rem] !rounded-3xl" />
+          <SkeletonLoader className="h-40 !rounded-3xl" />
+          <SkeletonLoader className="h-8 !rounded-xl" />
+          <SkeletonLoader className="h-40 !rounded-3xl" />
+        </div>
+      ) : (
+        <>
+          {flags.concentratedLiquidity &&
+          queryPool?.type === "concentrated" &&
+          !isMobile ? (
+            <ConcentratedLiquidityPool poolId={poolId} />
+          ) : Boolean(queryPool?.sharePool) ? (
+            queryPool && <SharePool poolId={poolId} />
+          ) : queryPool ? (
+            <BasePoolDetails pool={queryPool!.pool} />
+          ) : null}
+        </>
+      )}
+    </>
+  );
+});
 
-export const getStaticPaths: GetStaticPaths = async () => {
+/* export const getStaticPaths: GetStaticPaths = async () => {
   const { num_pools } = await queryNumPools();
 
   const paths = Array.from({ length: Number(num_pools) + 1 }, (_, i) => ({
@@ -124,6 +121,6 @@ export const getStaticPaths: GetStaticPaths = async () => {
 export const getStaticProps: GetStaticProps = async ({ params }) => {
   const id = params?.id as string;
   return { props: { id: id ?? "-" } };
-};
+}; */
 
 export default Pool;

--- a/packages/web/pages/pool/[id].tsx
+++ b/packages/web/pages/pool/[id].tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react-lite";
-import { GetStaticPaths, GetStaticProps, InferGetStaticPropsType } from "next";
+import { GetStaticProps, InferGetStaticPropsType } from "next";
 import { useRouter } from "next/router";
 import { NextSeo } from "next-seo";
 import { FunctionComponent, useEffect, useMemo, useState } from "react";
@@ -14,7 +14,6 @@ import { useTranslation, useWindowSize } from "~/hooks";
 import { useNavBar } from "~/hooks";
 import { useFeatureFlags } from "~/hooks/use-feature-flags";
 import { TradeTokens } from "~/modals";
-import { queryNumPools } from "~/server/queries/osmosis";
 import { useStore } from "~/stores";
 
 interface Props {
@@ -111,15 +110,15 @@ const Pool: FunctionComponent<Props> = observer(
   }
 );
 
-export const getStaticPaths: GetStaticPaths = async () => {
-  const { num_pools } = await queryNumPools();
+// export const getStaticPaths: GetStaticPaths = async () => {
+//   const { num_pools } = await queryNumPools();
 
-  const paths = Array.from({ length: Number(num_pools) + 1 }, (_, i) => ({
-    params: { id: String(i + 1) },
-  }));
+//   const paths = Array.from({ length: Number(num_pools) + 1 }, (_, i) => ({
+//     params: { id: String(i + 1) },
+//   }));
 
-  return { paths, fallback: "blocking" };
-};
+//   return { paths, fallback: "blocking" };
+// };
 
 export const getStaticProps: GetStaticProps = async ({ params }) => {
   const id = params?.id as string;

--- a/packages/web/pages/pool/[id].tsx
+++ b/packages/web/pages/pool/[id].tsx
@@ -1,5 +1,5 @@
 import { observer } from "mobx-react-lite";
-import { GetStaticProps, InferGetStaticPropsType } from "next";
+import { GetStaticPaths, GetStaticProps, InferGetStaticPropsType } from "next";
 import { useRouter } from "next/router";
 import { NextSeo } from "next-seo";
 import { FunctionComponent, useEffect, useMemo, useState } from "react";
@@ -14,6 +14,7 @@ import { useTranslation, useWindowSize } from "~/hooks";
 import { useNavBar } from "~/hooks";
 import { useFeatureFlags } from "~/hooks/use-feature-flags";
 import { TradeTokens } from "~/modals";
+import { queryNumPools } from "~/server/queries/osmosis";
 import { useStore } from "~/stores";
 
 interface Props {
@@ -110,15 +111,15 @@ const Pool: FunctionComponent<Props> = observer(
   }
 );
 
-// export const getStaticPaths: GetStaticPaths = async () => {
-//   const { num_pools } = await queryNumPools();
+export const getStaticPaths: GetStaticPaths = async () => {
+  const { num_pools } = await queryNumPools();
 
-//   const paths = Array.from({ length: Number(num_pools) + 1 }, (_, i) => ({
-//     params: { id: String(i + 1) },
-//   }));
+  const paths = Array.from({ length: Number(num_pools) + 1 }, (_, i) => ({
+    params: { id: String(i + 1) },
+  }));
 
-//   return { paths, fallback: "blocking" };
-// };
+  return { paths, fallback: "blocking" };
+};
 
 export const getStaticProps: GetStaticProps = async ({ params }) => {
   const id = params?.id as string;

--- a/packages/web/server/api/edge-routers/assets-router.ts
+++ b/packages/web/server/api/edge-routers/assets-router.ts
@@ -42,8 +42,6 @@ export const assetsRouter = createTRPCRouter({
     .query(async ({ input: { findMinDenomOrSymbol, userOsmoAddress } }) => {
       const asset = await getAsset({ anyDenom: findMinDenomOrSymbol });
 
-      if (!asset) throw new Error("Asset not found " + findMinDenomOrSymbol);
-
       return await getUserAssetInfo({
         asset,
         userOsmoAddress,
@@ -100,8 +98,6 @@ export const assetsRouter = createTRPCRouter({
     )
     .query(async ({ input: { findMinDenomOrSymbol, userOsmoAddress } }) => {
       const asset = await getAsset({ anyDenom: findMinDenomOrSymbol });
-
-      if (!asset) throw new Error("Asset not found " + findMinDenomOrSymbol);
 
       const userAsset = await getUserAssetInfo({ asset, userOsmoAddress });
       const userMarketInfoAsset = await getAssetMarketInfo({

--- a/packages/web/server/api/edge-routers/assets-router.ts
+++ b/packages/web/server/api/edge-routers/assets-router.ts
@@ -83,7 +83,9 @@ export const assetsRouter = createTRPCRouter({
     }),
   getRecommendedAssets: publicProcedure.query(async () => {
     const assets = await Promise.all(
-      RecommendedSwapDenoms.map((denom) => getAsset({ anyDenom: denom }))
+      RecommendedSwapDenoms.map((denom) =>
+        getAsset({ anyDenom: denom }).catch(() => null)
+      )
     );
 
     return assets.filter((a): a is Asset => !!a);

--- a/packages/web/server/api/edge-routers/swap-router.ts
+++ b/packages/web/server/api/edge-routers/swap-router.ts
@@ -103,17 +103,7 @@ export const swapRouter = createTRPCRouter({
         );
         const timeMs = Date.now() - startTime;
 
-        // validate assets
-        if (!(await getAsset({ anyDenom: tokenInDenom }))) {
-          throw new Error(
-            `Token in denom is not configured in asset list: ${tokenInDenom}`
-          );
-        }
         const tokenOutAsset = await getAsset({ anyDenom: tokenOutDenom });
-        if (!tokenOutAsset)
-          throw new Error(
-            `Token out denom is not configured in asset list: ${tokenOutDenom}`
-          );
 
         // calculate fiat value of amounts
         // get fiat value

--- a/packages/web/server/queries/complex/assets/__tests__/assets.spec.ts
+++ b/packages/web/server/queries/complex/assets/__tests__/assets.spec.ts
@@ -62,12 +62,10 @@ describe("getAsset", () => {
     const asset = await getAsset({ anyDenom: "ACRE" });
 
     expect(asset).toBeTruthy();
-    expect(asset?.coinDenom).toEqual("ACRE");
+    expect(asset.coinDenom).toEqual("ACRE");
   });
 
-  it("should return undefined if no asset matches the provided denom", async () => {
-    const asset = await getAsset({ anyDenom: "NON_EXISTING_DENOM" });
-
-    expect(asset).toBeUndefined();
+  it("should throw if no asset matches the provided denom", () => {
+    expect(getAsset({ anyDenom: "NON_EXISTING_DENOM" })).rejects.toBeDefined();
   });
 });

--- a/packages/web/server/queries/complex/assets/index.ts
+++ b/packages/web/server/queries/complex/assets/index.ts
@@ -40,7 +40,7 @@ export async function getAsset({
 }): Promise<Asset> {
   const assets = await getAssets({ assetList, findMinDenomOrSymbol: anyDenom });
   const asset = assets[0];
-  if (!asset) throw new Error(anyDenom + " not found");
+  if (!asset) throw new Error(anyDenom + " not found in asset list");
   return asset;
 }
 

--- a/packages/web/server/queries/complex/assets/index.ts
+++ b/packages/web/server/queries/complex/assets/index.ts
@@ -29,16 +29,19 @@ export type AssetFilter = z.infer<typeof AssetFilterSchema>;
 
 /** Search is performed on the raw asset list data, instead of `Asset` type. */
 const searchableAssetListAssetKeys = ["symbol", "base", "name", "display"];
-/** Get an individual asset explicitly by it's denom (any type) */
+/** Get an individual asset explicitly by it's denom (any type).
+ *  @throws If asset not found. */
 export async function getAsset({
   assetList = AssetLists,
   anyDenom,
 }: {
   assetList?: AssetList[];
   anyDenom: string;
-}): Promise<Asset | undefined> {
+}): Promise<Asset> {
   const assets = await getAssets({ assetList, findMinDenomOrSymbol: anyDenom });
-  return assets[0];
+  const asset = assets[0];
+  if (!asset) throw new Error(anyDenom + " not found");
+  return asset;
 }
 
 const minimalAssetsCache = new LRUCache<string, CacheEntry>(

--- a/packages/web/server/queries/complex/assets/price.ts
+++ b/packages/web/server/queries/complex/assets/price.ts
@@ -65,6 +65,8 @@ async function getCoingeckoPrice({
  * 3. Calculated the price of the destination coin recursively (i.e. usd-coin or another pool like uosmo)
  *
  * Note: For now only "usd" is supported.
+ *
+ * @throws If the asset is not found in the asset list registry or the asset's price info is not found.
  */
 async function calculatePriceFromPriceId({
   asset,
@@ -73,8 +75,8 @@ async function calculatePriceFromPriceId({
   asset: Pick<Asset, "base" | "price_info" | "coingecko_id">;
   currency: "usd";
 }): Promise<Dec | undefined> {
-  if (!asset) return undefined;
-  if (!asset.price_info && !asset.coingecko_id) return undefined;
+  if (!asset.price_info && !asset.coingecko_id)
+    throw new Error("No price info or coingecko id for " + asset.base);
 
   /**
    * Fetch directly from coingecko if there's no price info.
@@ -86,7 +88,7 @@ async function calculatePriceFromPriceId({
     });
   }
 
-  if (!asset.price_info) return undefined;
+  if (!asset.price_info) throw new Error("No price info for " + asset.base);
 
   const poolPriceRoute = {
     destCoinMinimalDenom: asset.price_info.dest_coin_minimal_denom,
@@ -94,7 +96,7 @@ async function calculatePriceFromPriceId({
     sourceCoinMinimalDenom: asset.base,
   };
 
-  if (!poolPriceRoute) return undefined;
+  if (!poolPriceRoute) throw new Error("No pool price route for " + asset.base);
 
   const tokenInIbc = poolPriceRoute.sourceCoinMinimalDenom;
   const tokenOutIbc = poolPriceRoute.destCoinMinimalDenom;
@@ -109,7 +111,17 @@ async function calculatePriceFromPriceId({
     assetLists: AssetLists,
   });
 
-  if (!tokenInAsset || !tokenOutAsset) return undefined;
+  if (!tokenInAsset)
+    throw new Error(
+      poolPriceRoute.sourceCoinMinimalDenom +
+        " price source coin not in asset list."
+    );
+
+  if (!tokenOutAsset)
+    throw new Error(
+      poolPriceRoute.destCoinMinimalDenom +
+        " price dest coin not in asset list."
+    );
 
   const rawPool: PoolRaw = (
     await queryPaginatedPools({
@@ -117,11 +129,20 @@ async function calculatePriceFromPriceId({
     })
   )?.pools[0];
 
-  if (!rawPool) return undefined;
+  if (!rawPool)
+    throw new Error(
+      "Pool " + poolPriceRoute.poolId + " not found for calculating price."
+    );
 
   const pool = makeStaticPoolFromRaw(rawPool);
 
-  if (!tokenOutAsset.decimals || !tokenInAsset.decimals) return undefined;
+  if (!tokenOutAsset.decimals || !tokenInAsset.decimals)
+    throw new Error(
+      "Invalid decimals in " +
+        tokenOutAsset.symbol +
+        " or " +
+        tokenInAsset.symbol
+    );
 
   const multiplication = DecUtils.getTenExponentN(
     tokenOutAsset.decimals - tokenInAsset.decimals
@@ -145,12 +166,17 @@ async function calculatePriceFromPriceId({
     currency,
   });
 
-  if (!destCoinPrice) return undefined;
+  if (!destCoinPrice)
+    throw new Error(
+      "No destination coin price found for " + tokenOutAsset.symbol
+    );
 
   return spotPriceDec.mul(destCoinPrice);
 }
 
-/** Finds the fiat value of a single unit of a given asset for a given fiat currency. */
+/** Finds the fiat value of a single unit of a given asset for a given fiat currency.
+ *  @throws If the asset is not found in the asset list registry or the asset's price info is not found.
+ */
 export async function getAssetPrice({
   asset,
   currency = "usd",
@@ -168,17 +194,17 @@ export async function getAssetPrice({
     assetLists: AssetLists,
   });
 
+  if (!assetListAsset) {
+    throw new Error(
+      `Asset ${asset.sourceDenom} not found on asset list registry.`
+    );
+  }
+
   let coingeckoAsset:
     | NonNullable<
         Awaited<ReturnType<typeof queryCoingeckoSearch>>["coins"]
       >[number]
     | undefined;
-
-  if (!assetListAsset) {
-    console.error(
-      `Asset ${asset.sourceDenom} not found on asset list registry.`
-    );
-  }
 
   const shouldCalculateUsingPools = Boolean(assetListAsset?.priceInfo);
 
@@ -191,10 +217,6 @@ export async function getAssetPrice({
       !shouldCalculateUsingPools &&
       asset.coinDenom
     ) {
-      console.warn(
-        "Searching on Coingecko registry for asset",
-        asset.coinDenom
-      );
       coingeckoAsset = await getCoingeckoCoin({ denom: asset.coinDenom });
     }
   } catch (e) {
@@ -211,13 +233,16 @@ export async function getAssetPrice({
   }
 
   if (!id) {
-    return undefined;
+    throw new Error(
+      `Asset ${asset.sourceDenom} has no identifier for pricing.`
+    );
   }
 
   return await getCoingeckoPrice({ coingeckoId: id, currency });
 }
 
-/** Calculates the fiat value of an asset given any denom and base amount. */
+/** Calculates the fiat value of an asset given any denom and base amount.
+ *  @throws If the asset is not found in the asset list registry or the asset's price info is not found. */
 export async function calcAssetValue({
   anyDenom,
   amount,
@@ -229,14 +254,14 @@ export async function calcAssetValue({
 }): Promise<Dec | undefined> {
   const asset = await getAsset({ anyDenom });
 
-  if (!asset) return;
+  if (!asset) throw new Error(anyDenom + " not found in asset list");
 
   const price = await getAssetPrice({
     asset,
     currency,
   });
 
-  if (!price) return;
+  if (!price) throw new Error(anyDenom + " price not available");
 
   const tokenDivision = DecUtils.getTenExponentN(asset.coinDecimals);
 

--- a/packages/web/server/queries/complex/assets/price.ts
+++ b/packages/web/server/queries/complex/assets/price.ts
@@ -254,8 +254,6 @@ export async function calcAssetValue({
 }): Promise<Dec | undefined> {
   const asset = await getAsset({ anyDenom });
 
-  if (!asset) throw new Error(anyDenom + " not found in asset list");
-
   const price = await getAssetPrice({
     asset,
     currency,

--- a/packages/web/server/queries/complex/assets/user.ts
+++ b/packages/web/server/queries/complex/assets/user.ts
@@ -66,6 +66,7 @@ export async function mapGetUserAssetInfos<TAsset extends Asset>({
         amount: balance.amount,
       }).catch(() => {
         console.error(asset.coinMinimalDenom, "likely missing price config");
+        return undefined;
       });
 
       return {

--- a/packages/web/server/queries/complex/pools/index.ts
+++ b/packages/web/server/queries/complex/pools/index.ts
@@ -41,9 +41,13 @@ export type PoolFilter = z.infer<typeof PoolFilterSchema>;
 
 const searchablePoolKeys = ["id", "coinDenoms"];
 
-export async function getPool(poolId: string): Promise<Pool | undefined> {
+/** Get's an individual pool by ID.
+ *  @throws If pool not found. */
+export async function getPool(poolId: string): Promise<Pool> {
   const pools = await getPools();
-  return pools.find(({ id }) => id === poolId);
+  const pool = pools.find(({ id }) => id === poolId);
+  if (!pool) throw new Error(poolId + " not found");
+  return pool;
 }
 
 /** Fetches cached pools from node and returns them as a more useful and simplified TS type.

--- a/packages/web/server/queries/complex/pools/providers/imperator.ts
+++ b/packages/web/server/queries/complex/pools/providers/imperator.ts
@@ -55,7 +55,7 @@ export async function queryPaginatedPools({
       (pool) => ("pool_id" in pool ? pool.pool_id : pool.id) === poolIdParam
     );
     if (!pool) {
-      throw { status: 404, pools: [] };
+      throw new Error("Pool not found: " + poolIdParam);
     }
     return { status: 200, pools: [pool], totalNumberOfPools };
   }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

We found when getting the testnet to work, our tRPC procedures failed too silently, often with no message. I think throwing and bubbling exceptions is a great way to surface the root cause of issues, and helps us save time from having to step-through debug.

Going forward, our strategy with tRPC complex functions is to throw early and often. Then, we can catch these errors with `catch()` calls at the procedure level, or let it bubble up to the browser console, where the error and call stack can be read. This should not greatly affect end-user UX, as they should not see their browser crash, but ideally they'd see an error UI or at least no UI for the desired data.

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/86a1z26fp)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->
* `getAsset`, `getAssetPrice`, `calcAssetValue`, `getPool` throw instead of return undefined.
  * Especially with `getAssetPrice`, the complex algorithm for traversing pool spot prices now throws specific errors for what in the asset list is not configured, or what pool data is not expected
* Add catch statements strategically, where it's not critical the data is found (return value is optional from tRPC)
* Remove some redundant throw statements

UNRELATED
* Revert static path generation of pool detail pages, due to issues with running out of memory in Vercel build container (generating an HTML page for each 1300+ pools)

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

* On testnet deployment, we should be able to see better errors in console for why a quote or price won't load

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
