### PR TITLE
Fall back to calculating price from pool routes if SQS doesn't return a price

### DIFF
--- a/packages/web/server/queries/complex/assets/price/providers/sidecar.ts
+++ b/packages/web/server/queries/complex/assets/price/providers/sidecar.ts
@@ -10,7 +10,6 @@ import {
 import { EdgeDataLoader } from "~/utils/batching";
 import { LARGE_LRU_OPTIONS } from "~/utils/cache";
 
-import { getPriceFromCoinGecko } from "./coingecko";
 import { getPriceFromPools } from "./pools";
 
 const sidecarCache = new LRUCache<string, CacheEntry>(LARGE_LRU_OPTIONS);
@@ -70,9 +69,7 @@ export function getPriceBatched(asset: Asset) {
         loader
           .load(asset.coinMinimalDenom)
           .then((price) => new Dec(price))
-          .catch(() =>
-            getPriceFromPools(asset).catch(() => getPriceFromCoinGecko(asset))
-          )
+          .catch(() => getPriceFromPools(asset))
       ),
   });
 }

--- a/packages/web/server/queries/complex/assets/price/providers/sidecar.ts
+++ b/packages/web/server/queries/complex/assets/price/providers/sidecar.ts
@@ -11,6 +11,7 @@ import { EdgeDataLoader } from "~/utils/batching";
 import { LARGE_LRU_OPTIONS } from "~/utils/cache";
 
 import { getPriceFromCoinGecko } from "./coingecko";
+import { getPriceFromPools } from "./pools";
 
 const sidecarCache = new LRUCache<string, CacheEntry>(LARGE_LRU_OPTIONS);
 
@@ -69,7 +70,9 @@ export function getPriceBatched(asset: Asset) {
         loader
           .load(asset.coinMinimalDenom)
           .then((price) => new Dec(price))
-          .catch(() => getPriceFromCoinGecko(asset))
+          .catch(() =>
+            getPriceFromPools(asset).catch(() => getPriceFromCoinGecko(asset))
+          )
       ),
   });
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

I'm seeing in Vercel logs that it's quite common for users to request prices for assets with 0 decimals, such as DYS or BOOT. Currently, SQS prices endpoint does not return prices for them due to performance reasons.

Do get prices to users, we will catch such cases and calculate prices from pools instead.

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->
* Fall back to calculating prices from pools for prices unavailable from SQS. Long term SQS will return prices for such assets.

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
