### PR TITLE
fix: Token Out Fiat Value Opacity

### DIFF
--- a/packages/web/components/swap-tool/index.tsx
+++ b/packages/web/components/swap-tool/index.tsx
@@ -654,7 +654,7 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
                   </h5>
                   <span
                     className={classNames(
-                      "subtitle1 md:caption text-osmoverse-300 opacity-100 transition-opacity",
+                      "subtitle1 md:caption text-osmoverse-300 transition-opacity",
                       {
                         "opacity-0":
                           !swapState.tokenOutFiatValue ||


### PR DESCRIPTION
Before: 
![image](https://github.com/osmosis-labs/osmosis-frontend/assets/21092519/eef6f060-da8c-4de2-9eb2-99ae11917182)

After:
![image](https://github.com/osmosis-labs/osmosis-frontend/assets/21092519/28a1223f-6ed0-4576-9e14-4fcb3ee60a69)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the visual styling of the `SwapTool` component to dynamically adjust opacity based on specific conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->