### PR TITLE
fix: undefined error message breaking feedback

### DIFF
--- a/packages/stores/src/tx/utils.ts
+++ b/packages/stores/src/tx/utils.ts
@@ -15,8 +15,13 @@ export function isError(tx: any) {
 
 // isSlipageErrorMessage checks if the error message is related to slippage
 // Returns true if so, false otherwise.
+// Returns false if the message is empty.
 // Does simple string matching against chain errors.
 export function isSlipageErrorMessage(msg: string) {
+  if (!msg) {
+    return false;
+  }
+
   return (
     // https://github.com/osmosis-labs/osmosis/blob/b029dfed00128e0d3ca1b866c4e93dc48dd21456/x/concentrated-liquidity/swaps.go#L170
     // https://github.com/osmosis-labs/osmosis/blob/7f5dc22951ca99f31220540ec968de84ddb776f3/x/gamm/keeper/swap.go#L72


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Noticed that the error feedback breaks with a strange message when users do not have enough balances.

![image](https://github.com/osmosis-labs/osmosis-frontend/assets/34196718/8e029bc1-025f-4f0d-9fc0-b0a24a9b396f)


Traced it to this change. Upon adding this change, observed that a more meaningful error is returned

