### PR TITLE
Add remote cache support, remove server imports

### DIFF
--- a/.github/workflows/jest-tests.yml
+++ b/.github/workflows/jest-tests.yml
@@ -1,7 +1,6 @@
 name: Jest Tests Workflow
 
 on: [push]
-env: ${{ secrets.TWITTER_KV_STORE_REST_API_TOKEN, secrets.TWITTER_KV_STORE_REST_API_URL }}
 
 jobs:
   test:

--- a/.github/workflows/jest-tests.yml
+++ b/.github/workflows/jest-tests.yml
@@ -1,6 +1,7 @@
 name: Jest Tests Workflow
 
 on: [push]
+env: ${{ secrets.TWITTER_KV_STORE_REST_API_TOKEN, secrets.TWITTER_KV_STORE_REST_API_URL }}
 
 jobs:
   test:

--- a/packages/web/integrations/bridges/axelar/axelar-transfer-status-source.ts
+++ b/packages/web/integrations/bridges/axelar/axelar-transfer-status-source.ts
@@ -1,34 +1,40 @@
 import { ITxStatusReceiver, ITxStatusSource } from "@osmosis-labs/stores";
-import { CacheEntry } from "cachified";
-import { LRUCache } from "lru-cache";
 
-import { IS_TESTNET } from "~/config";
-import { AxelarBridgeProvider } from "~/integrations/bridges/axelar/axelar-bridge-provider";
-import { BridgeTransferStatusError } from "~/integrations/bridges/errors";
-import {
+import type {
+  BridgeProviderContext,
   BridgeTransferStatus,
   GetTransferStatusParams,
 } from "~/integrations/bridges/types";
 import { poll } from "~/utils/promise";
 
+import { getTransferStatus } from "./queries";
+import { providerName } from "./types";
+
 /** Tracks (polls Axelar endpoint) and reports status updates on Axelar bridge transfers. */
 export class AxelarTransferStatusSource implements ITxStatusSource {
-  readonly keyPrefix = AxelarBridgeProvider.providerName.toLowerCase();
+  readonly keyPrefix = providerName;
   readonly sourceDisplayName = "Axelar Bridge";
   public statusReceiverDelegate?: ITxStatusReceiver;
 
-  private axelarProvider: AxelarBridgeProvider;
+  axelarScanBaseUrl: "https://axelarscan.io" | "https://testnet.axelarscan.io";
+  axelarApiBaseUrl:
+    | "https://testnet.api.axelarscan.io"
+    | "https://api.axelarscan.io";
 
-  constructor() {
-    this.axelarProvider = new AxelarBridgeProvider({
-      env: IS_TESTNET ? "testnet" : "mainnet",
-      cache: new LRUCache<string, CacheEntry>({ max: 10 }),
-    });
+  constructor(readonly env: BridgeProviderContext["env"]) {
+    this.axelarScanBaseUrl =
+      env === "mainnet"
+        ? "https://axelarscan.io"
+        : "https://testnet.axelarscan.io";
+    this.axelarApiBaseUrl =
+      env === "mainnet"
+        ? "https://api.axelarscan.io"
+        : "https://testnet.api.axelarscan.io";
   }
 
   /** Request to start polling a new transaction. */
   trackTxStatus(serializedParamsOrHash: string): void {
-    const txHash = serializedParamsOrHash.startsWith("{")
+    const sendTxHash = serializedParamsOrHash.startsWith("{")
       ? (JSON.parse(serializedParamsOrHash) as GetTransferStatusParams)
           .sendTxHash
       : serializedParamsOrHash;
@@ -37,19 +43,68 @@ export class AxelarTransferStatusSource implements ITxStatusSource {
 
     poll({
       fn: async () => {
+        const transferStatus = await getTransferStatus(
+          sendTxHash,
+          this.axelarApiBaseUrl
+        );
+
+        // could be { message: "Internal Server Error" } TODO: display server errors or connection issues to user
+        if (
+          !Array.isArray(transferStatus) ||
+          (Array.isArray(transferStatus) && transferStatus.length === 0)
+        ) {
+          return;
+        }
+
         try {
-          return this.axelarProvider.getTransferStatus({ sendTxHash: txHash });
-        } catch (e) {
-          if (e instanceof BridgeTransferStatusError) {
-            throw new Error(e.errors.map((err) => err.message).join(", "));
+          const [data] = transferStatus;
+          const idWithoutSourceChain =
+            data.type && data.type === "wrap" && data.wrap
+              ? data.wrap.tx_hash
+              : data?.id.split("_")[0].toLowerCase();
+
+          // insufficient fee
+          if (data.send && data.send.insufficient_fee) {
+            return {
+              id: idWithoutSourceChain,
+              status: "failed",
+              reason: "insufficientFee",
+            } as BridgeTransferStatus;
           }
+
+          if (data.status === "executed") {
+            return {
+              id: idWithoutSourceChain,
+              status: "success",
+            } as BridgeTransferStatus;
+          }
+
+          if (
+            // any of all complete stages does not return success
+            data.send &&
+            data.link &&
+            data.confirm_deposit &&
+            data.ibc_send && // transfer is complete
+            (data.send.status !== "success" ||
+              data.confirm_deposit.status !== "success" ||
+              data.ibc_send.status !== "success")
+          ) {
+            return {
+              id: idWithoutSourceChain,
+              status: "failed",
+            } as BridgeTransferStatus;
+          }
+        } catch {
+          return undefined;
         }
       },
       validate: (incomingStatus) => incomingStatus !== undefined,
       interval: 30_000,
       maxAttempts: undefined, // unlimited attempts while tab is open or until success/fail
     })
-      .then((s) => this.receiveConclusiveStatus(snapshotKey, s))
+      .then((s) => {
+        if (s) this.receiveConclusiveStatus(snapshotKey, s);
+      })
       .catch((e) => console.error(`Polling Squid has failed`, e));
   }
 
@@ -72,6 +127,6 @@ export class AxelarTransferStatusSource implements ITxStatusSource {
       ? (JSON.parse(serializedParamsOrKey) as GetTransferStatusParams)
           .sendTxHash
       : serializedParamsOrKey;
-    return `${this.axelarProvider.axelarScanBaseUrl}/transfer/${txHash}`;
+    return `${this.axelarScanBaseUrl}/transfer/${txHash}`;
   }
 }

--- a/packages/web/integrations/bridges/axelar/axelar-transfer-status-source.ts
+++ b/packages/web/integrations/bridges/axelar/axelar-transfer-status-source.ts
@@ -102,10 +102,10 @@ export class AxelarTransferStatusSource implements ITxStatusSource {
       interval: 30_000,
       maxAttempts: undefined, // unlimited attempts while tab is open or until success/fail
     })
+      .catch((e) => console.error(`Polling Axelar has failed`, e))
       .then((s) => {
         if (s) this.receiveConclusiveStatus(snapshotKey, s);
-      })
-      .catch((e) => console.error(`Polling Squid has failed`, e));
+      });
   }
 
   receiveConclusiveStatus(
@@ -117,7 +117,7 @@ export class AxelarTransferStatusSource implements ITxStatusSource {
       this.statusReceiverDelegate?.receiveNewTxStatus(key, status, reason);
     } else {
       console.error(
-        "Squid transfer finished poll but neither succeeded or failed"
+        "Axelar transfer finished poll but neither succeeded or failed"
       );
     }
   }

