### PR TITLE
[DO NOT MERGE] Use stage worker proxy to test staging data endpoints

### DIFF
--- a/packages/server/src/env.ts
+++ b/packages/server/src/env.ts
@@ -13,8 +13,13 @@ export const CMS_REPOSITORY_PATH = process.env.CMS_REPOSITORY_PATH;
 export const GITHUB_RAW_DEFAULT_BASEURL = "https://raw.githubusercontent.com";
 
 // data services
-export const TIMESERIES_DATA_URL = process.env.NEXT_PUBLIC_TIMESERIES_DATA_URL;
-export const INDEXER_DATA_URL = process.env.NEXT_PUBLIC_INDEXER_DATA_URL;
+// export const TIMESERIES_DATA_URL = process.env.NEXT_PUBLIC_TIMESERIES_DATA_URL;
+// export const INDEXER_DATA_URL = process.env.NEXT_PUBLIC_INDEXER_DATA_URL;
+
+// hardcoding numia staging proxy
+export const TIMESERIES_DATA_URL = "https://data-proxy-numia-stage.osmosis-labs.workers.dev"
+export const INDEXER_DATA_URL = "https://data-proxy-numia-stage.osmosis-labs.workers.dev"
+
 export const SIDECAR_BASE_URL =
   process.env.NEXT_PUBLIC_SIDECAR_BASE_URL ?? "https://sqs.osmosis.zone/";
 export const TFM_BASE_URL = process.env.NEXT_PUBLIC_TFM_API_BASE_URL;

--- a/packages/stores/src/queries-external/index.ts
+++ b/packages/stores/src/queries-external/index.ts
@@ -11,9 +11,9 @@ export * from "./token-data";
 export * from "./token-historical-chart";
 
 export const IMPERATOR_TIMESERIES_DEFAULT_BASEURL =
-  "https://api-osmosis.imperator.co";
+  "https://data-proxy-numia-stage.osmosis-labs.workers.dev";
 export const IMPERATOR_INDEXER_DEFAULT_BASEURL =
-  "https://api-osmosis-chain.imperator.co";
+  "https://data-proxy-numia-stage.osmosis-labs.workers.dev";
 
 /**
  * This domain has a whitelist, so in local development an auth token is required
@@ -21,4 +21,4 @@ export const IMPERATOR_INDEXER_DEFAULT_BASEURL =
 export const COINGECKO_API_DEFAULT_BASEURL =
   "https://coingecko.osmosis.zone/api";
 
-export const NUMIA_INDEXER_BASEURL = "https://public-osmosis-api.numia.xyz";
+export const NUMIA_INDEXER_BASEURL = "https://data-proxy-numia-stage.osmosis-labs.workers.dev";


### PR DESCRIPTION
Replace data endpoints to point to a new proxy that serves imperator (prod) and numia (stage).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Updated the base URLs for various APIs to new endpoints, enhancing the connection to Imperator timeseries, indexer APIs, and the Numia indexer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->