### PR TITLE
feat: Do not Block FE Pipeline on FE Staging E2E Server Tests Error and Add Slack Alerts

### DIFF
--- a/.github/workflows/server-e2e-tests.yml
+++ b/.github/workflows/server-e2e-tests.yml
@@ -56,6 +56,9 @@ jobs:
           NEXT_PUBLIC_SIDECAR_BASE_URL: ${{ matrix.server-url }}
           NEXT_PUBLIC_TIMESERIES_DATA_URL: ${{ matrix.timeseries-url }}
 
+      # Send Slack alert if 'tests' job fails
+      # Here we include the 'steps.tests.outcome != 'success'' function to check if the job failed
+      # even after the 'continue-on-error' flag is set to true.
       - name: Send Slack alert if test fails
         id: slack
         if: ${{ steps.tests.outcome != 'success' || failure() }}

--- a/.github/workflows/server-e2e-tests.yml
+++ b/.github/workflows/server-e2e-tests.yml
@@ -49,12 +49,13 @@ jobs:
         run: echo "SQS Server URL:${{ matrix.server-url }}"
 
       - name: Run Tests
+        id: tests
         run: yarn test:e2e --filter=server
-        # continue-on-error: ${{ matrix.env == 'staging' }}
+        continue-on-error: ${{ matrix.env == 'staging' }}
         env:
           NEXT_PUBLIC_SIDECAR_BASE_URL: ${{ matrix.server-url }}
           NEXT_PUBLIC_TIMESERIES_DATA_URL: ${{ matrix.timeseries-url }}
 
       - name: Send Slack Alert if is Staging and last step failed
-        if: ${{ failure() && matrix.env == 'staging' }}
+        if: ${{ steps.tests.outcome != 'success' && matrix.env == 'staging' }}
         run: echo "Send Slack Alert"

--- a/.github/workflows/server-e2e-tests.yml
+++ b/.github/workflows/server-e2e-tests.yml
@@ -63,13 +63,13 @@ jobs:
         with:
           payload: |
             {
-              "text": "🚨 Front-End Server E2E Test Failure Alert 🚨",
+              "text": "🚨 Frontend Server E2E Tests Failure Alert 🚨",
               "blocks": [
                 {
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": "Front-End Server E2E Test Failure"
+                    "text": "Frontend Server E2E Tests Failure"
                   }
                 },
                 {

--- a/.github/workflows/server-e2e-tests.yml
+++ b/.github/workflows/server-e2e-tests.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Run Tests
         run: yarn test:e2e --filter=server
-        continue-on-error: ${{ matrix.env == 'staging' }}
+        # continue-on-error: ${{ matrix.env == 'staging' }}
         env:
           NEXT_PUBLIC_SIDECAR_BASE_URL: ${{ matrix.server-url }}
           NEXT_PUBLIC_TIMESERIES_DATA_URL: ${{ matrix.timeseries-url }}

--- a/.github/workflows/server-e2e-tests.yml
+++ b/.github/workflows/server-e2e-tests.yml
@@ -50,6 +50,11 @@ jobs:
 
       - name: Run Tests
         run: yarn test:e2e --filter=server
+        continue-on-error: ${{ matrix.env == 'staging' }}
         env:
           NEXT_PUBLIC_SIDECAR_BASE_URL: ${{ matrix.server-url }}
           NEXT_PUBLIC_TIMESERIES_DATA_URL: ${{ matrix.timeseries-url }}
+
+      - name: Send Slack Alert if is Staging and last step failed
+        if: ${{ failure() && matrix.env == 'staging' }}
+        run: echo "Send Slack Alert"

--- a/.github/workflows/server-e2e-tests.yml
+++ b/.github/workflows/server-e2e-tests.yml
@@ -63,13 +63,27 @@ jobs:
         with:
           payload: |
             {
-              "text": "GitHub Action build result: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}",
+              "text": "🚨 Front-End Server E2E Test Failure Alert 🚨",
               "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "Front-End Server E2E Test Failure"
+                  }
+                },
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "GitHub Action build result: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+                    "text": "*Environment:* ${{ matrix.env }}\n*Server URL:* ${{ matrix.server-url }}\n*Timeseries URL:* ${{ matrix.timeseries-url }}"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Click here to view the run: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|GitHub Actions Run>"
                   }
                 }
               ]

--- a/.github/workflows/server-e2e-tests.yml
+++ b/.github/workflows/server-e2e-tests.yml
@@ -56,6 +56,23 @@ jobs:
           NEXT_PUBLIC_SIDECAR_BASE_URL: ${{ matrix.server-url }}
           NEXT_PUBLIC_TIMESERIES_DATA_URL: ${{ matrix.timeseries-url }}
 