--- a/packages/web/integrations/bridges/axelar/types.ts
+++ b/packages/web/integrations/bridges/axelar/types.ts
@@ -4,6 +4,8 @@ import type {
 } from "~/config/generated/chain-list";
 import { SourceChain } from "~/integrations/bridge-info";
 
+export const providerName = "Axelar" as const;
+
 const IS_TESTNET = process.env.NEXT_PUBLIC_IS_TESTNET === "true";
 
 export interface AxelarBridgeConfig {

--- a/packages/web/integrations/bridges/skip/skip-bridge-provider.ts
+++ b/packages/web/integrations/bridges/skip/skip-bridge-provider.ts
@@ -1,6 +1,6 @@
 import { fromBech32, toBech32 } from "@cosmjs/encoding";
 import { CoinPretty } from "@keplr-wallet/unit";
-import { cosmosMsgOpts, TxStatus } from "@osmosis-labs/stores";
+import { cosmosMsgOpts } from "@osmosis-labs/stores";
 import cachified from "cachified";
 import { ethers, JsonRpcProvider } from "ethers";
 import { toHex } from "web3-utils";
@@ -24,15 +24,12 @@ import {
   BridgeProviderContext,
   BridgeQuote,
   BridgeTransactionRequest,
-  BridgeTransferStatus,
   CosmosBridgeTransactionRequest,
   EvmBridgeTransactionRequest,
   GetBridgeQuoteParams,
-  GetTransferStatusParams,
 } from "../types";
-import { SkipEvmTx, SkipMsg, SkipMultiChainMsg } from "./types";
+import { providerName, SkipEvmTx, SkipMsg, SkipMultiChainMsg } from "./types";
 
-const providerName = "Skip" as const;
 const logoUrl = "/bridges/skip.svg" as const;
 
 export class SkipBridgeProvider implements BridgeProvider {
@@ -306,45 +303,6 @@ export class SkipBridgeProvider implements BridgeProvider {
       },
       ttl: 20 * 1000, // 20 seconds,
     });
