### PR TITLE
refactor: separate assets hook from swap hook

### DIFF
--- a/packages/web/components/control/token-select-with-drawer.tsx
+++ b/packages/web/components/control/token-select-with-drawer.tsx
@@ -9,13 +9,13 @@ import { TokenSelectDrawer } from "~/components/drawers/token-select-drawer";
 import { Disableable } from "~/components/types";
 import { EventName, SwapPage } from "~/config";
 import { useAmplitudeAnalytics, useWindowSize } from "~/hooks";
-import { SwapState } from "~/hooks/use-swap";
+import { SwapAssets } from "~/hooks/use-swap";
 
 /** Will display balances if provided `CoinPretty` objects. Assumes denoms are unique. */
 export const TokenSelectWithDrawer: FunctionComponent<
   {
     isFromSelect: boolean;
-    swapState: SwapState;
+    swapAssets: SwapAssets;
     dropdownOpen?: boolean;
     canSelectTokens?: boolean;
     page?: SwapPage;
@@ -25,7 +25,7 @@ export const TokenSelectWithDrawer: FunctionComponent<
 > = observer(
   ({
     isFromSelect,
-    swapState,
+    swapAssets,
     dropdownOpen,
     disabled,
     canSelectTokens = true,
@@ -44,11 +44,11 @@ export const TokenSelectWithDrawer: FunctionComponent<
     const setIsSelectOpen =
       setDropdownState === undefined ? setIsSelectOpenLocal : setDropdownState;
 
-    const preSortedTokens = swapState.selectableAssets;
+    const preSortedTokens = swapAssets.selectableAssets;
 
     const selectedToken = isFromSelect
-      ? swapState.fromAsset
-      : swapState.toAsset;
+      ? swapAssets.fromAsset
+      : swapAssets.toAsset;
 
     const tokenSelectionAvailable =
       canSelectTokens && preSortedTokens.length > 1;
@@ -124,7 +124,7 @@ export const TokenSelectWithDrawer: FunctionComponent<
         <div className="pt-16">
           <TokenSelectDrawer
             isOpen={isSelectOpen}
-            swapState={swapState}
+            swapAssets={swapAssets}
             onClose={() => setIsSelectOpen(false)}
             onSelect={onSelect}
           />

--- a/packages/web/components/drawers/token-select-drawer.tsx
+++ b/packages/web/components/drawers/token-select-drawer.tsx
@@ -17,7 +17,7 @@ import { SearchBox } from "~/components/input";
 import { Tooltip } from "~/components/tooltip";
 import { useTranslation } from "~/hooks";
 import { useWindowSize } from "~/hooks";
-import { SwapState } from "~/hooks/use-swap";
+import { SwapAssets } from "~/hooks/use-swap";
 import { ActivateUnverifiedTokenConfirmation } from "~/modals";
 import { UnverifiedAssetsState } from "~/stores/user-settings";
 import { formatPretty } from "~/utils/formatter";
@@ -51,9 +51,9 @@ export const TokenSelectDrawer: FunctionComponent<{
   isOpen: boolean;
   onClose?: () => void;
   onSelect?: (tokenDenom: string) => void;
-  swapState: SwapState;
+  swapAssets: SwapAssets;
 }> = observer(
-  ({ isOpen, swapState, onClose: onCloseProp, onSelect: onSelectProp }) => {
+  ({ isOpen, swapAssets, onClose: onCloseProp, onSelect: onSelectProp }) => {
     const { t } = useTranslation();
     const { userSettings } = useStore();
     const { isMobile } = useWindowSize();
@@ -65,7 +65,7 @@ export const TokenSelectDrawer: FunctionComponent<{
       keyboardSelectedIndexRef,
     ] = useStateRef(0);
 
-    const [assets, setAssets] = useState(swapState.selectableAssets);
+    const [assets, setAssets] = useState(swapAssets.selectableAssets);
     const [isRequestingClose, setIsRequestingClose] = useState(false);
     const [confirmUnverifiedAssetDenom, setConfirmUnverifiedAssetDenom] =
       useState<string | null>(null);
@@ -80,8 +80,8 @@ export const TokenSelectDrawer: FunctionComponent<{
     // Only update tokens while not requesting to close
     useEffect(() => {
       if (isRequestingClose) return;
-      setAssets(swapState.selectableAssets);
-    }, [isRequestingClose, swapState.selectableAssets]);
+      setAssets(swapAssets.selectableAssets);
+    }, [isRequestingClose, swapAssets.selectableAssets]);
 
     const assetsRef = useLatest(assets);
 
@@ -93,7 +93,7 @@ export const TokenSelectDrawer: FunctionComponent<{
 
     const onClose = () => {
       setIsRequestingClose(true);
-      swapState.setAssetsQueryInput("");
+      swapAssets.setAssetsQueryInput("");
       setKeyboardSelectedIndex(0);
       onCloseProp?.();
     };
@@ -107,7 +107,7 @@ export const TokenSelectDrawer: FunctionComponent<{
       let isRecommended = false;
       const selectedAsset =
         assets.find((asset) => asset.coinDenom === coinDenom) ??
-        swapState.recommendedAssets.find((asset) => {
+        swapAssets.recommendedAssets.find((asset) => {
           if (asset.coinDenom === coinDenom) {
             isRecommended = true;
             return true;
@@ -187,7 +187,7 @@ export const TokenSelectDrawer: FunctionComponent<{
     });
 
     const onSearch = (nextValue: string) => {
-      swapState.setAssetsQueryInput(nextValue);
+      swapAssets.setAssetsQueryInput(nextValue);
       setKeyboardSelectedIndex(0);
     };
 
@@ -278,7 +278,7 @@ export const TokenSelectDrawer: FunctionComponent<{
                   onMouseDown={onMouseDownQuickSelect}
                   className="no-scrollbar flex space-x-4 overflow-x-auto px-4"
                 >
-                  {swapState.recommendedAssets.map((asset) => {
+                  {swapAssets.recommendedAssets.map((asset) => {
                     const { coinDenom, coinImageUrl } = asset;
 
                     return (
@@ -312,7 +312,7 @@ export const TokenSelectDrawer: FunctionComponent<{
               </div>
             </div>
 
-            {swapState.isLoadingSelectAssets ? (
+            {swapAssets.isLoadingSelectAssets ? (
               <Spinner className="m-auto" />
             ) : (
               <div className="flex flex-col overflow-auto">
@@ -420,10 +420,10 @@ export const TokenSelectDrawer: FunctionComponent<{
                   onVisible={() => {
                     // If this element becomes visible at bottom of list, fetch next page
                     if (
-                      !swapState.isFetchingNextPageAssets &&
-                      swapState.hasNextPageAssets
+                      !swapAssets.isFetchingNextPageAssets &&
+                      swapAssets.hasNextPageAssets
                     ) {
-                      swapState.fetchNextPageAssets();
+                      swapAssets.fetchNextPageAssets();
                     }
                   }}
                 />

--- a/packages/web/components/swap-tool/index.tsx
+++ b/packages/web/components/swap-tool/index.tsx
@@ -87,6 +87,8 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
       forceSwapInPoolId,
     });
 
+    const swapAssets = swapState.swapAssets;
+
     const manualSlippageInputRef = useRef<HTMLInputElement | null>(null);
     const [
       estimateDetailsContentRef,
@@ -98,14 +100,14 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
     // out amount less slippage calculated from slippage config
     const outAmountLessSlippage = useMemo(
       () =>
-        swapState.quote && swapState.toAsset
+        swapState.quote && swapAssets.toAsset
           ? new IntPretty(
               swapState.quote.amount
                 .toDec()
                 .mul(new Dec(1).sub(slippageConfig.slippage.toDec()))
             )
           : undefined,
-      [swapState.quote, swapState.toAsset, slippageConfig.slippage]
+      [swapState.quote, swapAssets.toAsset, slippageConfig.slippage]
     );
 
     const routesVisDisclosure = useDisclosure();
@@ -163,9 +165,9 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
       if (!swapState.inAmountInput.amount) return;
 
       const baseEvent = {
-        fromToken: swapState.fromAsset?.coinDenom,
+        fromToken: swapAssets.fromAsset?.coinDenom,
         tokenAmount: Number(swapState.inAmountInput.amount),
-        toToken: swapState.toAsset?.coinDenom,
+        toToken: swapAssets.toAsset?.coinDenom,
         isOnHome: !isInModal,
         isMultiHop: swapState.quote?.split.some(
           ({ pools }) => pools.length !== 1
@@ -352,8 +354,8 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
                             logEvent([
                               EventName.Swap.slippageToleranceSet,
                               {
-                                fromToken: swapState.fromAsset?.coinDenom,
-                                toToken: swapState.toAsset?.coinDenom,
+                                fromToken: swapAssets.fromAsset?.coinDenom,
+                                toToken: swapAssets.toAsset?.coinDenom,
                                 isOnHome: !isInModal,
                                 percentage: slippageConfig.slippage.toString(),
                                 page,
@@ -394,8 +396,8 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
                     {formatCoinMaxDecimalsByOne(
                       swapState.inAmountInput?.balance,
                       2,
-                      Math.min(swapState.fromAsset?.coinDecimals ?? 0, 8)
-                    ) || "0 " + (swapState.fromAsset?.coinDenom ?? "")}
+                      Math.min(swapAssets.fromAsset?.coinDecimals ?? 0, 8)
+                    ) || "0 " + (swapAssets.fromAsset?.coinDenom ?? "")}
                   </span>
                 </div>
                 <div className="flex items-center gap-1.5">
@@ -439,7 +441,7 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
                 <TokenSelectWithDrawer
                   isFromSelect
                   dropdownOpen={showFromTokenSelectDropdown}
-                  swapState={swapState}
+                  swapAssets={swapAssets}
                   setDropdownState={useCallback(
                     (isOpen) => {
                       if (isOpen) {
@@ -452,11 +454,11 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
                   )}
                   onSelect={useCallback(
                     (tokenDenom: string) => {
-                      swapState.setFromAssetDenom(tokenDenom);
+                      swapAssets.setFromAssetDenom(tokenDenom);
                       closeTokenSelectDropdowns();
                       fromAmountInputEl.current?.focus();
                     },
-                    [swapState, closeTokenSelectDropdowns]
+                    [swapAssets, closeTokenSelectDropdowns]
                   )}
                 />
                 <div className="flex w-full flex-col items-end">
@@ -511,7 +513,7 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
                 if (!isMobile) setHoveringSwitchButton(false);
               }}
               onClick={() => {
-                swapState.switchAssets();
+                swapAssets.switchAssets();
               }}
             >
               <div
@@ -563,13 +565,13 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
                 <TokenSelectWithDrawer
                   isFromSelect={false}
                   dropdownOpen={showToTokenSelectDropdown}
-                  swapState={swapState}
+                  swapAssets={swapAssets}
                   onSelect={useCallback(
                     (tokenDenom: string) => {
-                      swapState.setToAssetDenom(tokenDenom);
+                      swapAssets.setToAssetDenom(tokenDenom);
                       closeTokenSelectDropdowns();
                     },
-                    [swapState, closeTokenSelectDropdowns]
+                    [swapAssets, closeTokenSelectDropdowns]
                   )}
                   setDropdownState={useCallback(
                     (isOpen) => {
@@ -649,8 +651,8 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
                   : 44,
               }}
               isLoaded={
-                Boolean(swapState.toAsset) &&
-                Boolean(swapState.fromAsset) &&
+                Boolean(swapAssets.toAsset) &&
+                Boolean(swapAssets.fromAsset) &&
                 !swapState.isSpotPriceQuoteLoading
               }
             >
@@ -676,21 +678,21 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
                   })}
                 >
                   1{" "}
-                  <span title={swapState.fromAsset?.coinDenom}>
+                  <span title={swapAssets.fromAsset?.coinDenom}>
                     {ellipsisText(
-                      swapState.fromAsset?.coinDenom ?? "",
+                      swapAssets.fromAsset?.coinDenom ?? "",
                       isMobile ? 11 : 20
                     )}
                   </span>{" "}
                   {`≈ ${
-                    swapState.toAsset
+                    swapAssets.toAsset
                       ? formatPretty(
                           (swapState.quote?.inOutSpotPrice
                             ? new CoinPretty(
-                                swapState.toAsset,
+                                swapAssets.toAsset,
                                 swapState.quote.inOutSpotPrice.mul(
                                   DecUtils.getTenExponentN(
-                                    swapState.toAsset.coinDecimals
+                                    swapAssets.toAsset.coinDecimals
                                   )
                                 )
                               )
@@ -699,7 +701,7 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
                             new Dec(0),
                           {
                             maxDecimals: Math.min(
-                              swapState.toAsset.coinDecimals,
+                              swapAssets.toAsset.coinDecimals,
                               8
                             ),
                           }
@@ -843,7 +845,7 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
                   >
                     {outAmountLessSlippage &&
                       swapState.quote?.tokenOutPrice &&
-                      swapState.toAsset && (
+                      swapAssets.toAsset && (
                         <div
                           className={classNames(
                             "caption flex flex-col gap-0.5 text-right text-osmoverse-200"

--- a/packages/web/hooks/use-swap.ts
+++ b/packages/web/hooks/use-swap.ts
@@ -39,6 +39,7 @@ import { useWalletSelect } from "./wallet-select";
 import { useQueryParamState } from "./window/use-query-param-state";
 
 export type SwapState = ReturnType<typeof useSwap>;
+export type SwapAssets = ReturnType<typeof useSwapAssets>;
 
 type SwapOptions = {
   /** Initial from denom if `useQueryParams` is not `true` and there's no query param. */
@@ -393,7 +394,7 @@ export function useSwap({
   );
 
   return {
-    ...swapAssets,
+    swapAssets,
     inAmountInput,
     quote:
       isQuoteLoading || inAmountInput.isTyping


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Clean up the swap tool by separating the assets hook from the swap hook.

This leads to more readability and also avoiding React components rerendering due to quote updates when only assets are used within these components

### ClickUp Task

[ClickUp Task URL](PASTE_CLICKUP_TASK_URL_HERE)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->
