### PR TITLE
have astroport row in pools table link to astroport pool page

### DIFF
--- a/packages/web/components/complex/all-pools-table.tsx
+++ b/packages/web/components/complex/all-pools-table.tsx
@@ -680,7 +680,10 @@ function getPoolLink(pool: Pool): string {
 }
 
 function getPoolTypeTarget(pool: Pool) {
-  if (pool.type === "cosmwasm-transmuter") {
+  if (
+    pool.type === "cosmwasm-transmuter" ||
+    pool.type === "cosmwasm-astroport-pcl"
+  ) {
     return "_blank";
   }
   return "";

--- a/packages/web/components/complex/all-pools-table.tsx
+++ b/packages/web/components/complex/all-pools-table.tsx
@@ -672,6 +672,9 @@ function getPoolLink(pool: Pool): string {
   if (pool.type === "cosmwasm-transmuter") {
     return `https://celatone.osmosis.zone/osmosis-1/pools/${pool.id}`;
   }
+  if (pool.type === "cosmwasm-astroport-pcl") {
+    return `https://osmosis.astroport.fi/pools/${pool.id}`;
+  }
 
   return `/pool/${pool.id}`;
 }

--- a/packages/web/pages/pool/[id].tsx
+++ b/packages/web/pages/pool/[id].tsx
@@ -47,12 +47,14 @@ const Pool: FunctionComponent<Props> = ({
     // this uses a legacy query to fetch the pool data, we can deprecate this once we migrate to tRPC
     if (!pool || !isValidPoolId) return;
 
-    const isCosmwasmNotTransmuter =
-      pool.type.startsWith("cosmwasm") && pool.type !== "cosmwasm-transmuter";
+    const isCosmwasmNotSupported =
+      pool.type.startsWith("cosmwasm") &&
+      pool.type !== "cosmwasm-transmuter" &&
+      pool.type !== "cosmwasm-astroport-pcl";
 
     const celatoneUrl = `https://celatone.osmosis.zone/osmosis-1/pools/${poolId}`;
 
-    if (isCosmwasmNotTransmuter) window.location.href = celatoneUrl;
+    if (isCosmwasmNotSupported) window.location.href = celatoneUrl;
   }, [pool, poolId, isValidPoolId]);
   useEffect(() => {
     if ((!isValidPoolId || isError) && router.isReady) {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

### ClickUp Task

[ClickUp Task URL](PASTE_CLICKUP_TASK_URL_HERE)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced pool linking functionality to support a new pool type "cosmwasm-astroport-pcl," providing users with direct access to specific pool information.
	- Improved logic in the `Pool` component to handle redirection for the new pool type "cosmwasm-astroport-pcl," ensuring a smooth user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->