### PR TITLE
docs: comment for batch loader cache 

### DIFF
--- a/packages/server/src/queries/complex/assets/price/providers/sidecar.ts
+++ b/packages/server/src/queries/complex/assets/price/providers/sidecar.ts
@@ -39,7 +39,7 @@ function getBatchLoader() {
     key: "sidecar-batch-loader",
     // This TTL only controls the lifetime of the DataLoader instance, not the individual cache entries.
     // The value is chosen arbitrarily to prevent long-running batch loaders as recommended by the documentation
-    ttl: 1000 * 60 * 10, // 10 minute
+    ttl: 1000 * 60 * 10, // 10 minutes
     getFreshValue: () =>
       new EdgeDataLoader(
         (coinMinimalDenoms: readonly string[]) => {

--- a/packages/server/src/queries/complex/assets/price/providers/sidecar.ts
+++ b/packages/server/src/queries/complex/assets/price/providers/sidecar.ts
@@ -37,7 +37,9 @@ function getBatchLoader() {
   return cachified({
     cache: sidecarCache,
     key: "sidecar-batch-loader",
-    ttl: 1000 * 60, // 1 minute
+    // This TTL only controls the lifetime of the DataLoader instance, not the individual cache entries.
+    // The value is chosen arbitrarily to prevent long-running batch loaders as recommended by the documentation
+    ttl: 1000 * 60 * 10, // 10 minute
     getFreshValue: () =>
       new EdgeDataLoader(
         (coinMinimalDenoms: readonly string[]) => {

--- a/packages/server/src/queries/complex/assets/price/providers/sidecar.ts
+++ b/packages/server/src/queries/complex/assets/price/providers/sidecar.ts
@@ -37,7 +37,7 @@ function getBatchLoader() {
   return cachified({
     cache: sidecarCache,
     key: "sidecar-batch-loader",
-    ttl: 1000 * 60 * 10, // 10 minutes
+    ttl: 1000 * 60, // 10 minute
     getFreshValue: () =>
       new EdgeDataLoader(
         (coinMinimalDenoms: readonly string[]) => {

--- a/packages/server/src/queries/complex/assets/price/providers/sidecar.ts
+++ b/packages/server/src/queries/complex/assets/price/providers/sidecar.ts
@@ -37,7 +37,7 @@ function getBatchLoader() {
   return cachified({
     cache: sidecarCache,
     key: "sidecar-batch-loader",
-    ttl: 1000 * 60, // 10 minute
+    ttl: 1000 * 60, // 1 minute
     getFreshValue: () =>
       new EdgeDataLoader(
         (coinMinimalDenoms: readonly string[]) => {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant Linear task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change:

Lower sidecar batch loader prices cache to 1 minute.

Upon discussing this with @jonator , realized that this is a batch loader cache. Propose lowering it to 1 minute still as 10 minutes feels excessive.

### Linear Task

[Linear Task URL](PASTE_LINEAR_TASK_URL_HERE)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->
