### PR TITLE
allow the app to work even if developer does not have LD key in env

### DIFF
--- a/packages/web/hooks/use-feature-flags.ts
+++ b/packages/web/hooks/use-feature-flags.ts
@@ -26,10 +26,33 @@ export type AvailableFlags =
   | "topAnnouncementBanner"
   | "tfmProTradingNavbarButton";
 
-type ModifiedFlags =
-  | Exclude<AvailableFlags, "mobileNotifications">
-  | "_isInitialized"
-  | "_isClientIDPresent";
+type OptionalFlags = "_isInitialized" | "_isClientIDPresent";
+type RequiredFlags = Exclude<AvailableFlags, "mobileNotifications">;
+
+type ModifiedFlags = RequiredFlags & Partial<Record<OptionalFlags, boolean>>;
+
+const defaultFlags: Record<ModifiedFlags, boolean> = {
+  concentratedLiquidity: true,
+  staking: true,
+  swapsAdBanner: true,
+  notifications: true,
+  convertToStake: true,
+  upgrades: true,
+  tokenInfo: true,
+  newAssetsTable: false,
+  sidebarOsmoChangeAndChart: true,
+  multiBridgeProviders: true,
+  unlistedAssets: false,
+  earnPage: false,
+  sidecarRouter: true,
+  legacyRouter: true,
+  tfmRouter: true,
+  osmosisUpdatesPopUp: false,
+  aprBreakdown: true,
+  newPoolsTable: true,
+  topAnnouncementBanner: true,
+  tfmProTradingNavbarButton: true,
+};
 
 export const useFeatureFlags = () => {
   const launchdarklyFlags: Record<AvailableFlags, boolean> = useFlags();
@@ -45,10 +68,18 @@ export const useFeatureFlags = () => {
 
   return {
     ...launchdarklyFlags,
+    ...(process.env.NODE_ENV === "development" &&
+    !process.env.NEXT_PUBLIC_LAUNCH_DARKLY_CLIENT_SIDE_ID
+      ? defaultFlags
+      : {}),
     notifications: isMobile
       ? launchdarklyFlags.mobileNotifications
       : launchdarklyFlags.notifications,
-    _isInitialized: isInitialized,
+    _isInitialized:
+      process.env.NODE_ENV === "development" &&
+      !process.env.NEXT_PUBLIC_LAUNCH_DARKLY_CLIENT_SIDE_ID
+        ? true
+        : isInitialized,
     _isClientIDPresent: !!process.env.NEXT_PUBLIC_LAUNCH_DARKLY_CLIENT_SIDE_ID,
   } as Record<ModifiedFlags, boolean>;
 };

--- a/packages/web/hooks/use-feature-flags.ts
+++ b/packages/web/hooks/use-feature-flags.ts
@@ -27,10 +27,10 @@ export type AvailableFlags =
   | "topAnnouncementBanner"
   | "tfmProTradingNavbarButton";
 
-type OptionalFlags = "_isInitialized" | "_isClientIDPresent";
-type RequiredFlags = Exclude<AvailableFlags, "mobileNotifications">;
-
-type ModifiedFlags = RequiredFlags & Partial<Record<OptionalFlags, boolean>>;
+type ModifiedFlags =
+  | Exclude<AvailableFlags, "mobileNotifications">
+  | "_isInitialized"
+  | "_isClientIDPresent";
 
 const defaultFlags: Record<ModifiedFlags, boolean> = {
   concentratedLiquidity: true,
@@ -53,6 +53,8 @@ const defaultFlags: Record<ModifiedFlags, boolean> = {
   newPoolsTable: true,
   topAnnouncementBanner: true,
   tfmProTradingNavbarButton: true,
+  _isInitialized: false,
+  _isClientIDPresent: false,
 };
 
 export const useFeatureFlags = () => {

--- a/packages/web/hooks/use-feature-flags.ts
+++ b/packages/web/hooks/use-feature-flags.ts
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 
 import { useWindowSize } from "~/hooks";
 
+// NOTE: Please add a default value to any new flag you add to this list
 export type AvailableFlags =
   | "concentratedLiquidity"
   | "staking"


### PR DESCRIPTION
This PR will allow third party devs to get all the feature flags working even if they do not have the LD client ID by providing default values to the existing flags. 