### PR TITLE
Remove batching from select assets

### DIFF
--- a/packages/web/hooks/use-swap.ts
+++ b/packages/web/hooks/use-swap.ts
@@ -515,7 +515,16 @@ function useSwapAsset<TAsset extends Asset>(
       findMinDenomOrSymbol: minDenomOrSymbol ?? "",
       userOsmoAddress: account?.address,
     },
-    { enabled: queryEnabled }
+    {
+      enabled: queryEnabled,
+
+      // since asset is often point of attention, don't block on other potentially expensive queries
+      trpc: {
+        context: {
+          skipBatch: true,
+        },
+      },
+    }
   );
 
   return {


### PR DESCRIPTION
It could get batched with another more expensive tRPC query, causing unnecessary delays in asset info loading in swap tool.