### PR TITLE
feat: support cosmostation mobile

### DIFF
--- a/packages/web/config/wallet-registry.ts
+++ b/packages/web/config/wallet-registry.ts
@@ -76,6 +76,7 @@ export const WalletRegistry: RegistryWallet[] = [
   {
     ...CosmosKitWalletList["cosmostation-extension"],
     logo: "/wallets/cosmostation.png",
+    mobileDisabled: false,
     lazyInstall: () =>
       import("@cosmos-kit/cosmostation-extension").then(
         (m) => m.CosmostationExtensionWallet

--- a/packages/web/modals/wallet-select.tsx
+++ b/packages/web/modals/wallet-select.tsx
@@ -336,6 +336,22 @@ const LeftModalContent: FunctionComponent<
             }
 
             /**
+             * If on mobile and `cosmostation` is in `window`, it means that the user enters
+             * the frontend from Cosmostation's app in app browser. So, there is no need
+             * to use wallet connect, as it resembles the extension's usage.
+             */
+            if (
+              _window?.cosmostation &&
+              _window?.cosmostation?.mode === mobileWebModeName
+            ) {
+              return array
+                .filter(
+                  (wallet) => wallet.name === AvailableWallets.Cosmostation
+                )
+                .map((wallet) => ({ ...wallet, mobileDisabled: false }));
+            }
+
+            /**
              * If user is in a normal mobile browser, show only wallet connect
              */
             return wallet.name.endsWith("mobile") ? [...acc, wallet] : acc;


### PR DESCRIPTION
we fixed below issue and reopen this pr.
https://github.com/osmosis-labs/osmosis-frontend/pull/2576

---

## What is the purpose of the change

- This pr request supports cosmostation mobile wallet

## Brief Changelog

- Adds a new button for connecting Cosmostation in Cosmostation Mobile Wallet

## Testing and Verifying

- This change has been tested locally in cosmostation mobile wallet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced wallet selection for mobile users, particularly for those accessing from Cosmostation's app, ensuring a smoother experience by dynamically adjusting available wallet options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->