### PR TITLE
fix: tweets loading

### DIFF
--- a/packages/server/src/queries/twitter/twitter.ts
+++ b/packages/server/src/queries/twitter/twitter.ts
@@ -102,7 +102,7 @@ export class Twitter {
    */
   private async internalGetUserTweets(userId: string) {
     const url = new URL(
-      `/tweets/search/recent?query=${encodeURIComponent(
+      `2/tweets/search/recent?query=${encodeURIComponent(
         `from:${userId}`
       )}&max_results=10&tweet.fields=created_at&expansions=author_id,attachments.media_keys&media.fields=media_key,type,url&user.fields=description,profile_image_url,url`,
       TWITTER_API_URL

--- a/packages/web/.env
+++ b/packages/web/.env
@@ -28,7 +28,7 @@ NEXT_PUBLIC_SIDECAR_BASE_URL=https://sqs.osmosis.zone
 # NEXT_PUBLIC_INDEXER_DATA_URL=https://stage-proxy-data-indexer.osmosis-labs.workers.dev
 
 # Twitter api config, it's only used on server
-# TWITTER_API_URL=https://api.twitter.com/2/
+# TWITTER_API_URL=https://api.twitter.com/
 # TWITTER_API_ACCESS_TOKEN=
 # Twitter KV Store Cache
 # TWITTER_KV_STORE_REST_API_URL=


### PR DESCRIPTION
fixed tweets loading by migrating from twitter api v1 to v2.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant Linear task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change:

Twitter section is suddenly gone from all Asset Detail pages and we get error 404, this PR fix this issue.

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-186/fix-twitter-queries)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted Twitter API URL construction to ensure correct endpoint access for fetching recent tweets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->