### PR TITLE
WIP: Add auto-login for swaps (DO NOT MERGE)

### DIFF
--- a/packages/web/integrations/notifi/hooks/use-notifi-tx-login.tsx
+++ b/packages/web/integrations/notifi/hooks/use-notifi-tx-login.tsx
@@ -1,0 +1,128 @@
+import { useNotifiClientContext } from "@notifi-network/notifi-react-card";
+import { useEffect } from "react";
+
+import { useStore } from "~/stores";
+
+export const useNotifiTxLogin = () => {
+  const {
+    chainStore: {
+      osmosis: { chainId },
+    },
+    accountStore,
+    ephemeralKVStore,
+  } = useStore();
+  const { client } = useNotifiClientContext();
+
+  useEffect(() => {
+    const wallet = accountStore.getWallet(chainId);
+    if (!wallet?.address || client?.isAuthenticated) return;
+
+    console.log("DEBUG -- useNotifiTxLogin useEffect", wallet, client);
+
+    let deferredClearInterval = () => {};
+    if (client && !client.isAuthenticated) {
+      const existingLoginStart = ephemeralKVStore.get("notifi-tx-login");
+      if (
+        existingLoginStart &&
+        Date.now() - existingLoginStart.timestamp > 1000 * 60 * 5
+      ) {
+        // Before refreshing the login nonce, we need to check if the previous nonce is expired or in process
+        const lastExecutedTx = ephemeralKVStore.get("notifi-last-executed-tx");
+        if (lastExecutedTx) {
+          const memo = lastExecutedTx.memo as string;
+          if (memo.includes(existingLoginStart.nonce)) {
+            client
+              .completeLoginViaTransaction({
+                transactionSignature: lastExecutedTx.signature,
+              })
+              .then((result) => {
+                console.log(
+                  `DEBUG -- useNotifiTxLogin (completeLoginViaTransaction success)`,
+                  result
+                );
+              })
+              .catch((error) => {
+                console.log(
+                  "DEBUG -- useNotifiTxLogin (completeLoginViaTransaction error)",
+                  error
+                );
+              });
+            return;
+          }
+        }
+      } else {
+        if (existingLoginStart) {
+          return;
+        }
+      }
+
+      client
+        .beginLoginViaTransaction()
+        .then((result) => {
+          if (result) {
+            console.log(
+              "DEBUG -- useNotifiTxLogin (beginLoginViaTransaction)",
+              result
+            );
+            ephemeralKVStore.set("notifi-tx-login", {
+              nonce: result.logValue,
+              timestamp: Date.now(),
+            });
+          }
+        })
+        .catch((error) => {
+          console.log(
+            "DEBUG -- useNotifiTxLogin (beginLoginViaTransaction error)",
+            error
+          );
+        });
+
+      const interval = setInterval(() => {
+        const wallet = accountStore.getWallet(chainId);
+        if (!wallet?.address || client?.isAuthenticated) return;
+
+        console.log(
+          "DEBUG -- useNotifiTxLogin (timer) useNotifiTxLogin",
+          wallet,
+          client
+        );
+      }, Math.floor(Math.random() * 800000) + 600000); // a random interval between 8 and 10 minutes to avoid spamming the server
+
+      deferredClearInterval = () => clearInterval(interval);
+    }
+
+    return deferredClearInterval;
+  }, [accountStore, chainId, client, client.isAuthenticated, ephemeralKVStore]);
+
+  // useEffect is expected to be executed when a tx has completed and there's a new
+  // entry in ephemeralKVStore.get("notifi-last-executed-tx")
+  useEffect(() => {
+    if (!client || client.isAuthenticated) return;
+
+    const lastExecutedTx = ephemeralKVStore.get("notifi-last-executed-tx");
+    console.log(`DEBUG -- useNotifiTxLogin (lastExecutedTx)`, lastExecutedTx);
+
+    if (!lastExecutedTx) return;
+
+    // Finalize! This will complete the login process with the tx that was just executed and
+    // is expected to contain the signature/hash in the memo
+    client
+      .completeLoginViaTransaction({
+        transactionSignature: lastExecutedTx.signature,
+      })
+      .then((result) => {
+        console.log(
+          `DEBUG -- useNotifiTxLogin (completeLoginViaTransaction success)`,
+          result
+        );
+      })
+      .catch((error) => {
+        console.log(
+          "DEBUG -- useNotifiTxLogin (completeLoginViaTransaction error)",
+          error
+        );
+      });
+  }, [client, ephemeralKVStore]);
+
+  return {};
+};

