### PR TITLE
New assets page: make sure all volumes are showing correctly

### DIFF
--- a/packages/server/src/queries/complex/assets/market.ts
+++ b/packages/server/src/queries/complex/assets/market.ts
@@ -98,9 +98,9 @@ async function getAssetMarketCap({
  *  configured outside of our asset list (from data services).
  *  Returns `undefined` for a given coin denom if there was an error or it's not available. */
 export async function getAssetMarketActivity({
-  coinDenom,
+  coinMinimalDenom,
 }: {
-  coinDenom: string;
+  coinMinimalDenom: string;
 }) {
   const assetMarketMap = await cachified({
     cache: assetMarketCache,
@@ -112,13 +112,13 @@ export async function getAssetMarketActivity({
       const tokenInfoMap = new Map<string, MarketActivity>();
       allTokenData.forEach((tokenData) => {
         const activity = makeMarketActivityFromTokenData(tokenData);
-        tokenInfoMap.set(tokenData.symbol, activity);
+        tokenInfoMap.set(tokenData.denom.toUpperCase(), activity);
       });
       return tokenInfoMap;
     },
   });
 
-  return assetMarketMap.get(coinDenom);
+  return assetMarketMap.get(coinMinimalDenom.toUpperCase());
 }
 
 type MarketActivity = ReturnType<typeof makeMarketActivityFromTokenData>;

--- a/packages/server/src/trpc-routers/assets-router.ts
+++ b/packages/server/src/trpc-routers/assets-router.ts
@@ -260,9 +260,9 @@ export const assetsRouter = createTRPCRouter({
                       (price) => new PricePretty(DEFAULT_VS_CURRENCY, price)
                     )
                     .catch((e) => captureErrorAndReturn(e, undefined)),
-                  getAssetMarketActivity({
-                    coinDenom: asset.coinDenom,
-                  }).then((activity) => activity?.price24hChange),
+                  getAssetMarketActivity(asset).then(
+                    (activity) => activity?.price24hChange
+                  ),
                 ]);
 
                 return {

--- a/packages/server/src/trpc-routers/assets-router.ts
+++ b/packages/server/src/trpc-routers/assets-router.ts
@@ -273,7 +273,7 @@ export const assetsRouter = createTRPCRouter({
               })
             );
 
-            if (sortInput && sortInput.keyPath !== "usdValue") {
+            if (sortInput) {
               priceAssets = sort(
                 priceAssets,
                 sortInput.keyPath,

--- a/packages/web/localizations/de.json
+++ b/packages/web/localizations/de.json
@@ -202,7 +202,7 @@
       "withdrawButton": "Zurückziehen",
       "activate": "aktivieren Sie",
       "marketCap": "Marktkapitalisierung",
-      "volume24h": "Volumen (24 Std.)",
+      "volume24h": "Volumen",
       "priceChange24h": "24h Wechsel",
       "price": "Preis",
       "name": "Name"

--- a/packages/web/localizations/en.json
+++ b/packages/web/localizations/en.json
@@ -202,7 +202,7 @@
       "withdrawButton": "Withdraw",
       "activate": "Activate",
       "marketCap": "Market cap",
-      "volume24h": "Volume (24H)",
+      "volume24h": "Volume",
       "priceChange24h": "24h change",
       "price": "Price",
       "name": "Name"

--- a/packages/web/localizations/es.json
+++ b/packages/web/localizations/es.json
@@ -202,7 +202,7 @@
       "withdrawButton": "Retirar",
       "activate": "Activar",
       "marketCap": "Tapa del mercado",
-      "volume24h": "Volumen (24H)",
+      "volume24h": "Volumen",
       "priceChange24h": "cambio 24h",
       "price": "Precio",
       "name": "Nombre"

--- a/packages/web/localizations/fa.json
+++ b/packages/web/localizations/fa.json
@@ -202,7 +202,7 @@
       "withdrawButton": "برداشت",
       "activate": "فعال کنید",
       "marketCap": "ارزش بازار",
-      "volume24h": "میزان صدا (24 ساعت)",
+      "volume24h": "جلد",
       "priceChange24h": "تغییر 24 ساعته",
       "price": "قیمت",
       "name": "نام"

--- a/packages/web/localizations/fr.json
+++ b/packages/web/localizations/fr.json
@@ -202,7 +202,7 @@
       "withdrawButton": "Retirer",
       "activate": "Activer",
       "marketCap": "Capitalisation boursière",
-      "volume24h": "Volume (24H)",
+      "volume24h": "Volume",
       "priceChange24h": "changement 24h",
       "price": "Prix",
       "name": "Nom"

--- a/packages/web/localizations/gu.json
+++ b/packages/web/localizations/gu.json
@@ -202,7 +202,7 @@
       "withdrawButton": "ઉપાડો",
       "activate": "સક્રિય કરો",
       "marketCap": "માર્કેટ કેપ",
-      "volume24h": "વોલ્યુમ (24H)",
+      "volume24h": "વોલ્યુમ",
       "priceChange24h": "24 કલાક ફેરફાર",
       "price": "કિંમત",
       "name": "નામ"

--- a/packages/web/localizations/hi.json
+++ b/packages/web/localizations/hi.json
@@ -202,7 +202,7 @@
       "withdrawButton": "निकालना",
       "activate": "सक्रिय",
       "marketCap": "बाज़ार आकार",
-      "volume24h": "वॉल्यूम (24 घंटे)",
+      "volume24h": "आयतन",
       "priceChange24h": "24 घंटे का परिवर्तन",
       "price": "कीमत",
       "name": "नाम"

--- a/packages/web/localizations/ja.json
+++ b/packages/web/localizations/ja.json
@@ -202,7 +202,7 @@
       "withdrawButton": "撤回する",
       "activate": "活性化",
       "marketCap": "時価総額",
-      "volume24h": "ボリューム（24時間）",
+      "volume24h": "音量",
       "priceChange24h": "24時間の変更",
       "price": "価格",
       "name": "名前"

--- a/packages/web/localizations/ko.json
+++ b/packages/web/localizations/ko.json
@@ -202,7 +202,7 @@
       "withdrawButton": "출금",
       "activate": "활성화",
       "marketCap": "시가총액",
-      "volume24h": "거래량(24시간)",
+      "volume24h": "용량",
       "priceChange24h": "24시간 변경",
       "price": "가격",
       "name": "이름"

--- a/packages/web/localizations/pl.json
+++ b/packages/web/localizations/pl.json
@@ -202,7 +202,7 @@
       "withdrawButton": "Wypłać",
       "activate": "Aktywuj",
       "marketCap": "Kapitalizacja rynkowa",
-      "volume24h": "Głośność (24H)",
+      "volume24h": "Tom",
       "priceChange24h": "Zmiana 24h",
       "price": "Cena",
       "name": "Nazwa"

--- a/packages/web/localizations/pt-br.json
+++ b/packages/web/localizations/pt-br.json
@@ -202,7 +202,7 @@
       "withdrawButton": "Sacar",
       "activate": "Ativar",
       "marketCap": "Valor de mercado",
-      "volume24h": "Volume (24H)",
+      "volume24h": "Volume",
       "priceChange24h": "Mudança de 24h",
       "price": "Preço",
       "name": "Nome"

--- a/packages/web/localizations/ro.json
+++ b/packages/web/localizations/ro.json
@@ -202,7 +202,7 @@
       "withdrawButton": "Retrage",
       "activate": "Activati",
       "marketCap": "Capitalizarea pieței",
-      "volume24h": "Volum (24 ore)",
+      "volume24h": "Volum",
       "priceChange24h": "schimbare 24h",
       "price": "Preț",
       "name": "Nume"

--- a/packages/web/localizations/ru.json
+++ b/packages/web/localizations/ru.json
@@ -202,7 +202,7 @@
       "withdrawButton": "Отзывать",
       "activate": "Активировать",
       "marketCap": "Рыночная капитализация",
-      "volume24h": "Объем (24 часа)",
+      "volume24h": "Объем",
       "priceChange24h": "24-часовая смена",
       "price": "Цена",
       "name": "Имя"

--- a/packages/web/localizations/tr.json
+++ b/packages/web/localizations/tr.json
@@ -202,7 +202,7 @@
       "withdrawButton": "Çek",
       "activate": "Etkinleştir",
       "marketCap": "Piyasa değeri",
-      "volume24h": "Hacim (24 saat)",
+      "volume24h": "Hacim",
       "priceChange24h": "24 saat değişim",
       "price": "Fiyat",
       "name": "İsim"

--- a/packages/web/localizations/zh-cn.json
+++ b/packages/web/localizations/zh-cn.json
@@ -202,7 +202,7 @@
       "withdrawButton": "提币",
       "activate": "启用",
       "marketCap": "市值",
-      "volume24h": "成交量（24小时）",
+      "volume24h": "体积",
       "priceChange24h": "24小时变化",
       "price": "价格",
       "name": "姓名"

--- a/packages/web/localizations/zh-hk.json
+++ b/packages/web/localizations/zh-hk.json
@@ -202,7 +202,7 @@
       "withdrawButton": "轉出",
       "activate": "啟用",
       "marketCap": "市值",
-      "volume24h": "成交量（24小時）",
+      "volume24h": "體積",
       "priceChange24h": "24小時變化",
       "price": "價格",
       "name": "姓名"

--- a/packages/web/localizations/zh-tw.json
+++ b/packages/web/localizations/zh-tw.json
@@ -202,7 +202,7 @@
       "withdrawButton": "轉出",
       "activate": "啟用",
       "marketCap": "市值",
-      "volume24h": "成交量（24小時）",
+      "volume24h": "體積",
       "priceChange24h": "24小時變化",
       "price": "價格",
       "name": "姓名"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant Linear task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change:

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

You should now see volumes for WBTC:
<img width="1133" alt="Screenshot 2024-04-17 at 3 57 03 PM" src="https://github.com/osmosis-labs/osmosis-frontend/assets/4606373/415826da-089c-4855-8272-f7047e4f2196">


### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-193/make-sure-all-volumes-are-showing-correctly)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->
* Key API data by coinMinimalDenom instead of symbol (and double check casing)
* Update volume table header text to match designs

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->
