### PR TITLE
fix: Osmosis $W balance on Wormhole Page

### DIFF
--- a/packages/web/pages/wormhole.tsx
+++ b/packages/web/pages/wormhole.tsx
@@ -26,7 +26,7 @@ const config: WormholeConnectConfig = {
   rpcs: {
     solana:
       "https://mainnet.helius-rpc.com/?api-key=f4713222-8bbc-4495-aace-5693e719712e",
-    gateway: "https://tncnt-eu-wormchain-main-01.rpc.p2p.world/",
+    wormchain: "https://tncnt-eu-wormchain-main-01.rpc.p2p.world/",
   },
   tokensConfig: {
     W: {

--- a/packages/web/pages/wormhole.tsx
+++ b/packages/web/pages/wormhole.tsx
@@ -22,7 +22,7 @@ const WormholeConnect = dynamic(
 );
 
 const config: WormholeConnectConfig = {
-  networks: ["solana", "osmosis", "gateway"],
+  networks: ["solana", "osmosis"],
   rpcs: {
     solana:
       "https://mainnet.helius-rpc.com/?api-key=f4713222-8bbc-4495-aace-5693e719712e",

--- a/packages/web/pages/wormhole.tsx
+++ b/packages/web/pages/wormhole.tsx
@@ -22,10 +22,11 @@ const WormholeConnect = dynamic(
 );
 
 const config: WormholeConnectConfig = {
-  networks: ["solana", "osmosis"],
+  networks: ["solana", "osmosis", "gateway"],
   rpcs: {
     solana:
       "https://mainnet.helius-rpc.com/?api-key=f4713222-8bbc-4495-aace-5693e719712e",
+    gateway: "https://tncnt-eu-wormchain-main-01.rpc.p2p.world/",
   },
   tokensConfig: {
     W: {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant Linear task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change:

fixes the query for Osmosis $W balance on the Wormhole Page, needed for bridging W back to Solana.


Before change:
We have CORS errors, and error saying "failed to fetch balances":
![image](https://github.com/osmosis-labs/osmosis-frontend/assets/95667791/7b25144f-bb46-4307-8c3f-d2daa7c63bd4)
and Balances on Osmosis fails to load:
![image](https://github.com/osmosis-labs/osmosis-frontend/assets/95667791/00522da9-e558-4da4-89af-8a3a32003832)

After change:
No more CORS errors, and balance loads:
![image](https://github.com/osmosis-labs/osmosis-frontend/assets/95667791/7e760250-3fc5-4ac5-b866-560848bf0022)



## Brief Changelog

Adds gateway rpc to wormhole config in web/pages/wormhole.tsx, as recommended by Wormhole team.

## Testing and Verifying

This change has been tested locally by rebuilding the website and verified content and links are expected


I didn't touch math, so I'm not sure why math is failing lint check
