### PR TITLE
Use indexer for pools

### DIFF
--- a/packages/web/server/queries/complex/pools/index.ts
+++ b/packages/web/server/queries/complex/pools/index.ts
@@ -5,7 +5,7 @@ import { IS_TESTNET } from "~/config/env";
 import { search, SearchSchema } from "~/utils/search";
 
 import { PoolRawResponse } from "../../osmosis";
-import { getPoolsFromSidecar } from "./providers/sidecar";
+import { getPoolsFromIndexer } from "./providers/indexer";
 
 const allPooltypes = [
   "concentrated",
@@ -60,7 +60,7 @@ export async function getPool({ poolId }: { poolId: string }): Promise<Pool> {
  *  Params can be used to filter the results by a fuzzy search on the id, type, or coin denoms, as well as a specific id or type. */
 export async function getPools(
   params?: PoolFilter,
-  poolProvider: PoolProvider = getPoolsFromSidecar
+  poolProvider: PoolProvider = getPoolsFromIndexer
 ): Promise<Pool[]> {
   let pools = await poolProvider({ poolIds: params?.poolIds });
 


### PR DESCRIPTION
We moved our pools query to SQS since all of our indexer data sources were down. This saved our prod environment since we had no source for pools.

However, since we still need to calculate pool TVL from prices for SQS pools, I've often noticed performance issues in prod.

So, with the indexer back up, I'm going to switch our pools provider back to the indexer until we can get USDC TVL from the sidecar pools query.