### PR TITLE
fix: Lock Node Version to 18.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "private": true,
   "engines": {
-    "node": ">=18.0.0"
+    "node": "18.x"
   },
   "workspaces": {
     "packages": [


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

In our package.json, we specified that the Node.js version should be 18 or higher under engines. When Node.js version 20.x became the LTS version, our builds started failing because Vercel updated the Node.js version to 20.x, in line with our specified condition. Unfortunately, this version introduces changes that break our libraries. To resolve this, we will set the Node.js version in our package.json to specifically use version 18.x.

## Testing and Verifying

- [ ] Builds should work