### PR TITLE
Optimize asset queries

### DIFF
--- a/packages/web/components/token-details/token-details.tsx
+++ b/packages/web/components/token-details/token-details.tsx
@@ -13,7 +13,7 @@ import { AssetLists } from "~/config/generated/asset-lists";
 import { ChainList } from "~/config/generated/chain-list";
 import { useAmplitudeAnalytics, useTranslation } from "~/hooks";
 import { useCurrentLanguage } from "~/hooks";
-import { CoingeckoCoin } from "~/server/queries/coingecko/detail";
+import { CoingeckoCoin } from "~/server/queries/coingecko/coin";
 import { TokenCMSData } from "~/server/queries/external";
 import { useStore } from "~/stores";
 import { formatPretty } from "~/utils/formatter";

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -93,6 +93,7 @@
     "chain-registry": "^1.20.0",
     "class-variance-authority": "^0.7.0",
     "classnames": "^2.3.2",
+    "dataloader": "^2.2.2",
     "dayjs": "^1.10.7",
     "debounce": "^1.2.1",
     "dompurify": "^3.0.6",

--- a/packages/web/pages/assets/[denom].tsx
+++ b/packages/web/pages/assets/[denom].tsx
@@ -43,7 +43,7 @@ import {
 import {
   CoingeckoCoin,
   queryCoingeckoCoin,
-} from "~/server/queries/coingecko/detail";
+} from "~/server/queries/coingecko/coin";
 import {
   getTokenInfo,
   RichTweet,

--- a/packages/web/server/api/edge-routers/assets-router.ts
+++ b/packages/web/server/api/edge-routers/assets-router.ts
@@ -273,7 +273,7 @@ export const assetsRouter = createTRPCRouter({
               timeFrame: TimeFrame;
               numRecentFrames?: number;
             })),
-      })
+      }).catch(() => [])
     ),
   getAssetPairHistoricalPrice: publicProcedure
     .input(
@@ -300,6 +300,6 @@ export const assetsRouter = createTRPCRouter({
           quoteCoinMinimalDenom,
           baseCoinMinimalDenom,
           timeDuration: timeDuration as TimeDuration,
-        })
+        }).catch(() => ({ prices: [], min: 0, max: 0 }))
     ),
 });

--- a/packages/web/server/queries/base-utils.ts
+++ b/packages/web/server/queries/base-utils.ts
@@ -1,5 +1,6 @@
 import { Chain } from "@osmosis-labs/types";
 import { apiClient, getChainRestUrl } from "@osmosis-labs/utils";
+import DataLoader from "dataloader";
 
 import { ChainList } from "~/config/generated/chain-list";
 import { runIfFn } from "~/utils/function";
@@ -31,3 +32,25 @@ export const createNodeQuery =
     );
     return apiClient<Result>(url.toString());
   };
+
+/** Batching DataLoader with Vercel Edge compatible batching scheduler.
+ *
+ *  DataLoader creates a public API for loading data from a particular
+ *  data back-end with unique keys such as the id column of a SQL table
+ *  or document name in a MongoDB database, given a batch loading function.
+ *
+ *  Each DataLoader instance contains a unique memoized cache. Use caution
+ *  when used in long-lived applications or those which serve many users
+ *  with different access permissions and consider creating a new instance
+ *  per web request.
+ */
+export class EdgeDataLoader<K, V, C = K> extends DataLoader<K, V, C> {
+  constructor(...args: ConstructorParameters<typeof DataLoader<K, V, C>>) {
+    super(args[0], {
+      // workaround to work on Vercel Edge runtime
+      // prevents access of process.nextTick
+      batchScheduleFn: (cb) => setTimeout(cb, 0),
+      ...args[1],
+    } as ConstructorParameters<typeof DataLoader<K, V, C>>[1]);
+  }
+}

--- a/packages/web/server/queries/coingecko/coin.ts
+++ b/packages/web/server/queries/coingecko/coin.ts
@@ -2,7 +2,7 @@ import { apiClient } from "@osmosis-labs/utils";
 
 import { camelCaseToSnakeCase } from "~/utils/string";
 
