### PR TITLE
properly get native asset price when calculating gas price

### DIFF
--- a/packages/web/integrations/bridges/skip/types.ts
+++ b/packages/web/integrations/bridges/skip/types.ts
@@ -15,6 +15,7 @@ export type SkipAsset = {
   description?: string;
   coingecko_id?: string;
   recommended_symbol?: string;
+  is_evm_native?: boolean;
 };
 
 export type SkipChain = {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

In the bridging UI certain assets were not returning Skip quotes because it was failing to get the gas asset price. This updates the SkipBridgeProvider to successfully get this price.

One example is depositing USDC.axl from Ethereum.

### ClickUp Task

[ClickUp Task URL](PASTE_CLICKUP_TASK_URL_HERE)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

- Fix `SkipBridgeProvider` quote functionality

## Testing and Verifying

This change has been tested locally by rebuilding the website and verified content and links are expected

## Documentation and Release Note

No user-facing behavior changes.

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
