### PR TITLE
fix: Route Visualization Swap Fees

### DIFF
--- a/packages/web/server/queries/complex/pools/providers/__tests__/imperator.spec.ts
+++ b/packages/web/server/queries/complex/pools/providers/__tests__/imperator.spec.ts
@@ -31,7 +31,7 @@ describe("makePoolFromImperatorPool", () => {
     expect(result.id).toBe(weightedPool.pool_id.toString());
     expect(result.type).toBe("weighted");
     expect((result.raw as any).pool_assets).toBeDefined();
-    expect(result.spreadFactor.toDec().toString()).toBe("0.200000000000000000");
+    expect(result.spreadFactor.toDec().toString()).toBe("0.002000000000000000");
   });
 
   it("should return a valid pool object for a stable pool", async () => {
@@ -43,7 +43,7 @@ describe("makePoolFromImperatorPool", () => {
     expect(result.type).toBe("stable");
     expect((result.raw as any).pool_liquidity).toBeDefined();
     expect(result.reserveCoins.length).toBe(2);
-    expect(result.spreadFactor.toDec().toString()).toBe("0.300000000000000000");
+    expect(result.spreadFactor.toDec().toString()).toBe("0.003000000000000000");
   });
 
   it("should return a valid pool object for a concentrated liquidity pool", async () => {

--- a/packages/web/server/queries/complex/pools/providers/imperator.ts
+++ b/packages/web/server/queries/complex/pools/providers/imperator.ts
@@ -419,7 +419,11 @@ export async function makePoolFromImperatorPool(
     spreadFactor: RatePretty;
     totalFiatValueLocked: PricePretty;
   } = {
-    spreadFactor: new RatePretty(filteredPool.swap_fees),
+    spreadFactor: new RatePretty(
+      new Dec(filteredPool.swap_fees.toString()).mul(
+        DecUtils.getTenExponentN(-2)
+      )
+    ),
     totalFiatValueLocked: new PricePretty(
       DEFAULT_VS_CURRENCY,
       filteredPool.liquidity


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

The Route Visualization was incorrectly showing the swap fees for each pool, such as displaying 20% for Avax when it should be 0.2%. This error occurred because the backend was miscalculating the swap fee based on the Imperator response. The Imperator API already returns fees as a percentage, so we need to convert them to a base value first.

Before 
![image](https://github.com/osmosis-labs/osmosis-frontend/assets/21092519/d59d43a3-6b3e-43a9-b645-d5281afc1941)

After
![image](https://github.com/osmosis-labs/osmosis-frontend/assets/21092519/661ae7a5-7fc8-4222-a232-29ca4e4d88dc)


### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/86a24bej6)

## Brief Changelog

- Correctly calculate swap fee percentage on Imperator pool provider

## Testing and Verifying

- [ ] Should display correct swap fees in route vis
