### PR TITLE
fix: pools timeout

### DIFF
--- a/packages/utils/src/api-client.ts
+++ b/packages/utils/src/api-client.ts
@@ -108,6 +108,7 @@ export async function apiClient<T>(
         endpoint,
         config,
         data,
+        status: response.status,
       });
 
       if (e instanceof ApiClientError) {

--- a/packages/web/config/cache.ts
+++ b/packages/web/config/cache.ts
@@ -14,5 +14,5 @@ export const LARGE_LRU_OPTIONS: LRUCache.Options<
   CacheEntry<unknown>,
   unknown
 > = {
-  max: 2_000,
+  max: 1_500,
 };

--- a/packages/web/server/api/edge-routers/pools-router.ts
+++ b/packages/web/server/api/edge-routers/pools-router.ts
@@ -67,23 +67,30 @@ export const poolsRouter = createTRPCRouter({
         poolIncentives,
         superfluidPools,
       ] = await Promise.all([
-        timeout(function queryBalancesTimeout() {
-          return queryBalances({ bech32Address: userOsmoAddress });
-        }, 10000)(),
-        timeout(function queryAccountLockedCoinsTimeout() {
-          return queryAccountLockedCoins({
-            bech32Address: userOsmoAddress,
-          });
-        }, 10000)(),
-        timeout(function queryCLPositionsTimeout() {
-          return queryCLPositions({ bech32Address: userOsmoAddress });
-        }, 10000)(),
-        timeout(function getCachedPoolIncentivesMapTimeout() {
-          return getCachedPoolIncentivesMap();
-        }, 10000)(),
-        timeout(function getSuperfluidPoolIdsTimeout() {
-          return getSuperfluidPoolIds();
-        }, 10000)(),
+        timeout(
+          () => queryBalances({ bech32Address: userOsmoAddress }),
+          10000,
+          "queryBalances"
+        )(),
+        timeout(
+          () =>
+            queryAccountLockedCoins({
+              bech32Address: userOsmoAddress,
+            }),
+          10000,
+          "queryAccountLockedCoins"
+        )(),
+        timeout(
+          () => queryCLPositions({ bech32Address: userOsmoAddress }),
+          10000,
+          "queryCLPositions"
+        )(),
+        timeout(
+          () => getCachedPoolIncentivesMap(),
+          10000,
+          "getCachedPoolIncentivesMap"
+        )(),
+        timeout(() => getSuperfluidPoolIds(), 10000, "getSuperfluidPoolIds")(),
       ]);
 
       const gammAssets = [
@@ -106,9 +113,7 @@ export const poolsRouter = createTRPCRouter({
       }
 
       const eventualPools = (
-        await timeout(function getPoolsTimeout() {
-          return getPools();
-        }, 10000)()
+        await timeout(() => getPools(), 10000, "getPools")()
       ).filter((pool) => userPoolIdsSet.has(pool.id));
 
       const pools = await Promise.all(

--- a/packages/web/server/api/edge-routers/pools-router.ts
+++ b/packages/web/server/api/edge-routers/pools-router.ts
@@ -69,7 +69,7 @@ export const poolsRouter = createTRPCRouter({
       ] = await Promise.all([
         timeout(
           () => queryBalances({ bech32Address: userOsmoAddress }),
-          10000,
+          10_000, // 10 seconds
           "queryBalances"
         )(),
         timeout(
@@ -77,20 +77,24 @@ export const poolsRouter = createTRPCRouter({
             queryAccountLockedCoins({
               bech32Address: userOsmoAddress,
             }),
-          10000,
+          10_000, // 10 seconds
           "queryAccountLockedCoins"
         )(),
         timeout(
           () => queryCLPositions({ bech32Address: userOsmoAddress }),
-          10000,
+          10_000, // 10 seconds
           "queryCLPositions"
         )(),
         timeout(
           () => getCachedPoolIncentivesMap(),
-          10000,
+          10_000, // 10 seconds
           "getCachedPoolIncentivesMap"
         )(),
-        timeout(() => getSuperfluidPoolIds(), 10000, "getSuperfluidPoolIds")(),
+        timeout(
+          () => getSuperfluidPoolIds(),
+          10_000, // 10 seconds
+          "getSuperfluidPoolIds"
+        )(),
       ]);
 
       const gammAssets = [
@@ -113,7 +117,11 @@ export const poolsRouter = createTRPCRouter({
       }
 
       const eventualPools = (
-        await timeout(() => getPools(), 10000, "getPools")()
+        await timeout(
+          () => getPools(),
+          10_000, // 10 seconds
+          "getPools"
+        )()
       ).filter((pool) => userPoolIdsSet.has(pool.id));
 
       const pools = await Promise.all(

--- a/packages/web/server/api/edge-routers/pools-router.ts
+++ b/packages/web/server/api/edge-routers/pools-router.ts
@@ -67,23 +67,23 @@ export const poolsRouter = createTRPCRouter({
         poolIncentives,
         superfluidPools,
       ] = await Promise.all([
-        timeout(
-          () => queryBalances({ bech32Address: userOsmoAddress }),
-          10000
-        )(),
-        timeout(
-          () =>
-            queryAccountLockedCoins({
-              bech32Address: userOsmoAddress,
-            }),
-          10000
-        )(),
-        timeout(
-          () => queryCLPositions({ bech32Address: userOsmoAddress }),
-          10000
-        )(),
-        timeout(() => getCachedPoolIncentivesMap(), 10000)(),
-        timeout(() => getSuperfluidPoolIds(), 10000)(),
+        timeout(function queryBalancesTimeout() {
+          return queryBalances({ bech32Address: userOsmoAddress });
+        }, 10000)(),
+        timeout(function queryAccountLockedCoinsTimeout() {
+          return queryAccountLockedCoins({
+            bech32Address: userOsmoAddress,
+          });
+        }, 10000)(),
+        timeout(function queryCLPositionsTimeout() {
+          return queryCLPositions({ bech32Address: userOsmoAddress });
+        }, 10000)(),
+        timeout(function getCachedPoolIncentivesMapTimeout() {
+          return getCachedPoolIncentivesMap();
+        }, 10000)(),
+        timeout(function getSuperfluidPoolIdsTimeout() {
+          return getSuperfluidPoolIds();
+        }, 10000)(),
       ]);
 
       const gammAssets = [
@@ -105,9 +105,11 @@ export const poolsRouter = createTRPCRouter({
         }
       }
 
-      const eventualPools = (await timeout(() => getPools(), 10000)()).filter(
-        (pool) => userPoolIdsSet.has(pool.id)
-      );
+      const eventualPools = (
+        await timeout(function getPoolsTimeout() {
+          return getPools();
+        }, 10000)()
+      ).filter((pool) => userPoolIdsSet.has(pool.id));
 
       const pools = await Promise.all(
         eventualPools.map(async (pool) => {

--- a/packages/web/server/api/edge-routers/pools-router.ts
+++ b/packages/web/server/api/edge-routers/pools-router.ts
@@ -94,10 +94,9 @@ export const poolsRouter = createTRPCRouter({
         }
       }
 
-      const userPoolIds = Array.from(userPoolIdsSet);
-      const eventualPools = await getPools({
-        poolIds: userPoolIds,
-      });
+      const eventualPools = (await getPools()).filter((pool) =>
+        userPoolIdsSet.has(pool.id)
+      );
 
       const pools = await Promise.all(
         eventualPools.map(async (pool) => {

--- a/packages/web/server/queries/complex/pools/providers/imperator.ts
+++ b/packages/web/server/queries/complex/pools/providers/imperator.ts
@@ -16,6 +16,8 @@ import {
 import { CacheEntry, cachified } from "cachified";
 import { LRUCache } from "lru-cache";
 
+import { DEFAULT_LRU_OPTIONS } from "~/config/cache";
+
 import { queryBalances } from "../../../cosmos";
 import {
   FilteredPoolsResponse,
@@ -33,7 +35,7 @@ import { DEFAULT_VS_CURRENCY } from "../../assets/config";
 import { Pool } from "..";
 import { TransmuterPoolCodeIds } from "../env";
 
-const poolsCache = new LRUCache<string, CacheEntry>({ max: 1 });
+const poolsCache = new LRUCache<string, CacheEntry>(DEFAULT_LRU_OPTIONS);
 
 /** Get pools from imperator that are listed in asset list. */
 export async function getPoolsFromImperator(): Promise<Pool[]> {
@@ -41,6 +43,7 @@ export async function getPoolsFromImperator(): Promise<Pool[]> {
     cache: poolsCache,
     key: "imperator-pools",
     ttl: 5_000, // 5 seconds
+    staleWhileRevalidate: 10_000, // 10 seconds
     getFreshValue: async () => {
       const numPools = await queryNumPools();
       const { pools } = await queryFilteredPools(

--- a/packages/web/server/queries/complex/pools/providers/imperator.ts
+++ b/packages/web/server/queries/complex/pools/providers/imperator.ts
@@ -16,8 +16,6 @@ import {
 import { CacheEntry, cachified } from "cachified";
 import { LRUCache } from "lru-cache";
 
-import { LARGE_LRU_OPTIONS } from "~/config/cache";
-
 import { queryBalances } from "../../../cosmos";
 import {
   FilteredPoolsResponse,
@@ -35,34 +33,17 @@ import { DEFAULT_VS_CURRENCY } from "../../assets/config";
 import { Pool } from "..";
 import { TransmuterPoolCodeIds } from "../env";
 
-const poolsCache = new LRUCache<string, CacheEntry>(LARGE_LRU_OPTIONS);
+const poolsCache = new LRUCache<string, CacheEntry>({ max: 1 });
 
 /** Get pools from imperator that are listed in asset list. */
-export async function getPoolsFromImperator({
-  poolIds,
-}: {
-  poolIds?: string[];
-} = {}): Promise<Pool[]> {
-  let pools = await fetchPoolsFromImperator();
-
-  if (poolIds) {
-    pools = pools.filter((pool) => poolIds.includes(pool.pool_id.toString()));
-  }
-
-  return (await Promise.all(pools.map(makePoolFromImperatorPool))).filter(
-    (pool): pool is Pool => !!pool
-  );
-}
-
-function fetchPoolsFromImperator() {
+export async function getPoolsFromImperator(): Promise<Pool[]> {
   return cachified({
     cache: poolsCache,
     key: "imperator-pools",
     ttl: 5_000, // 5 seconds
-    staleWhileRevalidate: 5_000, // 5 seconds
     getFreshValue: async () => {
       const numPools = await queryNumPools();
-      let { pools } = await queryFilteredPools(
+      const { pools } = await queryFilteredPools(
         {
           min_liquidity: 0,
           order_by: "desc",
@@ -70,7 +51,9 @@ function fetchPoolsFromImperator() {
         },
         { offset: 0, limit: Number(numPools.num_pools) }
       );
-      return pools;
+      return (await Promise.all(pools.map(makePoolFromImperatorPool))).filter(
+        (pool): pool is Pool => !!pool
+      );
     },
   });
 }
@@ -421,187 +404,170 @@ async function getPoolsFromNode(): Promise<PoolRaw[]> {
 export async function makePoolFromImperatorPool(
   filteredPool: FilteredPoolsResponse["pools"][number]
 ): Promise<Pool | undefined> {
-  return cachified({
-    cache: poolsCache,
-    key: "pools-" + filteredPool.pool_id.toString(),
-    ttl: 5_000, // 5 seconds
-    staleWhileRevalidate: 5_000, // 5 seconds
-    getFreshValue: async (): Promise<Pool | undefined> => {
-      // deny pools containing tokens with gamm denoms
-      if (
-        Array.isArray(filteredPool.pool_tokens) &&
-        filteredPool.pool_tokens.some(
-          (token) => "denom" in token && token.denom.includes("gamm")
-        )
-      ) {
-        return;
-      }
+  // deny pools containing tokens with gamm denoms
+  if (
+    Array.isArray(filteredPool.pool_tokens) &&
+    filteredPool.pool_tokens.some(
+      (token) => "denom" in token && token.denom.includes("gamm")
+    )
+  ) {
+    return;
+  }
 
-      /** Metrics common to all pools. */
-      const basePool: {
-        spreadFactor: RatePretty;
-        totalFiatValueLocked: PricePretty;
-      } = {
-        spreadFactor: new RatePretty(
-          new Dec(filteredPool.swap_fees.toString()).mul(
-            DecUtils.getTenExponentN(-2)
-          )
-        ),
-        totalFiatValueLocked: new PricePretty(
-          DEFAULT_VS_CURRENCY,
-          filteredPool.liquidity
-        ),
-      };
+  /** Metrics common to all pools. */
+  const basePool: {
+    spreadFactor: RatePretty;
+    totalFiatValueLocked: PricePretty;
+  } = {
+    spreadFactor: new RatePretty(
+      new Dec(filteredPool.swap_fees.toString()).mul(
+        DecUtils.getTenExponentN(-2)
+      )
+    ),
+    totalFiatValueLocked: new PricePretty(
+      DEFAULT_VS_CURRENCY,
+      filteredPool.liquidity
+    ),
+  };
 
-      if (
-        filteredPool.type === "osmosis.concentratedliquidity.v1beta1.Pool" &&
-        !Array.isArray(filteredPool.pool_tokens)
-      ) {
-        if (
-          !filteredPool.pool_tokens.asset0 ||
-          !filteredPool.pool_tokens.asset1
-        )
-          return;
+  if (
+    filteredPool.type === "osmosis.concentratedliquidity.v1beta1.Pool" &&
+    !Array.isArray(filteredPool.pool_tokens)
+  ) {
+    if (!filteredPool.pool_tokens.asset0 || !filteredPool.pool_tokens.asset1)
+      return;
 
-        const token0 = filteredPool.pool_tokens.asset0.denom;
-        const token1 = filteredPool.pool_tokens.asset1.denom;
+    const token0 = filteredPool.pool_tokens.asset0.denom;
+    const token1 = filteredPool.pool_tokens.asset1.denom;
 
-        const token0Asset = await getAsset({ anyDenom: token0 }).catch(
-          () => null
-        );
-        const token1Asset = await getAsset({ anyDenom: token1 }).catch(
-          () => null
-        );
+    const token0Asset = await getAsset({ anyDenom: token0 }).catch(() => null);
+    const token1Asset = await getAsset({ anyDenom: token1 }).catch(() => null);
 
-        if (!token0Asset || !token1Asset) return;
+    if (!token0Asset || !token1Asset) return;
 
-        return {
-          id: filteredPool.pool_id.toString(),
-          type: "concentrated",
-          raw: {
-            address: filteredPool.address,
-            id: filteredPool.pool_id.toString(),
-            current_tick_liquidity: filteredPool.current_tick_liquidity,
-            token0,
-            token1,
-            current_sqrt_price: filteredPool.current_sqrt_price,
-            current_tick: filteredPool.current_tick,
-            tick_spacing: filteredPool.tick_spacing,
-            exponent_at_price_one: filteredPool.exponent_at_price_one,
-            spread_factor: filteredPool.spread_factor,
-          } as ConcentratedPoolRawResponse,
-          reserveCoins: [
-            new CoinPretty(token0Asset, filteredPool.pool_tokens.asset0.amount),
-            new CoinPretty(token1Asset, filteredPool.pool_tokens.asset0.amount),
-          ],
-          ...basePool,
-          spreadFactor: new RatePretty(filteredPool.spread_factor),
-        };
-      }
-
-      if (
-        filteredPool.type === "osmosis.cosmwasmpool.v1beta1.CosmWasmPool" &&
-        Array.isArray(filteredPool.pool_tokens)
-      ) {
-        const reserveCoins = await getReservesFromPoolTokens(
-          filteredPool.pool_tokens
-        );
-
-        if (!reserveCoins) return;
-
-        return {
-          id: filteredPool.pool_id.toString(),
-          type: TransmuterPoolCodeIds.includes(filteredPool.code_id)
-            ? "cosmwasm-transmuter"
-            : "cosmwasm",
-          raw: {
-            contract_address: filteredPool.contract_address,
-            pool_id: filteredPool.pool_id.toString(),
-            code_id: filteredPool.code_id,
-            instantiate_msg: filteredPool.instantiate_msg,
-          },
-          reserveCoins: reserveCoins,
-          ...basePool,
-        };
-      }
-
-      const sharePoolRawBase = {
+    return {
+      id: filteredPool.pool_id.toString(),
+      type: "concentrated",
+      raw: {
+        address: filteredPool.address,
         id: filteredPool.pool_id.toString(),
-        pool_params: {
-          exit_fee: new Dec(filteredPool.exit_fees.toString())
-            .mul(DecUtils.getTenExponentN(-2))
-            .toString(),
-          swap_fee: new Dec(filteredPool.swap_fees.toString())
-            .mul(DecUtils.getTenExponentN(-2))
-            .toString(),
-          smooth_weight_change_params: null,
-        },
-        total_shares: filteredPool.total_shares,
-      };
+        current_tick_liquidity: filteredPool.current_tick_liquidity,
+        token0,
+        token1,
+        current_sqrt_price: filteredPool.current_sqrt_price,
+        current_tick: filteredPool.current_tick,
+        tick_spacing: filteredPool.tick_spacing,
+        exponent_at_price_one: filteredPool.exponent_at_price_one,
+        spread_factor: filteredPool.spread_factor,
+      } as ConcentratedPoolRawResponse,
+      reserveCoins: [
+        new CoinPretty(token0Asset, filteredPool.pool_tokens.asset0.amount),
+        new CoinPretty(token1Asset, filteredPool.pool_tokens.asset0.amount),
+      ],
+      ...basePool,
+      spreadFactor: new RatePretty(filteredPool.spread_factor),
+    };
+  }
 
-      if (
-        filteredPool.type === "osmosis.gamm.v1beta1.Pool" &&
-        Array.isArray(filteredPool.pool_tokens)
-      ) {
-        const reserveCoins = await getReservesFromPoolTokens(
-          filteredPool.pool_tokens
-        );
+  if (
+    filteredPool.type === "osmosis.cosmwasmpool.v1beta1.CosmWasmPool" &&
+    Array.isArray(filteredPool.pool_tokens)
+  ) {
+    const reserveCoins = await getReservesFromPoolTokens(
+      filteredPool.pool_tokens
+    );
 
-        if (!reserveCoins) return;
+    if (!reserveCoins) return;
 
-        return {
-          id: filteredPool.pool_id.toString(),
-          type: "weighted",
-          raw: {
-            pool_assets: filteredPool.pool_tokens.map((token) => ({
-              token: {
-                denom: token.denom,
-                amount: floatNumberToStringInt(token.amount, token.exponent),
-              },
-              weight: token.weight_or_scaling.toString(),
-            })),
-            total_weight: filteredPool.total_weight_or_scaling.toString(),
-            ...sharePoolRawBase,
-          },
-          reserveCoins,
-          ...basePool,
-        };
-      }
+    return {
+      id: filteredPool.pool_id.toString(),
+      type: TransmuterPoolCodeIds.includes(filteredPool.code_id)
+        ? "cosmwasm-transmuter"
+        : "cosmwasm",
+      raw: {
+        contract_address: filteredPool.contract_address,
+        pool_id: filteredPool.pool_id.toString(),
+        code_id: filteredPool.code_id,
+        instantiate_msg: filteredPool.instantiate_msg,
+      },
+      reserveCoins: reserveCoins,
+      ...basePool,
+    };
+  }
 
-      if (
-        filteredPool.type ===
-          "osmosis.gamm.poolmodels.stableswap.v1beta1.Pool" &&
-        Array.isArray(filteredPool.pool_tokens)
-      ) {
-        const reserveCoins = await getReservesFromPoolTokens(
-          filteredPool.pool_tokens
-        );
-
-        if (!reserveCoins) return;
-
-        return {
-          id: filteredPool.pool_id.toString(),
-          type: "stable",
-          raw: {
-            pool_liquidity: filteredPool.pool_tokens.map((token) => ({
-              denom: token.denom,
-              amount: floatNumberToStringInt(token.amount, token.exponent),
-            })),
-            scaling_factors: filteredPool.pool_tokens.map((token) =>
-              token.weight_or_scaling.toString()
-            ),
-            scaling_factor_controller:
-              filteredPool.scaling_factor_controller ?? "",
-            ...sharePoolRawBase,
-          },
-          reserveCoins,
-          ...basePool,
-        };
-      }
-
-      throw new Error("Filtered pool not properly serialized as a valid pool.");
+  const sharePoolRawBase = {
+    id: filteredPool.pool_id.toString(),
+    pool_params: {
+      exit_fee: new Dec(filteredPool.exit_fees.toString())
+        .mul(DecUtils.getTenExponentN(-2))
+        .toString(),
+      swap_fee: new Dec(filteredPool.swap_fees.toString())
+        .mul(DecUtils.getTenExponentN(-2))
+        .toString(),
+      smooth_weight_change_params: null,
     },
-  });
+    total_shares: filteredPool.total_shares,
+  };
+
+  if (
+    filteredPool.type === "osmosis.gamm.v1beta1.Pool" &&
+    Array.isArray(filteredPool.pool_tokens)
+  ) {
+    const reserveCoins = await getReservesFromPoolTokens(
+      filteredPool.pool_tokens
+    );
+
+    if (!reserveCoins) return;
+
+    return {
+      id: filteredPool.pool_id.toString(),
+      type: "weighted",
+      raw: {
+        pool_assets: filteredPool.pool_tokens.map((token) => ({
+          token: {
+            denom: token.denom,
+            amount: floatNumberToStringInt(token.amount, token.exponent),
+          },
+          weight: token.weight_or_scaling.toString(),
+        })),
+        total_weight: filteredPool.total_weight_or_scaling.toString(),
+        ...sharePoolRawBase,
+      },
+      reserveCoins,
+      ...basePool,
+    };
+  }
+
+  if (
+    filteredPool.type === "osmosis.gamm.poolmodels.stableswap.v1beta1.Pool" &&
+    Array.isArray(filteredPool.pool_tokens)
+  ) {
+    const reserveCoins = await getReservesFromPoolTokens(
+      filteredPool.pool_tokens
+    );
+
+    if (!reserveCoins) return;
+
+    return {
+      id: filteredPool.pool_id.toString(),
+      type: "stable",
+      raw: {
+        pool_liquidity: filteredPool.pool_tokens.map((token) => ({
+          denom: token.denom,
+          amount: floatNumberToStringInt(token.amount, token.exponent),
+        })),
+        scaling_factors: filteredPool.pool_tokens.map((token) =>
+          token.weight_or_scaling.toString()
+        ),
+        scaling_factor_controller: filteredPool.scaling_factor_controller ?? "",
+        ...sharePoolRawBase,
+      },
+      reserveCoins,
+      ...basePool,
+    };
+  }
+
+  throw new Error("Filtered pool not properly serialized as a valid pool.");
 }
 
 /** Get's reserves from asset list and returns them as CoinPretty objects, or undefined if an asset is not listed. */

--- a/packages/web/server/queries/complex/pools/providers/sidecar.ts
+++ b/packages/web/server/queries/complex/pools/providers/sidecar.ts
@@ -2,7 +2,6 @@ import { CoinPretty, PricePretty, RatePretty } from "@keplr-wallet/unit";
 import cachified, { CacheEntry } from "cachified";
 import { LRUCache } from "lru-cache";
 
-import { DEFAULT_LRU_OPTIONS } from "~/config/cache";
 import { PoolRawResponse } from "~/server/queries/osmosis";
 import { queryPools } from "~/server/queries/sidecar";
 
@@ -13,7 +12,9 @@ import { Pool, PoolType } from "../index";
 
 type SidecarPool = Awaited<ReturnType<typeof queryPools>>[number];
 
-const poolsCache = new LRUCache<string, CacheEntry>(DEFAULT_LRU_OPTIONS);
+const poolsCache = new LRUCache<string, CacheEntry>({
+  max: 50,
+});
 
 /** Lightly cached pools from sidecar service. */
 export function getPoolsFromSidecar({

--- a/packages/web/server/queries/complex/pools/providers/sidecar.ts
+++ b/packages/web/server/queries/complex/pools/providers/sidecar.ts
@@ -13,7 +13,7 @@ import { Pool, PoolType } from "../index";
 type SidecarPool = Awaited<ReturnType<typeof queryPools>>[number];
 
 const poolsCache = new LRUCache<string, CacheEntry>({
-  max: 50,
+  max: 20,
 });
 
 /** Lightly cached pools from sidecar service. */

--- a/packages/web/server/queries/complex/pools/providers/sidecar.ts
+++ b/packages/web/server/queries/complex/pools/providers/sidecar.ts
@@ -2,7 +2,7 @@ import { CoinPretty, PricePretty, RatePretty } from "@keplr-wallet/unit";
 import cachified, { CacheEntry } from "cachified";
 import { LRUCache } from "lru-cache";
 
-import { LARGE_LRU_OPTIONS } from "~/config/cache";
+import { DEFAULT_LRU_OPTIONS } from "~/config/cache";
 import { PoolRawResponse } from "~/server/queries/osmosis";
 import { queryPools } from "~/server/queries/sidecar";
 
@@ -13,71 +13,66 @@ import { Pool, PoolType } from "../index";
 
 type SidecarPool = Awaited<ReturnType<typeof queryPools>>[number];
 
-const poolsCache = new LRUCache<string, CacheEntry>(LARGE_LRU_OPTIONS);
+const poolsCache = new LRUCache<string, CacheEntry>(DEFAULT_LRU_OPTIONS);
 
-export async function getPoolsFromSidecar({
+/** Lightly cached pools from sidecar service. */
+export function getPoolsFromSidecar({
   poolIds,
 }: {
   poolIds?: string[];
 } = {}): Promise<Pool[]> {
-  let eventualPools = await fetchPoolsFromSidecar();
-
-  if (poolIds) {
-    eventualPools = eventualPools.filter((pool) =>
-      poolIds.includes(getPoolIdFromChainPool(pool.chain_model))
-    );
-  }
-
-  const pools = await Promise.all(
-    eventualPools.map((sidecarPool) => makePoolFromSidecarPool(sidecarPool))
-  );
-  return pools.filter(Boolean) as Pool[];
-}
-
-function fetchPoolsFromSidecar() {
   return cachified({
     cache: poolsCache,
-    key: "sidecar-pools",
+    key: poolIds ? `sidecar-pools-${poolIds.join(",")}` : "sidecar-pools",
     ttl: 5_000, // 5 seconds
-    staleWhileRevalidate: 5_000, // 5 seconds
     getFreshValue: async () => {
-      return queryPools();
+      const sidecarPools = await queryPools({ poolIds });
+      const reserveCoins = await Promise.all(
+        sidecarPools.map((sidecarPool) =>
+          getListedReservesFromSidecarPool(sidecarPool).catch(() => null)
+        )
+      );
+      const totalFiatLockedValues = await Promise.all(
+        reserveCoins.map((reserve) =>
+          reserve ? calcTotalFiatValueLockedFromReserve(reserve) : null
+        )
+      );
+
+      const pools = await Promise.all(
+        sidecarPools.map((sidecarPool, index) =>
+          makePoolFromSidecarPool({
+            sidecarPool,
+            totalFiatValueLocked: totalFiatLockedValues[index],
+            reserveCoins: reserveCoins[index],
+          })
+        )
+      );
+      return pools.filter(Boolean) as Pool[];
     },
   });
 }
 
 /** Converts a single SQS pool model response to the standard and more useful Pool type. */
-async function makePoolFromSidecarPool(
-  sidecarPool: SidecarPool
-): Promise<Pool | undefined> {
-  const poolId = getPoolIdFromChainPool(sidecarPool.chain_model);
-  return cachified({
-    cache: poolsCache,
-    key: "pool-" + poolId,
-    ttl: 5_000, // 5 seconds
-    staleWhileRevalidate: 5_000, // 5 seconds
-    getFreshValue: async () => {
-      const reserveCoins = await getListedReservesFromSidecarPool(
-        sidecarPool
-      ).catch(() => null);
+async function makePoolFromSidecarPool({
+  sidecarPool,
+  reserveCoins,
+  totalFiatValueLocked,
+}: {
+  sidecarPool: SidecarPool;
+  reserveCoins: CoinPretty[] | null;
+  totalFiatValueLocked: PricePretty | null;
+}): Promise<Pool | undefined> {
+  // contains unlisted or invalid assets
+  if (!reserveCoins || !totalFiatValueLocked) return;
 
-      // contains unlisted or invalid assets
-      if (!reserveCoins) {
-        return;
-      }
-
-      return {
-        id: getPoolIdFromChainPool(sidecarPool.chain_model),
-        type: getPoolTypeFromChainPool(sidecarPool.chain_model),
-        raw: makePoolRawResponseFromChainPool(sidecarPool.chain_model),
-        spreadFactor: new RatePretty(sidecarPool.spread_factor),
-        reserveCoins,
-        totalFiatValueLocked: await calcTotalFiatValueLockedFromReserve(
-          reserveCoins
-        ),
-      };
-    },
-  });
+  return {
+    id: getPoolIdFromChainPool(sidecarPool.chain_model),
+    type: getPoolTypeFromChainPool(sidecarPool.chain_model),
+    raw: makePoolRawResponseFromChainPool(sidecarPool.chain_model),
+    spreadFactor: new RatePretty(sidecarPool.spread_factor),
+    reserveCoins,
+    totalFiatValueLocked,
+  };
 }
 
 function getPoolIdFromChainPool(

--- a/packages/web/server/queries/complex/pools/providers/sidecar.ts
+++ b/packages/web/server/queries/complex/pools/providers/sidecar.ts
@@ -25,6 +25,7 @@ export function getPoolsFromSidecar({
     cache: poolsCache,
     key: poolIds ? `sidecar-pools-${poolIds.join(",")}` : "sidecar-pools",
     ttl: 5_000, // 5 seconds
+    staleWhileRevalidate: 10_000, // 10 seconds
     getFreshValue: async () => {
       const sidecarPools = await queryPools({ poolIds });
       const reserveCoins = await Promise.all(

--- a/packages/web/server/queries/complex/pools/providers/sidecar.ts
+++ b/packages/web/server/queries/complex/pools/providers/sidecar.ts
@@ -31,14 +31,14 @@ export function getPoolsFromSidecar({
     getFreshValue: async () => {
       const sidecarPools = await timeout(
         () => queryPools({ poolIds }),
-        9000,
+        9_000, // 9 seconds
         "sidecarQueryPools"
       )();
       const reserveCoins = await Promise.all(
         sidecarPools.map((sidecarPool) =>
           timeout(
             () => getListedReservesFromSidecarPool(sidecarPool),
-            9000,
+            9_000, // 9 seconds
             "getListedReservesFromSidecarPool"
           )().catch((e) => {
             if (e instanceof AsyncTimeoutError) {
@@ -57,7 +57,7 @@ export function getPoolsFromSidecar({
           reserve
             ? timeout(
                 () => calcTotalFiatValueLockedFromReserve(reserve),
-                9000,
+                9_000, // 9 seconds
                 "sidecarCalcTotalFiatValueLockedFromReserve"
               )()
             : null

--- a/packages/web/utils/async.ts
+++ b/packages/web/utils/async.ts
@@ -15,7 +15,8 @@ export class AsyncTimeoutError extends Error {
  */
 export default function timeout<Fn extends (...args: any) => Promise<any>>(
   asyncFn: Fn,
-  milliseconds: number
+  milliseconds: number,
+  asyncFnName?: string
 ): (...args: Parameters<Fn>) => Promise<ReturnType<Fn>> {
   return (...args: Parameters<Fn>) =>
     new Promise<ReturnType<Fn>>(async (resolve, reject) => {
@@ -24,7 +25,7 @@ export default function timeout<Fn extends (...args: any) => Promise<any>>(
 
       // setup timer and call original function
       timer = setTimeout(() => {
-        let name = asyncFn.name || "anonymous";
+        let name = asyncFnName || asyncFn.name || "anonymous";
         let error = new AsyncTimeoutError(
           'Callback function "' + name + '" timed out.'
         );


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Following #2800, pools query sometimes took to long to load and the function was timing out. Most likely, the edge function was running out of memory because of individually cached pools. This PR reverts this change and increases the TTL. 

## Testing and Verifying

- [ ] Requests should not timeout after subsequent loads
