### PR TITLE
Fix: temporarily disable recommended assets

### DIFF
--- a/packages/web/pages/assets/[denom].tsx
+++ b/packages/web/pages/assets/[denom].tsx
@@ -21,7 +21,6 @@ import TokenPairHistoricalChart, {
 } from "~/components/chart/token-pair-historical";
 import SkeletonLoader from "~/components/loaders/skeleton-loader";
 import Spinner from "~/components/loaders/spinner";
-import RelatedAssets from "~/components/related-assets/related-assets";
 import { SwapTool } from "~/components/swap-tool";
 import TokenDetails from "~/components/token-details/token-details";
 import TwitterSection from "~/components/twitter-section/twitter-section";
@@ -41,7 +40,6 @@ import {
   useLocalStorageState,
   useNavBar,
 } from "~/hooks";
-import { useRoutablePools } from "~/hooks/data/use-routable-pools";
 import {
   CoingeckoCoin,
   queryCoingeckoCoin,
@@ -160,8 +158,7 @@ const AssetInfoView: FunctionComponent<AssetInfoPageProps> = observer(
       [assetInfoConfig]
     );
 
-    const routablePools = useRoutablePools();
-    const memoedPools = routablePools ?? [];
+    // const routablePools = useRoutablePools();
 
     const denom = useMemo(() => {
       return tokenDenom as string;
@@ -278,7 +275,9 @@ const AssetInfoView: FunctionComponent<AssetInfoPageProps> = observer(
                 />
               </div>
 
-              <RelatedAssets memoedPools={memoedPools} tokenDenom={denom} />
+              {/* {routablePools && (
+                <RelatedAssets memoedPools={routablePools} tokenDenom={denom} />
+              )} */}
             </div>
           </div>
         </main>


### PR DESCRIPTION
There is some reactivity or mobx query store bug causing pools to be infinitely queried in the token detail pages.

I'll disable this non-critical feature for now until I can integrate asset list v2, which includes the list of recommended assets. This prevents us from having to query pools.