### PR TITLE
feat: timeout height (transaction TTL)

### DIFF
--- a/packages/stores/src/account/base.ts
+++ b/packages/stores/src/account/base.ts
@@ -3,10 +3,9 @@ import {
   AminoMsg,
   encodeSecp256k1Pubkey,
   OfflineAminoSigner,
-  StdFee,
 } from "@cosmjs/amino";
 import { fromBase64 } from "@cosmjs/encoding";
-import { Int53, Uint53 } from "@cosmjs/math";
+import { Int53 } from "@cosmjs/math";
 import {
   EncodeObject,
   encodePubkey,
@@ -85,6 +84,7 @@ import {
   getEndpointString,
   getWalletEndpoints,
   logger,
+  makeSignDocAmino,
   removeLastSlash,
   TxFee,
 } from "./utils";
@@ -1146,42 +1146,4 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
       },
     });
   }
-}
-
-/**
- * The document to be signed
- * Referenced from CosmjsL
- * https://github.com/cosmos/cosmjs/blob/287278004b9e6a682a1a0b1664ba54646f65a1a0/packages/amino/src/signdoc.ts#L21-L35
- *
- * We copied it over to work around dependency updates.
- */
-export interface StdSignDoc {
-  readonly chain_id: string;
-  readonly account_number: string;
-  readonly sequence: string;
-  readonly fee: StdFee;
-  readonly msgs: readonly AminoMsg[];
-  readonly memo: string;
-  readonly timeout_height?: string;
-}
-
-// Creates the document to be signed from given parameters.
-export function makeSignDocAmino(
-  msgs: readonly AminoMsg[],
-  fee: StdFee,
-  chainId: string,
-  memo: string | undefined,
-  accountNumber: number | string,
-  sequence: number | string,
-  timeout_height?: bigint
-): StdSignDoc {
-  return {
-    chain_id: chainId,
-    account_number: Uint53.fromString(accountNumber.toString()).toString(),
-    sequence: Uint53.fromString(sequence.toString()).toString(),
-    fee: fee,
-    msgs: msgs,
-    memo: memo || "",
-    ...(timeout_height && { timeout_height: timeout_height.toString() }),
-  };
 }

--- a/packages/stores/src/account/base.ts
+++ b/packages/stores/src/account/base.ts
@@ -93,9 +93,9 @@ import { WalletConnectionInProgressError } from "./wallet-errors";
 export const GasMultiplier = 1.5;
 
 // The number of heights from current before transaction times out.
-// 10 heights * 5 second block time = 50 seconds before transaction
+// 30 heights * 5 second block time = 150 seconds before transaction
 // timeout and mempool eviction.
-const timeoutHeightOffset: bigint = BigInt(10);
+const timeoutHeightOffset: bigint = BigInt(30);
 
 // The value of zero represent that there is not timeout height set.
 const timeoutHeightDisabledStr = "0";

--- a/packages/stores/src/account/base.ts
+++ b/packages/stores/src/account/base.ts
@@ -923,8 +923,6 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
         true
       );
 
-      console.log("account", account.getSequence());
-
       return {
         accountNumber: account.getAccountNumber(),
         sequence: account.getSequence(),

--- a/packages/stores/src/account/base.ts
+++ b/packages/stores/src/account/base.ts
@@ -52,7 +52,6 @@ import {
   getSourceDenomFromAssetList,
   isNil,
 } from "@osmosis-labs/utils";
-// eslint-disable-next-line import/no-extraneous-dependencies
 import axios from "axios";
 import { Buffer } from "buffer/";
 import cachified, { CacheEntry } from "cachified";

--- a/packages/stores/src/account/types.ts
+++ b/packages/stores/src/account/types.ts
@@ -1,3 +1,4 @@
+import { AminoMsg, StdFee } from "@cosmjs/amino";
 import { ChainWalletBase, SignOptions, Wallet } from "@cosmos-kit/core";
 import { MsgData } from "cosmjs-types/cosmos/base/abci/v1beta1/abci";
 import { UnionToIntersection } from "utility-types";
@@ -80,4 +81,21 @@ export interface TxEvents {
   onBroadcastFailed?: (string: string, e?: Error) => void;
   onBroadcasted?: (string: string, txHash: Uint8Array) => void;
   onFulfill?: (string: string, tx: any) => void;
+}
+
+/**
+ * The document to be signed
+ * Referenced from CosmjsL
+ * https://github.com/cosmos/cosmjs/blob/287278004b9e6a682a1a0b1664ba54646f65a1a0/packages/amino/src/signdoc.ts#L21-L35
+ *
+ * We copied it over to work around dependency updates.
+ */
+export interface StdSignDoc {
+  readonly chain_id: string;
+  readonly account_number: string;
+  readonly sequence: string;
+  readonly fee: StdFee;
+  readonly msgs: readonly AminoMsg[];
+  readonly memo: string;
+  readonly timeout_height?: string;
 }

--- a/packages/stores/src/account/utils.ts
+++ b/packages/stores/src/account/utils.ts
@@ -1,4 +1,6 @@
 import type { Chain } from "@chain-registry/types";
+import { AminoMsg } from "@cosmjs/amino/build/signdoc";
+import { Uint53 } from "@cosmjs/math";
 import { StdFee } from "@cosmjs/stargate";
 import {
   ChainName,
@@ -6,6 +8,8 @@ import {
   ExtendedHttpEndpoint,
   Logger,
 } from "@cosmos-kit/core";
+
+import { StdSignDoc } from "./types";
 
 export interface TxFee extends StdFee {
   /**
@@ -70,6 +74,27 @@ export function changeDecStringToProtoBz(decStr: string): string {
   }
 
   return r;
+}
+
+// Creates the document to be signed from given parameters.
+export function makeSignDocAmino(
+  msgs: readonly AminoMsg[],
+  fee: StdFee,
+  chainId: string,
+  memo: string | undefined,
+  accountNumber: number | string,
+  sequence: number | string,
+  timeout_height?: bigint
+): StdSignDoc {
+  return {
+    chain_id: chainId,
+    account_number: Uint53.fromString(accountNumber.toString()).toString(),
+    sequence: Uint53.fromString(sequence.toString()).toString(),
+    fee: fee,
+    msgs: msgs,
+    memo: memo || "",
+    ...(timeout_height && { timeout_height: timeout_height.toString() }),
+  };
 }
 
 export const DefaultGasPriceStep: {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Adding TX TTL for better feedback during spam and timely mempool eviction.

This PR introduces and additional field for transaction body and makes the necessary changes to serialize and sign it.

This will allow the chain to evict the transaction from mempool after reaching a certain height. This will be useful during times of spam or congestion where users will get some sort of feedback about transaction failure.

Today, due to a poor chain UX, the feedback is not always present.

The configuration is set to 10. At the current block time of 5 seconds, this gives user transactions approximately 50 seconds to succeed.

### Next steps

- We should set the timeout offset value via config: https://github.com/osmosis-labs/osmosis-frontend/issues/2740
- We should also update `cosmjs` and `cosmos-kit` deps as they are outdated, requiring us to reimplement some helpers in this PR: https://github.com/osmosis-labs/osmosis-frontend/issues/2738

### Test TX

https://www.mintscan.io/osmosis/tx/A336F54BDAB9EC2FAECE6D8F376C4BC2A19C565A04D444E4EAF7AAA4BE8B824B

A few more were tested from the address
