### PR TITLE
Router: silent failure for missing asset price config

### DIFF
--- a/packages/web/server/api/edge-routers/swap-router.ts
+++ b/packages/web/server/api/edge-routers/swap-router.ts
@@ -110,15 +110,15 @@ export const swapRouter = createTRPCRouter({
           ? await calcAssetValue({
               anyDenom: tokenInDenom,
               amount: quote.tokenInFeeAmount,
-            })
+            }).catch(() => null)
           : undefined;
         const tokenOutPrice = await getAssetPrice({
           asset: { coinMinimalDenom: tokenOutDenom },
-        });
+        }).catch(() => null);
         const tokenOutValue = await calcAssetValue({
           anyDenom: tokenOutDenom,
           amount: quote.amount,
-        });
+        }).catch(() => null);
         const tokenInFeeAmountFiatValue = tokenInFeeAmountValue
           ? new PricePretty(DEFAULT_VS_CURRENCY, tokenInFeeAmountValue)
           : undefined;


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

As with stDYDX, if an asset isn't configured for pricing yet we should not let that fail the router queries. Instead, we can simply omit the price data from the response.