-      - name: Send Slack Alert if last step failed
+      - name: Send Slack alert if test fails
+        id: slack
         if: ${{ steps.tests.outcome != 'success' || failure() }}
-        run: echo "Send Slack Alert ${{ matrix.env }}"
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "text": "GitHub Action build result: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "GitHub Action build result: ${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+                  }
+                }
+              ]
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SERVER_E2E_TESTS_SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/server-e2e-tests.yml
+++ b/.github/workflows/server-e2e-tests.yml
@@ -56,6 +56,6 @@ jobs:
           NEXT_PUBLIC_SIDECAR_BASE_URL: ${{ matrix.server-url }}
           NEXT_PUBLIC_TIMESERIES_DATA_URL: ${{ matrix.timeseries-url }}
 
-      - name: Send Slack Alert if is Staging and last step failed
-        if: ${{ steps.tests.outcome != 'success' && matrix.env == 'staging' }}
-        run: echo "Send Slack Alert"
+      - name: Send Slack Alert if last step failed
+        if: ${{ steps.tests.outcome != 'success' }}
+        run: echo "Send Slack Alert ${{ matrix.env }}"

--- a/.github/workflows/server-e2e-tests.yml
+++ b/.github/workflows/server-e2e-tests.yml
@@ -57,5 +57,5 @@ jobs:
           NEXT_PUBLIC_TIMESERIES_DATA_URL: ${{ matrix.timeseries-url }}
 
       - name: Send Slack Alert if last step failed
-        if: ${{ steps.tests.outcome != 'success' }}
+        if: ${{ steps.tests.outcome != 'success' || failure() }}
         run: echo "Send Slack Alert ${{ matrix.env }}"

--- a/.github/workflows/server-e2e-tests.yml
+++ b/.github/workflows/server-e2e-tests.yml
@@ -73,6 +73,7 @@ jobs:
                   }
                 }
               ]
+            }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SERVER_E2E_TESTS_SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/packages/server/src/trpc-routers/__tests_e2e__/swap-router.test.ts
+++ b/packages/server/src/trpc-routers/__tests_e2e__/swap-router.test.ts
@@ -13,6 +13,7 @@ import {
 } from "@osmosis-labs/utils";
 import { inferRouterInputs, inferRouterOutputs, initTRPC } from "@trpc/server";
 
+import { SIDECAR_BASE_URL } from "../../env";
 import {
   getCachedPoolMarketMetricsMap,
   getPoolsFromIndexer,
@@ -169,6 +170,11 @@ it("Sidecar - ATOM <> OSMO - should return valid quote", async () => {
     tokenOutDenom: tokenOut.coinMinimalDenom,
     preferredRouter,
   });
+
+  // TODO: TEMP VALUE
+  if (SIDECAR_BASE_URL === "https://sqs.stage.osmosis.zone") {
+    throw new Error("This test is not valid for the stage environment");
+  }
 
   assertValidQuote({
     quote: reply,

--- a/packages/server/src/trpc-routers/__tests_e2e__/swap-router.test.ts
+++ b/packages/server/src/trpc-routers/__tests_e2e__/swap-router.test.ts
@@ -170,9 +170,6 @@ it("Sidecar - ATOM <> OSMO - should return valid quote", async () => {
     preferredRouter,
   });
 
-  // TODO: TEMP VALUE
-  throw new Error("This test is not valid for the stage environment");
-
   assertValidQuote({
     quote: reply,
     tokenInAmount,

--- a/packages/server/src/trpc-routers/__tests_e2e__/swap-router.test.ts
+++ b/packages/server/src/trpc-routers/__tests_e2e__/swap-router.test.ts
@@ -13,7 +13,6 @@ import {
 } from "@osmosis-labs/utils";
 import { inferRouterInputs, inferRouterOutputs, initTRPC } from "@trpc/server";
 
-import { SIDECAR_BASE_URL } from "../../env";
 import {
   getCachedPoolMarketMetricsMap,
   getPoolsFromIndexer,
@@ -172,9 +171,7 @@ it("Sidecar - ATOM <> OSMO - should return valid quote", async () => {
   });
 
   // TODO: TEMP VALUE
-  if (SIDECAR_BASE_URL === "https://sqs.stage.osmosis.zone") {
-    throw new Error("This test is not valid for the stage environment");
-  }
+  throw new Error("This test is not valid for the stage environment");
 
   assertValidQuote({
     quote: reply,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant Linear task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change:

Due to flakiness in the SQS staging server, FE pipelines are frequently blocked. This delays other devs' priorities because. Instead of blocking a PR, these tests should send an alert through Slack on failure. 

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/STABI-121/do-not-block-fe-pipeline-on-fe-staging-e2e-server-tests-error)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved error handling in server tests with conditional continuation on errors for staging environment.
	- Enhanced monitoring by adding Slack alerts for test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->