### PR TITLE
Prevent double caching for sidecar price provider

### DIFF
--- a/packages/server/src/queries/complex/assets/price/index.ts
+++ b/packages/server/src/queries/complex/assets/price/index.ts
@@ -9,7 +9,7 @@ import { captureErrorAndReturn } from "../../../../utils/error";
 import { getAsset } from "..";
 import { getPriceFromSidecar } from "./providers/sidecar";
 
-/** Provides a price given a valid asset from asset list and a fiat currency code.
+/** Provides a price (no caching) given a valid asset from asset list and a fiat currency code.
  *  @throws if there's an issue getting the price. */
 export type PriceProvider = (
   assetLists: AssetList[],
@@ -61,7 +61,7 @@ export async function getAssetPrice({
   return cachified({
     key: `asset-price-${foundAsset.coinMinimalDenom}`,
     cache: pricesCache,
-    ttl: 1000 * 30, // 30 seconds, as calculating prices is expensive and cached remotely
+    ttl: 1000 * 10, // 10 seconds
     getFreshValue: () =>
       priceProvider(assetLists, chainList, foundAsset, currency),
   });

--- a/packages/server/src/queries/complex/assets/price/providers/sidecar.ts
+++ b/packages/server/src/queries/complex/assets/price/providers/sidecar.ts
@@ -14,14 +14,22 @@ import { getPriceFromPools } from "./pools";
 
 const sidecarCache = new LRUCache<string, CacheEntry>(LARGE_LRU_OPTIONS);
 
-/** Gets price from SQS query server. Currently only supports prices in USDC with decimals. Falls back to querying CoinGecko if not available.
+/** Gets price from SQS query server. Currently only supports prices in USDC with decimals. Falls back to pools then querying CoinGecko if not available.
  *  @throws if there's an issue getting the price. */
 export function getPriceFromSidecar(
   assetLists: AssetList[],
   chainList: Chain[],
   asset: Asset
 ) {
-  return getPriceBatched(assetLists, chainList, asset);
+  return getBatchLoader().then((loader) =>
+    loader
+      .load(asset.coinMinimalDenom)
+      .then((price) => new Dec(price))
+      .catch((e) => {
+        captureError(e);
+        return getPriceFromPools(assetLists, chainList, asset);
+      })
+  );
 }
 
 /** Prevent long-running batch loaders as recommended by `DataLoader` docs. */
@@ -59,28 +67,6 @@ function getBatchLoader() {
           // SQS imposes a limit on URI length from its Nginx configuration, so we impose a limit to avoid hitting that limit.
           maxBatchSize: 100,
         }
-      ),
-  });
-}
-
-export function getPriceBatched(
-  assetLists: AssetList[],
-  chainList: Chain[],
-  asset: Asset
-) {
-  return cachified({
-    cache: sidecarCache,
-    key: `sidecar-price-${asset.coinMinimalDenom}`,
-    ttl: 1000 * 60, // 1 minute
-    getFreshValue: () =>
-      getBatchLoader().then((loader) =>
-        loader
-          .load(asset.coinMinimalDenom)
-          .then((price) => new Dec(price))
-          .catch((e) => {
-            captureError(e);
-            return getPriceFromPools(assetLists, chainList, asset);
-          })
       ),
   });
 }


### PR DESCRIPTION
* In tRPC `getPrice`: updates price cache to 10s, and removes the redundant caching from Sidecar price provider

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
	- Reduced the caching duration for asset prices from 30 seconds to 10 seconds to provide more up-to-date price information.
- **New Features**
	- Updated the price fetching process to first attempt loading prices in batches, with a fallback to querying CoinGecko if batch loading fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->