### PR TITLE
Display compacted zeros on PriceChartHeader with compressZeros func…

### DIFF
--- a/packages/web/components/chart/__tests__/compress-zeros.spec.ts
+++ b/packages/web/components/chart/__tests__/compress-zeros.spec.ts
@@ -1,0 +1,64 @@
+import { compressZeros } from "~/components/chart/compress-zeros";
+
+describe("compressZeros function", () => {
+  it("should correctly compress zeros when no currency symbol is present", () => {
+    expect(compressZeros("123.00", false)).toEqual({
+      currencySign: undefined,
+      significantDigits: "123",
+      zeros: 2,
+      decimalDigits: "",
+    });
+  });
+
+  it("should correctly compress zeros when currency symbol is present", () => {
+    expect(compressZeros("$0.00", true)).toEqual({
+      currencySign: "$",
+      significantDigits: "0",
+      zeros: 2,
+      decimalDigits: "",
+    });
+  });
+
+  it("should correctly handle significant digits with leading zeros", () => {
+    expect(compressZeros("$001.2300", true)).toEqual({
+      currencySign: "$",
+      significantDigits: "001",
+      zeros: 0,
+      decimalDigits: "2300",
+    });
+  });
+
+  it("should return original value if there are no zeros to compress", () => {
+    expect(compressZeros("$123.45", true)).toEqual({
+      currencySign: "$",
+      significantDigits: "123",
+      zeros: 0,
+      decimalDigits: "45",
+    });
+  });
+
+  it("should correctly handle cases with only leading zeros", () => {
+    expect(compressZeros("$00.005", true)).toEqual({
+      currencySign: "$",
+      significantDigits: "00",
+      zeros: 2,
+      decimalDigits: "5",
+    });
+  });
+
+  it("should handle cases with no decimal part", () => {
+    expect(compressZeros("$123", true)).toEqual({
+      currencySign: "$",
+      significantDigits: "123",
+    });
+  });
+
+  it("should handle cases with no significant digits", () => {
+    expect(compressZeros("$0.00", true)).toEqual({
+      currencySign: "$",
+      significantDigits: "0",
+      zeros: 2,
+      decimalDigits: "",
+    });
+  });
+});

--- a/packages/web/components/chart/compress-zeros.ts
+++ b/packages/web/components/chart/compress-zeros.ts
@@ -1,0 +1,82 @@
+const ZERO = "0";
+const DOUBLE_ZERO = "00";
+
+const countZeros = (decimalDigits: string) => {
+  // Count the leading zeros
+  let zeroCount = 0;
+  for (let i = 0; i < decimalDigits.length; i++) {
+    if (decimalDigits[i] === ZERO) {
+      zeroCount++;
+    } else {
+      break;
+    }
+  }
+
+  return zeroCount;
+};
+
+export const compressZeros = (
+  formattedValue: string,
+  hasCurrencySymbol: boolean
+) => {
+  // Find the punctuation symbol marking the start of the decimal part
+  const punctuationSymbol = formattedValue.match(/[.,]/g)?.pop();
+
+  const significantDigitsSubStart = hasCurrencySymbol ? 1 : 0;
+  const currencySign = hasCurrencySymbol ? formattedValue[0] : undefined;
+
+  if (!punctuationSymbol) {
+    return {
+      currencySign,
+      significantDigits: formattedValue.substring(significantDigitsSubStart),
+    };
+  }
+  // Find the index of the punctuation symbol
+  const punctIdx = formattedValue.lastIndexOf(punctuationSymbol);
+
+  // If no punctuation symbol found or no zeros after it, return the original value
+  if (
+    !punctuationSymbol ||
+    !formattedValue.includes(ZERO, formattedValue.indexOf(punctuationSymbol))
+  ) {
+    return {
+      currencySign,
+      significantDigits: formattedValue.substring(
+        significantDigitsSubStart,
+        punctIdx
+      ),
+      zeros: 0,
+      decimalDigits: formattedValue.substring(punctIdx + 1),
+    };
+  }
+
+  // Extract characters after the punctuation symbol
+  const charsAfterPunct = formattedValue.slice(punctIdx + 1);
+
+  if (charsAfterPunct.substring(0, 2) !== DOUBLE_ZERO)
+    return {
+      currencySign,
+      significantDigits: formattedValue.substring(
+        significantDigitsSubStart,
+        punctIdx
+      ),
+      zeros: 0,
+      decimalDigits: charsAfterPunct,
+    };
+
+  // Count consecutive zeros
+  const zerosCount = countZeros(charsAfterPunct);
+  const otherDigits = charsAfterPunct.substring(zerosCount);
+
+  const canDisplayZeros = zerosCount !== 0 || otherDigits.length !== 0;
+
+  return {
+    currencySign,
+    significantDigits: formattedValue.substring(
+      significantDigitsSubStart,
+      punctIdx
+    ),
+    zeros: canDisplayZeros ? zerosCount : 0,
+    decimalDigits: otherDigits,
+  };
+};

--- a/packages/web/pages/assets/[denom].tsx
+++ b/packages/web/pages/assets/[denom].tsx
@@ -474,6 +474,7 @@ const TokenChartHeader = observer(() => {
         classes={{
           priceHeaderClass: "!text-h2 !font-h2 sm:!text-h4",
         }}
+        compactZeros
       />
     </header>
   );


### PR DESCRIPTION
…tion

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant Linear task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change:

Display compact zeros on token chart header like CoinGecko
<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

### Linear Task

[Linear Task URL](PASTE_LINEAR_TASK_URL_HERE)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->
