### PR TITLE
Optimize pools page query

### DIFF
--- a/packages/web/server/queries/complex/pools/incentives.ts
+++ b/packages/web/server/queries/complex/pools/incentives.ts
@@ -11,7 +11,6 @@ import { queryPriceRangeApr } from "~/server/queries/imperator";
 import { queryLockableDurations } from "~/server/queries/osmosis";
 
 import { queryPoolAprs } from "../../numia/pool-aprs";
-import { getPools, Pool, PoolFilter } from "./index";
 
 dayjs.extend(duration);
 dayjs.extend(relativeTime);
@@ -33,7 +32,7 @@ export type PoolIncentives = Partial<{
     osmosis: RatePretty;
     boost: RatePretty;
   }>;
-  incentiveTypes?: PoolIncentiveType[];
+  incentiveTypes: PoolIncentiveType[];
 }>;
 
 export const IncentivePoolFilterSchema = z.object({
@@ -44,58 +43,36 @@ export const IncentivePoolFilterSchema = z.object({
 /** Params for filtering pools. */
 export type IncentivePoolFilter = z.infer<typeof IncentivePoolFilterSchema>;
 
-export async function getPoolIncentives(poolId: string) {
-  const map = await getCachedPoolIncentivesMap();
-  return map.get(poolId);
-}
+/** Checks a pool's incentive data againt a given filter to determine if it's filtered out. */
+export function isIncentivePoolFiltered(
+  incentives: PoolIncentives,
+  filter: IncentivePoolFilter
+) {
+  // Filter pools if incentive types are specified.
+  // Any type in the given list of types has to be included at least once in the pool types.
+  if (filter.incentiveTypes && incentives) {
+    const hasIncentiveType = filter.incentiveTypes.some((type) =>
+      incentives.incentiveTypes?.includes(type)
+    );
+    if (!hasIncentiveType) return true;
+  } else if (
+    filter.incentiveTypes &&
+    !incentives &&
+    !filter.incentiveTypes.includes("none")
+  ) {
+    // "none" is a special case, where it includes pools that
+    // don't have an incentives of any type, where the pool incentives map
+    // returns nothing for that pool.
+    // Though, if numia indexes swap fee rewards, none will be filtered above.
+    return true;
+  }
 
-/** Fetches pools with given filter params if pools are not provided,
- *  and merges pool incentive info with the given pool type. */
-export async function mapGetPoolIncentives<TPool extends Pool>({
-  pools,
-  ...params
-}: {
-  pools?: TPool[];
-} & PoolFilter &
-  IncentivePoolFilter = {}): Promise<(PoolIncentives & TPool)[]> {
-  if (!pools) pools = (await getPools(params)) as TPool[];
-
-  const incentives = await getCachedPoolIncentivesMap();
-
-  return pools
-    .map((pool) => {
-      const poolIncentive = incentives.get(pool.id);
-
-      // Filter pools if incentive types are specified.
-      // Any type in the given list of types has to be included at least once in the pool types.
-      if (params.incentiveTypes && poolIncentive) {
-        const hasIncentiveType = params.incentiveTypes.some((type) =>
-          poolIncentive.incentiveTypes?.includes(type)
-        );
-        if (!hasIncentiveType) return;
-      } else if (
-        params.incentiveTypes &&
-        !poolIncentive &&
-        !params.incentiveTypes.includes("none")
-      ) {
-        // "none" is a special case, where it includes pools that
-        // don't have an incentives of any type, where the pool incentives map
-        // returns nothing for that pool.
-        // Though, if numia indexes swap fee rewards, none will be filtered above.
-        return;
-      }
-
-      return {
-        ...pool,
-        ...poolIncentive,
-      };
-    })
-    .filter(Boolean) as (PoolIncentives & TPool)[];
+  return false;
 }
 
 const incentivePoolsCache = new LRUCache<string, CacheEntry>({ max: 1 });
 /** Get a cached Map with pool IDs mapped to incentives for that pool. */
-async function getCachedPoolIncentivesMap(): Promise<
+export async function getCachedPoolIncentivesMap(): Promise<
   Map<string, PoolIncentives>
 > {
   return cachified({

--- a/packages/web/server/queries/complex/pools/incentives.ts
+++ b/packages/web/server/queries/complex/pools/incentives.ts
@@ -43,6 +43,11 @@ export const IncentivePoolFilterSchema = z.object({
 /** Params for filtering pools. */
 export type IncentivePoolFilter = z.infer<typeof IncentivePoolFilterSchema>;
 
+export async function getPoolIncentives(poolId: string) {
+  const map = await getCachedPoolIncentivesMap();
+  return map.get(poolId);
+}
+
 /** Checks a pool's incentive data againt a given filter to determine if it's filtered out. */
 export function isIncentivePoolFiltered(
   incentives: PoolIncentives,

--- a/packages/web/server/queries/complex/pools/market.ts
+++ b/packages/web/server/queries/complex/pools/market.ts
@@ -6,7 +6,6 @@ import { DEFAULT_LRU_OPTIONS } from "~/config/cache";
 
 import { queryPoolsFees } from "../../imperator";
 import { DEFAULT_VS_CURRENCY } from "../assets/config";
-import { getPools, Pool, PoolFilter } from "./index";
 
 export type PoolMarketMetrics = Partial<{
   volume7dUsd: PricePretty;
@@ -16,35 +15,9 @@ export type PoolMarketMetrics = Partial<{
   feesSpent7dUsd: PricePretty;
 }>;
 
-/** Get metrics for individual pool. */
-export async function getPoolMarketMetric(
-  poolId: string
-): Promise<PoolMarketMetrics | undefined> {
-  const poolMetrics = await getCachedPoolMarketMetricsMap();
-  return poolMetrics.get(poolId);
-}
-
-/** Maps and adds general supplementary market data such as current price and market cap to the given type.
- *  If no pools provided, they will be fetched and passed the given search params. */
-export async function mapGetPoolMarketMetrics<TPool extends Pool>({
-  pools,
-  ...params
-}: {
-  pools?: TPool[];
-} & PoolFilter = {}): Promise<(PoolMarketMetrics & TPool)[]> {
-  if (!pools) pools = (await getPools(params)) as TPool[];
-
-  const metrics = await getCachedPoolMarketMetricsMap();
-
-  return pools.map((pool) => ({
-    ...pool,
-    ...metrics.get(pool.id),
-  }));
-}
-
 const metricPoolsCache = new LRUCache<string, CacheEntry>(DEFAULT_LRU_OPTIONS);
 /** Get a cached Map with pool IDs mapped to market metrics for that pool. */
-function getCachedPoolMarketMetricsMap(): Promise<
+export function getCachedPoolMarketMetricsMap(): Promise<
   Map<string, PoolMarketMetrics>
 > {
   return cachified({


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

Instead of getting pools data, then fetching and mapping incentives data, then fetching and mapping market data; I fetch pools, incentives, and market data concurrently (via Promise.all) then combine the data per pool once the queries are complete. This makes use of the slower sidecar pools provider much more feasible as we are only as slow as the slowest of the above queries.

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/86a1uagzk)


<img width="1288" alt="Screenshot 2024-01-29 at 8 16 00 PM" src="https://github.com/osmosis-labs/osmosis-frontend/assets/4606373/68d9d66a-d419-4a82-847c-3da1a99c2511">
