### PR TITLE
Disable remote cache for prices

### DIFF
--- a/packages/web/server/queries/complex/assets/price.ts
+++ b/packages/web/server/queries/complex/assets/price.ts
@@ -13,7 +13,7 @@ import {
 } from "~/server/queries/coingecko";
 import { queryPaginatedPools } from "~/server/queries/complex/pools/providers/indexer";
 import { EdgeDataLoader } from "~/utils/batching";
-import { DEFAULT_LRU_OPTIONS, RemoteCache } from "~/utils/cache";
+import { DEFAULT_LRU_OPTIONS } from "~/utils/cache";
 
 import {
   queryTokenHistoricalChart,
@@ -25,7 +25,7 @@ import {
 } from "../../imperator";
 import { getAsset } from ".";
 
-const pricesCache = new RemoteCache();
+const pricesCache = new LRUCache<string, CacheEntry>(DEFAULT_LRU_OPTIONS);
 const coinGeckoCache = new LRUCache<string, CacheEntry>(DEFAULT_LRU_OPTIONS);
 
 /** Cached CoinGecko ID for needs of price function. */


### PR DESCRIPTION
When working on new assets page, I found, even with fast read times, the remote cache of prices was causing user asset breakdown and assets table to take a long time to load. For now, let's disable it and wait for SQS prices endpoint.