### PR TITLE
Fix: only show verified assets in image samples

### DIFF
--- a/packages/web/components/table/asset-info.tsx
+++ b/packages/web/components/table/asset-info.tsx
@@ -167,7 +167,9 @@ export const AssetsInfoTable: FunctionComponent<{
   }, [selectedCategory, assetPagesData]);
   const clientCategoryImageSamples = useMemo(() => {
     if (selectedCategory === "topGainers") {
-      const topGainers = assetsData.slice(undefined, 3);
+      const topGainers = assetsData
+        .filter((asset) => asset.isVerified)
+        .slice(undefined, 3);
       return {
         topGainers: topGainers
           .map((asset) => asset.coinImageUrl)


### PR DESCRIPTION
Small fix to sample images in top gainers category selector

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the selection logic for top gainers in the Assets Info Table to only include verified assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->