### PR TITLE
Improve legacy deposit/withdraw

### DIFF
--- a/packages/web/modals/token-select.tsx
+++ b/packages/web/modals/token-select.tsx
@@ -47,7 +47,7 @@ export const TokenSelectModal: FunctionComponent<
           size="large"
         />
       </div>
-      <ul className="flex max-h-64 flex-col overflow-y-auto">
+      <ul className="flex max-h-96 flex-col overflow-y-auto md:max-h-64">
         {props.tokens.map((t) => {
           const currency =
             t.token instanceof CoinPretty ? t.token.currency : t.token;

--- a/packages/web/modals/token-select.tsx
+++ b/packages/web/modals/token-select.tsx
@@ -47,7 +47,7 @@ export const TokenSelectModal: FunctionComponent<
           size="large"
         />
       </div>
-      <ul className="flex max-h-96 flex-col overflow-y-auto md:max-h-64">
+      <ul className="flex max-h-128 flex-col overflow-y-auto md:max-h-64">
         {props.tokens.map((t) => {
           const currency =
             t.token instanceof CoinPretty ? t.token.currency : t.token;

--- a/packages/web/modals/token-select.tsx
+++ b/packages/web/modals/token-select.tsx
@@ -47,7 +47,7 @@ export const TokenSelectModal: FunctionComponent<
           size="large"
         />
       </div>
-      <ul className="flex max-h-128 flex-col overflow-y-auto md:max-h-64">
+      <ul className="max-h-128 flex flex-col overflow-y-auto md:max-h-64">
         {props.tokens.map((t) => {
           const currency =
             t.token instanceof CoinPretty ? t.token.currency : t.token;

--- a/packages/web/modals/transfer-asset-select.tsx
+++ b/packages/web/modals/transfer-asset-select.tsx
@@ -4,7 +4,6 @@ import { observer } from "mobx-react-lite";
 import Image from "next/image";
 import { FunctionComponent, useEffect, useMemo, useState } from "react";
 
-import { Icon } from "~/components/assets";
 import { TokenSelect } from "~/components/control";
 import { CustomClasses } from "~/components/types";
 import { useTranslation } from "~/hooks";
@@ -135,20 +134,7 @@ export const TransferAssetSelectModal: FunctionComponent<
               <span className="subtitle2 text-white-mid">
                 {t("assets.transferAssetSelect.network")}
               </span>
-              <div
-                className={classNames("flex items-center gap-2", {
-                  "cursor-pointer":
-                    selectedToken?.originBridgeInfo &&
-                    selectedToken.originBridgeInfo.sourceChainTokens.length > 1,
-                })}
-                onClick={() => {
-                  if (
-                    selectedToken?.originBridgeInfo &&
-                    selectedToken.originBridgeInfo.sourceChainTokens.length > 1
-                  )
-                    setSourceChainDropdownOpen(!isSourceChainDropdownOpen);
-                }}
-              >
+              <div className="flex items-center gap-2">
                 <Network {...selectedNetwork} />
                 {selectedToken?.originBridgeInfo &&
                   selectedToken.originBridgeInfo.sourceChainTokens.length >
@@ -157,14 +143,7 @@ export const TransferAssetSelectModal: FunctionComponent<
                       className={classNames("flex items-center transition", {
                         "rotate-180": isSourceChainDropdownOpen,
                       })}
-                    >
-                      <Icon
-                        id="chevron-down"
-                        height={22}
-                        width={12}
-                        className="text-osmoverse-400"
-                      />
-                    </div>
+                    ></div>
                   )}
               </div>
               {isSourceChainDropdownOpen && (

--- a/packages/web/modals/transfer-asset-select.tsx
+++ b/packages/web/modals/transfer-asset-select.tsx
@@ -117,6 +117,7 @@ export const TransferAssetSelectModal: FunctionComponent<
               setSelectedTokenDenom(denom);
             }}
             selectedTokenDenom={selectedTokenDenom}
+            sortByBalances={isWithdraw}
           />
         </div>
         {selectedToken?.originBridgeInfo &&


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant Linear task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change:

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

Quick improvements to current deposit/withdraw flows until they get rebuilt in deposit/withdraw redesign project.

<img width="692" alt="Screenshot 2024-04-23 at 10 04 29 AM" src="https://github.com/osmosis-labs/osmosis-frontend/assets/4606373/0f42cd57-b42f-4dd2-a91c-2b7afc02685e">


### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-239/improve-legacy-depositwithdraw)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

* Remove option to select network (for assets like USDC.axl)
* Increase height of token select modal
* Sort by balances descending in token select if withdrawing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced the `TokenSelectModal` to support larger display areas on bigger screens.

- **Improvements**
	- Adjusted network information display within the `TransferAssetSelectModal` for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->