### PR TITLE
fix: Astroport PCl pool type not appearing in the v2 table

### DIFF
--- a/packages/web/components/complex/all-pools-table-v2.tsx
+++ b/packages/web/components/complex/all-pools-table-v2.tsx
@@ -151,7 +151,7 @@ export const AllPoolsTable: FunctionComponent<{
             query: filters.searchQuery,
           }
         : undefined,
-      types: [...filters.poolTypesFilter, "cosmwasm"],
+      types: [...filters.poolTypesFilter, "cosmwasm", "cosmwasm-astroport-pcl"],
       incentiveTypes: filters.poolIncentivesFilter,
       sort: sortKey
         ? {

--- a/packages/web/components/complex/all-pools-table-v2.tsx
+++ b/packages/web/components/complex/all-pools-table-v2.tsx
@@ -40,7 +40,8 @@ type Pool =
 type PoolTypeFilter = Exclude<Pool["type"], "cosmwasm">;
 type PoolIncentiveFilter = NonNullable<Pool["incentiveTypes"]>[number];
 
-const poolTypes = [
+// These are the options for filtering the pools.
+const poolFilterTypes = [
   "weighted",
   "stable",
   "concentrated",
@@ -78,8 +79,8 @@ const useAllPoolsTable = () => {
     {
       searchQuery: parseAsString,
       poolTypesFilter: parseAsArrayOf<PoolTypeFilter>(
-        parseAsStringLiteral<PoolTypeFilter>(poolTypes)
-      ).withDefault([...poolTypes]),
+        parseAsStringLiteral<PoolTypeFilter>(poolFilterTypes)
+      ).withDefault([...poolFilterTypes]),
       poolIncentivesFilter: parseAsArrayOf<PoolIncentiveFilter>(
         parseAsStringLiteral<PoolIncentiveFilter>(incentiveTypes)
       ).withDefault([...incentiveTypes]),
@@ -151,6 +152,8 @@ export const AllPoolsTable: FunctionComponent<{
             query: filters.searchQuery,
           }
         : undefined,
+      // These are all of the pools that we support fetching.
+      // In addiion, to pool filters, there are also general cosmwasm pools and cosmwasm Astroport PCL pools.
       types: [...filters.poolTypesFilter, "cosmwasm", "cosmwasm-astroport-pcl"],
       incentiveTypes: filters.poolIncentivesFilter,
       sort: sortKey


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Fixes Astroport PCL pool not appearing in the pools table
