### PR TITLE
feat: Acknowledge Verified Status of Native Tokens

### DIFF
--- a/packages/web/components/complex/assets-page-v1.tsx
+++ b/packages/web/components/complex/assets-page-v1.tsx
@@ -46,7 +46,12 @@ const DenomQueryParamKey = "denom";
 export const AssetsPageV1: FunctionComponent = observer(() => {
   const { isMobile } = useWindowSize();
   const { assetsStore } = useStore();
-  const { nativeBalances, ibcBalances, unverifiedIbcBalances } = assetsStore;
+  const {
+    nativeBalances,
+    ibcBalances,
+    unverifiedIbcBalances,
+    unverifiedNativeBalances,
+  } = assetsStore;
   const { t } = useTranslation();
   const flags = useFeatureFlags();
 
@@ -249,6 +254,7 @@ export const AssetsPageV1: FunctionComponent = observer(() => {
 
       <AssetsTableV1
         nativeBalances={nativeBalances}
+        unverifiedNativeBalances={unverifiedNativeBalances}
         ibcBalances={ibcBalances}
         unverifiedIbcBalances={unverifiedIbcBalances}
         onDeposit={onTableDeposit}

--- a/packages/web/components/table/assets-table-v1.tsx
+++ b/packages/web/components/table/assets-table-v1.tsx
@@ -43,7 +43,8 @@ import { HideBalancesState } from "~/stores/user-settings";
 import { UnverifiedAssetsState } from "~/stores/user-settings";
 
 interface Props {
-  nativeBalances: CoinBalance[];
+  nativeBalances: (CoinBalance & { isVerified: boolean })[];
+  unverifiedNativeBalances: (CoinBalance & { isVerified: boolean })[];
   ibcBalances: ((IBCBalance | IBCCW20ContractBalance) & {
     depositUrlOverride?: string;
     withdrawUrlOverride?: string;
@@ -82,16 +83,16 @@ function mapCommonFields(
 }
 
 function nativeBalancesToTableCell(
-  balances: CoinBalance[],
+  balances: (CoinBalance & { isVerified: boolean })[],
   osmosisChainId: string
 ): SortableTableCell[] {
-  return balances.map(({ balance, fiatValue }) => {
+  return balances.map(({ balance, fiatValue, isVerified }) => {
     const commonFields = mapCommonFields(balance, fiatValue);
     return {
       ...commonFields,
       chainId: osmosisChainId,
       chainName: "",
-      isVerified: true,
+      isVerified,
     };
   });
 }
@@ -99,6 +100,7 @@ function nativeBalancesToTableCell(
 export const AssetsTableV1: FunctionComponent<Props> = observer(
   ({
     nativeBalances,
+    unverifiedNativeBalances,
     ibcBalances,
     unverifiedIbcBalances,
     onDeposit: _onDeposit,
@@ -213,7 +215,7 @@ export const AssetsTableV1: FunctionComponent<Props> = observer(
             )
           ),
           ...nativeBalancesToTableCell(
-            nativeBalances.filter(
+            (isSearching ? unverifiedNativeBalances : nativeBalances).filter(
               ({ balance, fiatValue }) =>
                 !(
                   balance.denom === "OSMO" ||
@@ -236,6 +238,8 @@ export const AssetsTableV1: FunctionComponent<Props> = observer(
             assetLists: AssetLists,
           });
 
+          console.log(balance);
+
           return {
             ...balance,
             assetName: asset?.rawAsset.name,
@@ -243,10 +247,11 @@ export const AssetsTableV1: FunctionComponent<Props> = observer(
         }),
       [
         nativeBalances,
+        chainStore.osmosis.chainId,
         isSearching,
         unverifiedIbcBalances,
         ibcBalances,
-        chainStore.osmosis.chainId,
+        unverifiedNativeBalances,
         shouldDisplayUnverifiedAssets,
         onWithdraw,
         onDeposit,

--- a/packages/web/components/table/assets-table-v1.tsx
+++ b/packages/web/components/table/assets-table-v1.tsx
@@ -238,8 +238,6 @@ export const AssetsTableV1: FunctionComponent<Props> = observer(
             assetLists: AssetLists,
           });
 
-          console.log(balance);
-
           return {
             ...balance,
             assetName: asset?.rawAsset.name,

--- a/packages/web/stores/assets/assets-store.ts
+++ b/packages/web/stores/assets/assets-store.ts
@@ -108,7 +108,7 @@ export class ObservableAssets {
   }
 
   @computed
-  get nativeBalances(): CoinBalance[] {
+  get unverifiedNativeBalances(): (CoinBalance & { isVerified: boolean })[] {
     return this.chain.currencies
       .filter(
         (currency) =>
@@ -132,6 +132,9 @@ export class ObservableAssets {
         return !assetListAsset.keywords?.includes("osmosis-unlisted");
       }) // Remove unlisted assets if preview assets is disabled
       .map((currency) => {
+        const asset = this.assets.find(
+          (asset) => asset.symbol === currency.coinDenom
+        );
         const bal = this.queries.queryBalances
           .getQueryBech32Address(this.address ?? "")
           .getBalanceFromCurrency(currency);
@@ -141,6 +144,7 @@ export class ObservableAssets {
         return {
           balance: bal,
           fiatValue: this.priceStore.calculatePrice(bal),
+          isVerified: Boolean(asset?.keywords?.includes("osmosis-main")),
         };
       });
   }
@@ -277,6 +281,12 @@ export class ObservableAssets {
   })[] {
     return this.unverifiedIbcBalances.filter((ibcAsset) =>
       this.showUnverified ? true : ibcAsset.isVerified
+    );
+  }
+
+  get nativeBalances(): (CoinBalance & { isVerified: boolean })[] {
+    return this.unverifiedNativeBalances.filter((bal) =>
+      this.showUnverified ? true : bal.isVerified
     );
   }
 


### PR DESCRIPTION
## What is the purpose of the change

The Assets store was not taking into account the verified status of native Osmosis tokens. This PR adds the same checks to native balances as with IBC tokens.

![image](https://github.com/osmosis-labs/osmosis-frontend/assets/21092519/7874c08c-7329-466f-9e6b-60df0304ce8f)


## Testing

- [ ] Unverified native tokens like Wosmo should be labeled as such on the assets page   