### PR TITLE
fix: hide volume column on error on pools page v2

### DIFF
--- a/packages/web/components/complex/all-pools-table-v2.tsx
+++ b/packages/web/components/complex/all-pools-table-v2.tsx
@@ -186,13 +186,15 @@ export const AllPoolsTable: FunctionComponent<{
 
   // If more than half of the pools have volume data, we should format the volume column.
   // Otherwise, we should not format the volume column.
-  let volumePresenceCount = 0;
-  poolsData.forEach((pool) => {
-    if (pool.volume24hUsd) {
-      volumePresenceCount++;
-    }
-  });
-  let shouldFormatVolume = volumePresenceCount > poolsData.length / 2;
+  const shouldDisplayVolumeColumn = useMemo(() => {
+    let volumePresenceCount = 0;
+    poolsData.forEach((pool) => {
+      if (pool.volume24hUsd) {
+        volumePresenceCount++;
+      }
+    });
+    return volumePresenceCount > poolsData.length / 2;
+  }, [poolsData]);
 
   // Define columns
   const columnHelper = createColumnHelper<Pool>();
@@ -208,7 +210,7 @@ export const AllPoolsTable: FunctionComponent<{
     ];
 
     // Only show volume if more than half of the pools have volume data.
-    if (shouldFormatVolume) {
+    if (shouldDisplayVolumeColumn) {
       allColumns.push(
         columnHelper.accessor((row) => row.volume24hUsd?.toString() ?? "N/A", {
           id: "volume24hUsd",
@@ -303,7 +305,7 @@ export const AllPoolsTable: FunctionComponent<{
     setSortKey,
     cellGroupEventEmitter,
     quickAddLiquidity,
-    shouldFormatVolume,
+    shouldDisplayVolumeColumn,
   ]);
 
   /** Columns collapsed for screen size responsiveness. */
@@ -311,11 +313,11 @@ export const AllPoolsTable: FunctionComponent<{
     const collapsedColIds: string[] = [];
     if (width < Breakpoint.xxl) collapsedColIds.push("feesSpent7dUsd");
     if (width < Breakpoint.xlg) collapsedColIds.push("totalFiatValueLocked");
-    if (width < Breakpoint.lg && shouldFormatVolume)
+    if (width < Breakpoint.lg && shouldDisplayVolumeColumn)
       collapsedColIds.push("volume24hUsd");
     if (width < Breakpoint.md) collapsedColIds.push("poolQuickActions");
     return columns.filter(({ id }) => id && !collapsedColIds.includes(id));
-  }, [columns, width, shouldFormatVolume]);
+  }, [columns, width, shouldDisplayVolumeColumn]);
 
   const table = useReactTable({
     data: poolsData,

--- a/packages/web/components/complex/all-pools-table-v2.tsx
+++ b/packages/web/components/complex/all-pools-table-v2.tsx
@@ -184,6 +184,16 @@ export const AllPoolsTable: FunctionComponent<{
     [poolsPagesData]
   );
 
+  // If more than half of the pools have volume data, we should format the volume column.
+  // Otherwise, we should not format the volume column.
+  let volumePresenceCount = 0;
+  poolsData.forEach((pool) => {
+    if (pool.volume24hUsd) {
+      volumePresenceCount++;
+    }
+  });
+  let shouldFormatVolume = volumePresenceCount > poolsData.length / 2;
+
   // Define columns
   const columnHelper = createColumnHelper<Pool>();
   const cellGroupEventEmitter = useRef(new EventEmitter()).current;
@@ -195,20 +205,21 @@ export const AllPoolsTable: FunctionComponent<{
         header: t("pools.allPools.sort.poolName"),
         cell: PoolCompositionCell,
       }),
-      columnHelper.accessor((row) => row.volume24hUsd?.toString() ?? "0", {
-        id: "volume24hUsd",
-        header: () => (
-          <SortHeader
-            label={t("pools.allPools.sort.volume24h")}
-            sortKey="volume24hUsd"
-            disabled={isLoading}
-            currentSortKey={sortKey}
-            currentDirection={sortParams.allPoolsSortDir}
-            setSortDirection={setSortDirection}
-            setSortKey={setSortKey}
-          />
-        ),
-      }),
+      shouldFormatVolume &&
+        columnHelper.accessor((row) => row.volume24hUsd?.toString() ?? "N/A", {
+          id: "volume24hUsd",
+          header: () => (
+            <SortHeader
+              label={t("pools.allPools.sort.volume24h")}
+              sortKey="volume24hUsd"
+              disabled={isLoading}
+              currentSortKey={sortKey}
+              currentDirection={sortParams.allPoolsSortDir}
+              setSortDirection={setSortDirection}
+              setSortKey={setSortKey}
+            />
+          ),
+        }),
       columnHelper.accessor(
         (row) => row.totalFiatValueLocked?.toString() ?? "0",
         {

--- a/packages/web/server/api/edge-routers/pools-router.ts
+++ b/packages/web/server/api/edge-routers/pools-router.ts
@@ -252,7 +252,7 @@ export const poolsRouter = createTRPCRouter({
             const marketIncentivePools = pools
               .map((pool) => {
                 const incentivesForPool = incentives.get(pool.id);
-                const metricsForPool = marketMetrics.get(pool.id);
+                const metricsForPool = marketMetrics.get(pool.id) ?? {};
 
                 const isIncentiveFiltered =
                   incentivesForPool &&

--- a/packages/web/server/queries/complex/pools/market.ts
+++ b/packages/web/server/queries/complex/pools/market.ts
@@ -28,20 +28,34 @@ export function getCachedPoolMarketMetricsMap(): Promise<
       const map = new Map<string, PoolMarketMetrics>();
 
       // append fee revenue data to volume data
-      const poolsFees = await queryPoolsFees();
-      poolsFees.data.forEach(
-        ({ pool_id, volume_24h, volume_7d, fees_spent_24h, fees_spent_7d }) => {
-          map.set(pool_id, {
-            volume24hUsd: new PricePretty(DEFAULT_VS_CURRENCY, volume_24h),
-            volume7dUsd: new PricePretty(DEFAULT_VS_CURRENCY, volume_7d),
-            feesSpent24hUsd: new PricePretty(
-              DEFAULT_VS_CURRENCY,
-              fees_spent_24h
-            ),
-            feesSpent7dUsd: new PricePretty(DEFAULT_VS_CURRENCY, fees_spent_7d),
-          });
-        }
-      );
+      try {
+        const poolsFees = await queryPoolsFees();
+        poolsFees.data.forEach(
+          ({
+            pool_id,
+            volume_24h,
+            volume_7d,
+            fees_spent_24h,
+            fees_spent_7d,
+          }) => {
+            map.set(pool_id, {
+              volume24hUsd: new PricePretty(DEFAULT_VS_CURRENCY, volume_24h),
+              volume7dUsd: new PricePretty(DEFAULT_VS_CURRENCY, volume_7d),
+              feesSpent24hUsd: new PricePretty(
+                DEFAULT_VS_CURRENCY,
+                fees_spent_24h
+              ),
+              feesSpent7dUsd: new PricePretty(
+                DEFAULT_VS_CURRENCY,
+                fees_spent_7d
+              ),
+            });
+          }
+        );
+      } catch (err) {
+        // Return empty map if it fails
+        console.error("Failed to fetch pool metrics", err);
+      }
 
       return map;
     },


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Currently, our pools page bricks if volume data is unavailable.

This PR fixes the issue by avoiding to format the volume column in such a case.

It calculates the number of pools that have volume formatted. If greater than half, volume column is displayed and the missing pools show "N/A"

If less than half, then we do not show the volume column

This is related to the `/fees/v1/pools` query

### ClickUp Task

[ClickUp Task URL](PASTE_CLICKUP_TASK_URL_HERE)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

Tested this by force throwing an error from the endpoint.

See:
![image](https://github.com/osmosis-labs/osmosis-frontend/assets/34196718/d4d74231-e9ad-4a42-a0ca-9883701c81a2)

I added the error mock here: https://github.com/osmosis-labs/osmosis-frontend/blob/a1660e2e3244adb0653f370a3ff6a9f7983d2d10/packages/web/server/queries/imperator/pools-fees.ts#L17-L20

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
