### PR TITLE
Fix: get only asset info in swap tool

### DIFF
--- a/packages/web/components/navbar/index.tsx
+++ b/packages/web/components/navbar/index.tsx
@@ -380,7 +380,7 @@ const WalletInfo: FunctionComponent<
   const walletConnected = Boolean(wallet?.isWalletConnected);
 
   const { data: userOsmoAsset, isLoading: isLoadingUserOsmoAsset } =
-    api.edge.assets.getAsset.useQuery(
+    api.edge.assets.getUserAsset.useQuery(
       {
         findMinDenomOrSymbol: "OSMO",
         userOsmoAddress: wallet?.address as string,

--- a/packages/web/hooks/use-swap.ts
+++ b/packages/web/hooks/use-swap.ts
@@ -522,7 +522,7 @@ function useSwapAsset<TAsset extends Asset>(
   );
 
   return {
-    asset: existingAsset ?? asset,
+    asset: existingAsset ?? (asset as TAsset),
     isLoading: isLoading && !existingAsset,
   };
 }

--- a/packages/web/hooks/use-swap.ts
+++ b/packages/web/hooks/use-swap.ts
@@ -347,7 +347,7 @@ export function useSwapAssets({
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
-  } = api.edge.assets.getAssets.useInfiniteQuery(
+  } = api.edge.assets.getUserAssets.useInfiniteQuery(
     {
       search: queryInput,
       userOsmoAddress: account?.address,
@@ -493,10 +493,6 @@ function useSwapAsset<TAsset extends Asset>(
   minDenomOrSymbol?: string,
   existingAssets: TAsset[] = []
 ) {
-  const { chainStore, accountStore } = useStore();
-  const account = accountStore.getWallet(chainStore.osmosis.chainId);
-  const { isLoading: isLoadingWallet } = useWalletSelect();
-
   /** If `coinDenom` or `coinMinimalDenom` don't yield a result, we
    *  can fall back to the getAssets query which will perform
    *  a more comprehensive search. */
@@ -508,12 +504,10 @@ function useSwapAsset<TAsset extends Asset>(
   const queryEnabled =
     !isNil(minDenomOrSymbol) &&
     typeof minDenomOrSymbol === "string" &&
-    !isLoadingWallet &&
     !existingAsset;
   const { data: asset, isLoading } = api.edge.assets.getAsset.useQuery(
     {
       findMinDenomOrSymbol: minDenomOrSymbol ?? "",
-      userOsmoAddress: account?.address,
     },
     {
       enabled: queryEnabled,

--- a/packages/web/modals/profile.tsx
+++ b/packages/web/modals/profile.tsx
@@ -91,7 +91,7 @@ export const ProfileModal: FunctionComponent<
 
   const address = wallet?.address ?? "";
 
-  const { data: userOsmoAsset } = api.edge.assets.getAsset.useQuery(
+  const { data: userOsmoAsset } = api.edge.assets.getUserAsset.useQuery(
     {
       findMinDenomOrSymbol: "OSMO",
       userOsmoAddress: wallet?.address ?? "",

--- a/packages/web/server/api/edge-routers/assets-router.ts
+++ b/packages/web/server/api/edge-routers/assets-router.ts
@@ -37,6 +37,15 @@ const GetInfiniteAssetsInputSchema = InfiniteQuerySchema.merge(
 export const assetsRouter = createTRPCRouter({
   getAsset: publicProcedure
     .input(
+      z.object({
+        findMinDenomOrSymbol: z.string(),
+      })
+    )
+    .query(async ({ input: { findMinDenomOrSymbol } }) =>
+      getAsset({ anyDenom: findMinDenomOrSymbol })
+    ),
+  getUserAsset: publicProcedure
+    .input(
       z
         .object({
           findMinDenomOrSymbol: z.string(),
@@ -51,7 +60,7 @@ export const assetsRouter = createTRPCRouter({
         userOsmoAddress,
       });
     }),
-  getAssets: publicProcedure
+  getUserAssets: publicProcedure
     .input(GetInfiniteAssetsInputSchema)
     .query(
       async ({

--- a/packages/web/stores/index.tsx
+++ b/packages/web/stores/index.tsx
@@ -8,8 +8,8 @@ const storeContext = React.createContext<RootStore | null>(null);
 /** Once data is invalidated, React Query will automatically refetch data
  *  when the dependent component becomes visible. */
 function invalidateQueryData(apiUtils: ReturnType<typeof api.useUtils>) {
-  apiUtils.edge.assets.getAsset.invalidate();
-  apiUtils.edge.assets.getAssets.invalidate();
+  apiUtils.edge.assets.getUserAsset.invalidate();
+  apiUtils.edge.assets.getUserAssets.invalidate();
   apiUtils.edge.assets.getMarketAsset.invalidate();
   apiUtils.edge.assets.getMarketAssets.invalidate();
   apiUtils.edge.assets.getUserAssetsBreakdown.invalidate();


### PR DESCRIPTION
I realized the performance issue of loading to/from assets in swap tool was from needlessly getting the user's balance as well as the asset info. I refactored the tRPC procedure name to make this clearer, and only get the currency in the to/from portion of the swap tool.