### PR TITLE
feat: Display Pool Tokens in Swap Tool

### DIFF
--- a/packages/server/src/env.ts
+++ b/packages/server/src/env.ts
@@ -14,8 +14,12 @@ export const GITHUB_RAW_DEFAULT_BASEURL = "https://raw.githubusercontent.com";
 export const ASSET_LIST_COMMIT_HASH = process.env.ASSET_LIST_COMMIT_HASH;
 
 // data services
-export const TIMESERIES_DATA_URL = process.env.NEXT_PUBLIC_TIMESERIES_DATA_URL;
-export const INDEXER_DATA_URL = process.env.NEXT_PUBLIC_INDEXER_DATA_URL;
+export const TIMESERIES_DATA_URL =
+  process.env.NEXT_PUBLIC_TIMESERIES_DATA_URL ??
+  "https://stage-proxy-data-api.osmosis-labs.workers.dev";
+export const INDEXER_DATA_URL =
+  process.env.NEXT_PUBLIC_INDEXER_DATA_URL ??
+  "https://stage-proxy-data-indexer.osmosis-labs.workers.dev";
 export const SIDECAR_BASE_URL =
   process.env.NEXT_PUBLIC_SIDECAR_BASE_URL ?? "https://sqs.osmosis.zone/";
 export const TFM_BASE_URL = process.env.NEXT_PUBLIC_TFM_API_BASE_URL;

