### PR TITLE
refactor: remove pools query from router

### DIFF
--- a/packages/web/server/api/edge-routers/swap-router.ts
+++ b/packages/web/server/api/edge-routers/swap-router.ts
@@ -1,4 +1,10 @@
-import { CoinPretty, Int, PricePretty, RatePretty } from "@keplr-wallet/unit";
+import {
+  CoinPretty,
+  Dec,
+  Int,
+  PricePretty,
+  RatePretty,
+} from "@keplr-wallet/unit";
 import type {
   SplitTokenInQuote,
   TokenOutGivenInRouter,
@@ -15,7 +21,6 @@ import {
   getAssetPrice,
 } from "~/server/queries/complex/assets";
 import { DEFAULT_VS_CURRENCY } from "~/server/queries/complex/assets/config";
-import { getPool } from "~/server/queries/complex/pools";
 import { routeTokenOutGivenIn } from "~/server/queries/complex/pools/route-token-out-given-in";
 
 const osmosisChainId = ChainList[0].chain_id;
@@ -155,8 +160,6 @@ async function makeDisplayableSplit(split: SplitTokenInQuote["split"]) {
       const { pools, tokenInDenom, tokenOutDenoms } = existingSplit;
       const poolsWithInfos = await Promise.all(
         pools.map(async (pool, index) => {
-          const { id } = pool;
-          const pool_ = await getPool({ poolId: id }).catch(() => null);
           const inAsset = await getAsset({
             anyDenom: index === 0 ? tokenInDenom : tokenOutDenoms[index - 1],
           });
@@ -165,9 +168,11 @@ async function makeDisplayableSplit(split: SplitTokenInQuote["split"]) {
           });
 
           return {
-            id: pool.id,
-            spreadFactor: pool_?.spreadFactor,
-            type: pool_?.type,
+            ...pool,
+            spreadFactor: new RatePretty(
+              pool.swapFee ? pool.swapFee : new Dec(0)
+            ),
+            type: pool.type,
             inCurrency: inAsset,
             outCurrency: outAsset,
           };


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Avoid querying pools in the router. We have all info coming from quotes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced the logic of the `makeDisplayableSplit` function for efficiency and simplicity by utilizing direct properties from the `pool` object.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->