### PR TITLE
getUserPools: Catch query errors

### DIFF
--- a/packages/web/server/queries/complex/concentrated-liquidity/index.ts
+++ b/packages/web/server/queries/complex/concentrated-liquidity/index.ts
@@ -491,16 +491,7 @@ export async function mapGetUserPositions({
         ({ positions }) => positions
       );
 
-  const stakeCurrencyPromise = getAsset({
-    anyDenom: ChainList[0].staking.staking_tokens[0].denom,
-  });
-
-  const [positions, stakeCurrency] = await Promise.all([
-    positionsPromise,
-    stakeCurrencyPromise,
-  ]);
-
-  if (!stakeCurrency) throw new Error(`Stake currency (OSMO) not found`);
+  const positions = await positionsPromise;
 
   const userPositions = await Promise.all(
     positions
@@ -524,7 +515,7 @@ export async function mapGetUserPositions({
         }
         const currentValue = new PricePretty(
           DEFAULT_VS_CURRENCY,
-          (await calcSumCoinsValue([baseCoin, quoteCoin])) ?? 0
+          await calcSumCoinsValue([baseCoin, quoteCoin]).catch(() => 0)
         );
 
         const lowerTick = new Int(position.lower_tick);

--- a/packages/web/server/queries/complex/pools/user.ts
+++ b/packages/web/server/queries/complex/pools/user.ts
@@ -5,13 +5,19 @@ import {
   mapRawCoinToPretty,
 } from "~/server/queries/complex/assets";
 import { DEFAULT_VS_CURRENCY } from "~/server/queries/complex/assets/config";
-import { getCachedPoolIncentivesMap } from "~/server/queries/complex/pools/incentives";
+import {
+  getCachedPoolIncentivesMap,
+  PoolIncentives,
+} from "~/server/queries/complex/pools/incentives";
 import { queryBalances } from "~/server/queries/cosmos";
 import {
   StablePoolRawResponse,
   WeightedPoolRawResponse,
 } from "~/server/queries/osmosis";
-import { queryAccountPositions } from "~/server/queries/osmosis/concentratedliquidity";
+import {
+  LiquidityPosition,
+  queryAccountPositions,
+} from "~/server/queries/osmosis/concentratedliquidity";
 import {
   queryAccountLockedCoins,
   queryAccountUnlockingCoins,
@@ -29,20 +35,26 @@ export async function getUserPools(bech32Address: string) {
   const [accountPositions, poolIncentives, superfluidPoolIds] =
     await Promise.all([
       timeout(
-        () => queryAccountPositions({ bech32Address }),
+        () =>
+          queryAccountPositions({ bech32Address })
+            .then(({ positions }) => positions)
+            .catch(() => [] as LiquidityPosition[]),
         10_000, // 10 seconds
         "queryCLPositions"
-      )(),
+      )().catch(() => [] as LiquidityPosition[]),
       timeout(
-        () => getCachedPoolIncentivesMap(),
+        () =>
+          getCachedPoolIncentivesMap().catch(
+            () => new Map<string, PoolIncentives>()
+          ),
         10_000, // 10 seconds
         "getCachedPoolIncentivesMap"
-      )(),
+      )().catch(() => new Map<string, PoolIncentives>()),
       timeout(
-        () => getSuperfluidPoolIds(),
+        () => getSuperfluidPoolIds().catch(() => [] as string[]),
         10_000, // 10 seconds
         "getSuperfluidPoolIds"
-      )(),
+      )().catch(() => [] as string[]),
     ]);
 
   const { locked: lockedShares, poolIds } = await getUserShareRawCoins(
@@ -50,7 +62,7 @@ export async function getUserPools(bech32Address: string) {
   );
 
   const userUniquePoolIds = new Set(poolIds);
-  accountPositions.positions
+  accountPositions
     .map(({ position: { pool_id } }) => pool_id)
     .forEach((poolId) => userUniquePoolIds.add(poolId));
 
@@ -69,7 +81,7 @@ export async function getUserPools(bech32Address: string) {
       );
 
       if (type === "concentrated") {
-        const positions = accountPositions.positions.filter(
+        const positions = accountPositions.filter(
           ({ position: { pool_id } }) => pool_id === id
         );
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

Add some more fault tolerance to getUserPools to catch errors and timeouts and return data as missing instead of failing the procedure.

### ClickUp Task

[ClickUp Task URL](PASTE_CLICKUP_TASK_URL_HERE)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
