### PR TITLE
Feat: improve token info chart price fallback

### DIFF
--- a/packages/web/hooks/ui-config/use-asset-info-config.ts
+++ b/packages/web/hooks/ui-config/use-asset-info-config.ts
@@ -61,96 +61,107 @@ export const useAssetInfoConfig = (
     };
   }, [config.historicalRange]);
 
-  if (!coingeckoId) {
-    const {
-      data: historicalPriceData,
-      isLoading,
-      isError,
-    } = api.edge.assets.getAssetHistoricalPrice.useQuery(
-      {
-        coinDenom: denom ?? queryDenom,
-        timeFrame: {
-          custom: customTimeFrame,
+  const {
+    data: historicalPriceData,
+    isLoading,
+    isError,
+  } = api.edge.assets.getAssetHistoricalPrice.useQuery(
+    {
+      coinDenom: denom ?? queryDenom,
+      timeFrame: {
+        custom: customTimeFrame,
+      },
+    },
+    {
+      enabled: Boolean(denom ?? queryDenom),
+      staleTime: 1000 * 60 * 3, // 3 minutes
+      cacheTime: 1000 * 60 * 6, // 6 minutes
+      trpc: {
+        context: {
+          skipBatch: true,
         },
       },
-      {
-        enabled: Boolean(denom ?? queryDenom),
-        trpc: {
-          context: {
-            skipBatch: true,
-          },
-        },
-      }
-    );
+    }
+  );
 
-    if (historicalPriceData) config.setHistoricalData(historicalPriceData);
-    config.setIsHistoricalDataLoading(isLoading);
-    config.setHistoricalDataError(isError);
-  } else {
-    const {
-      data: historicalPriceData,
-      isLoading,
-      isError,
-    } = api.edge.assets.getCoingeckoAssetHistoricalPrice.useQuery(
-      {
-        id: coingeckoId,
-        timeFrame: config.historicalRange,
+  if (historicalPriceData) config.setHistoricalData(historicalPriceData);
+  config.setIsHistoricalDataLoading(isLoading);
+  config.setHistoricalDataError(isError);
+
+  const enableCoinGecko =
+    Boolean(coingeckoId) &&
+    coingeckoId !== undefined &&
+    historicalPriceData !== undefined &&
+    historicalPriceData.length === 0;
+
+  const {
+    data: coingeckoHistoricalPriceData,
+    isLoading: isLoadingCoingecko,
+    isError: isErrorCoingecko,
+  } = api.edge.assets.getCoingeckoAssetHistoricalPrice.useQuery(
+    {
+      id: coingeckoId ?? "",
+      timeFrame: config.historicalRange,
+    },
+    {
+      select(data) {
+        const historicalData = data?.prices.map(([timestamp, price]) => ({
+          time: timestamp / 1000,
+          close: price,
+          high: price,
+          low: price,
+          open: price,
+          volume: 0,
+        }));
+
+        if (config.historicalRange === "all") {
+          return historicalData;
+        }
+
+        let min = dayjs(new Date());
+        const max = dayjs(Date.now());
+        const maxTime = max.unix();
+
+        switch (config.historicalRange) {
+          case "1h":
+            min = min.subtract(1, "hour");
+            break;
+          case "1d":
+            min = min.subtract(1, "day");
+            break;
+          case "7d":
+            min = min.subtract(1, "week");
+            break;
+          case "1mo":
+            min = min.subtract(1, "month");
+            break;
+          case "1y":
+            min = min.subtract(1, "year");
+            break;
+        }
+
+        const minTime = min.unix();
+
+        return historicalData?.filter(
+          (price) => price.time <= maxTime && price.time >= minTime
+        );
       },
-      {
-        select(data) {
-          const historicalData = data?.prices.map(([timestamp, price]) => ({
-            time: timestamp / 1000,
-            close: price,
-            high: price,
-            low: price,
-            open: price,
-            volume: 0,
-          }));
-
-          if (config.historicalRange === "all") {
-            return historicalData;
-          }
-
-          let min = dayjs(new Date());
-          const max = dayjs(Date.now());
-          const maxTime = max.unix();
-
-          switch (config.historicalRange) {
-            case "1h":
-              min = min.subtract(1, "hour");
-              break;
-            case "1d":
-              min = min.subtract(1, "day");
-              break;
-            case "7d":
-              min = min.subtract(1, "week");
-              break;
-            case "1mo":
-              min = min.subtract(1, "month");
-              break;
-            case "1y":
-              min = min.subtract(1, "year");
-              break;
-          }
-
-          const minTime = min.unix();
-
-          return historicalData?.filter(
-            (price) => price.time <= maxTime && price.time >= minTime
-          );
+      enabled: enableCoinGecko,
+      staleTime: 1000 * 60 * 3, // 3 minutes
+      cacheTime: 1000 * 60 * 6, // 6 minutes
+      trpc: {
+        context: {
+          skipBatch: true,
         },
-        enabled: Boolean(coingeckoId),
-        trpc: {
-          context: {
-            skipBatch: true,
-          },
-        },
-      }
-    );
+      },
+    }
+  );
 
-    if (historicalPriceData) config.setHistoricalData(historicalPriceData);
-    config.setIsHistoricalDataLoading(isLoading);
-    config.setHistoricalDataError(isError);
+  if (enableCoinGecko) {
+    if (coingeckoHistoricalPriceData)
+      config.setHistoricalData(coingeckoHistoricalPriceData);
+    config.setIsHistoricalDataLoading(isLoadingCoingecko);
+    config.setHistoricalDataError(isErrorCoingecko);
   }
 
   return config;

--- a/packages/web/hooks/ui-config/use-asset-info-config.ts
+++ b/packages/web/hooks/ui-config/use-asset-info-config.ts
@@ -100,6 +100,11 @@ export const useAssetInfoConfig = (
     isError: isErrorCoingecko,
   } = api.edge.assets.getCoingeckoAssetHistoricalPrice.useQuery(
     {
+      /**
+       * We need to add a fallback but just to avoid ts errors,
+       * using `enabled` prop we make sure that we do not trigger
+       * the query if the id is undefined
+       */
       id: coingeckoId ?? "",
       timeFrame: config.historicalRange,
     },


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant Linear task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change:

This PR improves fallback handling for token info page graphs, in particular even if a token explicitly wants to use coingecko, however we try to retrieve the data from numia, if we get no results then we use coingecko services.

![image (2)](https://github.com/osmosis-labs/osmosis-frontend/assets/17269969/9121e30a-7855-437d-9937-2a9929a3c48d)

### Linear Task

[Linear Task URL](PASTE_LINEAR_TASK_URL_HERE)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->
