### PR TITLE
feat: Add Timeout for All Procedures

### DIFF
--- a/packages/web/server/api/edge-routers/pools-router.ts
+++ b/packages/web/server/api/edge-routers/pools-router.ts
@@ -20,7 +20,6 @@ import {
   getUserPools,
   getUserSharePools,
 } from "~/server/queries/complex/pools/user";
-import timeout from "~/utils/async";
 import { createSortSchema, sort } from "~/utils/sort";
 
 import { maybeCachePaginatedItems } from "../pagination";
@@ -109,68 +108,63 @@ export const poolsRouter = createTRPCRouter({
           limit,
         },
       }) =>
-        timeout(
-          () =>
-            maybeCachePaginatedItems({
-              getFreshItems: async () => {
-                const poolsPromise = getPools({
-                  search,
-                  minLiquidityUsd,
-                  types,
-                });
-                const incentivesPromise = getCachedPoolIncentivesMap();
-                const marketMetricsPromise = getCachedPoolMarketMetricsMap();
+        maybeCachePaginatedItems({
+          getFreshItems: async () => {
+            const poolsPromise = getPools({
+              search,
+              minLiquidityUsd,
+              types,
+            });
+            const incentivesPromise = getCachedPoolIncentivesMap();
+            const marketMetricsPromise = getCachedPoolMarketMetricsMap();
 
-                /** Get remote data via concurrent requests, if needed. */
-                const [pools, incentives, marketMetrics] = await Promise.all([
-                  poolsPromise,
-                  incentivesPromise,
-                  marketMetricsPromise,
-                ]);
+            /** Get remote data via concurrent requests, if needed. */
+            const [pools, incentives, marketMetrics] = await Promise.all([
+              poolsPromise,
+              incentivesPromise,
+              marketMetricsPromise,
+            ]);
 
-                const marketIncentivePools = pools
-                  .map((pool) => {
-                    const incentivesForPool = incentives.get(pool.id);
-                    const metricsForPool = marketMetrics.get(pool.id) ?? {};
+            const marketIncentivePools = pools
+              .map((pool) => {
+                const incentivesForPool = incentives.get(pool.id);
+                const metricsForPool = marketMetrics.get(pool.id) ?? {};
 
-                    const isIncentiveFiltered =
-                      incentivesForPool &&
-                      isIncentivePoolFiltered(incentivesForPool, {
-                        incentiveTypes,
-                      });
+                const isIncentiveFiltered =
+                  incentivesForPool &&
+                  isIncentivePoolFiltered(incentivesForPool, {
+                    incentiveTypes,
+                  });
 
-                    if (isIncentiveFiltered) return;
+                if (isIncentiveFiltered) return;
 
-                    return {
-                      ...pool,
-                      ...incentivesForPool,
-                      ...metricsForPool,
-                    };
-                  })
-                  .filter((pool): pool is NonNullable<typeof pool> => !!pool);
+                return {
+                  ...pool,
+                  ...incentivesForPool,
+                  ...metricsForPool,
+                };
+              })
+              .filter((pool): pool is NonNullable<typeof pool> => !!pool);
 
-                // won't sort if searching
-                if (search) return marketIncentivePools;
-                else
-                  return sort(
-                    marketIncentivePools,
-                    sortInput.keyPath,
-                    sortInput.direction
-                  );
-              },
-              cacheKey: JSON.stringify({
-                search,
-                sortInput,
-                minLiquidityUsd,
-                types,
-                incentiveTypes,
-              }),
-              cursor,
-              limit,
-            }),
-          12_000,
-          "getMarketIncentivePools"
-        )()
+            // won't sort if searching
+            if (search) return marketIncentivePools;
+            else
+              return sort(
+                marketIncentivePools,
+                sortInput.keyPath,
+                sortInput.direction
+              );
+          },
+          cacheKey: JSON.stringify({
+            search,
+            sortInput,
+            minLiquidityUsd,
+            types,
+            incentiveTypes,
+          }),
+          cursor,
+          limit,
+        })
     ),
   getSuperfluidPoolIds: publicProcedure.query(getSuperfluidPoolIds),
   getPoolMarketMetrics: publicProcedure

--- a/packages/web/server/api/trpc.ts
+++ b/packages/web/server/api/trpc.ts
@@ -9,6 +9,7 @@ import { type CreateNextContextOptions } from "@trpc/server/adapters/next";
 import { ZodError } from "zod";
 
 import { Errors } from "~/server/api/errors";
+import timeout from "~/utils/async";
 import { superjson } from "~/utils/superjson";
 
 /**
@@ -92,4 +93,10 @@ export const createTRPCRouter = t.router;
  * guarantee that a user querying is authorized, but we can still access user session data if they
  * are logged in.
  */
-export const publicProcedure = t.procedure;
+export const publicProcedure = t.procedure.use(async (opts) => {
+  /**
+   * Default timeout for all procedures
+   */
+  const result = await timeout(() => opts.next(), 12_000, opts.path)();
+  return result;
+});


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

After experiencing issues with edge functions timing out after 25 seconds, which also blocked any additional requests, we will implement a 12s timeout for all procedures. This change will help us identify which functions are timing out more easily and allow more requests to the same function, reducing overall bottlenecked traffic. Additionally, we will include the path name of any method that times out to facilitate further debugging.

## Brief Changelog

- Add timeout to all procedures

## Testing and Verifying

- [ ] All requests should resolve  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Implemented a timeout functionality for all server procedures to enhance performance and reliability.
- **Refactor**
	- Optimized data retrieval and processing in the pools management feature, including improved sorting and filtering based on incentives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->