### PR TITLE
earn:  use em dash instead of N/A for no locking duration

### DIFF
--- a/packages/web/components/earn/table/cells.tsx
+++ b/packages/web/components/earn/table/cells.tsx
@@ -161,7 +161,7 @@ export const LockCell = (item: CellContext<EarnStrategy, string>) => {
   return (
     <div className="flex flex-col">
       <ColumnCellCell>
-        {hasLockingDuration ? lockingDuration : "N/A"}
+        {hasLockingDuration ? lockingDuration : "—"}
       </ColumnCellCell>
       {hasLockingDuration && (
         <small className="text-sm font-subtitle2 text-osmoverse-400">


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant clickup task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

### ClickUp Task

[ClickUp Task URL](PASTE_CLICKUP_TASK_URL_HERE)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

## Documentation and Release Note

<!-- - Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- How is the feature or change documented? (not applicable / [Osmosis web dev guide](https://docs.osmosis.zone/developing/web-dev-guide.html) / not documented) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Bug Fixes**
	- Updated the display of locking duration in the earnings table to show "—" instead of "N/A" for better clarity.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->