### PR TITLE
Lower indexer pool cache time

### DIFF
--- a/packages/web/server/queries/complex/pools/providers/indexer.ts
+++ b/packages/web/server/queries/complex/pools/providers/indexer.ts
@@ -166,7 +166,7 @@ async function fetchAndProcessAllPools({
   return cachified({
     key: `all-pools-${minimumLiquidity}`,
     cache: allPoolsLruCache,
-    ttl: 1000 * 30, // 30 seconds
+    ttl: 1000 * 5, // 5 seconds
     async getFreshValue() {
       const poolManagerParamsPromise = getPoolmanagerParams();
       const numPoolsPromise = getNumPools();


### PR DESCRIPTION
This may be a culprit for slippage issues when LPing into CL pools. This should provide a more up to date sqrt price from CL pools for FE calculations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
	- Reduced the cache time-to-live (TTL) for fetching pool data, resulting in more up-to-date information being displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->