### PR TITLE
feat: Hide External Boost APR with Build Feature Flag (#2762)

### DIFF
--- a/packages/web/.env
+++ b/packages/web/.env
@@ -38,3 +38,6 @@ NEXT_PUBLIC_SIDECAR_BASE_URL=https://sqs.osmosis.zone
 # GITHUB_API_TOKEN=
 # NEXT_PUBLIC_SIDECAR_BASE_URL=
 # NEXT_PUBLIC_FE_CONTENT_COMMIT_HASH=
+
+# Pools that are excluded from showing external boost incentives APRs.
+# NEXT_PUBLIC_EXCLUDED_EXTERNAL_BOOSTS_POOL_IDS=

--- a/packages/web/components/cards/apr-breakdown.tsx
+++ b/packages/web/components/cards/apr-breakdown.tsx
@@ -3,6 +3,7 @@ import classNames from "classnames";
 import { observer } from "mobx-react-lite";
 import { FunctionComponent } from "react";
 
+import { ExcludedExternalBoostPools } from "~/config";
 import { useTranslation } from "~/hooks";
 import type { PoolIncentives } from "~/server/queries/complex/pools/incentives";
 import { useStore } from "~/stores";
@@ -19,13 +20,26 @@ export const AprBreakdownLegacy: FunctionComponent<
   const { queriesExternalStore } = useStore();
   const poolAprs = queriesExternalStore.queryPoolAprs.getForPool(poolId);
 
+  let totalApr = poolAprs?.totalApr;
+  let boostApr = poolAprs?.boost;
+
+  if (
+    poolAprs?.poolId &&
+    ExcludedExternalBoostPools.includes(poolAprs.poolId) &&
+    totalApr &&
+    boostApr
+  ) {
+    totalApr = new RatePretty(totalApr.toDec().sub(boostApr.toDec()));
+    boostApr = undefined;
+  }
+
   return (
     <AprBreakdown
-      total={poolAprs?.totalApr}
+      total={totalApr}
       swapFee={poolAprs?.swapFees}
       superfluid={poolAprs?.superfluid}
       osmosis={poolAprs?.osmosis}
-      boost={poolAprs?.boost}
+      boost={boostApr}
       className={className}
       showDisclaimerTooltip={showDisclaimerTooltip}
     />

--- a/packages/web/config/feature-flag.ts
+++ b/packages/web/config/feature-flag.ts
@@ -1,4 +1,4 @@
-import { IS_TESTNET } from "./env";
+import { EXCLUDED_EXTERNAL_BOOSTS_POOL_IDS, IS_TESTNET } from "./env";
 
 /** UI will go into "halt mode" if `true`. */
 export const IS_HALTED = false;
@@ -33,6 +33,13 @@ export const RecommendedSwapDenoms = [
   "TIA",
   "WBTC",
   "ETH",
+];
+
+/**
+ * Pools that are excluded from showing external boost incentives APRs.
+ */
+export const ExcludedExternalBoostPools = EXCLUDED_EXTERNAL_BOOSTS_POOL_IDS ?? [
+  "1423", // stDYDX/DYDX
 ];
 
 export const UnPoolWhitelistedPoolIds: { [poolId: string]: boolean } = {

--- a/packages/web/server/queries/complex/pools/incentives.ts
+++ b/packages/web/server/queries/complex/pools/incentives.ts
@@ -7,6 +7,7 @@ import { LRUCache } from "lru-cache";
 import { z } from "zod";
 
 import { DEFAULT_LRU_OPTIONS } from "~/config/cache";
+import { ExcludedExternalBoostPools } from "~/config/feature-flag";
 import { queryPriceRangeApr } from "~/server/queries/imperator";
 import { queryLockableDurations } from "~/server/queries/osmosis";
 
@@ -106,11 +107,21 @@ async function getCachedPoolIncentivesMap(): Promise<
       const aprs = await queryPoolAprs();
 
       return aprs.reduce((map, apr) => {
-        const total = maybeMakeRatePretty(apr.total_apr);
+        let total = maybeMakeRatePretty(apr.total_apr);
         const swapFee = maybeMakeRatePretty(apr.swap_fees);
         const superfluid = maybeMakeRatePretty(apr.superfluid);
         const osmosis = maybeMakeRatePretty(apr.osmosis);
-        const boost = maybeMakeRatePretty(apr.boost);
+        let boost = maybeMakeRatePretty(apr.boost);
+
+        // Temporarily exclude pools in this array from showing boost incentives given an issue on chain
+        if (
+          ExcludedExternalBoostPools.includes(apr.pool_id) &&
+          total &&
+          boost
+        ) {
+          total = new RatePretty(total.toDec().sub(boost.toDec()));
+          boost = undefined;
+        }
 
         // add list of incentives that are defined
         const incentiveTypes: PoolIncentiveType[] = [];


### PR DESCRIPTION
* feat: hide external boost with feature flag

* feat: allow using env vars to exclude boosted pools

* improvement: remove console log

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

### ClickUp Task

[ClickUp Task URL](PASTE_CLICKUP_TASK_URL_HERE)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
