### PR TITLE
Swap tool fix: tolerate route containing asset not in asset list

### DIFF
--- a/packages/server/src/trpc-routers/swap-router.ts
+++ b/packages/server/src/trpc-routers/swap-router.ts
@@ -19,7 +19,7 @@ import { routeTokenOutGivenIn } from "../queries/complex/pools/route-token-out-g
 import { OsmosisSidecarRemoteRouter } from "../queries/sidecar/router";
 import { TfmRemoteRouter } from "../queries/tfm/router";
 import { createTRPCRouter, publicProcedure } from "../trpc";
-import { captureErrorAndReturn } from "../utils/error";
+import { captureErrorAndReturn, captureIfError } from "../utils/error";
 
 const zodAvailableRouterKey = z.enum(["tfm", "sidecar", "legacy"]);
 export type RouterKey = z.infer<typeof zodAvailableRouterKey>;
@@ -165,14 +165,18 @@ function makeDisplayableSplit(
         type = getCosmwasmPoolTypeFromCodeId(pool_.codeId);
       }
 
-      const inAsset = getAsset({
-        assetLists,
-        anyDenom: index === 0 ? tokenInDenom : tokenOutDenoms[index - 1],
-      });
-      const outAsset = getAsset({
-        assetLists,
-        anyDenom: tokenOutDenoms[index],
-      });
+      const inAsset = captureIfError(() =>
+        getAsset({
+          assetLists,
+          anyDenom: index === 0 ? tokenInDenom : tokenOutDenoms[index - 1],
+        })
+      );
+      const outAsset = captureIfError(() =>
+        getAsset({
+          assetLists,
+          anyDenom: tokenOutDenoms[index],
+        })
+      );
 
       return {
         id: pool_.id,

--- a/packages/web/components/swap-tool/split-route.tsx
+++ b/packages/web/components/swap-tool/split-route.tsx
@@ -167,15 +167,13 @@ const Pools: FunctionComponent<Route> = observer(({ pools }) => {
               dynamicSpreadFactor,
             },
             index
-          ) => {
-            if (!inCurrency || !outCurrency) return null;
-
-            return (
-              <Tooltip
-                key={`${id}${index}`}
-                singleton={target}
-                content={
-                  <div className="space-y-3">
+          ) => (
+            <Tooltip
+              key={`${id}${index}`}
+              singleton={target}
+              content={
+                <div className="space-y-3">
+                  {inCurrency && outCurrency && (
                     <div className="flex space-x-2">
                       <div className="flex">
                         <div className="h-[20px] w-[20px]">
@@ -192,69 +190,74 @@ const Pools: FunctionComponent<Route> = observer(({ pools }) => {
                         <span>{outCurrency.coinDenom}</span>
                       </p>
                     </div>
+                  )}
 
-                    <div className="flex justify-center space-x-1 text-center text-xs font-medium">
+                  <div className="flex justify-center space-x-1 text-center text-xs font-medium">
+                    <p className="w-full whitespace-nowrap rounded-md bg-osmoverse-800 py-0.5 px-1.5">
+                      {t("swap.pool", { id })}
+                    </p>
+
+                    {spreadFactor && (
                       <p className="w-full whitespace-nowrap rounded-md bg-osmoverse-800 py-0.5 px-1.5">
-                        {t("swap.pool", { id })}
+                        {type === "concentrated"
+                          ? t("swap.routerTooltipSpreadFactor")
+                          : t("swap.routerTooltipFee")}{" "}
+                        {dynamicSpreadFactor
+                          ? t("swap.dynamicSpreadFactor")
+                          : spreadFactor.maxDecimals(2).toString()}
                       </p>
-
-                      {spreadFactor && (
-                        <p className="w-full whitespace-nowrap rounded-md bg-osmoverse-800 py-0.5 px-1.5">
-                          {type === "concentrated"
-                            ? t("swap.routerTooltipSpreadFactor")
-                            : t("swap.routerTooltipFee")}{" "}
-                          {dynamicSpreadFactor
-                            ? t("swap.dynamicSpreadFactor")
-                            : spreadFactor.maxDecimals(2).toString()}
-                        </p>
-                      )}
-                    </div>
-                    {(type === "concentrated" ||
-                      type === "stable" ||
-                      type === "cosmwasm-transmuter" ||
-                      type === "cosmwasm-astroport-pcl" ||
-                      type === "cosmwasm-whitewhale" ||
-                      type === "cosmwasm") && (
-                      <div className="flex items-center justify-center gap-1 space-x-1 text-center text-xs font-medium text-ion-400">
-                        {type === "concentrated" && (
-                          <Icon id="lightning-small" height={16} width={16} />
-                        )}
-                        {(type === "stable" ||
-                          type === "cosmwasm-transmuter") && (
-                          <Image
-                            alt="stable-pool"
-                            src="/icons/stableswap-pool.svg"
-                            width={16}
-                            height={16}
-                          />
-                        )}
-                        {type === "cosmwasm" && (
-                          <Icon id="setting" height={16} width={16} />
-                        )}
-                        {t(
-                          type === "concentrated"
-                            ? "clPositions.supercharged"
-                            : type === "cosmwasm-transmuter"
-                            ? "pool.transmuter"
-                            : type === "cosmwasm-astroport-pcl"
-                            ? "Astroport PCL"
-                            : type === "cosmwasm-whitewhale"
-                            ? "White Whale"
-                            : type === "cosmwasm"
-                            ? "pool.custom"
-                            : "pool.stableswapEnabled"
-                        )}
-                      </div>
                     )}
                   </div>
-                }
+                  {(type === "concentrated" ||
+                    type === "stable" ||
+                    type === "cosmwasm-transmuter" ||
+                    type === "cosmwasm-astroport-pcl" ||
+                    type === "cosmwasm-whitewhale" ||
+                    type === "cosmwasm") && (
+                    <div className="flex items-center justify-center gap-1 space-x-1 text-center text-xs font-medium text-ion-400">
+                      {type === "concentrated" && (
+                        <Icon id="lightning-small" height={16} width={16} />
+                      )}
+                      {(type === "stable" ||
+                        type === "cosmwasm-transmuter") && (
+                        <Image
+                          alt="stable-pool"
+                          src="/icons/stableswap-pool.svg"
+                          width={16}
+                          height={16}
+                        />
+                      )}
+                      {type === "cosmwasm" && (
+                        <Icon id="setting" height={16} width={16} />
+                      )}
+                      {t(
+                        type === "concentrated"
+                          ? "clPositions.supercharged"
+                          : type === "cosmwasm-transmuter"
+                          ? "pool.transmuter"
+                          : type === "cosmwasm-astroport-pcl"
+                          ? "Astroport PCL"
+                          : type === "cosmwasm-whitewhale"
+                          ? "White Whale"
+                          : type === "cosmwasm"
+                          ? "pool.custom"
+                          : "pool.stableswapEnabled"
+                      )}
+                    </div>
+                  )}
+                </div>
+              }
+            >
+              <button
+                className={classNames(
+                  "flex items-center space-x-2 rounded-full bg-osmoverse-800 hover:bg-osmoverse-700",
+                  inCurrency && outCurrency ? "p-1" : "p-2"
+                )}
+                onClick={() => {
+                  if (!isMobile) router.push("/pool/" + id);
+                }}
               >
-                <button
-                  className="flex items-center space-x-2 rounded-full bg-osmoverse-800 p-1 hover:bg-osmoverse-700"
-                  onClick={() => {
-                    if (!isMobile) router.push("/pool/" + id);
-                  }}
-                >
+                {inCurrency && outCurrency && (
                   <div className="flex">
                     <div className="h-[20px] w-[20px]">
                       <DenomImage currency={inCurrency} />
@@ -263,19 +266,19 @@ const Pools: FunctionComponent<Route> = observer(({ pools }) => {
                       <DenomImage currency={outCurrency} />
                     </div>
                   </div>
+                )}
 
-                  {pools.length < 4 &&
-                    !isMobile &&
-                    spreadFactor &&
-                    !dynamicSpreadFactor && (
-                      <p className="text-caption">
-                        {spreadFactor.maxDecimals(1).toString()}
-                      </p>
-                    )}
-                </button>
-              </Tooltip>
-            );
-          }
+                {pools.length < 4 &&
+                  !isMobile &&
+                  spreadFactor &&
+                  !dynamicSpreadFactor && (
+                    <p className="text-caption">
+                      {spreadFactor.maxDecimals(1).toString()}
+                    </p>
+                  )}
+              </button>
+            </Tooltip>
+          )
         )}
       </div>
     </>


### PR DESCRIPTION
Fix:

Rationale

If an asset in a pool in a route returned from router is not found, we should simply hide the route visualization instead of throwing an error in the router. This would allow the user to still swap assets through routes containing unlisted assets.

Example: BTSG => OSMO (or most tokens). We unlisted the BitSong fan tokens and BTSG is paired to most of those tokens. Users should still be able to swap though BTSG though.

DoD

* Swaps are possible with routes containing tokens not in asset list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved error handling in asset retrieval processes.
	- Enhanced visual presentation and user interaction in the `Pools` component, including updates to tooltips and button functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->