### PR TITLE
Fix: pool ratio percentage calc

### DIFF
--- a/packages/web/hooks/ui-config/use-add-concentrated-liquidity-config.ts
+++ b/packages/web/hooks/ui-config/use-add-concentrated-liquidity-config.ts
@@ -566,21 +566,13 @@ export class ObservableAddConcentratedLiquidityConfig {
       this.pool.currentSqrtPrice
     );
 
-    const amount0Value =
-      this.priceStore.calculatePrice(
-        new CoinPretty(this._baseDepositAmountIn.sendCurrency, amount0)
-      ) ?? new CoinPretty(this._baseDepositAmountIn.sendCurrency, 1);
-    const amount1Value =
-      this.priceStore.calculatePrice(
-        new CoinPretty(this._quoteDepositAmountIn.sendCurrency, amount1)
-      ) ?? new CoinPretty(this._quoteDepositAmountIn.sendCurrency, 1);
-    const totalValue = amount0Value.toDec().add(amount1Value.toDec());
+    const totalValue = amount0.toDec().add(amount1.toDec());
 
     if (totalValue.isZero()) return [new RatePretty(0), new RatePretty(0)];
 
     return [
-      new RatePretty(amount0Value.toDec().quo(totalValue)),
-      new RatePretty(amount1Value.toDec().quo(totalValue)),
+      new RatePretty(amount0.toDec().quo(totalValue)),
+      new RatePretty(amount1.toDec().quo(totalValue)),
     ];
   }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

When opening new position with in an LP, the ratio of the two tokens normally shows the percentage. Now, since yesterday, it alsways shows 50 50 in both tokens but the value ratio changes. The % percentage value does not get updated. Please fix.

The token balance is showing 50%/50%, but when I put in the amounts, the ratio changes to 60%/40%. The transaction in Keplr shows the correct amounts.

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/86a21c18d)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
