### PR TITLE
fix: dispaly volume and fees when half is available

### DIFF
--- a/packages/web/components/complex/all-pools-table-v2.tsx
+++ b/packages/web/components/complex/all-pools-table-v2.tsx
@@ -199,8 +199,8 @@ export const AllPoolsTable: FunctionComponent<{
       }
     });
     return {
-      shouldDisplayVolumeData: volumePresenceCount > poolsData.length,
-      shouldDisplayFeesData: feesPresenceCount > poolsData.length,
+      shouldDisplayVolumeData: volumePresenceCount > poolsData.length / 2,
+      shouldDisplayFeesData: feesPresenceCount > poolsData.length / 2,
     };
   }, [poolsData]);
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Fixes the condition for volume and fee display to show them when more than half is available.

The condition was made too strict in: https://github.com/osmosis-labs/osmosis-frontend/pull/2855 and we should relax it
