### PR TITLE
Remove categories type safety

### DIFF
--- a/packages/server/src/queries/complex/assets/categories.ts
+++ b/packages/server/src/queries/complex/assets/categories.ts
@@ -1,7 +1,4 @@
-import {
-  Asset,
-  AssetCategories as StaticAssetCategories,
-} from "@osmosis-labs/types";
+import { Asset } from "@osmosis-labs/types";
 import cachified, { CacheEntry } from "cachified";
 import { LRUCache } from "lru-cache";
 
@@ -9,14 +6,10 @@ import { DEFAULT_LRU_OPTIONS } from "../../../utils";
 import dayjs from "../../../utils/dayjs";
 import { queryUpcomingAssets } from "../../github";
 
-/** Re-exported static asset categories extended with dynamic categories. */
-export const AssetCategories = ["new", ...StaticAssetCategories] as const;
-export type Category = (typeof AssetCategories)[number];
-
 /** Filters an asset for whether it is included in the given list of categories. */
 export function isAssetInCategories(
   asset: Asset,
-  categories: Category[],
+  categories: string[],
   assetNewness = dayjs.duration(2_629_746_000), // default: 1 month
   now = dayjs()
 ) {

--- a/packages/server/src/queries/complex/assets/index.ts
+++ b/packages/server/src/queries/complex/assets/index.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 
 import { captureErrorAndReturn } from "../../../utils/error";
 import { search, SearchSchema } from "../../../utils/search";
-import { AssetCategories, isAssetInCategories } from "./categories";
+import { isAssetInCategories } from "./categories";
 
 /** An asset with minimal data that conforms to `Currency` type. */
 export type Asset = {
@@ -23,7 +23,7 @@ export const AssetFilterSchema = z.object({
   search: SearchSchema.optional(),
   onlyVerified: z.boolean().default(false).optional(),
   includePreview: z.boolean().default(false).optional(),
-  categories: z.array(z.enum(AssetCategories)).optional(),
+  categories: z.array(z.string()).optional(),
 });
 /** Params for filtering assets. */
 export type AssetFilter = z.input<typeof AssetFilterSchema>;

--- a/packages/types/src/asset-types.ts
+++ b/packages/types/src/asset-types.ts
@@ -123,14 +123,6 @@ export interface Price {
   denom: string;
 }
 
-export const AssetCategories = [
-  "stablecoin",
-  "defi",
-  "meme",
-  "liquid_staking",
-] as const;
-export type Category = (typeof AssetCategories)[number];
-
 export interface Asset {
   chainName: string;
   /** Denom as represented on source/origin chain. */
@@ -159,7 +151,7 @@ export interface Asset {
   /** Transfers should not be possible. */
   disabled: boolean;
 
-  categories: Category[];
+  categories: string[];
   /** Data needed for calculating this token's price via Osmosis pools. */
   price?: Price;
   /** The supported methods for transferring this token.

--- a/packages/web/components/assets/highlights-categories.tsx
+++ b/packages/web/components/assets/highlights-categories.tsx
@@ -1,4 +1,3 @@
-import { Category } from "@osmosis-labs/server";
 import Image from "next/image";
 import Link from "next/link";
 import { FunctionComponent, ReactNode } from "react";
@@ -18,7 +17,7 @@ type UpcomingReleaseAsset =
 
 export const HighlightsCategories: FunctionComponent<{
   isCategorySelected: boolean;
-  onSelectCategory: (category: Category) => void;
+  onSelectCategory: (category: string) => void;
   onSelectAllTopGainers: () => void;
 }> = ({ isCategorySelected, onSelectCategory, onSelectAllTopGainers }) => {
   const { t } = useTranslation();

--- a/packages/web/components/table/asset-info.tsx
+++ b/packages/web/components/table/asset-info.tsx
@@ -29,7 +29,7 @@ import { theme } from "~/tailwind.config";
 import { formatPretty } from "~/utils/formatter";
 import { api, RouterInputs, RouterOutputs } from "~/utils/trpc";
 
-import { AssetCategoriesSelectors, Category } from "../assets/categories";
+import { AssetCategoriesSelectors } from "../assets/categories";
 import { SearchBox } from "../input";
 import Spinner from "../loaders/spinner";
 import { HistoricalPriceCell } from "./cells/price";
@@ -53,8 +53,8 @@ export const AssetsInfoTable: FunctionComponent<{
   // State
 
   // category
-  const [selectedCategory, setCategory] = useState<Category | undefined>();
-  const selectCategory = useCallback((category: Category) => {
+  const [selectedCategory, setCategory] = useState<string | undefined>();
+  const selectCategory = useCallback((category: string) => {
     setCategory(category);
   }, []);
   const unselectCategory = useCallback(() => {


### PR DESCRIPTION
Removes type safety from asset category member, making it a bit easier to add new categories in asset list.

We will fully automate adding categories to UI in:
https://linear.app/osmosis/issue/FE-213/define-asset-categories-in-cms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified the handling and types of asset categories across various components, enhancing the user interface for category selection.
	- Changed the type of category parameters and properties from specific custom types to generic `string` arrays, making the system more flexible and easier to maintain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->