### PR TITLE
link on token info page to filtered pools page

### DIFF
--- a/packages/web/components/your-balance/your-balance.tsx
+++ b/packages/web/components/your-balance/your-balance.tsx
@@ -274,7 +274,7 @@ const YourBalance = observer(
               </Link>
             )}
             <Link
-              href="/pools"
+              href={`/pools?searchQuery=${denom}`}
               passHref
               className="flex flex-[0.5]"
               onClick={() =>

--- a/packages/web/components/your-balance/your-balance.tsx
+++ b/packages/web/components/your-balance/your-balance.tsx
@@ -274,7 +274,7 @@ const YourBalance = observer(
               </Link>
             )}
             <Link
-              href={`/pools?searchQuery=${denom}`}
+              href={`/pools?searchQuery=${encodeURIComponent(denom)}`}
               passHref
               className="flex flex-[0.5]"
               onClick={() =>


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

Right now, clicking the "Explore Pools" page on a token's info page, just goes the generic pools page.  This make it so it at least pre-populates the search field with the ticker name.

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Updated the link in the "Your Balance" component to dynamically adjust based on account details.
	- Modified the `href` attribute of a `Link` component to include a dynamic query parameter based on the `denom` variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->