### PR TITLE
hide fees column similar to volume on failure

### DIFF
--- a/packages/web/components/complex/all-pools-table-v2.tsx
+++ b/packages/web/components/complex/all-pools-table-v2.tsx
@@ -190,8 +190,11 @@ export const AllPoolsTable: FunctionComponent<{
     let volumePresenceCount = 0;
     let feesPresenceCount = 0;
     poolsData.forEach((pool) => {
-      if (pool.volume24hUsd && pool.feesSpent7dUsd) {
+      if (pool.volume24hUsd) {
         volumePresenceCount++;
+      }
+
+      if (pool.feesSpent7dUsd) {
         feesPresenceCount++;
       }
     });

--- a/packages/web/components/complex/all-pools-table-v2.tsx
+++ b/packages/web/components/complex/all-pools-table-v2.tsx
@@ -184,8 +184,8 @@ export const AllPoolsTable: FunctionComponent<{
     [poolsPagesData]
   );
 
-  // If more than half of the pools have volume and fees data, we should format the volume column.
-  // Otherwise, we should not format the volume column.
+  // If more than half of the pools have volume and fees data, we should format their respective columns.
+  // Otherwise, we should not display them.
   const { shouldDisplayVolumeData, shouldDisplayFeesData } = useMemo(() => {
     let volumePresenceCount = 0;
     let feesPresenceCount = 0;
@@ -254,6 +254,7 @@ export const AllPoolsTable: FunctionComponent<{
       )
     );
 
+    // Only show fees if more than half of the pools have fees data.
     if (shouldDisplayFeesData) {
       allColumns.push(
         columnHelper.accessor((row) => row.feesSpent7dUsd?.toString() ?? "0", {

--- a/packages/web/components/complex/all-pools-table-v2.tsx
+++ b/packages/web/components/complex/all-pools-table-v2.tsx
@@ -184,16 +184,21 @@ export const AllPoolsTable: FunctionComponent<{
     [poolsPagesData]
   );
 
-  // If more than half of the pools have volume data, we should format the volume column.
+  // If more than half of the pools have volume and fees data, we should format the volume column.
   // Otherwise, we should not format the volume column.
-  const shouldDisplayVolumeColumn = useMemo(() => {
+  const { shouldDisplayVolumeData, shouldDisplayFeesData } = useMemo(() => {
     let volumePresenceCount = 0;
+    let feesPresenceCount = 0;
     poolsData.forEach((pool) => {
-      if (pool.volume24hUsd) {
+      if (pool.volume24hUsd && pool.feesSpent7dUsd) {
         volumePresenceCount++;
+        feesPresenceCount++;
       }
     });
-    return volumePresenceCount > poolsData.length / 2;
+    return {
+      shouldDisplayVolumeData: volumePresenceCount > poolsData.length,
+      shouldDisplayFeesData: feesPresenceCount > poolsData.length,
+    };
   }, [poolsData]);
 
   // Define columns
@@ -210,7 +215,7 @@ export const AllPoolsTable: FunctionComponent<{
     ];
 
     // Only show volume if more than half of the pools have volume data.
-    if (shouldDisplayVolumeColumn) {
+    if (shouldDisplayVolumeData) {
       allColumns.push(
         columnHelper.accessor((row) => row.volume24hUsd?.toString() ?? "N/A", {
           id: "volume24hUsd",
@@ -229,8 +234,7 @@ export const AllPoolsTable: FunctionComponent<{
       );
     }
 
-    // Add all remaining columns
-    let remainingColumns = [
+    allColumns.push(
       columnHelper.accessor(
         (row) => row.totalFiatValueLocked?.toString() ?? "0",
         {
@@ -247,21 +251,29 @@ export const AllPoolsTable: FunctionComponent<{
             />
           ),
         }
-      ),
-      columnHelper.accessor((row) => row.feesSpent7dUsd?.toString() ?? "0", {
-        id: "feesSpent7dUsd",
-        header: () => (
-          <SortHeader
-            label={t("pools.allPools.sort.fees")}
-            sortKey="feesSpent7dUsd"
-            disabled={isLoading}
-            currentSortKey={sortKey}
-            currentDirection={sortParams.allPoolsSortDir}
-            setSortDirection={setSortDirection}
-            setSortKey={setSortKey}
-          />
-        ),
-      }),
+      )
+    );
+
+    if (shouldDisplayFeesData) {
+      allColumns.push(
+        columnHelper.accessor((row) => row.feesSpent7dUsd?.toString() ?? "0", {
+          id: "feesSpent7dUsd",
+          header: () => (
+            <SortHeader
+              label={t("pools.allPools.sort.fees")}
+              sortKey="feesSpent7dUsd"
+              disabled={isLoading}
+              currentSortKey={sortKey}
+              currentDirection={sortParams.allPoolsSortDir}
+              setSortDirection={setSortDirection}
+              setSortKey={setSortKey}
+            />
+          ),
+        })
+      );
+    }
+
+    let remainingColumns = [
       columnHelper.accessor((row) => row, {
         id: "aprBreakdown.total",
         header: () => (
@@ -305,19 +317,21 @@ export const AllPoolsTable: FunctionComponent<{
     setSortKey,
     cellGroupEventEmitter,
     quickAddLiquidity,
-    shouldDisplayVolumeColumn,
+    shouldDisplayVolumeData,
+    shouldDisplayFeesData,
   ]);
 
   /** Columns collapsed for screen size responsiveness. */
   const collapsedColumns = useMemo(() => {
     const collapsedColIds: string[] = [];
-    if (width < Breakpoint.xxl) collapsedColIds.push("feesSpent7dUsd");
+    if (width < Breakpoint.xxl && shouldDisplayFeesData)
+      collapsedColIds.push("feesSpent7dUsd");
     if (width < Breakpoint.xlg) collapsedColIds.push("totalFiatValueLocked");
-    if (width < Breakpoint.lg && shouldDisplayVolumeColumn)
+    if (width < Breakpoint.lg && shouldDisplayVolumeData)
       collapsedColIds.push("volume24hUsd");
     if (width < Breakpoint.md) collapsedColIds.push("poolQuickActions");
     return columns.filter(({ id }) => id && !collapsedColIds.includes(id));
-  }, [columns, width, shouldDisplayVolumeColumn]);
+  }, [columns, width, shouldDisplayVolumeData, shouldDisplayFeesData]);
 
   const table = useReactTable({
     data: poolsData,

--- a/packages/web/components/complex/all-pools-table-v2.tsx
+++ b/packages/web/components/complex/all-pools-table-v2.tsx
@@ -254,26 +254,29 @@ export const AllPoolsTable: FunctionComponent<{
             />
           ),
         }
-      )
+      ) as (typeof allColumns)[number]
     );
 
     // Only show fees if more than half of the pools have fees data.
     if (shouldDisplayFeesData) {
       allColumns.push(
-        columnHelper.accessor((row) => row.feesSpent7dUsd?.toString() ?? "0", {
-          id: "feesSpent7dUsd",
-          header: () => (
-            <SortHeader
-              label={t("pools.allPools.sort.fees")}
-              sortKey="feesSpent7dUsd"
-              disabled={isLoading}
-              currentSortKey={sortKey}
-              currentDirection={sortParams.allPoolsSortDir}
-              setSortDirection={setSortDirection}
-              setSortKey={setSortKey}
-            />
-          ),
-        })
+        columnHelper.accessor(
+          (row) => row.feesSpent7dUsd?.toString() ?? "N/A",
+          {
+            id: "feesSpent7dUsd",
+            header: () => (
+              <SortHeader
+                label={t("pools.allPools.sort.fees")}
+                sortKey="feesSpent7dUsd"
+                disabled={isLoading}
+                currentSortKey={sortKey}
+                currentDirection={sortParams.allPoolsSortDir}
+                setSortDirection={setSortDirection}
+                setSortKey={setSortKey}
+              />
+            ),
+          }
+        ) as (typeof allColumns)[number]
       );
     }
 

--- a/packages/web/server/queries/imperator/pools-fees.ts
+++ b/packages/web/server/queries/imperator/pools-fees.ts
@@ -16,6 +16,5 @@ export interface PoolFees {
 
 export function queryPoolsFees(): Promise<PoolFees> {
   const url = new URL("/fees/v1/pools", IMPERATOR_TIMESERIES_DEFAULT_BASEURL);
-  throw new Error("Not implemented");
   return apiClient<PoolFees>(url.toString());
 }

--- a/packages/web/server/queries/imperator/pools-fees.ts
+++ b/packages/web/server/queries/imperator/pools-fees.ts
@@ -16,5 +16,6 @@ export interface PoolFees {
 
 export function queryPoolsFees(): Promise<PoolFees> {
   const url = new URL("/fees/v1/pools", IMPERATOR_TIMESERIES_DEFAULT_BASEURL);
+  throw new Error("Not implemented");
   return apiClient<PoolFees>(url.toString());
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Similar to https://github.com/osmosis-labs/osmosis-frontend/pull/2849, it hides the fees column that currently formats "0" instead of being completely hidden

![image](https://github.com/osmosis-labs/osmosis-frontend/assets/34196718/53acc104-54a9-4352-b071-63f46c6787fe)

Tested by hardcoding an error and then removing: [6f5bfe2](https://github.com/osmosis-labs/osmosis-frontend/pull/2855/commits/6f5bfe27940a59756d019ecbfda8fd20d4dd4e4e)
## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
