### PR TITLE
Use only `coinMinimalDenom`  for price cache key

### DIFF
--- a/packages/web/components/input/search-box.tsx
+++ b/packages/web/components/input/search-box.tsx
@@ -81,7 +81,6 @@ export const SearchBox = forwardRef<HTMLInputElement, SearchBoxProps>(
 
     const _onInput = useCallback(
       (e: ChangeEvent<HTMLInputElement>) => {
-        console.log(e);
         onInput(e.target.value);
       },
       [onInput]

--- a/packages/web/components/pool-detail/share.tsx
+++ b/packages/web/components/pool-detail/share.tsx
@@ -122,8 +122,6 @@ export const SharePool: FunctionComponent<{ pool: Pool }> = observer(
       );
     const bondDurations = useMemo(() => bondDurations_ ?? [], [bondDurations_]);
 
-    console.log(bondDurations);
-
     const apiUtils = api.useUtils();
     const invalidateQueries: <T>(value: T) => T = useCallback(
       (value) => {

--- a/packages/web/server/queries/complex/assets/price.ts
+++ b/packages/web/server/queries/complex/assets/price.ts
@@ -226,8 +226,21 @@ export async function getAssetPrice({
   }>;
   currency?: CoingeckoVsCurrencies;
 }): Promise<Dec | undefined> {
+  const cacheKey = getAssetFromAssetList({
+    sourceDenom: asset.sourceDenom,
+    coinMinimalDenom: asset.coinMinimalDenom,
+    assetLists: AssetLists,
+  })?.coinMinimalDenom;
+
+  if (!cacheKey)
+    throw new Error(
+      `Asset ${
+        asset.coinDenom ?? asset.coinMinimalDenom ?? asset.sourceDenom
+      } not found in asset list registry.`
+    );
+
   return cachified({
-    key: `asset-price-${asset.coinDenom}-${asset.coinMinimalDenom}-${asset.sourceDenom}-${currency}`,
+    key: `asset-price-${cacheKey}`,
     cache: pricesCache,
     ttl: 1000 * 30, // 30 seconds, as calculating prices is expensive and cached remotely
     staleWhileRevalidate: 1000 * 60, // 1 minute

--- a/packages/web/server/queries/complex/assets/price.ts
+++ b/packages/web/server/queries/complex/assets/price.ts
@@ -247,7 +247,7 @@ export async function getAssetPrice({
     key: `asset-price-${assetListAsset.coinMinimalDenom}`,
     cache: pricesCache,
     ttl: 1000 * 30, // 30 seconds, as calculating prices is expensive and cached remotely
-    staleWhileRevalidate: 1000 * 60, // 1 minute
+    staleWhileRevalidate: 1000 * 60 * 5, // 5 minutes, to allow plenty of time for pools to be queried in background
     getFreshValue: async () => {
       if (assetListAsset.priceInfo) {
         return await calculatePriceThroughPools({

--- a/packages/web/server/queries/complex/pools/providers/__tests__/indexer.spec.ts
+++ b/packages/web/server/queries/complex/pools/providers/__tests__/indexer.spec.ts
@@ -3,7 +3,7 @@
  */
 
 import { getAsset } from "../../../assets";
-import { makePoolFromImperatorPool } from "../indexer";
+import { makePoolFromIndexerPool } from "../indexer";
 
 export const mockAsset = {
   coinDenom: "mockCoinDenom",
@@ -19,7 +19,7 @@ jest.mock("../../../assets", () => ({
   getAsset: jest.fn(),
 }));
 
-describe("makePoolFromImperatorPool", () => {
+describe("makePoolFromIndexerPool", () => {
   beforeEach(() => {
     // Mock the getAsset function before calling getPoolsFromSidecar
     (getAsset as jest.Mock).mockImplementation(() => {
@@ -28,7 +28,7 @@ describe("makePoolFromImperatorPool", () => {
   });
 
   it("should return a valid pool object for a weighted pool", async () => {
-    const result = await makePoolFromImperatorPool(weightedPool as any);
+    const result = await makePoolFromIndexerPool(weightedPool as any);
 
     if (!result) throw new Error("result is undefined");
 
@@ -39,7 +39,7 @@ describe("makePoolFromImperatorPool", () => {
   });
 
   it("should return a valid pool object for a stable pool", async () => {
-    const result = await makePoolFromImperatorPool(stablePool as any);
+    const result = await makePoolFromIndexerPool(stablePool as any);
 
     if (!result) throw new Error("result is undefined");
 
@@ -51,7 +51,7 @@ describe("makePoolFromImperatorPool", () => {
   });
 
   it("should return a valid pool object for a concentrated liquidity pool", async () => {
-    const result = await makePoolFromImperatorPool(concentratedPool as any);
+    const result = await makePoolFromIndexerPool(concentratedPool as any);
 
     if (!result) throw new Error("result is undefined");
 
@@ -62,9 +62,7 @@ describe("makePoolFromImperatorPool", () => {
   });
 
   it("should return a valid pool object for a cosmwasm transmuter pool", async () => {
-    const result = await makePoolFromImperatorPool(
-      cosmwasmTransmuterPool as any
-    );
+    const result = await makePoolFromIndexerPool(cosmwasmTransmuterPool as any);
 
     if (!result) throw new Error("result is undefined");
 
@@ -74,7 +72,7 @@ describe("makePoolFromImperatorPool", () => {
   });
 
   it("should return a valid pool object for a cosmwasm pool", async () => {
-    const result = await makePoolFromImperatorPool(cosmwasmPool as any);
+    const result = await makePoolFromIndexerPool(cosmwasmPool as any);
 
     if (!result) throw new Error("result is undefined");
 

--- a/packages/web/server/queries/complex/pools/providers/indexer.ts
+++ b/packages/web/server/queries/complex/pools/providers/indexer.ts
@@ -75,7 +75,7 @@ export async function getPoolsFromIndexer({
         },
         { offset: 0, limit: Number(numPools.num_pools) }
       );
-      return (await Promise.all(pools.map(makePoolFromImperatorPool))).filter(
+      return (await Promise.all(pools.map(makePoolFromIndexerPool))).filter(
         (pool): pool is Pool =>
           !!pool && (poolIds ? poolIds.includes(pool.id) : true)
       );
@@ -358,7 +358,7 @@ function makeCoinFromToken(poolToken: PoolToken): CoinPrimitive {
   };
 }
 
-export async function makePoolFromImperatorPool(
+export async function makePoolFromIndexerPool(
   filteredPool: FilteredPoolsResponse["pools"][number]
 ): Promise<Pool | undefined> {
   // deny pools containing tokens with gamm denoms


### PR DESCRIPTION
The way we formed the cache key may cause some unnecessary cache misses in the remote cache. The `getAssetPrice` receives an object identifying the asset with either `coinMinimalDenom` or `sourceDenom`. So, we may get cache misses depending on what identifier is used.

This change has us query the asset list with those identifiers and using the the valid asset's `coinMinimalDenom` as the sole cache key. On Osmosis, it will be a guaranteed unique representation/identifier for that asset.

Also, I narrowed the type to fail builds if at least one identifier is not provided, which may prevent future bugs.

You can see the simplification when querying the cache directly:
<img width="1170" alt="Screenshot 2024-03-06 at 9 44 11 AM" src="https://github.com/osmosis-labs/osmosis-frontend/assets/4606373/57420a15-25ef-44fc-ae27-18529f96437b">
