### PR TITLE
Remove pool 1423 from hardcoded boosts

### DIFF
--- a/packages/web/config/feature-flag.ts
+++ b/packages/web/config/feature-flag.ts
@@ -38,9 +38,8 @@ export const RecommendedSwapDenoms = [
 /**
  * Pools that are excluded from showing external boost incentives APRs.
  */
-export const ExcludedExternalBoostPools = EXCLUDED_EXTERNAL_BOOSTS_POOL_IDS ?? [
-  "1423", // stDYDX/DYDX
-];
+export const ExcludedExternalBoostPools =
+  EXCLUDED_EXTERNAL_BOOSTS_POOL_IDS ?? [];
 
 export const UnPoolWhitelistedPoolIds: { [poolId: string]: boolean } = {
   // #560 (UST/OSMO)

--- a/packages/web/config/feature-flag.ts
+++ b/packages/web/config/feature-flag.ts
@@ -38,8 +38,8 @@ export const RecommendedSwapDenoms = [
 /**
  * Pools that are excluded from showing external boost incentives APRs.
  */
-export const ExcludedExternalBoostPools =
-  EXCLUDED_EXTERNAL_BOOSTS_POOL_IDS ?? [];
+export const ExcludedExternalBoostPools: string[] =
+  (EXCLUDED_EXTERNAL_BOOSTS_POOL_IDS ?? []) as string[];
 
 export const UnPoolWhitelistedPoolIds: { [poolId: string]: boolean } = {
   // #560 (UST/OSMO)


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

- remove pool 1423 from hardcoded boost exclusion

### ClickUp Task

[ClickUp Task URL](PASTE_CLICKUP_TASK_URL_HERE)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
