### PR TITLE
hotfix: Disable Swap Fee Simulation According to Feature Flag or User OSMO Amount

### DIFF
--- a/packages/web/components/swap-tool/index.tsx
+++ b/packages/web/components/swap-tool/index.tsx
@@ -38,7 +38,6 @@ import { useSwap } from "~/hooks/use-swap";
 import { DEFAULT_VS_CURRENCY } from "~/server/queries/complex/assets/config";
 import { useStore } from "~/stores";
 import { formatCoinMaxDecimalsByOne, formatPretty } from "~/utils/formatter";
-import { sum } from "~/utils/math";
 import { ellipsisText } from "~/utils/string";
 
 export interface SwapToolProps {
@@ -776,12 +775,7 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
                       <span className="caption text-osmoverse-200">
                         {`≈ ${new PricePretty(
                           DEFAULT_VS_CURRENCY,
-                          sum([
-                            swapState.quote?.tokenInFeeAmountFiatValue?.toDec() ??
-                              new Dec(0),
-                            swapState.networkFee?.gasUsdValueToPay?.toDec() ??
-                              new Dec(0),
-                          ])
+                          swapState.totalFee
                         )} `}
                       </span>
                     </div>

--- a/packages/web/components/swap-tool/index.tsx
+++ b/packages/web/components/swap-tool/index.tsx
@@ -26,7 +26,7 @@ import { SplitRoute } from "~/components/swap-tool/split-route";
 import { InfoTooltip } from "~/components/tooltip";
 import { Button } from "~/components/ui/button";
 import { EventName, SwapPage } from "~/config";
-import { useTranslation } from "~/hooks";
+import { useFeatureFlags, useTranslation } from "~/hooks";
 import {
   useAmplitudeAnalytics,
   useDisclosure,
@@ -70,6 +70,7 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
     const { logEvent } = useAmplitudeAnalytics();
     const { isLoading: isWalletLoading, onOpenWalletSelect } =
       useWalletSelect();
+    const featureFlags = useFeatureFlags();
 
     const account = accountStore.getWallet(chainId);
 
@@ -752,6 +753,7 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
                     </div>
                   )}
                 {(swapState.networkFee || swapState.isLoadingNetworkFee) &&
+                featureFlags.swapToolSimulateFee &&
                 !swapState.error ? (
                   <div className="flex items-center justify-between">
                     <span className="caption">{t("swap.networkFee")}</span>
@@ -767,22 +769,23 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
                 ) : undefined}
                 {((swapState.quote?.tokenInFeeAmountFiatValue &&
                   swapState.quote?.swapFee) ||
-                  (swapState.networkFee && !swapState.isLoadingNetworkFee)) && (
-                  <div className="flex justify-between">
-                    <span className="caption">{t("swap.totalFee")}</span>
-                    <span className="caption text-osmoverse-200">
-                      {`≈ ${new PricePretty(
-                        DEFAULT_VS_CURRENCY,
-                        sum([
-                          swapState.quote?.tokenInFeeAmountFiatValue?.toDec() ??
-                            new Dec(0),
-                          swapState.networkFee?.gasUsdValueToPay?.toDec() ??
-                            new Dec(0),
-                        ])
-                      )} `}
-                    </span>
-                  </div>
-                )}
+                  (swapState.networkFee && !swapState.isLoadingNetworkFee)) &&
+                  featureFlags.swapToolSimulateFee && (
+                    <div className="flex justify-between">
+                      <span className="caption">{t("swap.totalFee")}</span>
+                      <span className="caption text-osmoverse-200">
+                        {`≈ ${new PricePretty(
+                          DEFAULT_VS_CURRENCY,
+                          sum([
+                            swapState.quote?.tokenInFeeAmountFiatValue?.toDec() ??
+                              new Dec(0),
+                            swapState.networkFee?.gasUsdValueToPay?.toDec() ??
+                              new Dec(0),
+                          ])
+                        )} `}
+                      </span>
+                    </div>
+                  )}
                 <hr className="text-white-faint" />
                 <div className="flex justify-between gap-1">
                   <span className="caption max-w-[140px]">

