### PR TITLE
Asset detail page: nav back to portfolio

### DIFF
--- a/packages/web/components/table/asset-balances.tsx
+++ b/packages/web/components/table/asset-balances.tsx
@@ -297,34 +297,37 @@ export const AssetBalancesTable: FunctionComponent<{
               </td>
             </tr>
           )}
-          {virtualRows.map((virtualRow) => (
-            <tr
-              className="group transition-colors duration-200 ease-in-out hover:cursor-pointer hover:bg-osmoverse-850"
-              key={rows[virtualRow.index].id}
-              onClick={() =>
-                router.push(
-                  `/assets/${rows[virtualRow.index].original.coinDenom}`
-                )
-              }
-            >
-              {rows[virtualRow.index].getVisibleCells().map((cell) => (
-                <td
-                  className="transition-colors duration-200 ease-in-out"
-                  key={cell.id}
-                >
-                  <Link
-                    href={`/assets/${
-                      rows[virtualRow.index].original.coinDenom
-                    }`}
-                    onClick={(e) => e.stopPropagation()}
-                    passHref
+          {virtualRows.map((virtualRow) => {
+            const pushUrl = `/assets/${
+              rows[virtualRow.index].original.coinDenom
+            }?ref=portfolio`;
+
+            return (
+              <tr
+                className="group transition-colors duration-200 ease-in-out hover:cursor-pointer hover:bg-osmoverse-850"
+                key={rows[virtualRow.index].id}
+                onClick={() => router.push(pushUrl)}
+              >
+                {rows[virtualRow.index].getVisibleCells().map((cell) => (
+                  <td
+                    className="transition-colors duration-200 ease-in-out"
+                    key={cell.id}
                   >
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </Link>
-                </td>
-              ))}
-            </tr>
-          ))}
+                    <Link
+                      href={pushUrl}
+                      onClick={(e) => e.stopPropagation()}
+                      passHref
+                    >
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext()
+                      )}
+                    </Link>
+                  </td>
+                ))}
+              </tr>
+            );
+          })}
           {isFetchingNextPage && (
             <tr>
               <td className="!text-center" colSpan={collapsedColumns.length}>

--- a/packages/web/pages/assets/[denom].tsx
+++ b/packages/web/pages/assets/[denom].tsx
@@ -15,6 +15,7 @@ import { GetStaticPathsResult, GetStaticProps } from "next";
 import Image from "next/image";
 import { useRouter } from "next/router";
 import { NextSeo } from "next-seo";
+import { useQueryState } from "nuqs";
 import { FunctionComponent } from "react";
 import { useMemo } from "react";
 import { useEffect } from "react";
@@ -117,6 +118,8 @@ const AssetInfoView: FunctionComponent<AssetInfoPageProps> = observer(
       ],
     });
 
+    const [ref] = useQueryState("ref");
+
     useNavBar({
       title: (
         <LinkButton
@@ -130,9 +133,11 @@ const AssetInfoView: FunctionComponent<AssetInfoPageProps> = observer(
               className="text-osmoverse-200"
             />
           }
-          label={t("menu.assets")}
-          ariaLabel={t("menu.assets")}
-          href="/assets"
+          label={ref === "portfolio" ? t("menu.portfolio") : t("menu.assets")}
+          ariaLabel={
+            ref === "portfolio" ? t("menu.portfolio") : t("menu.assets")
+          }
+          href={ref === "portfolio" ? "/portfolio" : "/assets"}
         />
       ),
       ctas: [],


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant Linear task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change:

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

Adds a `ref=portfolio` query param to allow asset detail page to navigate back to portfolio if that's where the user came from:
<img width="939" alt="Screenshot 2024-04-19 at 9 12 26 AM" src="https://github.com/osmosis-labs/osmosis-frontend/assets/4606373/0bf73627-5e9b-4dfb-b3f9-34347d1958f1">

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-211/token-info-back-to-portfolio-page)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->
* Use ref query param to signal to asset detail page that it should navigate back to portfolio page

Note: I attempted to use `document.referrer` but I found it was not returning the expected value (URI of previous page).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced navigation within the `AssetBalancesTable` by wrapping content in clickable links.
	- Added conditional rendering in asset pages based on query parameters to improve accessibility and relevance.

- **Refactor**
	- Improved the onClick navigation in the `AssetBalancesTable` for a more streamlined user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->