### PR TITLE
Portfolio: fix sorting and display of balances

### DIFF
--- a/packages/server/src/trpc-routers/assets-router.ts
+++ b/packages/server/src/trpc-routers/assets-router.ts
@@ -273,7 +273,7 @@ export const assetsRouter = createTRPCRouter({
               })
             );
 
-            if (sortInput && sortInput.keyPath !== "usdValue") {
+            if (sortInput) {
               priceAssets = sort(
                 priceAssets,
                 sortInput.keyPath,

--- a/packages/web/components/table/asset-balances.tsx
+++ b/packages/web/components/table/asset-balances.tsx
@@ -342,13 +342,11 @@ type AssetCellComponent<TProps = {}> = FunctionComponent<
 >;
 
 const BalanceCell: AssetCellComponent = ({ amount, usdValue }) => (
-  <div className="ml-auto flex w-28 flex-col">
-    <span>
-      {amount ? formatPretty(amount.hideDenom(true), { maxDecimals: 8 }) : "0"}
-    </span>
-    {usdValue && (
-      <span className="caption text-osmoverse-300">{usdValue.toString()}</span>
-    )}
+  <div className="ml-auto flex flex-col">
+    {usdValue && <div>{usdValue.toString()}</div>}
+    <div className="caption whitespace-nowrap text-osmoverse-300">
+      {amount ? formatPretty(amount, { maxDecimals: 8 }) : "0"}
+    </div>
   </div>
 );
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant Linear task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change:

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

Small changes

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-199/portfolio-flip-balances-and-usd-value)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the asset sorting functionality by removing a specific conditional check.
	- Updated the display logic in the asset balances table to conditionally show USD values and rearrange elements for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->