### PR TITLE
fix: TFM router tRPC error propagation

### DIFF
--- a/packages/web/integrations/tfm/router.ts
+++ b/packages/web/integrations/tfm/router.ts
@@ -62,7 +62,9 @@ export class TfmRemoteRouter implements TokenOutGivenInRouter {
       // TFM will always return the max out that can be swapped
       // But since it will result in failed tx, return an error
       if (priceImpactTokenOut?.gt(new Dec(maxAllowedPriceImpact))) {
-        throw new Error(`{Price impact ${priceImpactTokenOut} is greater than max allowed of ${maxAllowedPriceImpact}`);
+        throw new Error(
+          `{Price impact ${priceImpactTokenOut} is greater than max allowed of ${maxAllowedPriceImpact}`
+        );
       }
 
       // convert quote response to SplitTokenInQuote

--- a/packages/web/integrations/tfm/router.ts
+++ b/packages/web/integrations/tfm/router.ts
@@ -1,5 +1,4 @@
 import { Dec, Int } from "@keplr-wallet/unit";
-import { NotEnoughLiquidityError } from "@osmosis-labs/pools";
 import {
   NoRouteError,
   SplitTokenInQuote,
@@ -9,6 +8,11 @@ import {
 import { apiClient } from "@osmosis-labs/utils";
 
 import { GetSwapRouteResponse } from "./types";
+
+// TFM tends to frequently return quotes with too high price impact
+// If we don't limit it, it will result in failed tx for many concurrent users.
+// A single swap with high price impact would invalidate the route.
+const maxAllowedPriceImpact = 0.5;
 
 export class TfmRemoteRouter implements TokenOutGivenInRouter {
   protected readonly baseUrl: URL;
@@ -57,8 +61,8 @@ export class TfmRemoteRouter implements TokenOutGivenInRouter {
 
       // TFM will always return the max out that can be swapped
       // But since it will result in failed tx, return an error
-      if (priceImpactTokenOut?.gt(new Dec(0.5))) {
-        throw new NotEnoughLiquidityError();
+      if (priceImpactTokenOut?.gt(new Dec(maxAllowedPriceImpact))) {
+        throw new Error(`{Price impact ${priceImpactTokenOut} is greater than max allowed of ${maxAllowedPriceImpact}`);
       }
 
       // convert quote response to SplitTokenInQuote
@@ -91,9 +95,12 @@ export class TfmRemoteRouter implements TokenOutGivenInRouter {
         throw new NoRouteError();
       }
 
-      throw new Error(
-        tfmJsonError?.data?.error?.message ?? "Unexpected TFM router error"
-      );
+      if (tfmJsonError?.data?.error?.message) {
+        throw new Error(tfmJsonError.data.error.message);
+      }
+
+      // if not a custom TFM error, throw the original error
+      throw e as Error;
     }
   }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

This PR fixes TFM error propagation.

Previously, it would return "Unexpected TFM error" without sufficient context to debug.

Now:
![image](https://github.com/osmosis-labs/osmosis-frontend/assets/34196718/b96537fb-d3f8-4e3d-a1b1-b721c4f56020)


