### PR TITLE
feat(assets-table): enhance search functionality and UI 

### DIFF
--- a/packages/web/components/table/assets-table-v1.tsx
+++ b/packages/web/components/table/assets-table-v1.tsx
@@ -571,8 +571,8 @@ export const AssetsTableV1: FunctionComponent<Props> = observer(
                   size="small"
                   onFocusChange={delayOnFalse(setSearchBoxInputIsFocused)}
                   rightIcon={() => (
-                    <div className="w-10 text-end">
-                      <text className="inline-block rounded bg-osmoverse-800 px-2 text-sm tracking-wider text-osmoverse-200 transition-colors">
+                    <div className="mr-2 w-10 text-end lg:hidden">
+                      <text className="sr-3 inline-block rounded bg-osmoverse-800 px-2 text-sm tracking-wider text-osmoverse-200 transition-colors">
                         {searchBoxInputIsFocused ? "esc" : " / "}
                       </text>
                     </div>

--- a/packages/web/components/table/assets-table-v1.tsx
+++ b/packages/web/components/table/assets-table-v1.tsx
@@ -805,11 +805,9 @@ const useWebSearchBoxState = () => {
       searchBoxRef.current?.focus();
     },
     { event: "keydown" },
-    [searchBoxRef]
+    []
   );
-  useKey("Escape", () => searchBoxRef.current?.blur(), { event: "keydown" }, [
-    searchBoxRef,
-  ]);
+  useKey("Escape", () => searchBoxRef.current?.blur(), { event: "keydown" }, []);
   return {
     searchBoxIsFocused,
     searchBoxRef,

--- a/packages/web/components/table/assets-table-v1.tsx
+++ b/packages/web/components/table/assets-table-v1.tsx
@@ -3,14 +3,7 @@ import { getAssetFromAssetList } from "@osmosis-labs/utils";
 import { observer } from "mobx-react-lite";
 import Image from "next/image";
 import Link from "next/link";
-import {
-  type FunctionComponent,
-  useCallback,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
-import { useKey } from "react-use";
+import { type FunctionComponent, useCallback, useMemo, useState } from "react";
 
 import { Icon } from "~/components/assets";
 import { SortMenu } from "~/components/control";
@@ -40,7 +33,6 @@ import {
   useWindowSize,
 } from "~/hooks";
 import { useFilteredData, useSortedData } from "~/hooks/data";
-import { useControllableState } from "~/hooks/use-controllable-state";
 import { ActivateUnverifiedTokenConfirmation } from "~/modals";
 import { useStore } from "~/stores";
 import {
@@ -50,6 +42,8 @@ import {
 } from "~/stores/assets";
 import { HideBalancesState } from "~/stores/user-settings";
 import { UnverifiedAssetsState } from "~/stores/user-settings";
+
+import { useWebSearchBoxInputState } from "./hooks/use-web-search-box-input-state";
 
 interface Props {
   nativeBalances: (CoinBalance & { isVerified: boolean })[];
@@ -128,8 +122,11 @@ export const AssetsTableV1: FunctionComponent<Props> = observer(
       ["OSMO", "ATOM", "TIA"]
     );
 
-    const { searchBoxIsFocused, setSearchBoxIsFocused, searchBoxRef } =
-      useWebSearchBoxState();
+    const {
+      searchBoxInputIsFocused,
+      setSearchBoxInputIsFocused,
+      searchBoxRef,
+    } = useWebSearchBoxInputState();
     const [isSearching, setIsSearching] = useState(false);
     const [confirmUnverifiedTokenDenom, setConfirmUnverifiedTokenDenom] =
       useState<string | null>(null);
@@ -385,8 +382,8 @@ export const AssetsTableV1: FunctionComponent<Props> = observer(
     };
 
     const shouldShowTop5 = useMemo(
-      () => searchBoxIsFocused && (!query || query.length === 0),
-      [query, searchBoxIsFocused]
+      () => searchBoxInputIsFocused && (!query || query.length === 0),
+      [query, searchBoxInputIsFocused]
     );
     // const shouldShowTop5 = false;
 
@@ -476,7 +473,9 @@ export const AssetsTableV1: FunctionComponent<Props> = observer(
               }}
               placeholder={t("assets.table.search")}
               size="small"
-              onFocusChange={(isFocused) => setSearchBoxIsFocused(isFocused)}
+              onFocusChange={(isFocused) =>
+                setSearchBoxInputIsFocused(isFocused)
+              }
             />
             <div className="flex flex-wrap place-content-between items-center gap-3">
               <div className="flex shrink-0 flex-wrap gap-2">
@@ -570,12 +569,12 @@ export const AssetsTableV1: FunctionComponent<Props> = observer(
                   placeholder={t("assets.table.search")}
                   size="small"
                   onFocusChange={(isFocused) =>
-                    setSearchBoxIsFocused(isFocused)
+                    setSearchBoxInputIsFocused(isFocused)
                   }
                   rightIcon={() => (
                     <div className="w-10 text-end">
                       <text className="inline-block rounded bg-osmoverse-800 px-2 text-sm tracking-wider text-osmoverse-200 transition-colors">
-                        {searchBoxIsFocused ? "esc" : " /"}
+                        {searchBoxInputIsFocused ? "esc" : " /"}
                       </text>
                     </div>
                   )}
@@ -795,30 +794,3 @@ export const AssetsTableV1: FunctionComponent<Props> = observer(
     );
   }
 );
-
-const useWebSearchBoxState = () => {
-  const [searchBoxIsFocused, setSearchBoxIsFocused] = useControllableState({
-    defaultValue: false,
-  });
-  const searchBoxRef = useRef<HTMLInputElement>(null);
-  useKey(
-    "/",
-    (event) => {
-      event.preventDefault(); // Prevent the '/' from being entered into the input
-      searchBoxRef.current?.focus();
-    },
-    { event: "keydown" },
-    []
-  );
-  useKey(
-    "Escape",
-    () => searchBoxRef.current?.blur(),
-    { event: "keydown" },
-    []
-  );
-  return {
-    searchBoxIsFocused,
-    searchBoxRef,
-    setSearchBoxIsFocused,
-  };
-};

--- a/packages/web/components/table/assets-table-v1.tsx
+++ b/packages/web/components/table/assets-table-v1.tsx
@@ -750,7 +750,7 @@ export const AssetsTableV1: FunctionComponent<Props> = observer(
                         ) : (
                           <TransferButtonCell type="deposit" {...cell} />
                         ),
-                      className: "text-left w-32 min-w-32 max-w-[5rem]",
+                      className: "text-left w-32 min-w-32",
                     },
                     {
                       display: t("assets.table.columns.withdraw"),
@@ -759,7 +759,7 @@ export const AssetsTableV1: FunctionComponent<Props> = observer(
                         !cell.isVerified ? null : (
                           <TransferButtonCell type="withdraw" {...cell} />
                         ),
-                      className: "text-left w-32 min-w-32 max-w-[5rem]",
+                      className: "text-left w-32 min-w-32",
                     },
                   ] as ColumnDef<TableCell>[])),
             ]}

