### PR TITLE
refactor: lower coin price cache and stale time from 5 to 3 seconds

### DIFF
--- a/packages/web/hooks/queries/assets/use-coin-price.ts
+++ b/packages/web/hooks/queries/assets/use-coin-price.ts
@@ -9,8 +9,8 @@ export function useCoinPrice(coin?: CoinPretty) {
     },
     {
       enabled: Boolean(coin?.currency),
-      cacheTime: 1000 * 5, // 5 seconds
-      staleTime: 1000 * 5, // 5 seconds
+      cacheTime: 1000 * 3, // 3 second
+      staleTime: 1000 * 3, // 3 second
     }
   );
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant Linear task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change:

In addition to this cache client side, we also have it in SQS. We should incrementally lower the TTL in the client, to avoid the caching complexity and staleness problems around prices.

If this works well and performance is unaffected, we can evaluate further going down to 1-2 seconds