### PR TITLE
fix: Compute tokenInAmount Based on Pool's Liquidity and Retry E2E Tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "@babel/core": "^7.24.3",
     "@babel/preset-env": "^7.24.3",
     "@inlang/cli": "^2.11.0",
-    "@types/jest": "^27.4.0",
     "@typescript-eslint/eslint-plugin": "^7.4.0",
     "@typescript-eslint/parser": "^7.4.0",
     "babel-jest": "^29.7.0",
@@ -58,7 +57,9 @@
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "eslint-plugin-unicorn": "^48.0.1",
     "eslint-plugin-unused-imports": "^3.0.0",
+    "is-ci-cli": "^2.2.0",
     "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
     "jest-watch-typeahead": "^2.2.2",
     "lerna": "^4.0.0",
     "lint-staged": "^12.1.3",
@@ -69,9 +70,7 @@
     "prettier": "^2.8.8",
     "ts-jest": "^29.1.2",
     "turbo": "^1.13.0",
-    "typescript": "5.4.3",
-    "jest-environment-jsdom": "^29.7.0",
-    "is-ci-cli": "^2.2.0"
+    "typescript": "5.4.3"
   },
   "packageManager": "yarn@1.22.22",
   "resolutions": {

--- a/packages/server/src/trpc-routers/__tests_e2e__/swap-router.test.ts
+++ b/packages/server/src/trpc-routers/__tests_e2e__/swap-router.test.ts
@@ -26,6 +26,7 @@ import {
 } from "../../queries";
 import { AssetLists } from "../../queries/__tests__/mock-asset-lists";
 import { MockChains } from "../../queries/__tests__/mock-chains";
+import { getPriceFromSidecar } from "../../queries/complex/assets/price/providers/sidecar";
 import { createInnerTRPCContext } from "../../trpc";
 import { sort } from "../../utils";
 import { superjson } from "../../utils/superjson";
@@ -533,10 +534,29 @@ it("Sidecar — Should return valid quote for medium volume token", async () => 
 
   const [tokenIn, tokenOut] = mediumVolumePool.reserveCoins;
 
-  const tokenInAmount = new Dec(1)
+  const tokenInAsset = getAssetFromAssetList({
+    coinMinimalDenom: tokenIn.currency.coinMinimalDenom,
+    assetLists: AssetLists,
+  })!.rawAsset;
+
+  const tokenPrice = await getPriceFromSidecar(
+    AssetLists,
+    MockChains,
+    tokenInAsset
+  );
+
+  // Desired price is 10% of the total fiat value locked in the pool
+  const desiredPrice = mediumVolumePool.totalFiatValueLocked
+    .toDec()
+    .mul(new Dec(0.1));
+
+  // Desired token in amount is the desired price divided by the token price
+  const tokenInAmount = desiredPrice
+    .quo(tokenPrice)
     .mul(DecUtils.getTenExponentN(tokenIn.currency.coinDecimals))
     .truncate()
     .toString();
+
   const preferredRouter = "sidecar";
   const reply = await caller.swapRouter.routeTokenOutGivenIn({
     tokenInDenom: tokenIn.currency.coinMinimalDenom,
@@ -565,37 +585,53 @@ it("Sidecar — Should return valid quote for low volume token", async () => {
   const { averageVolume, sortedPoolsWithVolume } =
     await getSortedPoolsWithVolume();
 
-  const lowVolumeToken = sortedPoolsWithVolume.find(
+  const lowVolumeTokenPool = sortedPoolsWithVolume.find(
     (pool) =>
       // Find a token that less than or equal to 40% of the average volume
       pool.volume24hUsdDec.lte(averageVolume.mul(new Dec(0.4))) &&
       pool.reserveCoins.length === 2
   )!;
 
-  const [inAsset, outAsset] = lowVolumeToken.reserveCoins;
+  const [tokenIn, tokenOut] = lowVolumeTokenPool.reserveCoins;
 
-  const tokenInAmount = new Dec(1)
-    .mul(DecUtils.getTenExponentN(inAsset.currency.coinDecimals))
+  const tokenInAsset = getAssetFromAssetList({
+    coinMinimalDenom: tokenIn.currency.coinMinimalDenom,
+    assetLists: AssetLists,
+  })!.rawAsset;
+
+  const tokenPrice = await getPriceFromSidecar(
+    AssetLists,
+    MockChains,
+    tokenInAsset
+  );
+
+  // Desired price is 10% of the total fiat value locked in the pool
+  const desiredPrice = lowVolumeTokenPool.totalFiatValueLocked
+    .toDec()
+    .mul(new Dec(0.1));
+
+  // Desired token in amount is the desired price divided by the token price
+  const tokenInAmount = desiredPrice
+    .quo(tokenPrice)
+    .mul(DecUtils.getTenExponentN(tokenIn.currency.coinDecimals))
     .truncate()
     .toString();
+
   const preferredRouter = "sidecar";
   const reply = await caller.swapRouter.routeTokenOutGivenIn({
-    tokenInDenom: inAsset.currency.coinMinimalDenom,
+    tokenInDenom: tokenIn.currency.coinMinimalDenom,
     tokenInAmount,
-    tokenOutDenom: outAsset.currency.coinMinimalDenom,
+    tokenOutDenom: tokenOut.currency.coinMinimalDenom,
     preferredRouter,
-    forcePoolId: lowVolumeToken.id,
+    forcePoolId: lowVolumeTokenPool.id,
   });
 
   assertValidQuote({
     quote: reply,
     tokenInAmount,
-    tokenIn: getAssetFromAssetList({
-      coinMinimalDenom: inAsset.currency.coinMinimalDenom,
-      assetLists: AssetLists,
-    })!.rawAsset,
+    tokenIn: tokenInAsset,
     tokenOut: getAssetFromAssetList({
-      coinMinimalDenom: outAsset.currency.coinMinimalDenom,
+      coinMinimalDenom: tokenOut.currency.coinMinimalDenom,
       assetLists: AssetLists,
     })!.rawAsset,
     router: preferredRouter,

--- a/packages/server/src/trpc-routers/__tests_e2e__/swap-router.test.ts
+++ b/packages/server/src/trpc-routers/__tests_e2e__/swap-router.test.ts
@@ -554,7 +554,7 @@ it("Sidecar — Should return valid quote for medium volume token", async () => 
     .toDec()
     .mul(new Dec(0.1));
 
-  // Desired token in amount is the desired price divided by the token price
+  // Token in amount is the desired price divided by the token price
   const tokenInAmount = desiredPrice
     .quo(tokenPrice)
     .mul(DecUtils.getTenExponentN(tokenIn.currency.coinDecimals))
@@ -614,7 +614,7 @@ it("Sidecar — Should return valid quote for low volume token", async () => {
     .toDec()
     .mul(new Dec(0.1));
 
-  // Desired token in amount is the desired price divided by the token price
+  // Token in amount is the desired price divided by the token price
   const tokenInAmount = desiredPrice
     .quo(tokenPrice)
     .mul(DecUtils.getTenExponentN(tokenIn.currency.coinDecimals))

--- a/packages/server/src/trpc-routers/__tests_e2e__/swap-router.test.ts
+++ b/packages/server/src/trpc-routers/__tests_e2e__/swap-router.test.ts
@@ -186,7 +186,9 @@ function assertValidQuote({
   expect(parseFloat(amountFiatValue)).toBeGreaterThan(0);
 }
 
-it("Sidecar - ATOM <> OSMO - should return valid quote", async () => {
+jest.retryTimes(2, { logErrorsBeforeRetry: true });
+
+it.only("Sidecar - ATOM <> OSMO - should return valid quote", async () => {
   const tokenInAmount = "1000000";
   const tokenIn = atomAsset;
   const tokenOut = osmoAsset;
@@ -197,6 +199,8 @@ it("Sidecar - ATOM <> OSMO - should return valid quote", async () => {
     tokenOutDenom: tokenOut.coinMinimalDenom,
     preferredRouter,
   });
+
+  expect(false).toBeTruthy();
 
   assertValidQuote({
     quote: reply,

--- a/packages/server/src/trpc-routers/__tests_e2e__/swap-router.test.ts
+++ b/packages/server/src/trpc-routers/__tests_e2e__/swap-router.test.ts
@@ -188,7 +188,7 @@ function assertValidQuote({
 
 jest.retryTimes(2, { logErrorsBeforeRetry: true });
 
-it.only("Sidecar - ATOM <> OSMO - should return valid quote", async () => {
+it("Sidecar - ATOM <> OSMO - should return valid quote", async () => {
   const tokenInAmount = "1000000";
   const tokenIn = atomAsset;
   const tokenOut = osmoAsset;

--- a/packages/server/src/trpc-routers/__tests_e2e__/swap-router.test.ts
+++ b/packages/server/src/trpc-routers/__tests_e2e__/swap-router.test.ts
@@ -200,8 +200,6 @@ it("Sidecar - ATOM <> OSMO - should return valid quote", async () => {
     preferredRouter,
   });
 
-  expect(false).toBeTruthy();
-
   assertValidQuote({
     quote: reply,
     tokenInAmount,

--- a/yarn.lock
+++ b/yarn.lock
@@ -9997,14 +9997,6 @@
     expect "^29.0.0"
     pretty-format "^29.0.0"
 
-"@types/jest@^27.4.0":
-  version "27.4.0"
-  resolved "https://registry.npmjs.org/@types/jest/-/jest-27.4.0.tgz"
-  integrity sha512-gHl8XuC1RZ8H2j5sHv/JqsaxXkDDM9iDOgu0Wp8sjs4u/snb2PVehyWXJPr+ORA0RPpgw231mnutWI1+0hgjIQ==
-  dependencies:
-    jest-diff "^27.0.0"
-    pretty-format "^27.0.0"
-
 "@types/js-cookie@^2.2.6":
   version "2.2.7"
   resolved "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.2.7.tgz"
@@ -14704,11 +14696,6 @@ didyoumean@^1.2.2:
   resolved "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz"
   integrity sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==
 
-diff-sequences@^27.4.0:
-  version "27.4.0"
-  resolved "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.4.0.tgz"
-  integrity sha512-YqiQzkrsmHMH5uuh8OdQFU9/ZpADnwzml8z0O5HvRNda+5UZsaX/xN+AAxfR2hWq1Y7HZnAzO9J5lJXOuDz2Ww==
-
 diff-sequences@^29.4.3:
   version "29.4.3"
   resolved "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.4.3.tgz"
@@ -18094,16 +18081,6 @@ jest-config@^29.7.0:
     slash "^3.0.0"
     strip-json-comments "^3.1.1"
 
-jest-diff@^27.0.0:
-  version "27.4.6"
-  resolved "https://registry.npmjs.org/jest-diff/-/jest-diff-27.4.6.tgz"
-  integrity sha512-zjaB0sh0Lb13VyPsd92V7HkqF6yKRH9vm33rwBt7rPYrpQvS1nCvlIy2pICbKta+ZjWngYLNn4cCK4nyZkjS/w==
-  dependencies:
-    chalk "^4.0.0"
-    diff-sequences "^27.4.0"
-    jest-get-type "^27.4.0"
-    pretty-format "^27.4.6"
-
 jest-diff@^29.6.1:
   version "29.6.1"
   resolved "https://registry.npmjs.org/jest-diff/-/jest-diff-29.6.1.tgz"
@@ -18167,11 +18144,6 @@ jest-environment-node@^29.7.0:
     "@types/node" "*"
     jest-mock "^29.7.0"
     jest-util "^29.7.0"
-
-jest-get-type@^27.4.0:
-  version "27.4.0"
-  resolved "https://registry.npmjs.org/jest-get-type/-/jest-get-type-27.4.0.tgz"
-  integrity sha512-tk9o+ld5TWq41DkK14L4wox4s2D9MtTpKaAVzXfr5CUKm5ZK2ExcaFE0qls2W71zE/6R2TxxrK9w2r6svAFDBQ==
 
 jest-get-type@^29.4.3:
   version "29.4.3"
@@ -21781,15 +21753,6 @@ prettier@^2.6.2, prettier@^2.8.7, prettier@^2.8.8:
   version "2.8.8"
   resolved "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz"
   integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
-
-pretty-format@^27.0.0, pretty-format@^27.4.6:
-  version "27.4.6"
-  resolved "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.6.tgz"
-  integrity sha512-NblstegA1y/RJW2VyML+3LlpFjzx62cUrtBIKIWDXEDkjNeleA7Od7nrzcs/VLQvAeV4CgSYhrN39DRN88Qi/g==
-  dependencies:
-    ansi-regex "^5.0.1"
-    ansi-styles "^5.0.0"
-    react-is "^17.0.1"
 
 pretty-format@^27.0.2:
   version "27.5.1"


### PR DESCRIPTION
## What is the purpose of the change:

Improve the reliability of the Swap e2e tests by updating tests involving low and medium volume tokens. Ensure that the `tokenInAmount` used in these tests is within the available liquidity of the pool.








<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Updated `package.json` with package version changes and additions. Notably, removed `@types/jest`, added `is-ci-cli` and `jest-environment-jsdom`, and adjusted the ordering of dependencies.
- **Tests**
	- Enhanced end-to-end tests for the swap functionality to include new scenarios for medium and low volume tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->