### PR TITLE
Add sort by date for unbonding cards

### DIFF
--- a/packages/web/components/stake/unbonding-in-progress.tsx
+++ b/packages/web/components/stake/unbonding-in-progress.tsx
@@ -19,22 +19,30 @@ export const UnbondingInProgress: React.FC<{
   ): { amountOsmo: string; amountUSD: string; remainingTime: string }[] {
     const currentDate = new Date();
 
-    return unbondings
-      .map((unbonding) => {
-        const completionDate = new Date(unbonding.completionTime);
-        const timeDiff = dayjs.duration(
-          completionDate.getTime() - currentDate.getTime()
-        );
+    return (
+      unbondings
+        // Sort by completionTime
+        .sort(
+          (a, b) =>
+            new Date(a.completionTime).getTime() -
+            new Date(b.completionTime).getTime()
+        )
+        .map((unbonding) => {
+          const completionDate = new Date(unbonding.completionTime);
+          const timeDiff = dayjs.duration(
+            completionDate.getTime() - currentDate.getTime()
+          );
 
-        const prettifiedAmount = unbonding.balance;
-        return {
-          amountOsmo: prettifiedAmount.trim(true).toString(),
-          amountUSD:
-            priceStore.calculatePrice(prettifiedAmount)?.toString() || "",
-          remainingTime: timeDiff.humanize(),
-        };
-      })
-      .filter((entry) => parseInt(entry.remainingTime) > 0); // Filter out entries with completion time in the past
+          const prettifiedAmount = unbonding.balance;
+          return {
+            amountOsmo: prettifiedAmount.trim(true).toString(),
+            amountUSD:
+              priceStore.calculatePrice(prettifiedAmount)?.toString() || "",
+            remainingTime: timeDiff.humanize(),
+          };
+        })
+        .filter((entry) => parseInt(entry.remainingTime) > 0)
+    ); // Filter out entries with completion time in the past
   }
 
   const formattedUnbondings = formatUnbondings(unbondings);


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

- unbonding cards should be sorted by date to completion

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/86a1zu2m3)

## Brief Changelog

- sort by completion date

## Testing and Verifying
<img width="728" alt="Screenshot 2024-01-18 at 6 27 28 PM" src="https://github.com/osmosis-labs/osmosis-frontend/assets/30577966/e3ef7f8d-4542-4c40-985d-a6ac3348eaa8">



## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
