### PR TITLE
Fix: language select overflow

### DIFF
--- a/packages/web/components/control/language-select.tsx
+++ b/packages/web/components/control/language-select.tsx
@@ -80,7 +80,7 @@ const ListBoxContent: FunctionComponent<
   }, [languageSetting, open]);
 
   return (
-    <Listbox.Options className="absolute inset-0 z-50 bg-osmoverse-800 outline-none">
+    <Listbox.Options className="absolute inset-0 z-50 overflow-auto bg-osmoverse-800 outline-none">
       {options.map((option) => (
         <Listbox.Option
           key={option.value}

--- a/packages/web/modals/settings.tsx
+++ b/packages/web/modals/settings.tsx
@@ -1,3 +1,4 @@
+import classNames from "classnames";
 import { observer } from "mobx-react-lite";
 import { Fragment, FunctionComponent } from "react";
 
@@ -38,9 +39,17 @@ export const SettingsModal: FunctionComponent<ModalBaseProps> = observer(
 const SettingsContent = observer(() => {
   const { userSettings } = useStore();
   const { t } = useTranslation();
+  const languageSetting = userSettings.getUserSettingById(
+    "language"
+  ) as LanguageUserSetting;
 
   return (
-    <div className="relative mt-8 overflow-auto">
+    <div
+      className={classNames("relative mt-8", {
+        "overflow-auto": !languageSetting.state.isControlOpen,
+        "overflow-hidden": languageSetting.state.isControlOpen,
+      })}
+    >
       {userSettings.userSettings.map((setting) => (
         <Fragment key={setting.getLabel(t)}>
           {setting.controlComponent(setting.state as any, setting.setState)}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

As mentioned here: https://github.com/osmosis-labs/osmosis-frontend/pull/2697#issuecomment-1894293695, there is a graphical bug in the language select, this PR fixes this issue.

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

### ClickUp Task

[ClickUp Task URL](PASTE_CLICKUP_TASK_URL_HERE)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
