### PR TITLE
Fix: cl pool strategy selection reset

### DIFF
--- a/packages/web/hooks/ui-config/use-add-concentrated-liquidity-config.ts
+++ b/packages/web/hooks/ui-config/use-add-concentrated-liquidity-config.ts
@@ -421,19 +421,19 @@ export class ObservableAddConcentratedLiquidityConfig {
 
     // query returns prices with decimals for display
     const minPrice7d = this._priceRangeInput[0].removeCurrencyDecimals(min);
-    const maxPrice7d = this._priceRangeInput[0].removeCurrencyDecimals(max);
+    const maxPrice7d = this._priceRangeInput[1].removeCurrencyDecimals(max);
     const priceDiff = maxPrice7d
       .sub(minPrice7d)
       .mul(new Dec(MODERATE_STRATEGY_MULTIPLIER));
 
     return [
       roundPriceToNearestTick(
-        minPrice7d.sub(priceDiff),
+        minPrice7d.sub(priceDiff).abs(),
         this.pool.tickSpacing,
         true
       ),
       roundPriceToNearestTick(
-        maxPrice7d.add(priceDiff),
+        maxPrice7d.add(priceDiff).abs(),
         this.pool.tickSpacing,
         false
       ),
@@ -502,19 +502,19 @@ export class ObservableAddConcentratedLiquidityConfig {
 
     // query returns prices with decimals for display
     const minPrice1Mo = this._priceRangeInput[0].removeCurrencyDecimals(min);
-    const maxPrice1Mo = this._priceRangeInput[0].removeCurrencyDecimals(max);
+    const maxPrice1Mo = this._priceRangeInput[1].removeCurrencyDecimals(max);
     const priceDiff = maxPrice1Mo
       .sub(minPrice1Mo)
       .mul(new Dec(AGGRESSIVE_STRATEGY_MULTIPLIER));
 
     return [
       roundPriceToNearestTick(
-        minPrice1Mo.sub(priceDiff),
+        minPrice1Mo.sub(priceDiff).abs(),
         this.pool.tickSpacing,
         true
       ),
       roundPriceToNearestTick(
-        maxPrice1Mo.add(priceDiff),
+        maxPrice1Mo.add(priceDiff).abs(),
         this.pool.tickSpacing,
         false
       ),


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

If you try to select a moderate or aggressive strategy, the card does not remain selected but the custom one is set by default.

https://app.osmosis.zone/pool/1325

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/86a27gv87)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
