### PR TITLE
Mattupham/shadcn buttons swap

### DIFF
--- a/packages/web/components/swap-tool/index.tsx
+++ b/packages/web/components/swap-tool/index.tsx
@@ -16,7 +16,6 @@ import {
 import { useMeasure } from "react-use";
 
 import { Icon } from "~/components/assets";
-import { Button } from "~/components/buttons";
 import IconButton from "~/components/buttons/icon-button";
 import { TokenSelectWithDrawer } from "~/components/control/token-select-with-drawer";
 import { InputBox } from "~/components/input";
@@ -25,6 +24,8 @@ import { tError } from "~/components/localization";
 import { Popover } from "~/components/popover";
 import { SplitRoute } from "~/components/swap-tool/split-route";
 import { InfoTooltip } from "~/components/tooltip";
+// import { Button } from "~/components/buttons";
+import { Button } from "~/components/ui/button";
 import { EventName, SwapPage } from "~/config";
 import { useTranslation } from "~/hooks";
 import {
@@ -384,9 +385,10 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
                 </div>
                 <div className="flex items-center gap-1.5">
                   <Button
-                    mode="amount"
+                    variant="outline"
+                    size="sm"
                     className={classNames(
-                      "py-1 px-1.5 text-xs",
+                      "text-wosmongton-300",
                       swapState.inAmountInput.fraction === 0.5
                         ? "bg-wosmongton-100/20"
                         : "bg-transparent"
@@ -400,9 +402,10 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
                     {t("swap.HALF")}
                   </Button>
                   <Button
-                    mode="amount"
+                    variant="outline"
+                    size="sm"
                     className={classNames(
-                      "py-1 px-1.5 text-xs",
+                      "text-wosmongton-300",
                       swapState.inAmountInput.fraction === 1
                         ? "bg-wosmongton-100/20"
                         : "bg-transparent"
@@ -484,7 +487,7 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
                 </div>
               </div>
             </div>
-
+            {/* TODO - move this custom button to our own button component */}
             <button
               disabled={isSwapToolLoading}
               className={classNames(
@@ -549,7 +552,6 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
                 </div>
               </div>
             </button>
-
             <div className="rounded-xl bg-osmoverse-900 px-4 py-[22px] transition-all md:rounded-xl md:px-3 md:py-2.5">
               <div className="flex place-content-between items-center transition-transform">
                 <SkeletonLoader
@@ -634,7 +636,6 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
                 </div>
               </div>
             </div>
-
             <SkeletonLoader
               className={classNames(
                 "relative overflow-hidden rounded-lg bg-osmoverse-900 px-4 transition-all duration-300 ease-inOutBack md:px-3",
@@ -654,6 +655,7 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
                 Boolean(swapState.spotPriceQuote)
               }
             >
+              {/* TODO - move this custom button to our own button component */}
               <button
                 className={classNames(
                   "flex w-full place-content-between items-center transition-opacity",
@@ -832,12 +834,6 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
           </div>
           {swapButton ?? (
             <Button
-              mode={
-                showPriceImpactWarning &&
-                account?.walletStatus === WalletStatus.Connected
-                  ? "primary-warning"
-                  : "primary"
-              }
               disabled={
                 isWalletLoading ||
                 swapState.isQuoteLoading ||

--- a/packages/web/components/ui/button.tsx
+++ b/packages/web/components/ui/button.tsx
@@ -20,7 +20,7 @@ const buttonVariants = cva(
       },
       size: {
         default: "h-14 px-6 py-2 rounded-xl",
-        sm: "h-6 rounded-md px-3 text-xs",
+        sm: "h-6 rounded-md text-caption py-1 px-1.5",
         // lg: "h-14 rounded-xl px-8", // note - we don't use this size
         icon: "h-9 w-9",
       },


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

- swap page, replace buttons with shadcn button variants

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/86a2ehk7g)

## Brief Changelog

- replace buttons with simplified shadcn variants

## Testing and Verifying

https://github.com/osmosis-labs/osmosis-frontend/assets/30577966/09e5922c-d211-4286-b109-2779a0dad88e


## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
