### PR TITLE
feat: Standardize Edge Endpoint and Remove Region Lock

### DIFF
--- a/packages/web/pages/api/edge-trpc/[trpc].ts
+++ b/packages/web/pages/api/edge-trpc/[trpc].ts
@@ -7,7 +7,6 @@ import { createEdgeTRPCContext } from "~/server/api/trpc";
 // We're using the edge-runtime
 export const config = {
   runtime: "edge",
-  regions: ["cdg1"], // Only execute this function in the Paris region
 };
 
 export default async function handler(req: NextRequest) {

--- a/packages/web/pages/api/edge-trpc/[trpc].ts
+++ b/packages/web/pages/api/edge-trpc/[trpc].ts
@@ -12,7 +12,7 @@ export const config = {
 
 export default async function handler(req: NextRequest) {
   return fetchRequestHandler({
-    endpoint: "/api/edge-trpc",
+    endpoint: "/api/edge-trpc-main",
     router: edgeRouter,
     req,
     createContext: createEdgeTRPCContext,

--- a/packages/web/pages/api/pools-edge-trpc/[trpc].ts
+++ b/packages/web/pages/api/pools-edge-trpc/[trpc].ts
@@ -7,7 +7,6 @@ import { createEdgeTRPCContext } from "~/server/api/trpc";
 // We're using the edge-runtime
 export const config = {
   runtime: "edge",
-  regions: ["cdg1"], // Only execute this function in the Paris region
 };
 
 /**

--- a/packages/web/pages/api/pools-edge-trpc/[trpc].ts
+++ b/packages/web/pages/api/pools-edge-trpc/[trpc].ts
@@ -16,7 +16,7 @@ export const config = {
  */
 export default async function handler(req: NextRequest) {
   return fetchRequestHandler({
-    endpoint: "/api/pools-edge-trpc",
+    endpoint: "/api/edge-trpc-pools",
     router: edgeRouter,
     req,
     createContext: createEdgeTRPCContext,

--- a/packages/web/utils/trpc.ts
+++ b/packages/web/utils/trpc.ts
@@ -82,13 +82,15 @@ export const api = createTRPCNext<AppRouter>({
           // initialize the different links for different targets (edge and node)
           const servers = {
             node: makeSkipBatchLink(`${getBaseUrl()}/api/trpc`)(runtime),
-            edge: makeSkipBatchLink(`${getBaseUrl()}/api/edge-trpc`)(runtime),
+            edge: makeSkipBatchLink(`${getBaseUrl()}/api/edge-trpc-main`)(
+              runtime
+            ),
 
             /**
              * Create a separate link for the pools edge server since its query is too expensive
              * and it's slowing the other queries down because of JS single threaded nature.
              */
-            poolsEdge: makeSkipBatchLink(`${getBaseUrl()}/api/pools-edge-trpc`)(
+            poolsEdge: makeSkipBatchLink(`${getBaseUrl()}/api/edge-trpc-pools`)(
               runtime
             ),
           };


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

This PR standardizes the edge routes to `/api/edge-trpc-*`. This will be useful for matching all paths in services like Cloudflare. 
