### PR TITLE
hide daily earn behind feature flag

### DIFF
--- a/packages/web/components/pool-detail/share.tsx
+++ b/packages/web/components/pool-detail/share.tsx
@@ -25,6 +25,7 @@ import { EventName } from "~/config";
 import { useTranslation, useWalletSelect } from "~/hooks";
 import {
   useAmplitudeAnalytics,
+  useFeatureFlags,
   useLockTokenConfig,
   useSuperfluidPool,
   useWindowSize,
@@ -56,6 +57,7 @@ export const SharePool: FunctionComponent<{ pool: Pool }> = observer(
     const { t } = useTranslation();
     const { isMobile } = useWindowSize();
     const { isLoading: isWalletLoading } = useWalletSelect();
+    const { displayDailyEarn } = useFeatureFlags();
 
     const [poolDetailsContainerRef, { y: poolDetailsContainerOffset }] =
       useMeasure<HTMLDivElement>();
@@ -598,20 +600,21 @@ export const SharePool: FunctionComponent<{ pool: Pool }> = observer(
                 </div>
 
                 <div className="flex flex-col place-content-between gap-3 rounded-4xl bg-osmoverse-1000 px-8 py-7">
-                  <div className="flex flex-col gap-2">
-                    <span className="body2 text-osmoverse-300">
-                      {t("pool.currentDailyEarn")}
-                    </span>
-                    <h4 className="text-osmoverse-100">
-                      {t("pool.dailyEarnAmount", {
-                        amount:
-                          queryAccountPoolRewards
-                            .getUsdRewardsForPool(pool.id)
-                            ?.day.toString() ?? "$0",
-                      })}
-                    </h4>
-                  </div>
-
+                  {displayDailyEarn && (
+                    <div className="flex flex-col gap-2">
+                      <span className="body2 text-osmoverse-300">
+                        {t("pool.currentDailyEarn")}
+                      </span>
+                      <h4 className="text-osmoverse-100">
+                        {t("pool.dailyEarnAmount", {
+                          amount:
+                            queryAccountPoolRewards
+                              .getUsdRewardsForPool(pool.id)
+                              ?.day.toString() ?? "$0",
+                        })}
+                      </h4>
+                    </div>
+                  )}
                   {userSharePool.availableValue.toDec().isPositive() &&
                     bondDurations.some((duration) => duration.bondable) && (
                       <ArrowButton

--- a/packages/web/hooks/use-feature-flags.ts
+++ b/packages/web/hooks/use-feature-flags.ts
@@ -24,7 +24,8 @@ export type AvailableFlags =
   | "tfmProTradingNavbarButton"
   | "positionRoi"
   | "swapToolSimulateFee"
-  | "portfolioPageAndNewAssetsPage";
+  | "portfolioPageAndNewAssetsPage"
+  | "displayDailyEarn";
 
 type ModifiedFlags =
   | Exclude<AvailableFlags, "mobileNotifications">
@@ -51,6 +52,7 @@ const defaultFlags: Record<ModifiedFlags, boolean> = {
   positionRoi: true,
   swapToolSimulateFee: false,
   portfolioPageAndNewAssetsPage: false,
+  displayDailyEarn: false,
   _isInitialized: false,
   _isClientIDPresent: false,
 };


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant Linear task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change:

Because of data stability issues, we should hide this box in pool detail pages behind a FF. This would allow us to avoid misleading users with faulty values when the data endpoint is having issues.

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-233/pool-detail-page-hide-dollarday-behind-ff)

## Brief Changelog


Hide daily earn behind feature flag

## Testing and Verifying



This change has been tested locally by rebuilding the website and verified content and links are expected



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added the `useFeatureFlags` hook to manage feature flags.
	- Introduced conditional rendering based on the `displayDailyEarn` flag for showing daily earnings in the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->