### PR TITLE
Update default timeout number of blocks

### DIFF
--- a/packages/stores/src/account/types.ts
+++ b/packages/stores/src/account/types.ts
@@ -102,9 +102,9 @@ export interface StdSignDoc {
 }
 
 // The number of heights from current before transaction times out.
-// 30 heights * 5 second block time = 150 seconds before transaction
+// 60 heights * 3 second block time = 180 seconds before transaction
 // timeout and mempool eviction.
-const defaultTimeoutHeightOffset = 30;
+const defaultTimeoutHeightOffset = 60;
 
 export const NEXT_TX_TIMEOUT_HEIGHT_OFFSET: bigint = BigInt(
   process.env.TIMEOUT_HEIGHT_OFFSET


### PR DESCRIPTION
The current timeout height has felt far too quick while using a ledger since v24.

50 blocks would keep the timeout preserved, I changed it to 60 blocks to give a bit more headroom.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the timeout settings to extend the duration before a transaction is timed out and evicted from the mempool, enhancing transaction reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->