### PR TITLE
chore vscode ignore build folders in search

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,8 @@
     ["classes\\=([^;]*);", "\"([^\"]*)\""],
     ["classes\\=([^;]*);", "\\`([^\\`]*)\\`"]
   ],
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "search.exclude": {
+    "build/": true
+  }
 }


### PR DESCRIPTION
Add `search.exclude` to settings.json

## What is the purpose of the change:

When searching vscode we can not ignore the build folders.

### No Associated Linear Task

## Brief Changelog

`vscode/settings.json` added ignore path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated settings to exclude the `build/` directory from search operations in the development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->