### PR TITLE
redirect to celatone

### DIFF
--- a/packages/web/server/queries/complex/pools/index.ts
+++ b/packages/web/server/queries/complex/pools/index.ts
@@ -48,7 +48,6 @@ const searchablePoolKeys = ["id", "coinDenoms"];
 /** Get's an individual pool by ID.
  *  @throws If pool not found. */
 export async function getPool({ poolId }: { poolId: string }): Promise<Pool> {
-  console.log("--------- getPool ---------");
   const pools = await getPools({ poolIds: [poolId] });
   const pool = pools.find(({ id }) => id === poolId);
   if (!pool) throw new Error(poolId + " not found");
@@ -64,10 +63,6 @@ export async function getPools(
   poolProvider: PoolProvider = getPoolsFromSidecar
 ): Promise<Pool[]> {
   let pools = await poolProvider({ poolIds: params?.poolIds });
-
-  console.log("--------- getPools ---------");
-
-  console.log("params: ", params);
 
   if (params?.types) {
     pools = pools.filter(({ type }) =>


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

- legacy queries for pools don't fully support cosmwasm (non transmuter) pools

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/86a2bcd4e)

## Brief Changelog

-  redirect these pools to celatone URL pool pages

## Testing and Verifying

- click or navigate on a non-cosmwasm pool 2, 5, 8
- on a cosmwasm pool that is transmuter, opens basic pools page (balances, liquidity) - 1211
-  on a cosmwasm pool that is not transmuter, open celatone - 352, 373


https://github.com/osmosis-labs/osmosis-frontend/assets/30577966/09c70fa1-5c15-4689-93f3-96790538418e



## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
