### PR TITLE
change N/D on token info to be '-'

### DIFF
--- a/packages/web/components/token-details/token-details.tsx
+++ b/packages/web/components/token-details/token-details.tsx
@@ -290,7 +290,7 @@ const TokenStats: FunctionComponent<TokenStatsProps> = observer(
             {t("tokenInfos.marketCapRank")}
           </p>
           <h5 className="text-xl font-h5 leading-8">
-            {marketCapRank ? `#${marketCapRank}` : t("tokenInfos.noData")}
+            {marketCapRank ? `#${marketCapRank}` : "-"}
           </h5>
         </li>
         <li className="flex flex-col items-start gap-3">
@@ -300,7 +300,7 @@ const TokenStats: FunctionComponent<TokenStatsProps> = observer(
           <h5 className="text-xl font-h5 leading-8">
             {marketCap && usdFiat
               ? formatPretty(new PricePretty(usdFiat, new Dec(marketCap)))
-              : t("tokenInfos.noData")}
+              : "-"}
           </h5>
         </li>
         <li className="flex flex-col items-start gap-3">
@@ -314,7 +314,7 @@ const TokenStats: FunctionComponent<TokenStatsProps> = observer(
                   notation: "compact",
                   compactDisplay: "short",
                 })
-              : t("tokenInfos.noData")}
+              : "-"}
           </h5>
         </li>
         {/* <li className="flex flex-col items-start gap-3">
@@ -326,7 +326,7 @@ const TokenStats: FunctionComponent<TokenStatsProps> = observer(
               ? formatPretty(
                   new PricePretty(usdFiat, new Dec(totalValueLocked))
                 )
-              : t("tokenInfos.noData")}
+              : "-"}
           </h5>
         </li> */}
       </ul>

--- a/packages/web/localizations/de.json
+++ b/packages/web/localizations/de.json
@@ -864,7 +864,6 @@
     "marketCap": "Marktkapitalisierung",
     "circulatingSupply": "Umlaufversorgung",
     "tvl": "TVL",
-    "noData": "ND",
     "buyToken": "Kaufen Sie {coinDenom}",
     "staking": "Abstecken",
     "liquidityInOSMOPools": "Liquidität in {number} {denom} Pools"

--- a/packages/web/localizations/en.json
+++ b/packages/web/localizations/en.json
@@ -864,7 +864,7 @@
     "marketCap": "Market Cap",
     "circulatingSupply": "Circulating Supply",
     "tvl": "TVL",
-    "noData": "N.D.",
+    "noData": "-",
     "buyToken": "Buy {coinDenom}",
     "staking": "Staking",
     "liquidityInOSMOPools": "Liquidity in {number} {denom} pools"

--- a/packages/web/localizations/en.json
+++ b/packages/web/localizations/en.json
@@ -864,7 +864,6 @@
     "marketCap": "Market Cap",
     "circulatingSupply": "Circulating Supply",
     "tvl": "TVL",
-    "noData": "-",
     "buyToken": "Buy {coinDenom}",
     "staking": "Staking",
     "liquidityInOSMOPools": "Liquidity in {number} {denom} pools"

--- a/packages/web/localizations/es.json
+++ b/packages/web/localizations/es.json
@@ -864,7 +864,6 @@
     "marketCap": "Tapa del mercado",
     "circulatingSupply": "Suministro circulante",
     "tvl": "TVL",
-    "noData": "N.D.",
     "buyToken": "Comprar {coinDenom}",
     "staking": "Replanteo",
     "liquidityInOSMOPools": "Liquidez en pools {number} {denom}"

--- a/packages/web/localizations/fa.json
+++ b/packages/web/localizations/fa.json
@@ -864,7 +864,6 @@
     "marketCap": "ارزش بازار",
     "circulatingSupply": "عرضه در گردش",
     "tvl": "TVL",
-    "noData": "ND",
     "buyToken": "خرید {coinDenom}",
     "staking": "شرط بندی",
     "liquidityInOSMOPools": "نقدینگی در استخرهای {number} {denom}"

--- a/packages/web/localizations/fr.json
+++ b/packages/web/localizations/fr.json
@@ -864,7 +864,6 @@
     "marketCap": "Capitalisation boursière",
     "circulatingSupply": "Approvisionnement en circulation",
     "tvl": "TVL",
-    "noData": "ND",
     "buyToken": "Acheter {coinDenom}",
     "staking": "Jalonnement",
     "liquidityInOSMOPools": "Liquidité dans les pools {number} {denom}"

--- a/packages/web/localizations/gu.json
+++ b/packages/web/localizations/gu.json
@@ -864,7 +864,6 @@
     "marketCap": "માર્કેટ કેપ",
     "circulatingSupply": "પરિભ્રમણ પુરવઠો",
     "tvl": "ટીવીએલ",
-    "noData": "એનડી",
     "buyToken": "{coinDenom} ખરીદો",
     "staking": "સ્ટેકિંગ",
     "liquidityInOSMOPools": "{number} {denom} પુલમાં પ્રવાહિતા"

