### PR TITLE
Add stale while revalidate values

### DIFF
--- a/packages/web/server/queries/complex/assets/market.ts
+++ b/packages/web/server/queries/complex/assets/market.ts
@@ -35,6 +35,7 @@ export async function getMarketAsset<TAsset extends Asset>({
     cache: marketInfoCache,
     key: asset.coinDenom + asset.coinMinimalDenom,
     ttl: 1000 * 60 * 5, // 5 minutes
+    staleWhileRevalidate: 1000 * 60 * 10, // 10 mins
     getFreshValue: async () => {
       const currentPrice = await getAssetPrice({ asset }).catch(() => null);
       const marketCap = await getAssetMarketCap(asset).catch(() => null);

--- a/packages/web/server/queries/complex/assets/price.ts
+++ b/packages/web/server/queries/complex/assets/price.ts
@@ -31,7 +31,8 @@ async function getCoingeckoCoin({ denom }: { denom: string }) {
   return cachified({
     cache: pricesCache,
     key: `coingecko-coin-${denom}`,
-    ttl: 60 * 1000, // 1 minute
+    ttl: 1000 * 60, // 1 minute
+    staleWhileRevalidate: 1000 * 60 * 2, // 2 minutes
     getFreshValue: async () => {
       const { coins } = await queryCoingeckoSearch(denom);
       return coins?.find(

--- a/packages/web/server/queries/complex/concentrated-liquidity/index.ts
+++ b/packages/web/server/queries/complex/concentrated-liquidity/index.ts
@@ -173,7 +173,8 @@ function getUnbondingClPositions({ bech32Address }: { bech32Address: string }) {
   return cachified({
     cache: concentratedLiquidityCache,
     key: `unbonding-cl-positions-${bech32Address}`,
-    ttl: 5 * 1000, // 5 seconds
+    ttl: 1000 * 5, // 5 seconds
+    staleWhileRevalidate: 1000 * 60 * 5, // 5 minutes
     getFreshValue: () => queryCLUnbondingPositions({ bech32Address }),
   });
 }
@@ -182,7 +183,8 @@ function getDelegatedClPositions({ bech32Address }: { bech32Address: string }) {
   return cachified({
     cache: concentratedLiquidityCache,
     key: `delegated-cl-positions-${bech32Address}`,
-    ttl: 5 * 1000, // 5 seconds
+    ttl: 1000 * 5, // 5 seconds
+    staleWhileRevalidate: 1000 * 60 * 5, // 5 minutes
     getFreshValue: () => queryDelegatedClPositions({ bech32Address }),
   });
 }
@@ -195,7 +197,8 @@ function getUndelegatingClPositions({
   return cachified({
     cache: concentratedLiquidityCache,
     key: `undelegating-cl-positions-${bech32Address}`,
-    ttl: 5 * 1000, // 5 seconds
+    ttl: 1000 * 5, // 5 seconds
+    staleWhileRevalidate: 1000 * 60 * 5, // 5 minutes
     getFreshValue: () => queryUndelegatingClPositions({ bech32Address }),
   });
 }

--- a/packages/web/server/queries/complex/cosmos/distribution-params.ts
+++ b/packages/web/server/queries/complex/cosmos/distribution-params.ts
@@ -11,7 +11,8 @@ export function getDistributionParams({ chainId }: { chainId: string }) {
   return cachified({
     cache: distributionCache,
     key: `distribution-params-${chainId}`,
-    ttl: 30 * 1000, // 30 seconds
+    ttl: 1000 * 30, // 30 seconds
+    staleWhileRevalidate: 1000 * 60 * 5, // 5 minutes
     getFreshValue: async () => {
       const { params } = await queryDistributionParams({ chainId });
       return {

--- a/packages/web/server/queries/complex/get-timeout-height.ts
+++ b/packages/web/server/queries/complex/get-timeout-height.ts
@@ -1,10 +1,14 @@
 import { ChainIdHelper } from "@keplr-wallet/cosmos";
 import { Int } from "@keplr-wallet/unit";
 import { getChain } from "@osmosis-labs/utils";
+import cachified, { CacheEntry } from "cachified";
+import { LRUCache } from "lru-cache";
 
 import { ChainList } from "~/config/generated/chain-list";
 import { queryRPCStatus } from "~/server/queries/cosmos";
+import { DEFAULT_LRU_OPTIONS } from "~/utils/cache";
 
+const timeoutCache = new LRUCache<string, CacheEntry>(DEFAULT_LRU_OPTIONS);
 export async function getTimeoutHeight({
   chainId,
   destinationAddress,
@@ -12,44 +16,54 @@ export async function getTimeoutHeight({
   chainId?: string;
   destinationAddress?: string;
 }) {
-  const destinationCosmosChain = getChain({
-    chainList: ChainList,
-    chainId,
-    destinationAddress,
+  return cachified({
+    cache: timeoutCache,
+    key: `timeout-height-${chainId}-${destinationAddress}`,
+    ttl: 1000 * 4, // 4 seconds (just less block time)
+    staleWhileRevalidate: 1000 * 60, // 1 min
+    getFreshValue: async () => {
+      const destinationCosmosChain = getChain({
+        chainList: ChainList,
+        chainId,
+        destinationAddress,
+      });
+
+      if (!destinationCosmosChain) {
+        throw new Error("Could not find destination Cosmos chain");
+      }
+
+      const destinationNodeStatus = await queryRPCStatus({
+        restUrl: destinationCosmosChain.apis.rpc[0].address,
+      });
+
+      const network = destinationNodeStatus.result.node_info.network;
+      const latestBlockHeight =
+        destinationNodeStatus.result.sync_info.latest_block_height;
+
+      if (!network) {
+        throw new Error(
+          `Failed to fetch the network chain id of ${destinationCosmosChain.chain_id}`
+        );
+      }
+
+      if (!latestBlockHeight || latestBlockHeight === "0") {
+        throw new Error(
+          `Failed to fetch the latest block of ${destinationCosmosChain.chain_id}`
+        );
+      }
+
+      const revisionNumber = ChainIdHelper.parse(network).version.toString();
+
+      return {
+        /**
+         * Omit the revision_number if the chain's version is 0.
+         * Sending the value as 0 will cause the transaction to fail.
+         */
+        revisionNumber: revisionNumber !== "0" ? revisionNumber : undefined,
+        revisionHeight: new Int(latestBlockHeight)
+          .add(new Int("150"))
+          .toString(),
+      };
+    },
   });
-
-  if (!destinationCosmosChain) {
-    throw new Error("Could not find destination Cosmos chain");
-  }
-
-  const destinationNodeStatus = await queryRPCStatus({
-    restUrl: destinationCosmosChain.apis.rpc[0].address,
-  });
-
-  const network = destinationNodeStatus.result.node_info.network;
-  const latestBlockHeight =
-    destinationNodeStatus.result.sync_info.latest_block_height;
-
-  if (!network) {
-    throw new Error(
-      `Failed to fetch the network chain id of ${destinationCosmosChain.chain_id}`
-    );
-  }
-
-  if (!latestBlockHeight || latestBlockHeight === "0") {
-    throw new Error(
-      `Failed to fetch the latest block of ${destinationCosmosChain.chain_id}`
-    );
-  }
-
-  const revisionNumber = ChainIdHelper.parse(network).version.toString();
-
-  return {
-    /**
-     * Omit the revision_number if the chain's version is 0.
-     * Sending the value as 0 will cause the transaction to fail.
-     */
-    revisionNumber: revisionNumber !== "0" ? revisionNumber : undefined,
-    revisionHeight: new Int(latestBlockHeight).add(new Int("150")).toString(),
-  };
 }

--- a/packages/web/server/queries/complex/osmosis/epochs.ts
+++ b/packages/web/server/queries/complex/osmosis/epochs.ts
@@ -16,8 +16,8 @@ export function getEpochs() {
   return cachified({
     cache: epochsCache,
     key: "epochs",
-    // 30 seconds
-    ttl: 30 * 1000,
+    ttl: 1000 * 30, // 30 seconds
+    staleWhileRevalidate: 1000 * 60 * 5, // 5 minutes
     getFreshValue: async () => {
       const { epochs } = await queryEpochs();
       return epochs;
@@ -29,7 +29,8 @@ export async function getEpochProvisions(): Promise<CoinPretty | undefined> {
   return cachified({
     cache: epochsCache,
     key: "epoch-provisions",
-    ttl: 30 * 1000,
+    ttl: 1000 * 30, // 30 seconds
+    staleWhileRevalidate: 1000 * 60 * 5, // 5 minutes
     getFreshValue: async () => {
       const [mintParams, provisionsResponse] = await Promise.all([
         queryOsmosisMintParams(),

--- a/packages/web/server/queries/complex/osmosis/osmosis-params.ts
+++ b/packages/web/server/queries/complex/osmosis/osmosis-params.ts
@@ -12,7 +12,8 @@ export async function getOsmosisMintParams() {
   return cachified({
     cache: paramsCache,
     key: "osmosis-mint-params",
-    ttl: 30 * 1000, // 30 seconds
+    ttl: 1000 * 30, // 30 seconds
+    staleWhileRevalidate: 1000 * 60 * 5, // 5 minutes
     getFreshValue: async () => {
       const { params: mintParams } = await queryOsmosisMintParams();
 
@@ -47,7 +48,8 @@ export async function getSuperfluidParams() {
   return cachified({
     cache: paramsCache,
     key: "osmosis-superfluid-params",
-    ttl: 30 * 1000, // 30 seconds
+    ttl: 1000 * 30, // 30 seconds
+    staleWhileRevalidate: 1000 * 60 * 5, // 5 minutes
     getFreshValue: async () => {
       const { params } = await querySuperfluidParams();
 

--- a/packages/web/server/queries/complex/pools/incentives.ts
+++ b/packages/web/server/queries/complex/pools/incentives.ts
@@ -84,7 +84,8 @@ export function getCachedPoolIncentivesMap(): Promise<
   return cachified({
     cache: incentivePoolsCache,
     key: "pools-incentives-map",
-    ttl: 1000 * 60 * 5, // 5 minutes
+    ttl: 1000 * 30, // 30 seconds
+    staleWhileRevalidate: 1000 * 60 * 5, // 5 minutes
     getFreshValue: async () => {
       const aprs = await queryPoolAprs();
 

--- a/packages/web/server/queries/complex/pools/route-token-out-given-in.ts
+++ b/packages/web/server/queries/complex/pools/route-token-out-given-in.ts
@@ -72,6 +72,7 @@ export async function getRouter(
     key: "router" + minLiquidityUsd,
     cache: routerCache,
     ttl: routerCacheTtl,
+    staleWhileRevalidate: routerCacheTtl + 1000 * 30, // add 30 seconds
     async getFreshValue() {
       // fetch pool data
       const numPoolsResponse = await queryNumPools();

--- a/packages/web/server/queries/complex/pools/superfluid.ts
+++ b/packages/web/server/queries/complex/pools/superfluid.ts
@@ -10,6 +10,7 @@ export function getSuperfluidPoolIds() {
     cache: superfluidCache,
     key: "superfluid-pool-ids",
     ttl: 1000 * 60 * 5, // 5 mins
+    staleWhileRevalidate: 1000 * 60 * 10, // 10 mins
     getFreshValue: async () => {
       const { assets: superfluidAssets } = await queryAllSuperfluidAssets();
 

--- a/packages/web/server/queries/complex/staking/apr.ts
+++ b/packages/web/server/queries/complex/staking/apr.ts
@@ -19,7 +19,8 @@ export async function getAverageStakingApr({
 }): Promise<Dec> {
   return await cachified({
     cache: averageStakingAprCache,
-    ttl: 1000 * 60 * 60, // 60 minutes since APR changes once a day at an unkown time
+    ttl: 1000 * 60 * 30, // 30 minutes since APR changes once a day at an unkown time
+    staleWhileRevalidate: 1000 * 60 * 60, // 1 hour
     key: `average-staking-apr-${startDate}-${endDate}`,
     getFreshValue: async () => {
       try {

--- a/packages/web/server/queries/complex/staking/validator.ts
+++ b/packages/web/server/queries/complex/staking/validator.ts
@@ -13,10 +13,11 @@ export async function getValidators({ status }: { status: BondStatus }) {
   return cachified({
     cache: validatorsCache,
     key: "validators",
+    ttl: 1000 * 60 * 5, // 5 minutes
+    staleWhileRevalidate: 1000 * 60 * 10, // 10 mins
     getFreshValue: async () => {
       return (await queryValidators({ status })).validators;
     },
-    ttl: 1000 * 60 * 5, // 5 minutes
   });
 }
 
@@ -29,6 +30,7 @@ export async function getValidatorInfo({
     cache: validatorsCache,
     key: `validator-${validatorBech32Address}`,
     ttl: 1000 * 10, // 10 seconds
+    staleWhileRevalidate: 1000 * 60 * 10, // 10 mins
     getFreshValue: async () => {
       let jailed = false;
       let inactive = false;


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

Updates our caching strategy to allow users to receive cached values while fresh values are fetched in the background during the `ttl - staleWhileRevalidate` time window.

### ClickUp Task

[ClickUp Task URL](PASTE_CLICKUP_TASK_URL_HERE)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->
* Update ttl values and add staleWhileRevalidate to all uses of cachified
* Use cachified for timeout height

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

* Notice faster load times while data is loaded in the background