--- a/packages/web/components/table/assets-table-v1.tsx
+++ b/packages/web/components/table/assets-table-v1.tsx
@@ -571,13 +571,13 @@ export const AssetsTableV1: FunctionComponent<Props> = observer(
                   onFocusChange={(isFocused) =>
                     setSearchBoxIsFocused(isFocused)
                   }
-                  rightIcon={() =>
-                    !searchBoxIsFocused && (
-                      <text className="mr-2 rounded bg-osmoverse-800 px-2 text-sm tracking-wider text-osmoverse-200 transition-colors">
-                        /
+                  rightIcon={() => (
+                    <div className="w-10 text-end">
+                      <text className="inline-block rounded bg-osmoverse-800 px-2 text-sm tracking-wider text-osmoverse-200 transition-colors">
+                        {searchBoxIsFocused ? "esc" : " /"}
                       </text>
-                    )
-                  }
+                    </div>
+                  )}
                 />
                 <SortMenu
                   selectedOptionId={sortKey}

--- a/packages/web/components/table/assets-table-v1.tsx
+++ b/packages/web/components/table/assets-table-v1.tsx
@@ -807,7 +807,12 @@ const useWebSearchBoxState = () => {
     { event: "keydown" },
     []
   );
-  useKey("Escape", () => searchBoxRef.current?.blur(), { event: "keydown" }, []);
+  useKey(
+    "Escape",
+    () => searchBoxRef.current?.blur(),
+    { event: "keydown" },
+    []
+  );
   return {
     searchBoxIsFocused,
     searchBoxRef,

--- a/packages/web/components/table/assets-table-v1.tsx
+++ b/packages/web/components/table/assets-table-v1.tsx
@@ -388,6 +388,7 @@ export const AssetsTableV1: FunctionComponent<Props> = observer(
       () => searchBoxIsFocused && (!query || query.length === 0),
       [query, searchBoxIsFocused]
     );
+    // const shouldShowTop5 = false;
 
     const tableData = useMemo(() => {
       const data: TableCell[] = [];
@@ -709,12 +710,13 @@ export const AssetsTableV1: FunctionComponent<Props> = observer(
                 display: t("assets.table.columns.assetChain"),
                 displayCell: AssetNameCell,
                 sort: sortColumnWithKeys(["coinDenom", "chainName"]),
+                className: "w-32 min-w-32",
               },
               {
                 display: t("assets.table.columns.balance"),
                 displayCell: BalanceCell,
                 sort: sortColumnWithKeys(["fiatValueRaw"], "descending"),
-                className: "text-right pr-24 lg:pr-8 1.5md:pr-1",
+                className: "text-right pr-24 lg:pr-8 1.5md:pr-1 w-32 min-w-32",
               },
               ...(mergeWithdrawCol
                 ? ([
@@ -749,7 +751,7 @@ export const AssetsTableV1: FunctionComponent<Props> = observer(
                         ) : (
                           <TransferButtonCell type="deposit" {...cell} />
                         ),
-                      className: "text-left",
+                      className: "text-left w-32 min-w-32 max-w-[5rem]",
                     },
                     {
                       display: t("assets.table.columns.withdraw"),
@@ -758,6 +760,7 @@ export const AssetsTableV1: FunctionComponent<Props> = observer(
                         !cell.isVerified ? null : (
                           <TransferButtonCell type="withdraw" {...cell} />
                         ),
+                      className: "text-left w-32 min-w-32 max-w-[5rem]",
                     },
                   ] as ColumnDef<TableCell>[])),
             ]}

--- a/packages/web/components/table/assets-table-v1.tsx
+++ b/packages/web/components/table/assets-table-v1.tsx
@@ -250,10 +250,23 @@ export const AssetsTableV1: FunctionComponent<Props> = observer(
             coinMinimalDenom: currency?.coinMinimalDenom,
             assetLists: AssetLists,
           });
-
+          let isFavorite = favoritesList.includes(balance.coinDenom);
+          const onToggleFavorite = () => {
+            // debugger;
+            isFavorite = !favoritesList.includes(balance.coinDenom);
+            if (isFavorite) {
+              onSetFavoritesList([...favoritesList, balance.coinDenom]);
+            } else {
+              onSetFavoritesList(
+                favoritesList.filter((d) => d !== balance.coinDenom)
+              );
+            }
+          };
           return {
             ...balance,
+            onToggleFavorite,
             assetName: asset?.rawAsset.name,
+            isFavorite,
           };
         }),
       [
@@ -266,6 +279,8 @@ export const AssetsTableV1: FunctionComponent<Props> = observer(
         shouldDisplayUnverifiedAssets,
         onWithdraw,
         onDeposit,
+        onSetFavoritesList,
+        favoritesList,
       ]
     );
 
