### PR TITLE
Swap tool: calculate in/out spot price on client

### DIFF
--- a/packages/pools/src/router/types.ts
+++ b/packages/pools/src/router/types.ts
@@ -62,7 +62,6 @@ export type SplitTokenInQuote = Quote & {
   /** In amount after fees paid are subtracted. */
   tokenInFeeAmount?: Int;
   swapFee?: Dec;
-  inOutSpotPrice?: Dec;
 };
 
 export type Logger = {

--- a/packages/server/src/queries/sidecar/router.ts
+++ b/packages/server/src/queries/sidecar/router.ts
@@ -41,7 +41,6 @@ export class OsmosisSidecarRemoteRouter implements TokenOutGivenInRouter {
         route: routes,
         effective_fee,
         price_impact,
-        in_base_out_quote_spot_price,
       } = await apiClient<SidecarQuoteResponse>(queryUrl.toString());
 
       const swapFee = new Dec(effective_fee);
@@ -53,7 +52,6 @@ export class OsmosisSidecarRemoteRouter implements TokenOutGivenInRouter {
         swapFee,
         priceImpactTokenOut: priceImpact,
         tokenInFeeAmount: tokenIn.amount.toDec().mul(swapFee).truncate(),
-        inOutSpotPrice: new Dec(in_base_out_quote_spot_price),
         split: routes.map(({ pools, in_amount }) => ({
           initialAmount: new Int(in_amount),
           pools: pools.map(({ id, spread_factor, type, code_id }) => ({

--- a/packages/web/components/swap-tool/index.tsx
+++ b/packages/web/components/swap-tool/index.tsx
@@ -1,11 +1,5 @@
 import { WalletStatus } from "@cosmos-kit/core";
-import {
-  CoinPretty,
-  Dec,
-  DecUtils,
-  IntPretty,
-  PricePretty,
-} from "@keplr-wallet/unit";
+import { Dec, IntPretty, PricePretty } from "@keplr-wallet/unit";
 import { NoRouteError, NotEnoughLiquidityError } from "@osmosis-labs/pools";
 import { DEFAULT_VS_CURRENCY } from "@osmosis-labs/server";
 import { ellipsisText } from "@osmosis-labs/utils";
@@ -685,18 +679,7 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
                   {`≈ ${
                     swapState.toAsset
                       ? formatPretty(
-                          (swapState.quote?.inOutSpotPrice
-                            ? new CoinPretty(
-                                swapState.toAsset,
-                                swapState.quote.inOutSpotPrice.mul(
-                                  DecUtils.getTenExponentN(
-                                    swapState.toAsset.coinDecimals
-                                  )
-                                )
-                              )
-                            : null) ??
-                            swapState.spotPriceQuote?.amount ??
-                            new Dec(0),
+                          swapState.inBaseOutQuoteSpotPrice ?? new Dec(0),
                           {
                             maxDecimals: Math.min(
                               swapState.toAsset.coinDecimals,

--- a/packages/web/hooks/use-swap.ts
+++ b/packages/web/hooks/use-swap.ts
@@ -122,7 +122,7 @@ export function useSwap({
       tokenOutDenom: swapAssets.toAsset?.coinMinimalDenom ?? "",
       forcePoolId: forceSwapInPoolId,
     },
-    isToFromAssets && !Boolean(quote?.inOutSpotPrice)
+    isToFromAssets
   );
 
   /** Collate errors coming first from user input and then tRPC and serialize accordingly. */
@@ -135,10 +135,7 @@ export function useSwap({
 
     // only show spot price error if there's no quote
     if (
-      (quote &&
-        !quote.inOutSpotPrice &&
-        !quote.amount.toDec().isPositive() &&
-        !error) ||
+      (quote && !quote.amount.toDec().isPositive() && !error) ||
       (!quote && spotPriceQuoteError)
     )
       error = spotPriceQuoteError;
@@ -392,6 +389,34 @@ export function useSwap({
     )
   );
 
+  /** Spot price, current or effective, of the currently selected tokens. */
+  const inBaseOutQuoteInSpotPrice = useMemo(() => {
+    // get in/out spot price from quote if user requested a quote
+    if (
+      inAmountInput.amount &&
+      quote &&
+      swapAssets.toAsset &&
+      !inAmountInput.isTyping
+    ) {
+      return new CoinPretty(
+        swapAssets.toAsset,
+        quote.amount
+          .toDec()
+          .quo(inAmountInput.amount.toDec())
+          .mulTruncate(
+            DecUtils.getTenExponentN(swapAssets.toAsset.coinDecimals)
+          )
+      );
+    }
+    return spotPriceQuote?.amount;
+  }, [
+    spotPriceQuote,
+    swapAssets.toAsset,
+    inAmountInput.amount,
+    inAmountInput.isTyping,
+    quote,
+  ]);
+
   return {
     ...swapAssets,
     inAmountInput,
@@ -401,6 +426,7 @@ export function useSwap({
         : !Boolean(quoteError)
         ? quote
         : undefined,
+    inBaseOutQuoteSpotPrice: inBaseOutQuoteInSpotPrice,
     totalFee: sum([
       quote?.tokenInFeeAmountFiatValue?.toDec() ?? new Dec(0),
       networkFee?.gasUsdValueToPay?.toDec() ?? new Dec(0),

--- a/packages/web/hooks/use-swap.ts
+++ b/packages/web/hooks/use-swap.ts
@@ -390,7 +390,7 @@ export function useSwap({
   );
 
   /** Spot price, current or effective, of the currently selected tokens. */
-  const inBaseOutQuoteInSpotPrice = useMemo(() => {
+  const inBaseOutQuoteSpotPrice = useMemo(() => {
     // get in/out spot price from quote if user requested a quote
     if (
       inAmountInput.amount &&
@@ -426,7 +426,7 @@ export function useSwap({
         : !Boolean(quoteError)
         ? quote
         : undefined,
-    inBaseOutQuoteSpotPrice: inBaseOutQuoteInSpotPrice,
+    inBaseOutQuoteSpotPrice,
     totalFee: sum([
       quote?.tokenInFeeAmountFiatValue?.toDec() ?? new Dec(0),
       networkFee?.gasUsdValueToPay?.toDec() ?? new Dec(0),


### PR DESCRIPTION
This PR removes the need to use a value returned from the router as the effective (execution) spot price of the trade. Instead, we calculate this on the client from the in token and quoted out token amounts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Simplified spot price calculation logic across the application.
- **Bug Fixes**
	- Improved error handling for spot price calculations in the swap functionality.
- **New Features**
	- Updated swap tool to display spot prices more accurately based on user input and quote data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->