### PR TITLE
Add BEAST Deposit Override

### DIFF
--- a/packages/web/config/ibc-overrides.ts
+++ b/packages/web/config/ibc-overrides.ts
@@ -585,6 +585,12 @@ const MainnetIBCAdditionalData: Partial<
     depositUrlOverride: "https://www.bskt.fi/wormhole",
     withdrawUrlOverride: "https://www.bskt.fi/wormhole",
   },
+  BEAST: {
+    depositUrlOverride:
+      "https://pro.osmosis.zone/ibc?chainFrom=injective-1&chainTo=osmosis-1&token0=peggy0xA4426666addBE8c4985377d36683D17FB40c31Be&token1=ibc%2FB84F8CC583A54DA8173711C0B66B22FDC1954FEB1CA8DBC66C89919DAFE02000",
+    withdrawUrlOverride:
+      "https://pro.osmosis.zone/ibc?chainFrom=osmosis-1&chainTo=injective-1&token0=ibc%2FB84F8CC583A54DA8173711C0B66B22FDC1954FEB1CA8DBC66C89919DAFE02000&token1=peggy0xA4426666addBE8c4985377d36683D17FB40c31Be",
+  },
 };
 
 export const IBCAdditionalData: AdditionalData = IS_TESTNET


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Add BEAST Deposit Override to use Osmosis Pro (TFM)

## Brief Changelog

- Add Deposit and Withdraw URL overrides for BEAST from injective to go to pro.osmosis.zone

## Testing and Verifying

This change has been tested locally by rebuilding the website and verified content and links are expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Integrated configuration overrides for the BEAST network to enhance deposit and withdrawal functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->