### PR TITLE
Feat: add search filter inside pools page url query

### DIFF
--- a/packages/web/hooks/input/use-search-query-input.ts
+++ b/packages/web/hooks/input/use-search-query-input.ts
@@ -1,5 +1,6 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 
+import { useQueryParamState } from "~/hooks/window/use-query-param-state";
 import type { Search } from "~/utils/search";
 
 import { useDebouncedState } from "../use-debounced-state";
@@ -8,19 +9,29 @@ import { useDebouncedState } from "../use-debounced-state";
  *  to perform a search remotely (is debounced). */
 export function useSearchQueryInput(debounceMs = 500) {
   // get selectable currencies for trading, including user balances if wallect connected
-  const [searchInput, setSearchInput_] = useState<string>("");
+  const [searchInput, setSearchInput_, isReady] = useQueryParamState<string>(
+    "s",
+    ""
+  );
 
   // generate debounced search from user inputs
   const [debouncedSearchInput, setDebouncedSearchInput] =
     useDebouncedState<string>("", debounceMs);
+
   const setSearchInput = useCallback(
     (input: string) => {
       const sanitizedSearchInput = input.replace(/#/g, "").trim();
       setSearchInput_(sanitizedSearchInput);
       setDebouncedSearchInput(sanitizedSearchInput);
     },
-    [setDebouncedSearchInput]
+    [setDebouncedSearchInput, setSearchInput_]
   );
+
+  useEffect(() => {
+    if (searchInput && isReady) {
+      setSearchInput(searchInput);
+    }
+  }, [isReady]);
 
   const queryInput: Search | undefined = useMemo(
     () => (debouncedSearchInput ? { query: debouncedSearchInput } : undefined),


### PR DESCRIPTION
added search filter inside pools page query filters.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

In the pools page, it is convenient to keep track in the query params also of the text string searched by the user, so that the page state can be restored when sharing the link.
It is also useful to be able to open the pools page in which I display for example only OSMO pools.

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

### ClickUp Task

[ClickUp Task URL](PASTE_CLICKUP_TASK_URL_HERE)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
