### PR TITLE
chore: web package debugger configuration for vs code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Next.js Node Debug",
+            "runtimeExecutable": "${workspaceFolder}/node_modules/next/dist/bin/next",
+            "cwd": "${workspaceFolder}/packages/web",
+            "console": "integratedTerminal"
+        }
+    ]
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Progress towards: https://github.com/osmosis-labs/osmosis-frontend/issues/2739

## What is the purpose of the change

This PR adds a VS code debugger configuration.

It enables starting the app and setting breakpoints in the `web` package. I'm still investigating how to achieve setting breakpoints in other packages and tracking progress in #2739.
