### PR TITLE
Feat: rename riskReportCardUrl with riskReportUrl

### DIFF
--- a/packages/server/src/queries/data-services/earn.ts
+++ b/packages/server/src/queries/data-services/earn.ts
@@ -165,7 +165,7 @@ export interface StrategyCMSData {
   /**
    * URL to risk report on Google Sheets.
    */
-  riskReportUrl: string;
+  riskReportUrl?: string;
   /**
    * Start date and time (UTC) of the strategy.
    */
@@ -218,10 +218,6 @@ export interface StrategyCMSData {
    */
   categories: string[];
   hasLockingDuration?: boolean;
-  /**
-   * Link to the individual file related to the risk report for this strategy
-   */
-  riskReportCardUrl?: string;
 }
 
 export interface EarnStrategyBalance {

--- a/packages/web/components/earn/table/cells.tsx
+++ b/packages/web/components/earn/table/cells.tsx
@@ -178,8 +178,8 @@ function _getRiskLabel(risk: number) {
 
 export const RiskCell = (item: CellContext<EarnStrategy, number>) => {
   const RiskLink =
-    item.row.original.riskReportCardUrl &&
-    item.row.original.riskReportCardUrl.length > 0
+    item.row.original.riskReportUrl &&
+    item.row.original.riskReportUrl.length > 0
       ? Link
       : "div";
 
@@ -187,7 +187,7 @@ export const RiskCell = (item: CellContext<EarnStrategy, number>) => {
     <div className="flex items-center justify-center">
       <div className="flex flex-col items-center gap-1">
         <RiskLink
-          href={item.row.original.riskReportCardUrl ?? ""}
+          href={item.row.original.riskReportUrl ?? ""}
           className="relative h-6"
           target="_blank"
         >


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant Linear task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change:

rename riskReportCardUrl with riskReportUrl

### Linear Task

[Linear Task URL](PASTE_LINEAR_TASK_URL_HERE)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Refactor**
	- Updated the data model to make the risk report URL optional and removed outdated properties for consistency.
	- Renamed variables in the web component for better clarity and consistency.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->