--- a/packages/web/config/ibc-overrides.ts
+++ b/packages/web/config/ibc-overrides.ts
@@ -31,7 +31,7 @@ type AdditionalData = Partial<
 const TestnetIBCAdditionalData: Partial<
   Record<TestnetAssetSymbols, AdditionalDataValue>
 > = {
-  "aUSDC.axl.axl": {
+  "aUSDC.axl": {
     sourceChainNameOverride: "Goerli Ethereum",
     originBridgeInfo: {
       bridge: "axelar" as const,

--- a/packages/web/hooks/use-estimate-tx-fees.ts
+++ b/packages/web/hooks/use-estimate-tx-fees.ts
@@ -64,9 +64,11 @@ async function estimateTxFeesQueryFn({
 export function useEstimateTxFees({
   messages,
   chainId,
+  enabled = true,
 }: {
   messages: EncodeObject[] | undefined;
   chainId: string;
+  enabled?: boolean;
 }) {
   const { accountStore } = useStore();
   const apiUtils = api.useUtils();
@@ -88,6 +90,7 @@ export function useEstimateTxFees({
     cacheTime: 3_000, // 3 seconds
     retry: false,
     enabled:
+      enabled &&
       !isNil(messages) &&
       Array.isArray(messages) &&
       messages.length > 0 &&

--- a/packages/web/hooks/use-feature-flags.ts
+++ b/packages/web/hooks/use-feature-flags.ts
@@ -22,7 +22,8 @@ export type AvailableFlags =
   | "aprBreakdown"
   | "topAnnouncementBanner"
   | "tfmProTradingNavbarButton"
-  | "positionRoi";
+  | "positionRoi"
+  | "swapToolSimulateFee";
 
 type ModifiedFlags =
   | Exclude<AvailableFlags, "mobileNotifications">
@@ -47,6 +48,7 @@ const defaultFlags: Record<ModifiedFlags, boolean> = {
   topAnnouncementBanner: true,
   tfmProTradingNavbarButton: true,
   positionRoi: true,
+  swapToolSimulateFee: false,
   _isInitialized: false,
   _isClientIDPresent: false,
 };

--- a/packages/web/hooks/use-swap.ts
+++ b/packages/web/hooks/use-swap.ts
@@ -28,6 +28,7 @@ import type { RouterKey } from "~/server/api/local-routers/swap-router";
 import type { AppRouter } from "~/server/api/root";
 import type { Asset } from "~/server/queries/complex/assets";
 import { useStore } from "~/stores";
+import { sum } from "~/utils/math";
 import { api, RouterInputs } from "~/utils/trpc";
 
 import { useAmountInput } from "./input/use-amount-input";
@@ -403,6 +404,10 @@ export function useSwap({
         : !Boolean(quoteError)
         ? quote
         : undefined,
+    totalFee: sum([
+      quote?.tokenInFeeAmountFiatValue?.toDec() ?? new Dec(0),
+      networkFee?.gasUsdValueToPay?.toDec() ?? new Dec(0),
+    ]),
     networkFee,
     isLoadingNetworkFee,
     error: precedentError,

--- a/packages/web/hooks/use-swap.ts
+++ b/packages/web/hooks/use-swap.ts
@@ -282,10 +282,11 @@ export function useSwap({
     useEstimateTxFees({
       chainId: chainStore.osmosis.chainId,
       messages,
+      enabled: featureFlags.swapToolSimulateFee,
     });
   const { data: userOsmoCoin } = api.edge.assets.getUserAsset.useQuery(
     { findMinDenomOrSymbol: "OSMO", userOsmoAddress: account?.address },
-    { enabled: Boolean(account?.address) }
+    { enabled: Boolean(account?.address) && featureFlags.swapToolSimulateFee }
   );
 
   /** Send trade token in transaction. */

--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -88,7 +88,7 @@ module.exports = withSentryConfig(
     silent: true,
 
     org: "osmosis-labs",
-    project: "javascript-nextjs",
+    project: "osmosis-web",
   },
   {
     // For all available options, see:

--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -87,7 +87,7 @@ module.exports = withSentryConfig(
     // Suppresses source map uploading logs during build
     silent: true,
 
-    org: "osmosis-wu",
+    org: "osmosis-labs",
     project: "javascript-nextjs",
   },
   {

--- a/packages/web/sentry.client.config.ts
+++ b/packages/web/sentry.client.config.ts
@@ -5,7 +5,7 @@
 import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
-  dsn: "https://c696452bb7ce4cc98150142ebea1c32f@o4505285755600896.ingest.sentry.io/4505285757698048",
+  dsn: "https://c696452bb7ce4cc98150142ebea1c32f@o4505285755600896.ingest.us.sentry.io/4505285757698048",
 
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: 1,

--- a/packages/web/sentry.edge.config.ts
+++ b/packages/web/sentry.edge.config.ts
@@ -6,7 +6,7 @@
 import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
-  dsn: "https://c696452bb7ce4cc98150142ebea1c32f@o4505285755600896.ingest.sentry.io/4505285757698048",
+  dsn: "https://c696452bb7ce4cc98150142ebea1c32f@o4505285755600896.ingest.us.sentry.io/4505285757698048",
 
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: 1,

--- a/packages/web/sentry.server.config.ts
+++ b/packages/web/sentry.server.config.ts
@@ -5,7 +5,7 @@
 import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
-  dsn: "https://c696452bb7ce4cc98150142ebea1c32f@o4505285755600896.ingest.sentry.io/4505285757698048",
+  dsn: "https://c696452bb7ce4cc98150142ebea1c32f@o4505285755600896.ingest.us.sentry.io/4505285757698048",
 
   // Adjust this value in production, or use tracesSampler for greater control
   tracesSampleRate: 1,


### PR DESCRIPTION
## Description

Swaps are failing because our current simulation does not support other fee tokens. This PR disables the simulated fee when a user lacks sufficient OSMO or the feature flag (swap-tool-simulated-fee) is off. 

## Testing and Verifying

- [ ] Should leave fee estimation to the wallet if a user does not have sufficient OSMO
- [ ] Feature flag should disable fee estimation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a simulation feature for calculating transaction fees in the swap tool, enhancing user experience by providing an estimate of the total fee before executing a swap.
- **Refactor**
	- Improved fee calculation logic in the swap functionality to better handle user inputs and feature flags.
- **Chores**
	- Updated dependencies in swap-related hooks for improved performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->