### PR TITLE
Assets page: fall back to CoinGecko for market cap

### DIFF
--- a/packages/server/src/queries/coingecko/coin.ts
+++ b/packages/server/src/queries/coingecko/coin.ts
@@ -77,6 +77,7 @@ export interface CoingeckoCoin {
   sentiment_votes_up_percentage: number;
   sentiment_votes_down_percentage: number;
   watchlist_portfolio_users: number;
+  market_cap: number;
   market_cap_rank: number;
   coingecko_rank: number;
   coingecko_score: number;


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant Linear task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change:

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->
As is done in token info pages, this falls back to CoinGecko to get market caps:
<img width="1108" alt="Screenshot 2024-04-17 at 7 36 32 PM" src="https://github.com/osmosis-labs/osmosis-frontend/assets/4606373/3c432be0-3af1-469a-a229-36c8f8a6ad53">

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-157/assets-page-fall-back-to-coingecko-for-missing-market-caps)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

* Send batched calls to CoinGecko's `/coins/markets` endpoint to get market caps for coins we don't have data for

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

Assets, particularly Axelar-bridged Ethereum assets, such as MATIC, have market cap data now. It is still sortable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced asset information with the addition of market cap data for coins.
	- Improved efficiency in retrieving and handling Coingecko coin data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->