### PR TITLE
SQS prices: remove 0 dec check

### DIFF
--- a/packages/web/server/queries/complex/assets/price/providers/sidecar.ts
+++ b/packages/web/server/queries/complex/assets/price/providers/sidecar.ts
@@ -58,9 +58,6 @@ function getBatchLoader() {
 }
 
 export function getPriceBatched(asset: Asset) {
-  if (asset.decimals === 0)
-    throw new Error("SQS currently does not support 0 decimal tokens");
-
   return cachified({
     cache: sidecarCache,
     key: `coingecko-price-${asset.coinMinimalDenom}`,


### PR DESCRIPTION
SQS now returns prices for 0 dec tokens

Before merging this, this should not return an error:
https://sqsprod.osmosis.zone/tokens/prices?base=ibc%2FE27CD305D33F150369AB526AEB6646A76EC3FFB1A6CA58A663B5DE657A89D55D