### PR TITLE
Fix: user balances query

### DIFF
--- a/packages/server/src/queries/cosmos/bank/balances.ts
+++ b/packages/server/src/queries/cosmos/bank/balances.ts
@@ -13,5 +13,6 @@ export const queryBalances = createNodeQuery<
     bech32Address: string;
   }
 >({
-  path: ({ bech32Address }) => `/cosmos/bank/v1beta1/balances/${bech32Address}`,
+  path: ({ bech32Address }) =>
+    `/cosmos/bank/v1beta1/balances/${bech32Address}?pagination.limit=1000`,
 });


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant Linear task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change:

The goal of this PR is to fix all services dependent on the `queryBalances` service, such as the trpc `getUserAssetsBreakdown` route, because of paging limitations if a user has many balances at the moment he is not shown some of them.

To solve this problem I introduced a pageLimit of 1000 elements.

### Linear Task

[Linear Task URL](PASTE_LINEAR_TASK_URL_HERE)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->
