### PR TITLE
improvement: Fetch Token In Price Before Quote

### DIFF
--- a/packages/web/hooks/input/use-amount-input.ts
+++ b/packages/web/hooks/input/use-amount-input.ts
@@ -102,14 +102,14 @@ export function useAmountInput(currency?: Currency, inputDebounceMs = 500) {
     setDebounceInAmount(amount ?? null);
   }, [setDebounceInAmount, amount]);
 
-  let coin: CoinPretty | undefined;
+  let coinForPrice: CoinPretty | undefined;
   if (!isNil(amount)) {
-    coin = amount;
+    coinForPrice = amount;
   } else if (!isNil(currency)) {
-    coin = new CoinPretty(currency, 0);
+    coinForPrice = new CoinPretty(currency, 0);
   }
 
-  const { price } = useCoinPrice(coin);
+  const { price } = useCoinPrice(coinForPrice);
   const fiatValue = useMemo(
     () => mulPrice(amount, price, DEFAULT_VS_CURRENCY),
     [amount, price]

--- a/packages/web/hooks/input/use-amount-input.ts
+++ b/packages/web/hooks/input/use-amount-input.ts
@@ -102,6 +102,12 @@ export function useAmountInput(currency?: Currency, inputDebounceMs = 500) {
     setDebounceInAmount(amount ?? null);
   }, [setDebounceInAmount, amount]);
 
+  /**
+   * When the `amount` is `undefined` due to the absence of valid input,
+   * we should create a CoinPretty object using the currency. This allows
+   * us to fetch the price before generating a quote, displaying results
+   * faster on slow networks.
+   */
   let coinForPrice: CoinPretty | undefined;
   if (!isNil(amount)) {
     coinForPrice = amount;

--- a/packages/web/hooks/input/use-amount-input.ts
+++ b/packages/web/hooks/input/use-amount-input.ts
@@ -7,6 +7,7 @@ import {
 import { DEFAULT_VS_CURRENCY } from "@osmosis-labs/server";
 import { InsufficientBalanceError } from "@osmosis-labs/stores";
 import { Currency } from "@osmosis-labs/types";
+import { isNil } from "@osmosis-labs/utils";
 import { useCallback, useState } from "react";
 import { useMemo } from "react";
 import { useEffect } from "react";
@@ -101,7 +102,14 @@ export function useAmountInput(currency?: Currency, inputDebounceMs = 500) {
     setDebounceInAmount(amount ?? null);
   }, [setDebounceInAmount, amount]);
 
-  const { price } = useCoinPrice(amount);
+  let coin: CoinPretty | undefined;
+  if (!isNil(amount)) {
+    coin = amount;
+  } else if (!isNil(currency)) {
+    coin = new CoinPretty(currency, 0);
+  }
+
+  const { price } = useCoinPrice(coin);
   const fiatValue = useMemo(
     () => mulPrice(amount, price, DEFAULT_VS_CURRENCY),
     [amount, price]


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant Linear task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change:

We currently fetch the price after generating a quote, which causes a delay visible to users on slow networks—they see a blank space where the price should be while it loads. To address this and improve efficiency, we will start fetching the price as soon as the swap tool loads or after a token is selected.

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/STABI-106/on-swap-page-getting-the-base-asset-prices-should-be-fetched-in)

## Testing and Verifying

- [ ] Can perform swaps
- [ ] Token in and token out price loads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
	- Enhanced the logic for price calculation based on input amount and currency in the input handling functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->