### PR TITLE
Fix: add liquidity for classic pools

### DIFF
--- a/packages/web/components/complex/add-liquidity.tsx
+++ b/packages/web/components/complex/add-liquidity.tsx
@@ -134,7 +134,7 @@ const AmountInput: FunctionComponent<{
   currency: Currency;
   weightFraction: RatePretty;
   index: number;
-}> = ({ addLiquidityConfig, weightFraction, currency, index }) => {
+}> = observer(({ addLiquidityConfig, weightFraction, currency, index }) => {
   const { chainStore } = useStore();
   const { isMobile } = useWindowSize();
   const { t } = useTranslation();
@@ -143,6 +143,7 @@ const AmountInput: FunctionComponent<{
   const inputAmount = addLiquidityConfig.isSingleAmountIn
     ? addLiquidityConfig.singleAmountInConfig?.amount ?? "0"
     : addLiquidityConfig.getAmountAt(index);
+
   const onInputAmount = (value: string) => {
     if (addLiquidityConfig.isSingleAmountIn) {
       addLiquidityConfig.singleAmountInConfig?.setAmount(value);
@@ -154,12 +155,14 @@ const AmountInput: FunctionComponent<{
   const inputAmountValue = useCoinFiatValue(
     useMemo(
       () =>
-        new CoinPretty(currency, inputAmount).moveDecimalPointRight(
-          currency.coinDecimals
-        ),
+        new CoinPretty(
+          currency,
+          inputAmount.length === 0 ? "0" : inputAmount
+        ).moveDecimalPointRight(currency.coinDecimals),
       [currency, inputAmount]
     )
   );
+
   const assetBalance = addLiquidityConfig.isSingleAmountIn
     ? addLiquidityConfig.singleAmountInBalance
     : addLiquidityConfig.getSenderBalanceAt(index);
@@ -249,4 +252,4 @@ const AmountInput: FunctionComponent<{
       </div>
     </div>
   );
-};
+});

--- a/packages/web/modals/lock-tokens.tsx
+++ b/packages/web/modals/lock-tokens.tsx
@@ -163,14 +163,17 @@ export const LockTokensModal: FunctionComponent<
           ))}
         </div>
         {superfluidPoolDetail?.isSuperfluid && (
-          <Checkbox
-            variant="secondary"
-            checked={superfluidDurationSelected && electSuperfluid}
-            onClick={() => setElectSuperfluid(!electSuperfluid)}
-            disabled={!superfluidDurationSelected || hasSuperfluidValidator}
-          >
-            <div
-              className={classNames("flex flex-col gap-1", {
+          <div className="flex gap-3">
+            <Checkbox
+              id="superfluid-checkbox"
+              variant="secondary"
+              checked={superfluidDurationSelected && electSuperfluid}
+              onClick={() => setElectSuperfluid(!electSuperfluid)}
+              disabled={!superfluidDurationSelected || hasSuperfluidValidator}
+            />
+            <label
+              htmlFor="superfluid-checkbox"
+              className={classNames("flex cursor-pointer flex-col gap-1", {
                 "opacity-30":
                   !superfluidDurationSelected || hasSuperfluidValidator,
               })}
@@ -188,8 +191,8 @@ export const LockTokensModal: FunctionComponent<
                   })}
                 </span>
               )}
-            </div>
-          </Checkbox>
+            </label>
+          </div>
         )}
         <div className="flex flex-col gap-2">
           <div className="flex place-content-between items-center">


### PR DESCRIPTION
This PR fixes a bug that didn't feel like adding liquidity to classic pools, the UI was breaking down

### ClickUp Task

[ClickUp Task URL](PASTE_CLICKUP_TASK_URL_HERE)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