--- a/packages/web/integrations/notifi/notifi-modal-context.tsx
+++ b/packages/web/integrations/notifi/notifi-modal-context.tsx
@@ -9,6 +9,7 @@ import {
   useState,
 } from "react";
 
+import { useNotifiTxLogin } from "~/integrations/notifi/hooks/use-notifi-tx-login";
 import { useNotifiConfig } from "~/integrations/notifi/notifi-config-context";
 import { HistoryRowData } from "~/integrations/notifi/notifi-subscription-card/fetched-card/history-rows";
 import { ModalBaseProps } from "~/modals";
@@ -47,6 +48,8 @@ const NotifiModalContext = createContext<NotifiModalFunctions>({
 export const NotifiModalContextProvider: FunctionComponent<
   PropsWithChildren<{ account: string }>
 > = ({ account, children }) => {
+  console.log("DEBUG -- NotifiModalContextProvider notifi-modal-context");
+  useNotifiTxLogin();
   const { setCardView } = useNotifiSubscriptionContext();
   const [innerState, setInnerState] = useState<Partial<ModalBaseProps>>({});
   const [location, setLocation] = useState<Location>("signup");

--- a/packages/web/stores/index.tsx
+++ b/packages/web/stores/index.tsx
@@ -2,7 +2,6 @@ import React, { FunctionComponent, useState } from "react";
 
 import { RootStore } from "~/stores/root";
 import { api } from "~/utils/trpc";
-
 const storeContext = React.createContext<RootStore | null>(null);
 
 /** Once data is invalidated, React Query will automatically refetch data
@@ -22,7 +21,9 @@ export const StoreProvider: FunctionComponent = ({ children }) => {
       new RootStore({
         txEvents: {
           onBroadcastFailed: () => invalidateQueryData(apiUtils),
-          onFulfill: () => invalidateQueryData(apiUtils),
+          onFulfill: (str, tx) => {
+            invalidateQueryData(apiUtils);
+          },
         },
       })
   );

--- a/packages/web/stores/index.tsx
+++ b/packages/web/stores/index.tsx
@@ -21,8 +21,11 @@ export const StoreProvider: FunctionComponent = ({ children }) => {
       new RootStore({
         txEvents: {
           onBroadcastFailed: () => invalidateQueryData(apiUtils),
-          onFulfill: (str, tx) => {
+          onFulfill: () => {
             invalidateQueryData(apiUtils);
+            // NOTIFI QUESTION - We need a way to let the Notifi card know that the transaction has been fulfilled.
+            // In order to do that, we'd need to wrap a Notifi context around StoreProvider, which we thought
+            // would be a bit too much, and could possibly cause re-renders of the entire subtree.
           },
         },
       })

--- a/packages/web/stores/root.ts
+++ b/packages/web/stores/root.ts
@@ -85,6 +85,10 @@ export class RootStore {
 
   public readonly profileStore: ProfileStore;
 
+  // NOTIFI QUESTION - We didn't want to modify the store here, but didn't see a better place to have
+  // the tx nonce that should be used on any new tx, or receiving the tx hash once it was executed
+  public readonly ephemeralKVStore: Map<string, any>;
+
   constructor({
     txEvents,
   }: {
@@ -263,5 +267,7 @@ export class RootStore {
 
     const profileStoreKvStore = makeLocalStorageKVStore("profile_store");
     this.profileStore = new ProfileStore(profileStoreKvStore);
+
+    this.ephemeralKVStore = new Map();
   }
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant Linear task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change:
Allow login to Notifi to begin receiving updates immediately after a tx has occurred.


Periodically grab a nonce from Notifi in the background.
When a tx is executed, put the nonce in the memo.
Let the Notifi card context know that a new tx has just executed, with the hash so that it can complete auth flow.

## Testing and Verifying

WIP looking for feedback on if we should modify the root store wrap the StoreProvider with a Notifi context.