@@ -388,44 +403,28 @@ export const AssetsTableV1: FunctionComponent<Props> = observer(
       () => searchBoxInputIsFocused && (!query || query.length === 0),
       [query, searchBoxInputIsFocused]
     );
-    // const shouldShowTop5 = false;
 
     const tableData = useMemo(() => {
+      if (shouldShowTop5) {
+        return filteredSortedCells.filter((coin) => {
+          if (TOP_5.includes(coin.coinDenom)) {
+            return true;
+          }
+          return false;
+        });
+      }
       const data: TableCell[] = [];
       const favorites: TableCell[] = [];
-      if (shouldShowTop5) {
-        return filteredSortedCells.filter((coin) =>
-          TOP_5.includes(coin.coinDenom)
-        );
-      }
       filteredSortedCells.forEach((coin) => {
         if (favoritesList.includes(coin.coinDenom)) {
-          coin.isFavorite = true;
-          coin.onToggleFavorite = () => {
-            const newFavorites = favoritesList.filter(
-              (d) => d !== coin.coinDenom
-            );
-            onSetFavoritesList(newFavorites);
-          };
           favorites.push(coin);
         } else {
-          coin.isFavorite = false;
-          coin.onToggleFavorite = () => {
-            const newFavorites = [...favoritesList, coin.coinDenom];
-            onSetFavoritesList(newFavorites);
-          };
           data.push(coin);
         }
       });
       const tableData = favorites.concat(data);
       return showAllAssets ? tableData : tableData.slice(0, 10);
-    }, [
-      favoritesList,
-      filteredSortedCells,
-      onSetFavoritesList,
-      showAllAssets,
-      shouldShowTop5,
-    ]);
+    }, [favoritesList, filteredSortedCells, showAllAssets, shouldShowTop5]);
 
     const rowDefs = useMemo<RowDef[]>(
       () =>

--- a/packages/web/components/table/assets-table-v1.tsx
+++ b/packages/web/components/table/assets-table-v1.tsx
@@ -43,7 +43,10 @@ import {
 import { HideBalancesState } from "~/stores/user-settings";
 import { UnverifiedAssetsState } from "~/stores/user-settings";
 
-import { useWebSearchBoxInputState } from "./hooks/use-web-search-box-input-state";
+import {
+  delayOnFalse,
+  useWebSearchBoxInputState,
+} from "./hooks/use-web-search-box-input-state";
 
 interface Props {
   nativeBalances: (CoinBalance & { isVerified: boolean })[];
@@ -473,9 +476,7 @@ export const AssetsTableV1: FunctionComponent<Props> = observer(
               }}
               placeholder={t("assets.table.search")}
               size="small"
-              onFocusChange={(isFocused) =>
-                setSearchBoxInputIsFocused(isFocused)
-              }
+              onFocusChange={delayOnFalse(setSearchBoxInputIsFocused)}
             />
             <div className="flex flex-wrap place-content-between items-center gap-3">
               <div className="flex shrink-0 flex-wrap gap-2">
@@ -568,9 +569,7 @@ export const AssetsTableV1: FunctionComponent<Props> = observer(
                   }}
                   placeholder={t("assets.table.search")}
                   size="small"
-                  onFocusChange={(isFocused) =>
-                    setSearchBoxInputIsFocused(isFocused)
-                  }
+                  onFocusChange={delayOnFalse(setSearchBoxInputIsFocused)}
                   rightIcon={() => (
                     <div className="w-10 text-end">
                       <text className="inline-block rounded bg-osmoverse-800 px-2 text-sm tracking-wider text-osmoverse-200 transition-colors">

--- a/packages/web/components/table/assets-table-v1.tsx
+++ b/packages/web/components/table/assets-table-v1.tsx
@@ -574,7 +574,7 @@ export const AssetsTableV1: FunctionComponent<Props> = observer(
                   rightIcon={() => (
                     <div className="w-10 text-end">
                       <text className="inline-block rounded bg-osmoverse-800 px-2 text-sm tracking-wider text-osmoverse-200 transition-colors">
-                        {searchBoxInputIsFocused ? "esc" : " /"}
+                        {searchBoxInputIsFocused ? "esc" : " / "}
                       </text>
                     </div>
                   )}

--- a/packages/web/components/table/cells/asset-name.tsx
+++ b/packages/web/components/table/cells/asset-name.tsx
@@ -30,7 +30,7 @@ export const AssetNameCell: FunctionComponent<Partial<Cell>> = observer(
 
     return (
       <div
-        className={classNames("flex items-center gap-2", {
+        className={classNames("flex w-48 items-center gap-2", {
           "opacity-40": !shouldDisplayUnverifiedAssets && !isVerified,
         })}
         onMouseEnter={() => setShowStar(true)}

--- a/packages/web/components/table/cells/balance.tsx
+++ b/packages/web/components/table/cells/balance.tsx
@@ -8,7 +8,7 @@ export const BalanceCell: FunctionComponent<Partial<Cell>> = ({
   fiatValue,
 }) =>
   amount ? (
-    <div className="right flex flex-col">
+    <div className="right flex w-48 flex-col">
       <span className="body1 text-white-high">
         <DesktopOnlyPrivateText text={amount} />
       </span>

--- a/packages/web/components/table/hooks/use-web-search-box-input-state.tsx
+++ b/packages/web/components/table/hooks/use-web-search-box-input-state.tsx
@@ -1,0 +1,33 @@
+import { useRef } from "react";
+import { useKey } from "react-use";
+
+import { useControllableState } from "~/hooks/use-controllable-state";
+
+export const useWebSearchBoxInputState = () => {
+  const [searchBoxInputIsFocused, setSearchBoxInputIsFocused] =
+    useControllableState({
+      defaultValue: false,
+    });
+  const searchBoxRef = useRef<HTMLInputElement>(null);
+  useKey(
+    "/",
+    (event) => {
+      event.preventDefault(); // Prevent the '/' from being entered into the input
+      searchBoxRef.current?.focus();
+    },
+    { event: "keydown" },
+    []
+  );
+  useKey(
+    "Escape",
+    () => searchBoxRef.current?.blur(),
+    { event: "keydown" },
+    []
+  );
+
+  return {
+    searchBoxInputIsFocused,
+    searchBoxRef,
+    setSearchBoxInputIsFocused,
+  };
+};

--- a/packages/web/components/table/hooks/use-web-search-box-input-state.tsx
+++ b/packages/web/components/table/hooks/use-web-search-box-input-state.tsx
@@ -3,6 +3,18 @@ import { useKey } from "react-use";
 
 import { useControllableState } from "~/hooks/use-controllable-state";
 
+export const delayOnFalse =
+  (callback: (newValue: boolean) => void, ms: number = 100) =>
+  (newVale: boolean) => {
+    if (!newVale) {
+      setTimeout(() => {
+        callback(false);
+      }, ms);
+    } else {
+      callback(true);
+    }
+  };
+
 export const useWebSearchBoxInputState = () => {
   const [searchBoxInputIsFocused, setSearchBoxInputIsFocused] =
     useControllableState({


### PR DESCRIPTION
## What is the purpose of the change

In the Assets Page, user should see the top five relevant tokens on focus of the search input.

### ClickUp Task

[ClickUp Task URL](https://app.clickup.com/t/86a2cmyj5)

## Brief Changelog

When the user actually inputs text into the search, the defaults should disappear and be replaced by normal search items using existing logic.

- [x] Set special computed state derived from the input focus/blur state and the search query.
- [x] Add key shortcuts to get and exit search.

## Testing and Verifying

Once the search input in the asset page is focused the user should see only the top 5 tokens:

OSMO
ATOM
USDC
DYM
TIA

User should not see the load more button.

<img width="1134" alt="Screenshot 2024-03-05 at 12 34 02 AM" src="https://github.com/osmosis-labs/osmosis-frontend/assets/61532/6464fe98-9874-4e30-a5ac-5b3c5626d85b">

<img width="1166" alt="Screenshot 2024-03-05 at 12 33 48 AM" src="https://github.com/osmosis-labs/osmosis-frontend/assets/61532/abb2925c-c687-4e7d-a09a-e3866b015707">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced the `AssetsTableV1` component to display only favorite assets when the search box is focused and contains no query.
	- Added keyboard interaction improvements for focusing and blurring the search box in the `AssetsTableV1` component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->