--- a/packages/web/localizations/hi.json
+++ b/packages/web/localizations/hi.json
@@ -864,7 +864,6 @@
     "marketCap": "बाज़ार आकार",
     "circulatingSupply": "परिसंचारी आपूर्ति",
     "tvl": "टी वी लाइनों",
-    "noData": "रा",
     "buyToken": "खरीदें {coinDenom}",
     "staking": "जताया",
     "liquidityInOSMOPools": "{number} {denom} पूल में तरलता"

--- a/packages/web/localizations/ja.json
+++ b/packages/web/localizations/ja.json
@@ -864,7 +864,6 @@
     "marketCap": "時価総額",
     "circulatingSupply": "循環供給",
     "tvl": "TVL",
-    "noData": "ND",
     "buyToken": "{coinDenom}を購入する",
     "staking": "ステーキング",
     "liquidityInOSMOPools": "{number} {denom}プールの流動性"

--- a/packages/web/localizations/ko.json
+++ b/packages/web/localizations/ko.json
@@ -864,7 +864,6 @@
     "marketCap": "시가총액",
     "circulatingSupply": "순환 공급",
     "tvl": "TVL",
-    "noData": "ND",
     "buyToken": "{coinDenom} 구매",
     "staking": "스테이킹",
     "liquidityInOSMOPools": "{number} {denom} 풀의 유동성"

--- a/packages/web/localizations/pl.json
+++ b/packages/web/localizations/pl.json
@@ -864,7 +864,6 @@
     "marketCap": "Kapitalizacja rynkowa",
     "circulatingSupply": "Krążące zaopatrzenie",
     "tvl": "TVL",
-    "noData": "ND",
     "buyToken": "Kup {coinDenom}",
     "staking": "Stawianie",
     "liquidityInOSMOPools": "Płynność w pulach {number} {denom}"

--- a/packages/web/localizations/pt-br.json
+++ b/packages/web/localizations/pt-br.json
@@ -864,7 +864,6 @@
     "marketCap": "Valor de mercado",
     "circulatingSupply": "Fornecimento Circulante",
     "tvl": "TVL",
-    "noData": "DE",
     "buyToken": "Compre {coinDenom}",
     "staking": "Estacamento",
     "liquidityInOSMOPools": "Liquidez em pools {number} {denom}"

--- a/packages/web/localizations/ro.json
+++ b/packages/web/localizations/ro.json
@@ -864,7 +864,6 @@
     "marketCap": "Capitalizarea pieței",
     "circulatingSupply": "Aprovizionare în circulație",
     "tvl": "TVL",
-    "noData": "ND",
     "buyToken": "Cumpărați {coinDenom}",
     "staking": "Miza",
     "liquidityInOSMOPools": "Lichiditate în pool {number} {denom}"

--- a/packages/web/localizations/ru.json
+++ b/packages/web/localizations/ru.json
@@ -864,7 +864,6 @@
     "marketCap": "Рыночная капитализация",
     "circulatingSupply": "Оборотное снабжение",
     "tvl": "ТВЛ",
-    "noData": "без даты",
     "buyToken": "Купить {coinDenom}",
     "staking": "Стейкинг",
     "liquidityInOSMOPools": "Ликвидность в пулах {number} {denom}"

--- a/packages/web/localizations/tr.json
+++ b/packages/web/localizations/tr.json
@@ -864,7 +864,6 @@
     "marketCap": "Piyasa değeri",
     "circulatingSupply": "Dolaşımdaki Tedarik",
     "tvl": "TVL",
-    "noData": "ND",
     "buyToken": "{coinDenom} satın alın",
     "staking": "Staking",
     "liquidityInOSMOPools": "{number} {denom} havuzlarındaki likidite"

--- a/packages/web/localizations/zh-cn.json
+++ b/packages/web/localizations/zh-cn.json
@@ -864,7 +864,6 @@
     "marketCap": "市值",
     "circulatingSupply": "循环供应",
     "tvl": "TVL",
-    "noData": "ND",
     "buyToken": "购买{coinDenom}",
     "staking": "质押",
     "liquidityInOSMOPools": "{number} {denom}池中的流动性"

--- a/packages/web/localizations/zh-hk.json
+++ b/packages/web/localizations/zh-hk.json
@@ -864,7 +864,6 @@
     "marketCap": "市值",
     "circulatingSupply": "循環供應",
     "tvl": "TVL",
-    "noData": "ND",
     "buyToken": "購買{coinDenom}",
     "staking": "質押",
     "liquidityInOSMOPools": "{number} {denom}池中的流動性"

--- a/packages/web/localizations/zh-tw.json
+++ b/packages/web/localizations/zh-tw.json
@@ -864,7 +864,6 @@
     "marketCap": "市值",
     "circulatingSupply": "循環供應",
     "tvl": "TVL",
-    "noData": "ND",
     "buyToken": "購買{coinDenom}",
     "staking": "質押",
     "liquidityInOSMOPools": "{number} {denom}池中的流動性"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant Linear task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change:

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

### Linear Task

[Linear Task URL](PASTE_LINEAR_TASK_URL_HERE)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated the display text for "noData" from "N.D." to "-" in English localization settings.
	- Updated various localization files to remove the "noData" key or translation, impacting the display of "no data" messages in multiple languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->