-import { authHeaders, DETAILS_API_URL } from ".";
+import { authHeaders, CoingeckoVsCurrencies, DETAILS_API_URL } from ".";
 
 export interface CoingeckoReposUrl {
   github: string[];
@@ -113,7 +113,7 @@ export async function queryCoingeckoCoin(
 ) {
   const url = new URL(`/api/v3/coins/${id}`, DETAILS_API_URL);
 
-  url.searchParams.append("localization", lang);
+  url.searchParams.append("locale", lang);
 
   if (options) {
     for (const [key, value] of Object.entries(options)) {
@@ -122,6 +122,22 @@ export async function queryCoingeckoCoin(
   }
 
   return apiClient<CoingeckoCoin>(url.toString(), {
+    headers: authHeaders,
+  });
+}
+
+export async function queryCoingeckoCoins(
+  ids: string[],
+  vsCurrency: CoingeckoVsCurrencies = "usd",
+  lang = "en"
+) {
+  const url = new URL("/api/v3/coins/markets", DETAILS_API_URL);
+
+  url.searchParams.append("vs_currency", vsCurrency);
+  url.searchParams.append("locale", lang);
+  url.searchParams.append("ids", ids.join(","));
+
+  return apiClient<CoingeckoCoin[]>(url.toString(), {
     headers: authHeaders,
   });
 }

--- a/packages/web/server/queries/coingecko/index.ts
+++ b/packages/web/server/queries/coingecko/index.ts
@@ -1,4 +1,5 @@
-export * from "./detail";
+export * from "./coin";
+export * from "./list";
 export * from "./price";
 export * from "./search";
 

--- a/packages/web/server/queries/coingecko/list.ts
+++ b/packages/web/server/queries/coingecko/list.ts
@@ -1,0 +1,14 @@
+import { apiClient } from "@osmosis-labs/utils";
+
+import { authHeaders, DETAILS_API_URL } from ".";
+
+export type CoingeckoActiveCoin = { id: string; symbol: string; name: string };
+
+/** Returns CoinGecko coin IDs supported by CoinGecko. */
+export async function queryCoingeckoCoinIds() {
+  const url = new URL("/api/v3/coins/list", DETAILS_API_URL);
+
+  return apiClient<CoingeckoActiveCoin[]>(url.toString(), {
+    headers: authHeaders,
+  });
+}

--- a/packages/web/server/queries/coingecko/price.ts
+++ b/packages/web/server/queries/coingecko/price.ts
@@ -8,7 +8,7 @@ interface SimplePriceResponse {
   /**
    * price of coin for this currency
    */
-  [coin: string]: Partial<Record<CoingeckoVsCurrencies, number>>;
+  [coinGeckoId: string]: Partial<Record<CoingeckoVsCurrencies, number>>;
 }
 
 export async function querySimplePrice(

--- a/packages/web/server/queries/complex/assets/market.ts
+++ b/packages/web/server/queries/complex/assets/market.ts
@@ -102,7 +102,7 @@ async function getAssetMarketCap({
 }
 
 /** Used with `DataLoader` to make batched calls to CoinGecko.
- *  This allows us to provide coins in a batch to CoinGecko, which is more efficient than making individual calls. */
+ *  This allows us to provide IDs in a batch to CoinGecko, which is more efficient than making individual calls. */
 async function batchFetchCoingeckoCoins(keys: readonly string[]) {
   const coins = await queryCoingeckoCoins(keys as string[]);
   return keys.map(

--- a/packages/web/server/queries/complex/assets/market.ts
+++ b/packages/web/server/queries/complex/assets/market.ts
@@ -1,12 +1,12 @@
 import { Dec, PricePretty, RatePretty } from "@keplr-wallet/unit";
 import { AssetList } from "@osmosis-labs/types";
 import cachified, { CacheEntry } from "cachified";
-import DataLoader from "dataloader";
 import { LRUCache } from "lru-cache";
 
 import { DEFAULT_LRU_OPTIONS } from "~/config/cache";
 import { AssetLists } from "~/config/generated/asset-lists";
 
+import { EdgeDataLoader } from "../../base-utils";
 import { queryCoingeckoCoinIds, queryCoingeckoCoins } from "../../coingecko";
 import {
   queryAllTokenData,
@@ -111,10 +111,7 @@ async function batchFetchCoingeckoCoins(keys: readonly string[]) {
       new Error(`No CoinGecko coin result for ${key}`)
   );
 }
-const coingeckoCoinBatchLoader = new DataLoader(batchFetchCoingeckoCoins, {
-  // workaround to work on Vercel Edge runtime
-  batchScheduleFn: (cb) => setTimeout(cb, 0),
-});
+const coingeckoCoinBatchLoader = new EdgeDataLoader(batchFetchCoingeckoCoins);
 
 /** Gets the CoinGecko coin object for a given CoinGecko ID.
  *  Returns `undefined` if the token ID is not actively listed on CoinGecko. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -9819,6 +9819,11 @@ data-urls@^3.0.2:
     whatwg-mimetype "^3.0.0"
     whatwg-url "^11.0.0"
 
+dataloader@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-2.2.2.tgz#216dc509b5abe39d43a9b9d97e6e5e473dfbe3e0"
+  integrity sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g==
+
 date-fns@^2.29.3, date-fns@^2.30.0:
   version "2.30.0"
   resolved "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

* Reduce excessive querying of market caps per asset
* Add batched querying for CoinGecko coins and prices
* Validates that a CoinGecko ID is active on CoinGecko before querying CoinGecko

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/86a293kn6)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->
- Add [DataLoader](https://www.npmjs.com/package/dataloader#batch-function) package for batching queries by ID into a query by multiple IDs

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

Should notice improved performance for assets page v2. Also, the Vercel logs should show decreased requests.

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
