### PR TITLE
Update Sentry config

### DIFF
--- a/packages/web/sentry.client.config.ts
+++ b/packages/web/sentry.client.config.ts
@@ -21,8 +21,10 @@ Sentry.init({
 
   environment: process.env.NODE_ENV || "development",
 
-  enabled:
-    process.env.NODE_ENV !== "development" && process.env.NODE_ENV !== "test",
+  // Temporarily disable due to client-side noise coming from extensions, Cosmos Kit, etc.
+  enabled: false,
+  // enabled:
+  //   process.env.NODE_ENV !== "development" && process.env.NODE_ENV !== "test",
 
   // You can remove this option if you're not planning to use the Sentry Session Replay feature:
   integrations: [

--- a/packages/web/sentry.server.config.ts
+++ b/packages/web/sentry.server.config.ts
@@ -8,7 +8,7 @@ Sentry.init({
   dsn: "https://c696452bb7ce4cc98150142ebea1c32f@o4505285755600896.ingest.us.sentry.io/4505285757698048",
 
   // Adjust this value in production, or use tracesSampler for greater control
-  tracesSampleRate: 0.5,
+  tracesSampleRate: 1,
 
   enabled:
     process.env.NODE_ENV !== "development" && process.env.NODE_ENV !== "test",


### PR DESCRIPTION
* Disable Sentry on client due to noise issues exceeding our quota
  * Currently drafting an ADR on what observability stack we want to use, and we will re-approach client side monitoring once that ADR is completed.
* Set sample rate on server to 100%, to help identify any outstanding issues on server

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Temporarily disabled the Sentry client to reduce client-side noise.
- **Refactor**
	- Adjusted server-side monitoring settings to capture all traces for improved diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->