### PR TITLE
CL add liq: Increase default slippage to 10%, refresh pool data

### DIFF
--- a/packages/stores/src/account/osmosis/index.ts
+++ b/packages/stores/src/account/osmosis/index.ts
@@ -582,12 +582,10 @@ export class OsmosisAccountImpl {
     superfluidValidatorAddress?: string,
     baseDeposit?: { currency: Currency; amount: string },
     quoteDeposit?: { currency: Currency; amount: string },
-    maxSlippage = "10",
+    maxSlippage = "15",
     memo: string = "",
     onFulfill?: (tx: DeliverTxResponse) => void
   ) {
-    if (poolId === "1247" || poolId === "1248") maxSlippage = "15";
-
     const queries = this.queries;
 
     const queryPool = queries.queryPools.getPool(poolId);

--- a/packages/stores/src/account/osmosis/index.ts
+++ b/packages/stores/src/account/osmosis/index.ts
@@ -843,7 +843,7 @@ export class OsmosisAccountImpl {
       denom: string;
       amount: string;
     },
-    maxSlippage = DEFAULT_SLIPPAGE,
+    maxSlippage = "10",
     memo: string = "",
     onFulfill?: (tx: DeliverTxResponse) => void
   ) {

--- a/packages/stores/src/account/osmosis/index.ts
+++ b/packages/stores/src/account/osmosis/index.ts
@@ -582,7 +582,7 @@ export class OsmosisAccountImpl {
     superfluidValidatorAddress?: string,
     baseDeposit?: { currency: Currency; amount: string },
     quoteDeposit?: { currency: Currency; amount: string },
-    maxSlippage = "5",
+    maxSlippage = "10",
     memo: string = "",
     onFulfill?: (tx: DeliverTxResponse) => void
   ) {

--- a/packages/stores/src/account/osmosis/index.ts
+++ b/packages/stores/src/account/osmosis/index.ts
@@ -843,7 +843,7 @@ export class OsmosisAccountImpl {
       denom: string;
       amount: string;
     },
-    maxSlippage = "10",
+    maxSlippage = "20",
     memo: string = "",
     onFulfill?: (tx: DeliverTxResponse) => void
   ) {

--- a/packages/web/hooks/ui-config/use-add-concentrated-liquidity-config.ts
+++ b/packages/web/hooks/ui-config/use-add-concentrated-liquidity-config.ts
@@ -61,7 +61,12 @@ export function useAddConcentratedLiquidityConfig(
   const account = accountStore.getWallet(osmosisChainId);
   const address = account?.address ?? "";
 
-  const { data: pool } = api.edge.pools.getPool.useQuery({ poolId });
+  const { data: pool } = api.edge.pools.getPool.useQuery(
+    { poolId },
+    {
+      refetchInterval: 5_000, // 5 seconds
+    }
+  );
 
   const [config] = useState(
     () =>


### PR DESCRIPTION
Been seeing quite a few slippage errors of users adding CL liq and getting on chain errors.

This increases the slippage tolerance to hopefully see a decrease in these messages. Also, it refreshes the pool every 5 seconds to keep the current sqrt price value for the pool up-to-date as the user enters amount values.

The Issues on Sentry:
https://osmosis-labs.sentry.io/issues/?project=4505285757698048&query=is%3Aunresolved+slippage&referrer=issue-list&sort=user&statsPeriod=14d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Updated the default `maxSlippage` values in Osmosis account settings for enhanced transaction flexibility under varying conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->