### PR TITLE
Update ibc-overrides for polygon.USDC.axl, avalanche.USDC.axl, and moonbeam.DOT.axl

### DIFF
--- a/packages/web/config/ibc-overrides.ts
+++ b/packages/web/config/ibc-overrides.ts
@@ -327,7 +327,7 @@ const MainnetIBCAdditionalData: Partial<
     },
     fiatRamps: [{ rampKey: "layerswapcoinbase" as const, assetKey: "USDC" }],
   },
-  "polygon.USDC": {
+  "polygon.USDC.axl": {
     sourceChainNameOverride: "Polygon",
     originBridgeInfo: {
       bridge: "axelar" as const,
@@ -336,7 +336,7 @@ const MainnetIBCAdditionalData: Partial<
       sourceChainTokens: [AxelarSourceChainTokenConfigs.polygonusdc.polygon],
     },
   },
-  "avalanche.USDC": {
+  "avalanche.USDC.axl": {
     sourceChainNameOverride: "Avalanche",
     originBridgeInfo: {
       bridge: "axelar" as const,
@@ -347,7 +347,7 @@ const MainnetIBCAdditionalData: Partial<
       ],
     },
   },
-  "DOT.axl": {
+  "moonbeam.DOT.axl": {
     sourceChainNameOverride: "Moonbeam",
     originBridgeInfo: {
       bridge: "axelar" as const,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Update ibc-overrides for polygon.USDC.axl, avalanche.USDC.axl, and moonbeam.DOT.axl

Were using the old symbols

_(E.g.: This pull request improves area A by adding ...._ -->


## Brief Changelog


Update ibc-overrides.ts to use the updated symbols for these assets.

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying



This change has been tested locally by rebuilding the website and verified content and links are expected
