### PR TITLE
feat: configure timeout height via environment variable

### DIFF
--- a/packages/stores/src/account/base.ts
+++ b/packages/stores/src/account/base.ts
@@ -74,6 +74,7 @@ import { aminoConverters } from "./amino-converters";
 import {
   AccountStoreWallet,
   DeliverTxResponse,
+  NEXT_TX_TIMEOUT_HEIGHT_OFFSET,
   RegistryWallet,
   TxEvent,
   TxEvents,
@@ -91,11 +92,6 @@ import {
 import { WalletConnectionInProgressError } from "./wallet-errors";
 
 export const GasMultiplier = 1.5;
-
-// The number of heights from current before transaction times out.
-// 30 heights * 5 second block time = 150 seconds before transaction
-// timeout and mempool eviction.
-const timeoutHeightOffset: bigint = BigInt(30);
 
 // The value of zero represent that there is not timeout height set.
 const timeoutHeightDisabledStr = "0";
@@ -827,7 +823,7 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
     }
 
     // Otherwise we compute the timeout height as given by latest block height + offset.
-    return BigInt(latestBlockHeight) + timeoutHeightOffset;
+    return BigInt(latestBlockHeight) + NEXT_TX_TIMEOUT_HEIGHT_OFFSET;
   }
 
   private async signDirect(

--- a/packages/stores/src/account/types.ts
+++ b/packages/stores/src/account/types.ts
@@ -99,3 +99,14 @@ export interface StdSignDoc {
   readonly memo: string;
   readonly timeout_height?: string;
 }
+
+// The number of heights from current before transaction times out.
+// 30 heights * 5 second block time = 150 seconds before transaction
+// timeout and mempool eviction.
+const defaultTimeoutHeightOffset = 30;
+
+export const NEXT_TX_TIMEOUT_HEIGHT_OFFSET: bigint = BigInt(
+  process.env.TIMEOUT_HEIGHT_OFFSET
+    ? process.env.TIMEOUT_HEIGHT_OFFSET
+    : defaultTimeoutHeightOffset
+);


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Closes #2740

Setting up tx timeout offset to be set via environment variable.

Already added the vercel env for all environments:
![image](https://github.com/osmosis-labs/osmosis-frontend/assets/34196718/59798b3f-40cb-4ff8-b404-25dd89d51410)

## Testing

- Tested swaps in preview
 