### PR TITLE
Fix reading tRPC client error

### DIFF
--- a/packages/web/hooks/use-swap.ts
+++ b/packages/web/hooks/use-swap.ts
@@ -135,7 +135,13 @@ export function useSwap({
     let error = quoteError;
 
     // only show spot price error if there's no quote
-    if (quote && !quote.amount.toDec().isPositive() && !error)
+    if (
+      (quote &&
+        !quote.inOutSpotPrice &&
+        !quote.amount.toDec().isPositive() &&
+        !error) ||
+      (!quote && spotPriceQuoteError)
+    )
       error = spotPriceQuoteError;
 
     const errorFromTrpc = makeRouterErrorFromTrpcError(error)?.error;
@@ -759,7 +765,7 @@ function makeRouterErrorFromTrpcError(
     }
   | undefined {
   if (isNil(error)) return;
-  const tprcShapeMsg = error?.shape?.message;
+  const tprcShapeMsg = error?.message;
 
   if (tprcShapeMsg?.includes(NoRouteError.defaultMessage)) {
     return { error: new NoRouteError(), isUnexpected: false };


### PR DESCRIPTION
Fix reading the TRPC client error message coming from quote router. This allows the swap button to display the specific error being returned form the router.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for spot price quotes in the swap functionality, ensuring clearer error messages are displayed under specific conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->