### PR TITLE
SQS: Get code ID and inOutSpotPrice from SQS quote response

### DIFF
--- a/packages/pools/src/router/route.ts
+++ b/packages/pools/src/router/route.ts
@@ -10,6 +10,9 @@ export interface ResultPool {
   type?: PoolType;
   inCurrency?: Currency;
   outCurrency?: Currency;
+
+  /** Code ID if Cosmwasm pool. */
+  codeId?: string;
 }
 
 /** Single route through pools. */

--- a/packages/web/integrations/sidecar/router.ts
+++ b/packages/web/integrations/sidecar/router.ts
@@ -41,7 +41,7 @@ export class OsmosisSidecarRemoteRouter implements TokenOutGivenInRouter {
         route: routes,
         effective_fee,
         price_impact,
-        // in_out_spot_price,
+        in_base_out_quote_spot_price,
       } = await apiClient<SidecarQuoteResponse>(queryUrl.toString());
 
       const swapFee = new Dec(effective_fee);
@@ -53,13 +53,14 @@ export class OsmosisSidecarRemoteRouter implements TokenOutGivenInRouter {
         swapFee,
         priceImpactTokenOut: priceImpact,
         tokenInFeeAmount: tokenIn.amount.toDec().mul(swapFee).truncate(),
-        // inOutSpotPrice: new Dec(in_out_spot_price),
+        inOutSpotPrice: new Dec(in_base_out_quote_spot_price),
         split: routes.map(({ pools, in_amount }) => ({
           initialAmount: new Int(in_amount),
-          pools: pools.map(({ id, spread_factor, type }) => ({
+          pools: pools.map(({ id, spread_factor, type, code_id }) => ({
             id: id.toString(),
             type: translatePoolTypeFromSidecar(type),
             swapFee: new Dec(spread_factor),
+            codeId: code_id?.toString(),
           })),
           tokenInDenom: tokenIn.denom,
           tokenOutDenoms: pools.map(({ token_out_denom }) => token_out_denom),

--- a/packages/web/integrations/sidecar/types.ts
+++ b/packages/web/integrations/sidecar/types.ts
@@ -6,7 +6,7 @@ export type SidecarQuoteResponse = {
   amount_out: string;
   effective_fee: string;
   price_impact: string;
-  in_out_spot_price: string;
+  in_base_out_quote_spot_price: string;
   route: {
     in_amount: string;
     out_amount: string;
@@ -21,6 +21,9 @@ export type SidecarQuoteResponse = {
       spread_factor: string;
       taker_fee: string;
       token_out_denom: string;
+
+      /** Code ID, if a Cosmwasm pool. */
+      code_id?: number;
     }[];
   }[];
 };

--- a/packages/web/server/api/local-routers/swap-router.ts
+++ b/packages/web/server/api/local-routers/swap-router.ts
@@ -15,7 +15,8 @@ import {
   getAssetPrice,
 } from "~/server/queries/complex/assets";
 import { DEFAULT_VS_CURRENCY } from "~/server/queries/complex/assets/config";
-import { getPool, Pool } from "~/server/queries/complex/pools";
+import { Pool } from "~/server/queries/complex/pools";
+import { getCosmwasmPoolTypeFromCodeId } from "~/server/queries/complex/pools/env";
 import { routeTokenOutGivenIn } from "~/server/queries/complex/pools/route-token-out-given-in";
 import { captureErrorAndReturn } from "~/utils/error";
 
@@ -158,10 +159,10 @@ async function makeDisplayableSplit(split: SplitTokenInQuote["split"]) {
         pools.map(async (pool_, index) => {
           let type: Pool["type"] = pool_.type as Pool["type"];
 
-          if (type === "cosmwasm") {
-            const pool = await getPool({ poolId: pool_.id });
-            type = pool.type;
+          if (pool_?.codeId) {
+            type = getCosmwasmPoolTypeFromCodeId(pool_.codeId);
           }
+
           const inAsset = await getAsset({
             anyDenom: index === 0 ? tokenInDenom : tokenOutDenoms[index - 1],
           });


### PR DESCRIPTION
Gets code ID and in/out spot price returned from SQS.

* Code ID: if a cosmwasm pool in a route, we use the Code ID to get the specific Cosmwasm pool type from FE hardcoded values.
* Returns the in/out spot price from SQS, which used to be returned from querying the router by passing 1 in token in. This avoids the edge case where 1 token in is too much for the liquidity of the selected token pair. Example: swapping any BTC variant for a low liq token out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new property to enhance pool result details.
	- Enhanced swap functionality with improved pool type determination based on new criteria.
- **Refactor**
	- Updated field names and processing logic for clearer financial terminology and data handling.
	- Adjusted internal logic for setting pool types to utilize new property efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->