### PR TITLE
feat: :sparkles: improve pool chart price format

### DIFF
--- a/packages/web/components/cards/my-position/expanded.tsx
+++ b/packages/web/components/cards/my-position/expanded.tsx
@@ -40,7 +40,7 @@ import { SuperfluidValidatorModal } from "~/modals";
 import { IncreaseConcentratedLiquidityModal } from "~/modals/increase-concentrated-liquidity";
 import { RemoveConcentratedLiquidityModal } from "~/modals/remove-concentrated-liquidity";
 import { useStore } from "~/stores";
-import { formatPretty } from "~/utils/formatter";
+import { formatPretty, getPriceExtendedFormatOptions } from "~/utils/formatter";
 import { RouterOutputs } from "~/utils/trpc";
 
 const ConcentratedLiquidityDepthChart = dynamic(
@@ -514,8 +514,15 @@ const ChartHeader: FunctionComponent<{
     quoteDenom,
     hoverPrice,
   } = config;
+
+  const formatOpts = useMemo(
+    () => getPriceExtendedFormatOptions(new Dec(hoverPrice)),
+    [hoverPrice]
+  );
+
   return (
     <PriceChartHeader
+      formatOpts={formatOpts}
       historicalRange={historicalRange}
       setHistoricalRange={setHistoricalRange}
       baseDenom={baseDenom}

--- a/packages/web/components/chart/token-pair-historical.tsx
+++ b/packages/web/components/chart/token-pair-historical.tsx
@@ -24,7 +24,11 @@ import { Icon } from "~/components/assets";
 import { ChartButton } from "~/components/ui/button";
 import { type PriceRange, useTranslation } from "~/hooks";
 import { theme } from "~/tailwind.config";
-import { FormatOptions, formatPretty } from "~/utils/formatter";
+import {
+  FormatOptions,
+  formatPretty,
+  getPriceExtendedFormatOptions,
+} from "~/utils/formatter";
 import { getDecimalCount } from "~/utils/number";
 
 const TokenPairHistoricalChart: FunctionComponent<{
@@ -212,39 +216,15 @@ const TokenPairHistoricalChart: FunctionComponent<{
 
                 const closeDec = new Dec(close);
 
-                /**
-                 * We need to know how long the integer part of the number is in order to calculate then how many decimal places.
-                 */
-                const integerPartLength =
-                  closeDec.truncate().toString().length ?? 0;
-
-                /**
-                 * If a number is less then $100, we only show 4 significant digits, examples:
-                 *  OSMO: $1.612
-                 *  AXL: $0.9032
-                 *  STARS: $0.03673
-                 *  HUAHUA: $0.00001231
-                 *
-                 * If a number is greater or equal to $100, we show a dynamic significant digits based on it's integer part, examples:
-                 * BTC: $47,334.21
-                 * ETH: $3,441.15
-                 */
-                const maximumSignificantDigits = closeDec.lt(new Dec(100))
-                  ? 4
-                  : integerPartLength + 2;
+                const formatOpts = getPriceExtendedFormatOptions(closeDec);
 
                 return (
                   <div className="relative flex flex-col gap-1 rounded-xl bg-osmoverse-1000 p-3 shadow-md">
                     <h6 className="text-h6 font-semibold text-white-full">
                       {fiatSymbol}
-                      {formatPretty(new Dec(close), {
+                      {formatPretty(closeDec, {
                         maxDecimals,
-                        notation: "standard",
-                        maximumSignificantDigits,
-                        minimumSignificantDigits: maximumSignificantDigits,
-                        minimumFractionDigits: 4,
-                        maximumFractionDigits: 4,
-                        disabledTrimZeros: true,
+                        ...formatOpts,
                       }) || ""}
                     </h6>
 

--- a/packages/web/components/complex/add-conc-liquidity.tsx
+++ b/packages/web/components/complex/add-conc-liquidity.tsx
@@ -40,7 +40,7 @@ import {
   useHistoricalAndLiquidityData,
 } from "~/hooks/ui-config/use-historical-and-depth-data";
 import { useStore } from "~/stores";
-import { formatPretty } from "~/utils/formatter";
+import { formatPretty, getPriceExtendedFormatOptions } from "~/utils/formatter";
 
 import { Tooltip } from "../tooltip";
 
@@ -710,8 +710,14 @@ const ChartHeader: FunctionComponent<{
   const { historicalRange, setHistoricalRange, hoverPrice, priceDecimal } =
     chartConfig;
 
+  const formatOpts = useMemo(
+    () => getPriceExtendedFormatOptions(new Dec(hoverPrice)),
+    [hoverPrice]
+  );
+
   return (
     <PriceChartHeader
+      formatOpts={formatOpts}
       historicalRange={historicalRange}
       setHistoricalRange={setHistoricalRange}
       baseDenom={baseDepositAmountIn.sendCurrency.coinDenom}

--- a/packages/web/components/pool-detail/concentrated.tsx
+++ b/packages/web/components/pool-detail/concentrated.tsx
@@ -27,8 +27,7 @@ import {
 import { AddLiquidityModal } from "~/modals";
 import { ConcentratedLiquidityLearnMoreModal } from "~/modals/concentrated-liquidity-intro";
 import { useStore } from "~/stores";
-import { formatPretty } from "~/utils/formatter";
-import { getNumberMagnitude } from "~/utils/number";
+import { formatPretty, getPriceExtendedFormatOptions } from "~/utils/formatter";
 import { api } from "~/utils/trpc";
 import { removeQueryParam } from "~/utils/url";
 
@@ -133,6 +132,11 @@ export const ConcentratedLiquidityPool: FunctionComponent<{ poolId: string }> =
         removeQueryParam(OpenCreatePositionSearchParam);
       }
     }, [openCreatePosition]);
+
+    const formatOpts = useMemo(
+      () => getPriceExtendedFormatOptions(currentPrice),
+      [currentPrice]
+    );
 
     return (
       <main className="m-auto flex min-h-screen max-w-container flex-col gap-8 bg-osmoverse-900 px-8 py-4 md:gap-4 md:p-4">
@@ -290,14 +294,7 @@ export const ConcentratedLiquidityPool: FunctionComponent<{ poolId: string }> =
                       }
                     )}
                   >
-                    {formatPretty(currentPrice, {
-                      maxDecimals:
-                        getNumberMagnitude(Number(currentPrice.toString())) <=
-                        -3
-                          ? 0
-                          : 2,
-                      scientificMagnitudeThreshold: 3,
-                    })}
+                    {formatPretty(currentPrice, formatOpts)}
                   </h6>
                 )}
               </div>
@@ -397,8 +394,14 @@ const ChartHeader: FunctionComponent<{
     hoverPrice,
   } = config;
 
+  const formatOpts = useMemo(
+    () => getPriceExtendedFormatOptions(new Dec(hoverPrice)),
+    [hoverPrice]
+  );
+
   return (
     <PriceChartHeader
+      formatOpts={formatOpts}
       historicalRange={historicalRange}
       setHistoricalRange={setHistoricalRange}
       baseDenom={baseDenom}

--- a/packages/web/modals/increase-concentrated-liquidity.tsx
+++ b/packages/web/modals/increase-concentrated-liquidity.tsx
@@ -3,7 +3,12 @@ import type { UserPosition, UserPositionDetails } from "@osmosis-labs/server";
 import { observer } from "mobx-react-lite";
 import dynamic from "next/dynamic";
 import Image from "next/image";
-import React, { FunctionComponent, useCallback, useEffect } from "react";
+import React, {
+  FunctionComponent,
+  useCallback,
+  useEffect,
+  useMemo,
+} from "react";
 
 import { MyPositionStatus } from "~/components/cards/my-position/status";
 import { PriceChartHeader } from "~/components/chart/token-pair-historical";
@@ -22,7 +27,7 @@ import {
 } from "~/hooks/ui-config/use-historical-and-depth-data";
 import { ModalBase, ModalBaseProps } from "~/modals/base";
 import { useStore } from "~/stores";
-import { formatPretty } from "~/utils/formatter";
+import { formatPretty, getPriceExtendedFormatOptions } from "~/utils/formatter";
 
 const ConcentratedLiquidityDepthChart = dynamic(
   () => import("~/components/chart/concentrated-liquidity-depth"),
@@ -299,11 +304,17 @@ const ChartHeader: FunctionComponent<{
 
   const { baseDepositAmountIn, quoteDepositAmountIn } = addLiquidityConfig;
 
+  const formatOpts = useMemo(
+    () => getPriceExtendedFormatOptions(new Dec(hoverPrice)),
+    [hoverPrice]
+  );
+
   return (
     <PriceChartHeader
       classes={{
         priceHeaderClass: "text-h5 font-h5 text-osmoverse-200",
       }}
+      formatOpts={formatOpts}
       historicalRange={historicalRange}
       setHistoricalRange={setHistoricalRange}
       baseDenom={baseDepositAmountIn.sendCurrency.coinDenom}

--- a/packages/web/pages/assets/[denom].tsx
+++ b/packages/web/pages/assets/[denom].tsx
@@ -48,6 +48,7 @@ import {
 import { useAssetInfoConfig, useFeatureFlags, useNavBar } from "~/hooks";
 import { useStore } from "~/stores";
 import { SUPPORTED_LANGUAGES } from "~/stores/user-settings";
+import { getPriceExtendedFormatOptions } from "~/utils/formatter";
 import { getDecimalCount } from "~/utils/number";
 import { createContext } from "~/utils/react-context";
 
@@ -428,41 +429,19 @@ const TokenChartHeader = observer(() => {
     minimumDecimals
   );
 
-  /**
-   * We need to know how long the integer part of the number is in order to calculate then how many decimal places.
-   */
-  const integerPartLength =
-    assetInfoConfig.hoverPrice?.toDec().truncate().toString().length ?? 0;
-
-  /**
-   * If a number is less then $100, we only show 4 significant digits, examples:
-   *  OSMO: $1.612
-   *  AXL: $0.9032
-   *  STARS: $0.03673
-   *  HUAHUA: $0.00001231
-   *
-   * If a number is greater or equal to $100, we show a dynamic significant digits based on it's integer part, examples:
-   * BTC: $47,334.21
-   * ETH: $3,441.15
-   */
-  const maximumSignificantDigits = assetInfoConfig.hoverPrice
-    ?.toDec()
-    .lt(new Dec(100))
-    ? 4
-    : integerPartLength + 2;
+  const formatOpts = useMemo(
+    () =>
+      getPriceExtendedFormatOptions(
+        assetInfoConfig.hoverPrice?.toDec() ?? new Dec(0)
+      ),
+    [assetInfoConfig.hoverPrice]
+  );
 
   return (
     <header>
       <SkeletonLoader isLoaded={Boolean(assetInfoConfig?.hoverPrice)}>
         <PriceChartHeader
-          formatOpts={{
-            notation: "standard",
-            maximumSignificantDigits,
-            minimumSignificantDigits: maximumSignificantDigits,
-            minimumFractionDigits: 4,
-            maximumFractionDigits: 4,
-            disabledTrimZeros: true,
-          }}
+          formatOpts={formatOpts}
           decimal={maxDecimals}
           showAllRange
           hoverPrice={Number(

--- a/packages/web/utils/formatter.ts
+++ b/packages/web/utils/formatter.ts
@@ -8,7 +8,11 @@ import {
 } from "@keplr-wallet/unit";
 import { trimZerosFromEnd } from "@osmosis-labs/stores";
 
-import { getNumberMagnitude, toScientificNotation } from "~/utils/number";
+import {
+  getDecimalCount,
+  getNumberMagnitude,
+  toScientificNotation,
+} from "~/utils/number";
 
 type CustomFormatOpts = {
   maxDecimals: number;
@@ -226,4 +230,43 @@ export function formatCoinMaxDecimalsByOne(
   return coin.toDec().gt(new Dec(1))
     ? coin.maxDecimals(aboveOneMaxDecimals).trim(true).toString()
     : coin.maxDecimals(belowOneMaxDecimals).trim(true).toString();
+}
+
+export function getPriceExtendedFormatOptions(value: Dec): FormatOptions {
+  /**
+   * We need to know how long the integer part of the number is in order to calculate then how many decimal places.
+   */
+  const integerPartLength = value.truncate().toString().length ?? 0;
+
+  /**
+   * If a number is less then $100, we only show 4 significant digits, examples:
+   *  OSMO: $1.612
+   *  AXL: $0.9032
+   *  STARS: $0.03673
+   *  HUAHUA: $0.00001231
+   *
+   * If a number is greater or equal to $100, we show a dynamic significant digits based on it's integer part, examples:
+   * BTC: $47,334.21
+   * ETH: $3,441.15
+   */
+  const maximumSignificantDigits = value.lt(new Dec(100))
+    ? 4
+    : integerPartLength + 2;
+
+  const minimumDecimals = 2;
+
+  const maxDecimals = Math.max(
+    getDecimalCount(parseFloat(value.toString())),
+    minimumDecimals
+  );
+
+  return {
+    maxDecimals,
+    notation: "standard",
+    maximumSignificantDigits,
+    minimumSignificantDigits: maximumSignificantDigits,
+    minimumFractionDigits: 4,
+    maximumFractionDigits: 4,
+    disabledTrimZeros: true,
+  };
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant Linear task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change:

Like we did for the token details page, we should display a long text instead of `3.04*10^3` and `3.04k`.

Before:
![image (4)](https://github.com/osmosis-labs/osmosis-frontend/assets/17269969/ee951a4f-58b6-4ee1-8f1c-647936e2779e)

After:
![Screenshot 2024-04-16 alle 11 27 40](https://github.com/osmosis-labs/osmosis-frontend/assets/17269969/2d19e85a-5fa3-4bfe-a622-9299ec576aa5)


### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-158/improve-pool-chart-price-format)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced price formatting options across various components for clearer and more precise financial data display.
- **Refactor**
	- Updated components to utilize centralized formatting options, improving consistency and maintainability of code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->