### PR TITLE
move cms for app store

### DIFF
--- a/packages/web/pages/apps.tsx
+++ b/packages/web/pages/apps.tsx
@@ -36,8 +36,8 @@ type AppStoreProps = {
   };
 };
 
-export const OsmosisAppListRepoName = "osmosis-labs/apps-list";
-export const OsmosisAppListFilePath = "applications.json";
+export const OsmosisAppListRepoName = "osmosis-labs/fe-content";
+export const OsmosisAppListFilePath = "cms/apps/applications.json";
 
 export const AppStore: React.FC<AppStoreProps> = ({ apps }) => {
   const [searchValue, setSearchValue] = useState<string>("");


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant Linear task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change:

based on https://github.com/osmosis-labs/fe-content/pull/55 being merged

Moves the app store cms from the `apps-list` repo to the `fe-content` repo

### Linear Task

[Linear Task URL](PASTE_LINEAR_TASK_URL_HERE)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the repository and file path constants for Osmosis applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->