--- a/packages/server/src/queries/complex/assets/user.ts
+++ b/packages/server/src/queries/complex/assets/user.ts
@@ -56,12 +56,16 @@ export async function mapGetAssetsWithUserBalances<TAsset extends Asset>({
   assets?: TAsset[];
   userOsmoAddress?: string;
   sortFiatValueDirection?: SortDirection;
+  /**
+   * If poolId is provided, only include assets that are part of the pool.
+   */
   poolId?: string;
 } & AssetFilter): Promise<(TAsset & MaybeUserAssetCoin)[]> {
   const { userOsmoAddress, search, sortFiatValueDirection } = params;
   let { assets } = params;
   if (!assets) assets = getAssets(params) as TAsset[];
 
+  // If poolId is provided, only include assets that are part of the pool.
   if (assets && !isNil(poolId)) {
     const { reserveCoins } = await getPool({
       assetLists: params.assetLists,

--- a/packages/server/src/trpc-routers/assets-router.ts
+++ b/packages/server/src/trpc-routers/assets-router.ts
@@ -59,7 +59,14 @@ export const assetsRouter = createTRPCRouter({
       }
     ),
   getUserAssets: publicProcedure
-    .input(GetInfiniteAssetsInputSchema.merge(UserOsmoAddressSchema))
+    .input(
+      GetInfiniteAssetsInputSchema.merge(UserOsmoAddressSchema).merge(
+        z.object({
+          // Optional poolId to filter assets by pool
+          poolId: z.string().optional(),
+        })
+      )
+    )
     .query(
       async ({
         input: {
@@ -70,6 +77,7 @@ export const assetsRouter = createTRPCRouter({
           onlyVerified,
           includePreview,
           categories,
+          poolId,
         },
         ctx,
       }) =>
@@ -83,6 +91,7 @@ export const assetsRouter = createTRPCRouter({
               sortFiatValueDirection: "desc",
               includePreview,
               categories,
+              poolId,
             }),
           cacheKey: JSON.stringify({
             search,
@@ -90,6 +99,7 @@ export const assetsRouter = createTRPCRouter({
             onlyVerified,
             includePreview,
             categories,
+            poolId,
           }),
           cursor,
           limit,

--- a/packages/server/src/trpc.ts
+++ b/packages/server/src/trpc.ts
@@ -96,6 +96,8 @@ export const publicProcedure = t.procedure
     return result;
   });
 
+export const createCallerFactory = t.createCallerFactory;
+
 /**
  * Creates a local link for tRPC operations.
  * This function is used to create a custom TRPCLink that intercepts operations and

--- a/packages/web/__mocks__/intersection-observer.ts
+++ b/packages/web/__mocks__/intersection-observer.ts
@@ -1,0 +1,13 @@
+function createIntersectionObserverMock() {
+  return {
+    observe: () => jest.fn(),
+    disconnect: () => jest.fn(),
+    unobserve: () => jest.fn(),
+  };
+}
+
+window.IntersectionObserver = jest
+  .fn()
+  .mockImplementation(createIntersectionObserverMock);
+
+export {};

--- a/packages/web/__mocks__/intersection-observer.ts
+++ b/packages/web/__mocks__/intersection-observer.ts
@@ -6,8 +6,10 @@ function createIntersectionObserverMock() {
   };
 }
 
-window.IntersectionObserver = jest
-  .fn()
-  .mockImplementation(createIntersectionObserverMock);
+if (typeof window !== "undefined") {
+  window.IntersectionObserver = jest
+    .fn()
+    .mockImplementation(createIntersectionObserverMock);
+}
 
 export {};

--- a/packages/web/__tests__/setup-tests.ts
+++ b/packages/web/__tests__/setup-tests.ts
@@ -1,6 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import "@testing-library/jest-dom";
 import "fake-indexeddb/auto";
+import "~/__mocks__/intersection-observer";
 
 import { server } from "~/__tests__/msw";
 

--- a/packages/web/components/control/token-select-with-drawer.tsx
+++ b/packages/web/components/control/token-select-with-drawer.tsx
@@ -21,6 +21,8 @@ export const TokenSelectWithDrawer: FunctionComponent<
     page?: EventPage;
     onSelect: (tokenDenom: string) => void;
     setDropdownState?: (isOpen: boolean) => void;
+    showRecommendedTokens?: boolean;
+    showSearchBox?: boolean;
   } & Disableable
 > = observer(
   ({
@@ -32,6 +34,8 @@ export const TokenSelectWithDrawer: FunctionComponent<
     page = "Swap Page",
     onSelect: onSelectProp,
     setDropdownState,
+    showRecommendedTokens = true,
+    showSearchBox = true,
   }) => {
     const { isMobile } = useWindowSize();
     const router = useRouter();
@@ -51,7 +55,7 @@ export const TokenSelectWithDrawer: FunctionComponent<
       : swapState.toAsset;
 
     const tokenSelectionAvailable =
-      canSelectTokens && preSortedTokens.length > 1;
+      canSelectTokens && preSortedTokens.length >= 1;
 
     const onSelect = (tokenDenom: string) => {
       logEvent([
@@ -79,6 +83,9 @@ export const TokenSelectWithDrawer: FunctionComponent<
                 setIsSelectOpen(!isSelectOpen);
               }
             }}
+            aria-label={`Select ${
+              isFromSelect ? "'from'" : "'to'"
+            } token. Current token is ${selectedToken.coinDenom}`}
           >
             {selectedToken.coinImageUrl && (
               <div className="mr-1 h-[50px] w-[50px] shrink-0 rounded-full md:h-7 md:w-7">
@@ -127,6 +134,8 @@ export const TokenSelectWithDrawer: FunctionComponent<
             swapState={swapState}
             onClose={() => setIsSelectOpen(false)}
             onSelect={onSelect}
+            showSearchBox={showSearchBox}
+            showRecommendedTokens={showRecommendedTokens}
           />
         </div>
       </div>

--- a/packages/web/components/drawers/token-select-drawer.tsx
+++ b/packages/web/components/drawers/token-select-drawer.tsx
@@ -51,9 +51,18 @@ export const TokenSelectDrawer: FunctionComponent<{
   isOpen: boolean;
   onClose?: () => void;
   onSelect?: (tokenDenom: string) => void;
+  showRecommendedTokens?: boolean;
+  showSearchBox?: boolean;
   swapState: SwapState;
 }> = observer(
-  ({ isOpen, swapState, onClose: onCloseProp, onSelect: onSelectProp }) => {
+  ({
+    isOpen,
+    swapState,
+    onClose: onCloseProp,
+    onSelect: onSelectProp,
+    showSearchBox = true,
+    showRecommendedTokens = true,
+  }) => {
     const { t } = useTranslation();
     const { userSettings } = useStore();
     const { isMobile } = useWindowSize();
@@ -260,56 +269,63 @@ export const TokenSelectDrawer: FunctionComponent<{
             </div>
 
             <div className="mb-2 shadow-[0_4px_8px_0_rgba(9,5,36,0.12)]">
-              <div className="px-4 py-4" onClick={(e) => e.stopPropagation()}>
-                <SearchBox
-                  ref={searchBoxRef}
-                  type="text"
-                  className="!w-full"
-                  placeholder={t("components.searchTokens")}
-                  onInput={onSearch}
-                  onKeyDown={searchBarKeyDown}
-                  size={isMobile ? "medium" : "large"}
-                />
-              </div>
-
-              <div className="mb-2 h-fit">
-                <div
-                  ref={quickSelectRef}
-                  onMouseDown={onMouseDownQuickSelect}
-                  className="no-scrollbar flex space-x-4 overflow-x-auto px-4"
-                >
-                  {swapState.recommendedAssets.map((asset) => {
-                    const { coinDenom, coinImageUrl } = asset;
-
-                    return (
-                      <button
-                        key={asset.coinDenom}
-                        className={classNames(
-                          "flex items-center space-x-3 rounded-lg border border-osmoverse-700 p-2",
-                          "transition-colors duration-150 ease-out hover:bg-osmoverse-900",
-                          "my-1 focus:bg-osmoverse-900"
-                        )}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onClickAsset(coinDenom);
-                        }}
-                      >
-                        {coinImageUrl && (
-                          <div className="h-[24px] w-[24px] rounded-full">
-                            <Image
-                              src={coinImageUrl}
-                              alt="token icon"
-                              width={24}
-                              height={24}
-                            />
-                          </div>
-                        )}
-                        <p className="subtitle1">{coinDenom}</p>
-                      </button>
-                    );
-                  })}
+              {showSearchBox && (
+                <div className="px-4 py-4" onClick={(e) => e.stopPropagation()}>
+                  <SearchBox
+                    ref={searchBoxRef}
+                    type="text"
+                    className="!w-full"
+                    placeholder={t("components.searchTokens")}
+                    onInput={onSearch}
+                    onKeyDown={searchBarKeyDown}
+                    size={isMobile ? "medium" : "large"}
+                  />
                 </div>
-              </div>
+              )}
+
+              {showRecommendedTokens && (
+                <div
+                  data-testid="recommended-assets-container"
+                  className="mb-2 h-fit"
+                >
+                  <div
+                    ref={quickSelectRef}
+                    onMouseDown={onMouseDownQuickSelect}
+                    className="no-scrollbar flex space-x-4 overflow-x-auto px-4"
+                  >
+                    {swapState.recommendedAssets.map((asset) => {
+                      const { coinDenom, coinImageUrl } = asset;
+
+                      return (
+                        <button
+                          key={asset.coinDenom}
+                          className={classNames(
+                            "flex items-center space-x-3 rounded-lg border border-osmoverse-700 p-2",
+                            "transition-colors duration-150 ease-out hover:bg-osmoverse-900",
+                            "my-1 focus:bg-osmoverse-900"
+                          )}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            onClickAsset(coinDenom);
+                          }}
+                        >
+                          {coinImageUrl && (
+                            <div className="h-[24px] w-[24px] rounded-full">
+                              <Image
+                                src={coinImageUrl}
+                                alt="token icon"
+                                width={24}
+                                height={24}
+                              />
+                            </div>
+                          )}
+                          <p className="subtitle1">{coinDenom}</p>
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
             </div>
 
             {swapState.isLoadingSelectAssets ? (
@@ -339,6 +355,7 @@ export const TokenSelectDrawer: FunctionComponent<{
                             "bg-osmoverse-900": keyboardSelectedIndex === index,
                           }
                         )}
+                        data-testid="token-select-asset"
                         onClick={(e) => {
                           e.stopPropagation();
                           onClickAsset?.(coinDenom);

--- a/packages/web/components/swap-tool/__tests__/swap-tool.spec.tsx
+++ b/packages/web/components/swap-tool/__tests__/swap-tool.spec.tsx
@@ -1,0 +1,231 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { Dec, PricePretty } from "@keplr-wallet/unit";
+import {
+  createCallerFactory,
+  DEFAULT_VS_CURRENCY,
+  FilteredPoolsResponse,
+  NumPoolsResponse,
+} from "@osmosis-labs/server";
+import { getAssetFromAssetList } from "@osmosis-labs/utils";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { rest } from "msw";
+import mockRouter from "next-router-mock";
+
+import { server, trpcMsw } from "~/__tests__/msw";
+import { renderWithProviders } from "~/__tests__/test-utils";
+import { SwapTool } from "~/components/swap-tool";
+import { AssetLists } from "~/config/generated/asset-lists";
+import { ChainList } from "~/config/generated/chain-list";
+import { appRouter } from "~/server/api/root-router";
+
+jest.mock("next/router", () => jest.requireActual("next-router-mock"));
+
+const createCaller = createCallerFactory(appRouter);
+const caller = createCaller({
+  /**
+   * The asset list and chain list used here are snapshots of the
+   * production asset list. In case of discrepancies due to outdated
+   * assets or chains, consider updating these mocks.
+   */
+  assetLists: AssetLists,
+  chainList: ChainList,
+});
+
+beforeEach(() => {
+  server.use(
+    trpcMsw.edge.assets.getUserAssets.query(async (req, res, ctx) => {
+      return res(
+        ctx.status(200),
+        ctx.data(await caller.edge.assets.getUserAssets(req.getInput()))
+      );
+    }),
+    trpcMsw.edge.assets.getAssetPrice.query((_req, res, ctx) => {
+      return res(
+        ctx.status(200),
+        ctx.data(new PricePretty(DEFAULT_VS_CURRENCY, new Dec(1)))
+      );
+    })
+  );
+});
+
+afterEach(() => {
+  mockRouter.setCurrentUrl("/");
+});
+
+it("should return only pool assets when sending a pool id and useOtherCurrencies is true", async () => {
+  const poolId = "908";
+  const rawPoolTokens = [
+    {
+      denom:
+        "ibc/0CD3A0285E1341859B5E86B6AB7682F023D03E97607CCC1DC95706411D866DF7",
+      amount: "249.68336812445327",
+      name: "Dai Stablecoin",
+      symbol: "DAI",
+      display: "dai",
+      exponent: "18",
+      coingecko_id: "dai",
+      weight_or_scaling: "1000000000000",
+      percent: "0.999999999998",
+      price: "1.0009205128376601",
+      price_24h_change: "-0.0005927567076408077",
+    },
+    {
+      denom:
+        "ibc/23CA6C8D1AB2145DD13EB1E089A2E3F960DC298B468CCE034E19E5A78B61136E",
+      amount: "823.563328",
+      name: "CMST",
+      symbol: "CMST",
+      display: "cmst",
+      exponent: "6",
+      coingecko_id: "composite",
+      weight_or_scaling: "1",
+      percent: "9.99999999998e-13",
+      price: "0.7051241017886",
+      price_24h_change: "0.7037924681345253",
+    },
+    {
+      denom:
+        "ibc/92BE0717F4678905E53F4E45B2DED18BC0CB97BF1F8B6A25AFEDF3D5A879B4D5",
+      amount: "250.470027",
+      name: "Inter Stable Token",
+      symbol: "IST",
+      display: "ist",
+      exponent: "6",
+      coingecko_id: "inter-stable-token",
+      weight_or_scaling: "1",
+      percent: "9.99999999998e-13",
+      price: "1.0004902227514614",
+      price_24h_change: "0.07891367083611964",
+    },
+  ];
+  const assets = rawPoolTokens.map((rawToken) =>
+    getAssetFromAssetList({
+      assetLists: AssetLists,
+      coinMinimalDenom: rawToken.denom,
+    })
+  );
+
+  expect(assets).toHaveLength(3);
+
+  server.use(
+    rest.get(
+      "https://stage-proxy-data-api.osmosis-labs.workers.dev/stream/pool/v1/all",
+      (_req, res, ctx) => {
+        return res(
+          ctx.status(200),
+          ctx.json({
+            pagination: {
+              next_offset: 1,
+              total_pools: 1,
+            },
+            pools: [
+              {
+                type: "osmosis.gamm.poolmodels.stableswap.v1beta1.Pool" as const,
+                pool_id: Number(poolId),
+                swap_fees: 0.01,
+                exit_fees: 0,
+                total_weight_or_scaling: 1000000000002,
+                total_shares: {
+                  denom: `gamm/pool/${poolId}`,
+                  amount: "8443258129578637381630355637",
+                },
+                pool_tokens: rawPoolTokens,
+                liquidity: 1081.220295254844,
+                liquidity_24h_change: 0.41118621205053774,
+                volume_24h: 200.52200454814368,
+                volume_24h_change: 1162.2634682787304,
+                volume_7d: 384.3539256324429,
+                address:
+                  "osmo1znf8ut62jkpgxn38q280td73w380j260vegz63yd29gm2hrps8csamg6u7",
+              },
+            ] as unknown as FilteredPoolsResponse["pools"],
+          } as FilteredPoolsResponse)
+        );
+      }
+    ),
+    rest.get(
+      "https://lcd-osmosis.keplr.app/osmosis/poolmanager/v1beta1/num_pools",
+      (_req, res, ctx) => {
+        return res(
+          ctx.status(200),
+          ctx.json({ num_pools: "1" } as NumPoolsResponse)
+        );
+      }
+    )
+  );
+
+  renderWithProviders(
+    <SwapTool
+      page="Pool Details Page"
+      useOtherCurrencies
+      initialSendTokenDenom={assets[0]?.symbol}
+      initialOutTokenDenom={assets[1]?.symbol}
+      useQueryParams={false}
+      forceSwapInPoolId={poolId}
+    />
+  );
+
+  await waitFor(() => {
+    expect(screen.getByText("Swap")).toBeInTheDocument();
+  });
+
+  // Click on asset 1 to open drawer
+  const fromTokenButton = screen.getByRole("button", {
+    name: `Select 'from' token. Current token is ${assets[0]!.symbol}`,
+  });
+  expect(fromTokenButton).toBeInTheDocument();
+
+  // asset 3 should not be visible as the token select list is not open
+  expect(screen.queryByText(assets[2]!.symbol)).toBeNull();
+
+  await userEvent.click(fromTokenButton);
+
+  // Check if drawer is open
+  expect(await screen.findByText("Select a token")).toBeInTheDocument();
+
+  // IST should be in the list
+  expect(screen.getByText(assets[2]!.symbol)).toBeInTheDocument();
+
+  // Recommended assets should not be visible
+  expect(screen.queryByTestId("recommended-assets-container")).toBeNull();
+
+  // Search box should not be visible
+  expect(screen.queryByPlaceholderText("Search")).toBeNull();
+
+  // Only the pool assets should be visible
+  expect(screen.getAllByTestId("token-select-asset")).toHaveLength(1);
+
+  // Close drawer
+  userEvent.click(screen.getByRole("button", { name: "Close" }));
+
+  // Should have been closed
+  await waitFor(() => {
+    expect(screen.queryByText("Select a token")).toBeNull();
+  });
+
+  // Click on asset 2 to open drawer
+  const toTokenButton = screen.getByRole("button", {
+    name: `Select 'to' token. Current token is ${assets[1]!.symbol}`,
+  });
+
+  // asset 3 should not be visible as the token select list is not open
+  expect(screen.queryByText(assets[2]!.symbol)).toBeNull();
+
+  await userEvent.click(toTokenButton);
+
+  // Check if drawer is open
+  expect(await screen.findByText("Select a token")).toBeInTheDocument();
+
+  // IST should be in the list
+  expect(screen.getByText(assets[2]!.symbol)).toBeInTheDocument();
+
+  // Recommended assets should not be visible
+  expect(screen.queryByTestId("recommended-assets-container")).toBeNull();
+
+  // Search box should not be visible
+  expect(screen.queryByPlaceholderText("Search")).toBeNull();
+
+  // Only the pool assets should be visible
+  expect(screen.getAllByTestId("token-select-asset")).toHaveLength(1);
+});

--- a/packages/web/components/swap-tool/index.tsx
+++ b/packages/web/components/swap-tool/index.tsx
@@ -41,12 +41,14 @@ import { useStore } from "~/stores";
 import { formatCoinMaxDecimalsByOne, formatPretty } from "~/utils/formatter";
 
 export interface SwapToolProps {
-  isInModal?: boolean;
+  fixedWidth?: boolean;
+  useOtherCurrencies: boolean | undefined;
+  useQueryParams: boolean | undefined;
   onRequestModalClose?: () => void;
   swapButton?: React.ReactElement;
   initialSendTokenDenom?: string;
   initialOutTokenDenom?: string;
-  page?: EventPage;
+  page: EventPage;
   forceSwapInPoolId?: string;
   onSwapSuccess?: (params: {
     sendTokenDenom: string;
@@ -56,12 +58,14 @@ export interface SwapToolProps {
 
 export const SwapTool: FunctionComponent<SwapToolProps> = observer(
   ({
-    isInModal,
+    fixedWidth,
+    useOtherCurrencies,
+    useQueryParams,
     onRequestModalClose,
     swapButton,
-    initialSendTokenDenom: sendTokenDenom,
-    initialOutTokenDenom: outTokenDenom,
-    page = "Swap Page",
+    initialSendTokenDenom,
+    initialOutTokenDenom,
+    page,
     forceSwapInPoolId,
     onSwapSuccess,
   }) => {
@@ -78,10 +82,10 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
 
     const slippageConfig = useSlippageConfig();
     const swapState = useSwap({
-      initialFromDenom: sendTokenDenom,
-      initialToDenom: outTokenDenom,
-      useOtherCurrencies: !isInModal,
-      useQueryParams: !isInModal,
+      initialFromDenom: initialSendTokenDenom,
+      initialToDenom: initialOutTokenDenom,
+      useOtherCurrencies,
+      useQueryParams,
       forceSwapInPoolId,
       maxSlippage: slippageConfig.slippage.toDec(),
     });
@@ -177,7 +181,7 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
         fromToken: swapState.fromAsset?.coinDenom,
         tokenAmount: Number(swapState.inAmountInput.amount),
         toToken: swapState.toAsset?.coinDenom,
-        isOnHome: !isInModal,
+        isOnHome: page === "Swap Page",
         isMultiHop: swapState.quote?.split.some(
           ({ pools }) => pools.length !== 1
         ),
@@ -244,6 +248,9 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
       !swapState.inAmountInput.hasErrorWithCurrentBalanceQuote &&
       !swapState.inAmountInput?.balance?.toDec().isZero() &&
       swapState.inAmountInput.isLoadingCurrentBalanceNetworkFee;
+
+    const showTokenSelectSearchBox = isNil(forceSwapInPoolId);
+    const showTokenSelectRecommendedTokens = isNil(forceSwapInPoolId);
 
     return (
       <>
@@ -377,7 +384,7 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
                               {
                                 fromToken: swapState.fromAsset?.coinDenom,
                                 toToken: swapState.toAsset?.coinDenom,
-                                isOnHome: !isInModal,
+                                isOnHome: page === "Swap Page",
                                 percentage: slippageConfig.slippage.toString(),
                                 page,
                               },
@@ -501,6 +508,8 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
                     },
                     [swapState, closeTokenSelectDropdowns]
                   )}
+                  showSearchBox={showTokenSelectSearchBox}
+                  showRecommendedTokens={showTokenSelectRecommendedTokens}
                 />
                 <div className="flex w-full flex-col items-end">
                   <input
@@ -625,6 +634,8 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
                     },
                     [setOneTokenSelectOpen, closeTokenSelectDropdowns]
                   )}
+                  showSearchBox={showTokenSelectSearchBox}
+                  showRecommendedTokens={showTokenSelectRecommendedTokens}
                 />
                 <div className="flex w-full flex-col items-end">
                   <h5
@@ -769,7 +780,7 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
                 ref={estimateDetailsContentRef}
                 className={classNames(
                   "absolute flex flex-col gap-4 pt-5 transition-opacity",
-                  isInModal ? "w-[94%]" : "w-[358px] md:w-[94%]",
+                  fixedWidth ? "w-[94%]" : "w-[358px] md:w-[94%]",
                   { "opacity-50": swapState.isQuoteLoading }
                 )}
               >

--- a/packages/web/hooks/use-swap.ts
+++ b/packages/web/hooks/use-swap.ts
@@ -91,6 +91,7 @@ export function useSwap(
     initialToDenom,
     useQueryParams,
     useOtherCurrencies,
+    poolId: forceSwapInPoolId,
   });
 
   const inAmountInput = useSwapAmountInput({
@@ -468,6 +469,13 @@ export function useSwapAssets({
   initialToDenom = DefaultDenoms[1],
   useQueryParams = true,
   useOtherCurrencies = true,
+  poolId,
+}: {
+  initialFromDenom?: string;
+  initialToDenom?: string;
+  useQueryParams?: boolean;
+  useOtherCurrencies?: boolean;
+  poolId?: string;
 } = {}) {
   const { chainStore, accountStore } = useStore();
   const account = accountStore.getWallet(chainStore.osmosis.chainId);
@@ -510,6 +518,7 @@ export function useSwapAssets({
     isFetchingNextPage,
   } = api.edge.assets.getUserAssets.useInfiniteQuery(
     {
+      poolId,
       search: queryInput,
       userOsmoAddress: account?.address,
       includePreview: showPreviewAssets,
@@ -523,8 +532,11 @@ export function useSwapAssets({
   );
 
   const allSelectableAssets = useMemo(
-    () => selectableAssetPages?.pages.flatMap(({ items }) => items) ?? [],
-    [selectableAssetPages?.pages]
+    () =>
+      useOtherCurrencies
+        ? selectableAssetPages?.pages.flatMap(({ items }) => items) ?? []
+        : [],
+    [selectableAssetPages?.pages, useOtherCurrencies]
   );
 
   const { asset: fromAsset } = useSwapAsset({

--- a/packages/web/modals/trade-tokens.tsx
+++ b/packages/web/modals/trade-tokens.tsx
@@ -10,27 +10,37 @@ export const TradeTokens: FunctionComponent<
     sendTokenDenom?: string;
     outTokenDenom?: string;
     forceSwapInPoolId?: string;
+    useOtherCurrencies?: boolean;
     page: EventPage;
   } & ModalBaseProps
-> = (props) => {
+> = ({
+  sendTokenDenom,
+  outTokenDenom,
+  forceSwapInPoolId,
+  useOtherCurrencies,
+  page,
+  ...modalProps
+}) => {
   const { showModalBase, accountActionButton, walletConnected } =
-    useConnectWalletModalRedirect({}, props.onRequestClose);
+    useConnectWalletModalRedirect({}, modalProps.onRequestClose);
 
   return (
     <ModalBase
-      {...props}
-      isOpen={showModalBase && props.isOpen}
+      {...modalProps}
+      isOpen={showModalBase && modalProps.isOpen}
       hideCloseButton
       className="!w-fit !p-0"
     >
       <SwapTool
-        isInModal
-        onRequestModalClose={props.onRequestClose}
+        fixedWidth
+        useQueryParams={false}
+        useOtherCurrencies={useOtherCurrencies}
+        onRequestModalClose={modalProps.onRequestClose}
         swapButton={!walletConnected ? accountActionButton : undefined}
-        initialSendTokenDenom={props.sendTokenDenom}
-        initialOutTokenDenom={props.outTokenDenom}
-        forceSwapInPoolId={props.forceSwapInPoolId}
-        page={props.page}
+        initialSendTokenDenom={sendTokenDenom}
+        initialOutTokenDenom={outTokenDenom}
+        forceSwapInPoolId={forceSwapInPoolId}
+        page={page}
       />
     </ModalBase>
   );

--- a/packages/web/pages/assets/[denom].tsx
+++ b/packages/web/pages/assets/[denom].tsx
@@ -237,7 +237,9 @@ const AssetInfoView: FunctionComponent<AssetInfoPageProps> = observer(
             <div className="flex flex-col gap-4">
               <div className="xl:hidden">
                 <SwapTool
-                  isInModal
+                  fixedWidth
+                  useQueryParams={false}
+                  useOtherCurrencies={false}
                   initialSendTokenDenom={denom === "USDC" ? "OSMO" : "USDC"}
                   initialOutTokenDenom={denom}
                   page="Token Info Page"

--- a/packages/web/pages/index.tsx
+++ b/packages/web/pages/index.tsx
@@ -60,6 +60,8 @@ const Home = () => {
         <div className="ml-auto mr-[15%] flex w-[27rem] flex-col gap-4 lg:mx-auto md:mt-mobile-header">
           {featureFlags.swapsAdBanner && <SwapAdsBanner />}
           <SwapTool
+            useQueryParams
+            useOtherCurrencies
             onSwapSuccess={({ sendTokenDenom, outTokenDenom }) => {
               setPreviousTrade({ sendTokenDenom, outTokenDenom });
             }}

--- a/packages/web/pages/pool/[id].tsx
+++ b/packages/web/pages/pool/[id].tsx
@@ -75,6 +75,7 @@ const Pool: FunctionComponent<Props> = ({
           }}
           sendTokenDenom={pool.reserveCoins[0].denom}
           outTokenDenom={pool.reserveCoins[1].denom}
+          useOtherCurrencies={pool.reserveCoins.length > 2}
           forceSwapInPoolId={poolId}
           page="Pool Details Page"
         />


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant Linear task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change:

There was a regression in the swap tool behavior on the pool details page following #3097. This PR resolved this by hiding the token select drawer. However, For StableSwap pools with >2 tokens, they will be able to see the token drawer.

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/STABI-127/fix-swap-tool)

## Brief Changelog

- Hide drawer when pools assets are less than 3
- Show drawer when pool assets are greater than 2
- Add integration test verifying this behavior
- Divide swap tool props to give devs better control of desired behavior on the different pages. 

## Testing and Verifying

- [ ] `/pool/908` should display the token select drawer without search and recommended assets as it has three assets
- [ ] Swap tool in other pages should be unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added filtering of assets based on pool ID in asset retrieval queries.
	- Introduced optional search box and recommended token toggles in the token selection components.
	- Enhanced the Swap Tool with new properties to support fixed width, usage of other currencies, and handling query parameters.
	- Modified the Trade Tokens modal to support transactions in multiple currencies.

- **Bug Fixes**
	- Updated the Swap Tool to ensure correct initial token denomination is set based on the asset page being viewed.

- **Tests**
	- Added mock implementation for IntersectionObserver to improve testing capabilities.

- **Documentation**
	- No visible changes for end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->