### PR TITLE
SQS prices: fall back to CoinGecko for missing prices

### DIFF
--- a/packages/web/server/queries/complex/assets/price/providers/sidecar.ts
+++ b/packages/web/server/queries/complex/assets/price/providers/sidecar.ts
@@ -10,6 +10,8 @@ import {
 import { EdgeDataLoader } from "~/utils/batching";
 import { LARGE_LRU_OPTIONS } from "~/utils/cache";
 
+import { getPriceFromCoinGecko } from "./coingecko";
+
 const sidecarCache = new LRUCache<string, CacheEntry>(LARGE_LRU_OPTIONS);
 
 /** Gets price from SQS query server. Currently only supports prices in USDC with decimals. Falls back to querying CoinGecko if not available.
@@ -67,10 +69,11 @@ export function getPriceBatched(asset: Asset) {
     ttl: 1000 * 60, // 1 minute
     staleWhileRevalidate: 1000 * 60 * 2, // 2 minutes
     getFreshValue: () =>
-      getBatchLoader().then(
-        (loader) =>
-          loader.load(asset.coinMinimalDenom).then((price) => new Dec(price))
-        // .catch(() => getPriceFromCoinGecko(asset))
+      getBatchLoader().then((loader) =>
+        loader
+          .load(asset.coinMinimalDenom)
+          .then((price) => new Dec(price))
+          .catch(() => getPriceFromCoinGecko(asset))
       ),
   });
 }


### PR DESCRIPTION
Try to get price from CoinGecko if SQS fails to provide a price.