### PR TITLE
Update DYM Deposit Override

### DIFF
--- a/packages/web/config/ibc-overrides.ts
+++ b/packages/web/config/ibc-overrides.ts
@@ -540,7 +540,7 @@ const MainnetIBCAdditionalData: Partial<
   },
   DYM: {
     depositUrlOverride:
-      "https://pro.osmosis.zone/ibc?chainFrom=dymension_1100-1&chainTo=osmosis-1&token0=adym&token1=ibc%2F9A76CDF0CBCEF37923F32518FA15E5DC92B9F56128292BC4D63C4AEA76CBB110",
+      "https://portal.dymension.xyz/ibc",
   },
   "injective.GLTO": {
     depositUrlOverride:

--- a/packages/web/config/ibc-overrides.ts
+++ b/packages/web/config/ibc-overrides.ts
@@ -539,8 +539,7 @@ const MainnetIBCAdditionalData: Partial<
       "https://pro.osmosis.zone/ibc?chainFrom=osmosis-1&chainTo=injective-1&token0=ibc%2F183C0BB962D2F57C957E0B134CFA0AC9D6F755C02DE9DC2A59089BA23009DEC3&token1=factory%2Finj1xtel2knkt8hmc9dnzpjz6kdmacgcfmlv5f308w%2Fninja",
   },
   DYM: {
-    depositUrlOverride:
-      "https://portal.dymension.xyz/ibc",
+    depositUrlOverride: "https://portal.dymension.xyz/ibc",
   },
   "injective.GLTO": {
     depositUrlOverride:


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change
Update DYM Deposit Override to Dymension Protal, which now supports Osmosis and works with Metamask (when Osmosis Pro's Leap MetaMask snaps doesn't work for all Metamask users)

## Brief Changelog

Update ibc-overrides.ts DYM Deposit transfer override to point to Dymension Portal instead.

## Testing and Verifying

This change has been tested locally by rebuilding the website and verified content and links are expected