-  }
-
-  async getTransferStatus({
-    sendTxHash,
-    fromChainId,
-  }: GetTransferStatusParams): Promise<BridgeTransferStatus | undefined> {
-    try {
-      const txStatus = await this.skipClient.transactionStatus({
-        chainID: fromChainId.toString(),
-        txHash: sendTxHash,
-      });
-
-      let status: TxStatus = "pending";
-      if (txStatus.state === "STATE_COMPLETED_SUCCESS") {
-        status = "success";
-      }
-
-      if (txStatus.state === "STATE_COMPLETED_ERROR") {
-        status = "failed";
-      }
-
-      return {
-        id: sendTxHash,
-        status,
-      };
-    } catch (error: any) {
-      if ("message" in error) {
-        if (error.message.includes("not found")) {
-          await this.skipClient.trackTransaction({
-            chainID: fromChainId.toString(),
-            txHash: sendTxHash,
-          });
-
-          return undefined;
-        }
-      }
-
-      throw error;
-    }
   }
 
   async getTransactionData(

--- a/packages/web/integrations/bridges/skip/skip-transfer-status-source.ts
+++ b/packages/web/integrations/bridges/skip/skip-transfer-status-source.ts
@@ -1,42 +1,44 @@
-import { ITxStatusReceiver, ITxStatusSource } from "@osmosis-labs/stores";
-import { CacheEntry } from "cachified";
-import { LRUCache } from "lru-cache";
-
-import { IS_TESTNET } from "~/config";
-import { BridgeTransferStatusError } from "~/integrations/bridges/errors";
-import { SkipBridgeProvider } from "~/integrations/bridges/skip/skip-bridge-provider";
 import {
+  ITxStatusReceiver,
+  ITxStatusSource,
+  TxStatus,
+} from "@osmosis-labs/stores";
+
+import SkipApiClient from "~/integrations/bridges/skip/queries";
+import type {
+  BridgeProviderContext,
   BridgeTransferStatus,
   GetTransferStatusParams,
 } from "~/integrations/bridges/types";
 import { poll } from "~/utils/promise";
 
+import { providerName } from "./types";
+
 /** Tracks (polls skip endpoint) and reports status updates on Skip bridge transfers. */
 export class SkipTransferStatusSource implements ITxStatusSource {
-  readonly keyPrefix = SkipBridgeProvider.providerName.toLowerCase();
+  readonly keyPrefix = providerName;
 
   sourceDisplayName = "Skip Bridge";
 
   statusReceiverDelegate?: ITxStatusReceiver | undefined;
 
-  private skipProvider: SkipBridgeProvider;
+  private skipClient: SkipApiClient;
+
   private axelarScanBaseUrl:
     | "https://axelarscan.io"
     | "https://testnet.axelarscan.io";
 
-  constructor() {
-    this.skipProvider = new SkipBridgeProvider({
-      env: IS_TESTNET ? "testnet" : "mainnet",
-      cache: new LRUCache<string, CacheEntry>({ max: 10 }),
-    });
+  constructor(env: BridgeProviderContext["env"]) {
+    this.skipClient = new SkipApiClient();
 
-    this.axelarScanBaseUrl = IS_TESTNET
-      ? "https://testnet.axelarscan.io"
-      : "https://axelarscan.io";
+    this.axelarScanBaseUrl =
+      env === "mainnet"
+        ? "https://axelarscan.io"
+        : "https://testnet.axelarscan.io";
   }
 
   trackTxStatus(serializedParams: string): void {
-    const { sendTxHash, fromChainId, toChainId } = JSON.parse(
+    const { sendTxHash, fromChainId } = JSON.parse(
       serializedParams
     ) as GetTransferStatusParams;
 
@@ -45,15 +47,37 @@ export class SkipTransferStatusSource implements ITxStatusSource {
     poll({
       fn: async () => {
         try {
-          return this.skipProvider.getTransferStatus({
-            sendTxHash,
-            fromChainId,
-            toChainId,
+          const txStatus = await this.skipClient.transactionStatus({
+            chainID: fromChainId.toString(),
+            txHash: sendTxHash,
           });
-        } catch (e) {
-          if (e instanceof BridgeTransferStatusError) {
-            throw new Error(e.errors.map((err) => err.message).join(", "));
+
+          let status: TxStatus = "pending";
+          if (txStatus.state === "STATE_COMPLETED_SUCCESS") {
+            status = "success";
           }
+
+          if (txStatus.state === "STATE_COMPLETED_ERROR") {
+            status = "failed";
+          }
+
+          return {
+            id: sendTxHash,
+            status,
+          };
+        } catch (error: any) {
+          if ("message" in error) {
+            if (error.message.includes("not found")) {
+              await this.skipClient.trackTransaction({
+                chainID: fromChainId.toString(),
+                txHash: sendTxHash,
+              });
+
+              return undefined;
+            }
+          }
+
+          throw error;
         }
       },
       validate: (incomingStatus) => {

--- a/packages/web/integrations/bridges/skip/skip-transfer-status-source.ts
+++ b/packages/web/integrations/bridges/skip/skip-transfer-status-source.ts
@@ -90,8 +90,10 @@ export class SkipTransferStatusSource implements ITxStatusSource {
       interval: 30_000,
       maxAttempts: undefined, // unlimited attempts while tab is open or until success/fail
     })
-      .then((s) => this.receiveConclusiveStatus(snapshotKey, s))
-      .catch((e) => console.error(`Polling Skip has failed`, e));
+      .catch((e) => console.error(`Polling Skip has failed`, e))
+      .then((s) => {
+        if (s) this.receiveConclusiveStatus(snapshotKey, s);
+      });
   }
 
   makeExplorerUrl(serializedParams: string): string {

--- a/packages/web/integrations/bridges/skip/types.ts
+++ b/packages/web/integrations/bridges/skip/types.ts
@@ -1,3 +1,5 @@
+export const providerName = "Skip" as const;
+
 export type SkipAsset = {
   denom: string;
   chain_id: string;

--- a/packages/web/integrations/bridges/squid/const.ts
+++ b/packages/web/integrations/bridges/squid/const.ts
@@ -1,0 +1,1 @@
+export const providerName = "Squid" as const;

--- a/packages/web/integrations/bridges/squid/squid-transfer-status-source.ts
+++ b/packages/web/integrations/bridges/squid/squid-transfer-status-source.ts
@@ -109,10 +109,10 @@ export class SquidTransferStatusSource implements ITxStatusSource {
       interval: 30_000,
       maxAttempts: undefined, // unlimited attempts while tab is open or until success/fail
     })
+      .catch((e) => console.error(`Polling Squid has failed`, e))
       .then((s) => {
         if (s) this.receiveConclusiveStatus(snapshotKey, s);
-      })
-      .catch((e) => console.error(`Polling Squid has failed`, e));
+      });
   }
 
   receiveConclusiveStatus(

--- a/packages/web/integrations/bridges/squid/squid-transfer-status-source.ts
+++ b/packages/web/integrations/bridges/squid/squid-transfer-status-source.ts
@@ -1,32 +1,40 @@
+import { StatusResponse } from "@0xsquid/sdk";
 import { ITxStatusReceiver, ITxStatusSource } from "@osmosis-labs/stores";
-import { CacheEntry } from "cachified";
-import { LRUCache } from "lru-cache";
+import { apiClient, ApiClientError } from "@osmosis-labs/utils";
 
-import { IS_TESTNET } from "~/config";
 import { BridgeTransferStatusError } from "~/integrations/bridges/errors";
-import { SquidBridgeProvider } from "~/integrations/bridges/squid/squid-bridge-provider";
-import {
+import type {
+  BridgeProviderContext,
   BridgeTransferStatus,
   GetTransferStatusParams,
 } from "~/integrations/bridges/types";
+import { ErrorTypes } from "~/utils/error-types";
 import { poll } from "~/utils/promise";
+
+// TODO: move to types file
+const providerName = "Squid" as const;
 
 /** Tracks (polls squid endpoint) and reports status updates on Squid bridge transfers. */
 export class SquidTransferStatusSource implements ITxStatusSource {
-  readonly keyPrefix = SquidBridgeProvider.providerName.toLowerCase();
+  readonly keyPrefix = providerName;
   readonly sourceDisplayName = "Squid Bridge";
   public statusReceiverDelegate?: ITxStatusReceiver;
+  readonly apiURL:
+    | "https://api.0xsquid.com"
+    | "https://testnet.api.squidrouter.com";
+  readonly squidScanBaseUrl:
+    | "https://axelarscan.io"
+    | "https://testnet.axelarscan.io";
 
-  private squidProvider: SquidBridgeProvider;
-
-  constructor() {
-    this.squidProvider = new SquidBridgeProvider(
-      process.env.NEXT_PUBLIC_SQUID_INTEGRATOR_ID!,
-      {
-        env: IS_TESTNET ? "testnet" : "mainnet",
-        cache: new LRUCache<string, CacheEntry>({ max: 10 }),
-      }
-    );
+  constructor(env: BridgeProviderContext["env"]) {
+    this.apiURL =
+      env === "mainnet"
+        ? "https://api.0xsquid.com"
+        : "https://testnet.api.squidrouter.com";
+    this.squidScanBaseUrl =
+      env === "mainnet"
+        ? "https://axelarscan.io"
+        : "https://testnet.axelarscan.io";
   }
 
   /** Request to start polling a new transaction. */
@@ -38,22 +46,72 @@ export class SquidTransferStatusSource implements ITxStatusSource {
     poll({
       fn: async () => {
         try {
-          return this.squidProvider.getTransferStatus({
-            sendTxHash,
-            fromChainId,
-            toChainId,
-          });
-        } catch (e) {
-          if (e instanceof BridgeTransferStatusError) {
-            throw new Error(e.errors.map((err) => err.message).join(", "));
+          const url = new URL(`${this.apiURL}/v1/status`);
+          url.searchParams.append("transactionId", sendTxHash);
+          if (fromChainId) {
+            url.searchParams.append("fromChainId", fromChainId.toString());
           }
+          if (toChainId) {
+            url.searchParams.append("toChainId", toChainId.toString());
+          }
+
+          const data = await apiClient<StatusResponse>(url.toString());
+
+          if (!data || !data.id || !data.squidTransactionStatus) {
+            return;
+          }
+
+          const squidTransactionStatus = data.squidTransactionStatus as
+            | "success"
+            | "needs_gas"
+            | "ongoing"
+            | "partial_success"
+            | "not_found";
+
+          if (
+            squidTransactionStatus === "not_found" ||
+            squidTransactionStatus === "ongoing" ||
+            squidTransactionStatus === "partial_success"
+          ) {
+            return;
+          }
+
+          return {
+            id: sendTxHash,
+            status: squidTransactionStatus === "success" ? "success" : "failed",
+            reason:
+              squidTransactionStatus === "needs_gas"
+                ? "insufficientFee"
+                : undefined,
+          } as BridgeTransferStatus;
+        } catch (e) {
+          const error = e as ApiClientError<{
+            errors: { errorType?: string; message?: string }[];
+          }>;
+
+          throw new BridgeTransferStatusError(
+            error.data?.errors?.map(
+              ({ errorType, message }) =>
+                ({
+                  errorType: errorType ?? ErrorTypes.UnexpectedError,
+                  message: message ?? "",
+                } ?? [
+                  {
+                    errorType: ErrorTypes.UnexpectedError,
+                    message: "Failed to fetch transfer status",
+                  },
+                ])
+            )
+          );
         }
       },
       validate: (incomingStatus) => incomingStatus !== undefined,
       interval: 30_000,
       maxAttempts: undefined, // unlimited attempts while tab is open or until success/fail
     })
-      .then((s) => this.receiveConclusiveStatus(snapshotKey, s))
+      .then((s) => {
+        if (s) this.receiveConclusiveStatus(snapshotKey, s);
+      })
       .catch((e) => console.error(`Polling Squid has failed`, e));
   }
 
@@ -75,6 +133,6 @@ export class SquidTransferStatusSource implements ITxStatusSource {
     const { sendTxHash } = JSON.parse(
       serializedParams
     ) as GetTransferStatusParams;
-    return `${this.squidProvider.squidScanBaseUrl}/gmp/${sendTxHash}`;
+    return `${this.squidScanBaseUrl}/gmp/${sendTxHash}`;
   }
 }

--- a/packages/web/integrations/bridges/types.ts
+++ b/packages/web/integrations/bridges/types.ts
@@ -13,9 +13,6 @@ export interface BridgeProvider {
    * @returns A promise that resolves to a GetBridgeQuoteResponse object.
    */
   getQuote(params: GetBridgeQuoteParams): Promise<BridgeQuote>;
-  getTransferStatus(
-    params: GetTransferStatusParams
-  ): Promise<BridgeTransferStatus | undefined>;
   getTransactionData: (
     params: GetBridgeQuoteParams
   ) => Promise<BridgeTransactionRequest>;

--- a/packages/web/modals/bridge-transfer-v2.tsx
+++ b/packages/web/modals/bridge-transfer-v2.tsx
@@ -832,7 +832,7 @@ export const TransferContent: FunctionComponent<
     (providerId: AvailableBridges, params: GetTransferStatusParams) => {
       if (inputAmountRaw !== "") {
         nonIbcBridgeHistoryStore.pushTxNow(
-          `${providerId.toLowerCase()}${JSON.stringify(params)}`,
+          `${providerId}${JSON.stringify(params)}`,
           new CoinPretty(originCurrency, inputAmount).trim(true).toString(),
           isWithdraw,
           osmosisAccount?.address ?? "" // use osmosis account for account keys (vs any EVM account)

--- a/packages/web/modals/bridge-transfer-v2.tsx
+++ b/packages/web/modals/bridge-transfer-v2.tsx
@@ -43,8 +43,8 @@ import {
 import {
   AxelarChainIds_SourceChainMap,
   SourceChainTokenConfig,
-} from "~/integrations/bridges/axelar";
-import { AvailableBridges } from "~/integrations/bridges/bridge-manager";
+} from "~/integrations/bridges/axelar/types";
+import type { AvailableBridges } from "~/integrations/bridges/bridge-manager";
 import {
   CosmosBridgeTransactionRequest,
   EvmBridgeTransactionRequest,

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -7,7 +7,7 @@
     "dev": "concurrently --raw --kill-others 'next dev' 'yarn watch'",
     "clean": "rm -rf node_modules; rm -rf .next; rm -rf config/generated",
     "build": "yarn generate && next build",
-    "test": "yarn generate && jest --passWithNoTests",
+    "test": "yarn generate && dotenv -c -- jest --passWithNoTests",
     "analyze": "dotenv -v ANALYZE=true -- next build",
     "start": "next start",
     "lint": "prettier --check \"**/*\" && next lint",

--- a/packages/web/server/queries/base-utils.ts
+++ b/packages/web/server/queries/base-utils.ts
@@ -1,9 +1,74 @@
 import { Chain } from "@osmosis-labs/types";
-import { apiClient, getChainRestUrl } from "@osmosis-labs/utils";
+import { apiClient, getChainRestUrl, isNil } from "@osmosis-labs/utils";
+import { createClient, VercelKV } from "@vercel/kv";
+import { Cache, CacheEntry, totalTtl } from "cachified";
 import DataLoader from "dataloader";
 
 import { ChainList } from "~/config/generated/chain-list";
 import { runIfFn } from "~/utils/function";
+import { superjson } from "~/utils/superjson";
+
+/** Batching DataLoader with Vercel Edge compatible batching scheduler.
+ *
+ *  DataLoader creates a public API for loading data from a particular
+ *  data back-end with unique keys such as the id column of a SQL table
+ *  or document name in a MongoDB database, given a batch loading function.
+ *
+ *  Each DataLoader instance contains a unique memoized cache. Use caution
+ *  when used in long-lived applications or those which serve many users
+ *  with different access permissions and consider creating a new instance
+ *  per web request.
+ */
+export class EdgeDataLoader<K, V, C = K> extends DataLoader<K, V, C> {
+  constructor(...args: ConstructorParameters<typeof DataLoader<K, V, C>>) {
+    super(args[0], {
+      // workaround to work on Vercel Edge runtime
+      // prevents access of process.nextTick
+      batchScheduleFn: (cb) => setTimeout(cb, 0),
+      ...args[1],
+    } as ConstructorParameters<typeof DataLoader<K, V, C>>[1]);
+  }
+}
+
+// inspired by: https://github.com/mannyv123/cachified-redis-adapter/blob/main/src/index.ts
+/** `cachified`-compatible implementation of a cache living on a remote resource. */
+export class RemoteCache implements Cache {
+  protected kvStore: VercelKV = createClient({
+    url: process.env.TWITTER_KV_STORE_REST_API_URL!,
+    token: process.env.TWITTER_KV_STORE_REST_API_TOKEN!,
+  });
+
+  name = "RemoteCache";
+
+  async get(key: string) {
+    const value = await this.kvStore.get(key);
+    if (isNil(value) || typeof value !== "string") {
+      return null;
+    }
+    // Note that parse can potentially throw an error here and the expectation is that the user of the adapter catches it
+    return superjson.parse(value) as CacheEntry<unknown>;
+  }
+
+  async set(key: string, value: CacheEntry<unknown>) {
+    const ttl = totalTtl(value?.metadata);
+    const createdTime = value?.metadata?.createdTime;
+
+    await this.kvStore.set(
+      key,
+      superjson.stringify(value),
+      ttl > 0 && ttl < Infinity && typeof createdTime === "number"
+        ? {
+            // convert the exat to seconds by dividing by 1000
+            exat: Math.ceil((ttl + createdTime) / 1000),
+          }
+        : undefined
+    );
+  }
+
+  async delete(key: string) {
+    await this.kvStore.del(key);
+  }
+}
 
 export const createNodeQuery =
   <Result, PathParameters extends Record<any, any> | unknown = unknown>({
@@ -32,25 +97,3 @@ export const createNodeQuery =
     );
     return apiClient<Result>(url.toString());
   };
-
-/** Batching DataLoader with Vercel Edge compatible batching scheduler.
- *
- *  DataLoader creates a public API for loading data from a particular
- *  data back-end with unique keys such as the id column of a SQL table
- *  or document name in a MongoDB database, given a batch loading function.
- *
- *  Each DataLoader instance contains a unique memoized cache. Use caution
- *  when used in long-lived applications or those which serve many users
- *  with different access permissions and consider creating a new instance
- *  per web request.
- */
-export class EdgeDataLoader<K, V, C = K> extends DataLoader<K, V, C> {
-  constructor(...args: ConstructorParameters<typeof DataLoader<K, V, C>>) {
-    super(args[0], {
-      // workaround to work on Vercel Edge runtime
-      // prevents access of process.nextTick
-      batchScheduleFn: (cb) => setTimeout(cb, 0),
-      ...args[1],
-    } as ConstructorParameters<typeof DataLoader<K, V, C>>[1]);
-  }
-}

--- a/packages/web/server/queries/base-utils.ts
+++ b/packages/web/server/queries/base-utils.ts
@@ -1,12 +1,9 @@
 import { Chain } from "@osmosis-labs/types";
-import { apiClient, getChainRestUrl, isNil } from "@osmosis-labs/utils";
-import { createClient, VercelKV } from "@vercel/kv";
-import { Cache, CacheEntry, totalTtl } from "cachified";
+import { apiClient, getChainRestUrl } from "@osmosis-labs/utils";
 import DataLoader from "dataloader";
 
 import { ChainList } from "~/config/generated/chain-list";
 import { runIfFn } from "~/utils/function";
-import { superjson } from "~/utils/superjson";
 
 /** Batching DataLoader with Vercel Edge compatible batching scheduler.
  *
@@ -27,46 +24,6 @@ export class EdgeDataLoader<K, V, C = K> extends DataLoader<K, V, C> {
       batchScheduleFn: (cb) => setTimeout(cb, 0),
       ...args[1],
     } as ConstructorParameters<typeof DataLoader<K, V, C>>[1]);
-  }
-}
-
-// inspired by: https://github.com/mannyv123/cachified-redis-adapter/blob/main/src/index.ts
-/** `cachified`-compatible implementation of a cache living on a remote resource. */
-export class RemoteCache implements Cache {
-  protected kvStore: VercelKV = createClient({
-    url: process.env.TWITTER_KV_STORE_REST_API_URL!,
-    token: process.env.TWITTER_KV_STORE_REST_API_TOKEN!,
-  });
-
-  name = "RemoteCache";
-
-  async get(key: string) {
-    const value = await this.kvStore.get(key);
-    if (isNil(value) || typeof value !== "string") {
-      return null;
-    }
-    // Note that parse can potentially throw an error here and the expectation is that the user of the adapter catches it
-    return superjson.parse(value) as CacheEntry<unknown>;
-  }
-
-  async set(key: string, value: CacheEntry<unknown>) {
-    const ttl = totalTtl(value?.metadata);
-    const createdTime = value?.metadata?.createdTime;
-
-    await this.kvStore.set(
-      key,
-      superjson.stringify(value),
-      ttl > 0 && ttl < Infinity && typeof createdTime === "number"
-        ? {
-            // convert the exat to seconds by dividing by 1000
-            exat: Math.ceil((ttl + createdTime) / 1000),
-          }
-        : undefined
-    );
-  }
-
-  async delete(key: string) {
-    await this.kvStore.del(key);
   }
 }
 

--- a/packages/web/server/queries/complex/assets/__tests__/assets.spec.ts
+++ b/packages/web/server/queries/complex/assets/__tests__/assets.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import { AssetLists } from "~/config/asset-list/mock-asset-lists";
 
 import { getAsset, getAssets } from "../index";

--- a/packages/web/server/queries/complex/concentrated-liquidity/__tests__/concentrated-liquidity.spec.ts
+++ b/packages/web/server/queries/complex/concentrated-liquidity/__tests__/concentrated-liquidity.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 import { CoinPretty, Dec, Int } from "@keplr-wallet/unit";
 import cases from "jest-in-case";
 

--- a/packages/web/server/queries/complex/pools/market.ts
+++ b/packages/web/server/queries/complex/pools/market.ts
@@ -23,7 +23,8 @@ export function getCachedPoolMarketMetricsMap(): Promise<
   return cachified({
     cache: metricPoolsCache,
     key: "pools-metrics-map",
-    ttl: 1000 * 60 * 5, // 5 minutes
+    ttl: 1000 * 10, // 10 seconds
+    staleWhileRevalidate: 1000 * 25, // 25 seconds, edge function run time limit
     getFreshValue: async () => {
       const map = new Map<string, PoolMarketMetrics>();
 

--- a/packages/web/server/queries/complex/pools/providers/__tests__/sidecar.spec.ts
+++ b/packages/web/server/queries/complex/pools/providers/__tests__/sidecar.spec.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment node
+ */
+
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { rest } from "msw";
 

--- a/packages/web/server/queries/complex/pools/providers/sidecar.ts
+++ b/packages/web/server/queries/complex/pools/providers/sidecar.ts
@@ -6,7 +6,6 @@ import { IS_TESTNET } from "~/config/env";
 import { PoolRawResponse } from "~/server/queries/osmosis";
 import { queryPools } from "~/server/queries/sidecar";
 import timeout, { AsyncTimeoutError } from "~/utils/async";
-import { RemoteCache } from "~/utils/cache";
 
 import { calcSumAssetsValue, getAsset } from "../../assets";
 import { DEFAULT_VS_CURRENCY } from "../../assets/config";
@@ -15,12 +14,9 @@ import { Pool, PoolType } from "../index";
 
 type SidecarPool = Awaited<ReturnType<typeof queryPools>>[number];
 
-const poolsCache =
-  typeof window === "undefined"
-    ? new RemoteCache()
-    : new LRUCache<string, CacheEntry>({
-        max: 20,
-      });
+const poolsCache = new LRUCache<string, CacheEntry>({
+  max: 20,
+});
 
 /** Lightly cached pools from sidecar service. */
 export function getPoolsFromSidecar({

--- a/packages/web/server/queries/complex/pools/providers/sidecar.ts
+++ b/packages/web/server/queries/complex/pools/providers/sidecar.ts
@@ -1,6 +1,5 @@
 import { CoinPretty, PricePretty, RatePretty } from "@keplr-wallet/unit";
-import cachified, { CacheEntry } from "cachified";
-import { LRUCache } from "lru-cache";
+import cachified from "cachified";
 
 import { IS_TESTNET } from "~/config/env";
 import { PoolRawResponse } from "~/server/queries/osmosis";
@@ -15,12 +14,7 @@ import { Pool, PoolType } from "../index";
 
 type SidecarPool = Awaited<ReturnType<typeof queryPools>>[number];
 
-const poolsCache =
-  typeof window === "undefined"
-    ? new RemoteCache()
-    : new LRUCache<string, CacheEntry>({
-        max: 20,
-      });
+const poolsCache = new RemoteCache();
 
 /** Lightly cached pools from sidecar service. */
 export function getPoolsFromSidecar({

--- a/packages/web/server/queries/complex/pools/providers/sidecar.ts
+++ b/packages/web/server/queries/complex/pools/providers/sidecar.ts
@@ -6,6 +6,7 @@ import { IS_TESTNET } from "~/config/env";
 import { PoolRawResponse } from "~/server/queries/osmosis";
 import { queryPools } from "~/server/queries/sidecar";
 import timeout, { AsyncTimeoutError } from "~/utils/async";
+import { RemoteCache } from "~/utils/cache";
 
 import { calcSumAssetsValue, getAsset } from "../../assets";
 import { DEFAULT_VS_CURRENCY } from "../../assets/config";
@@ -14,9 +15,12 @@ import { Pool, PoolType } from "../index";
 
 type SidecarPool = Awaited<ReturnType<typeof queryPools>>[number];
 
-const poolsCache = new LRUCache<string, CacheEntry>({
-  max: 20,
-});
+const poolsCache =
+  typeof window === "undefined"
+    ? new RemoteCache()
+    : new LRUCache<string, CacheEntry>({
+        max: 20,
+      });
 
 /** Lightly cached pools from sidecar service. */
 export function getPoolsFromSidecar({

--- a/packages/web/stores/root.ts
+++ b/packages/web/stores/root.ts
@@ -249,9 +249,9 @@ export class RootStore {
       this.chainStore.osmosis.chainId,
       makeLocalStorageKVStore("nonibc_transfer_history"),
       [
-        new AxelarTransferStatusSource(),
-        new SquidTransferStatusSource(),
-        new SkipTransferStatusSource(),
+        new AxelarTransferStatusSource(IS_TESTNET ? "testnet" : "mainnet"),
+        new SquidTransferStatusSource(IS_TESTNET ? "testnet" : "mainnet"),
+        new SkipTransferStatusSource(IS_TESTNET ? "testnet" : "mainnet"),
       ]
     );
 

--- a/packages/web/utils/cache.ts
+++ b/packages/web/utils/cache.ts
@@ -7,14 +7,14 @@ import { superjson } from "~/utils/superjson";
 
 const isTestEnv = process.env.NODE_ENV === "test";
 
-// inspired by: https://github.com/mannyv123/cachified-redis-adapter/blob/main/src/index.ts
+// Client implementation inspired by: https://github.com/mannyv123/cachified-redis-adapter/blob/main/src/index.ts
 /** `cachified`-compatible implementation of a cache living on a remote resource.
  *
- *  Data must be serializeable via `superjson` adapter.
+ *  Values must be serializeable via `superjson` transformer.
  *
- *  NOTE: uses an LRUCache in test environment to avoid hitting the remote resource as Vercel KV createClient secret env vars are not available in GH action.
+ *  NOTE: Uses an LRUCache in test environment to avoid hitting the remote resource as Vercel KV createClient secret env vars are not available in GH action.
  *
- *  WARNING: only available in node runtime.
+ *  WARNING: Only available in dev/prod node runtime (not browser).
  */
 export class RemoteCache implements Cache {
   protected kvStore: VercelKV | null = null;

--- a/packages/web/utils/cache.ts
+++ b/packages/web/utils/cache.ts
@@ -1,0 +1,50 @@
+import { isNil } from "@osmosis-labs/utils";
+import { createClient, VercelKV } from "@vercel/kv";
+import { Cache, CacheEntry, totalTtl } from "cachified";
+
+import { superjson } from "~/utils/superjson";
+
+// inspired by: https://github.com/mannyv123/cachified-redis-adapter/blob/main/src/index.ts
+/** `cachified`-compatible implementation of a cache living on a remote resource.
+ *
+ *  Data must be serializeable via `superjson` adapter.
+ *
+ *  WARNING: only available in node runtime.
+ */
+export class RemoteCache implements Cache {
+  protected kvStore: VercelKV = createClient({
+    url: process.env.TWITTER_KV_STORE_REST_API_URL!,
+    token: process.env.TWITTER_KV_STORE_REST_API_TOKEN!,
+  });
+
+  name = "RemoteCache";
+
+  async get<T>(key: string) {
+    const value = await this.kvStore.get(key);
+    if (isNil(value) || typeof value !== "string") {
+      return null;
+    }
+    // Note that parse can potentially throw an error here and the expectation is that the user of the adapter catches it
+    return superjson.parse(value) as CacheEntry<T>;
+  }
+
+  async set<T>(key: string, value: CacheEntry<T>) {
+    const ttl = totalTtl(value?.metadata);
+    const createdTime = value?.metadata?.createdTime;
+
+    await this.kvStore.set(
+      key,
+      superjson.stringify(value),
+      ttl > 0 && ttl < Infinity && typeof createdTime === "number"
+        ? {
+            // convert the exat to seconds by dividing by 1000
+            exat: Math.ceil((ttl + createdTime) / 1000),
+          }
+        : undefined
+    );
+  }
+
+  async delete(key: string) {
+    await this.kvStore.del(key);
+  }
+}

--- a/packages/web/utils/cache.ts
+++ b/packages/web/utils/cache.ts
@@ -12,7 +12,7 @@ const isTestEnv = process.env.NODE_ENV === "test";
  *
  *  Data must be serializeable via `superjson` adapter.
  *
- *  NOTE: uses an LRUCache in test environment to avoid hitting the remote resource.
+ *  NOTE: uses an LRUCache in test environment to avoid hitting the remote resource as Vercel KV createClient secret env vars are not available in GH action.
  *
  *  WARNING: only available in node runtime.
  */


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Reduces client bundle size by removing import of server code for use in bridge providers' transfer status source objects. Adds remote cache object (implemented with Vercel KV). Found root bundle to be reduced from 2.14 to 2.11 mb.

It's also worth noting that I dove into our [Vercel KV store in prod](https://vercel.com/osmo-labs/osmosis-frontend/stores/kv/store_cGqHAHqmtP0OA8YD/cli) and tweaked the settings to auto prune keys when full, and added more read replicas: Washington DC, Dublin, and Singapore.

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

* Add remote cache and use in sidecar pool provider
  * Uses superjson to let us easily cache complex objects
* Refactor bridge providers to track transfer statuses directly in the respective transfer status source implementations
* Fix tests that are intended to run in node env (vs dom env)
* Loads env vars for use in jest tests

TODO
- [x] Fix test GH Action by ensuring env vars are set

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/86a2b5x5j)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

* Transfer status from deposit/withdraws that use bridge providers should still work.
* Pools page should load, now from data in Vercel KV.

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
