### PR TITLE
SQS routes: add check for additional error message

### DIFF
--- a/packages/server/src/queries/sidecar/router.ts
+++ b/packages/server/src/queries/sidecar/router.ts
@@ -70,7 +70,10 @@ export class OsmosisSidecarRemoteRouter implements TokenOutGivenInRouter {
 
       const errorMessage = error.data?.message;
 
-      if (errorMessage?.includes("no routes were provided")) {
+      if (
+        errorMessage?.includes("no routes were provided") ||
+        errorMessage?.includes("no candidate routes found")
+      ) {
         throw new NoRouteError();
       }
 


### PR DESCRIPTION
https://linear.app/osmosis/issue/STABI-129/fe-client-for-sqs-routes-handle-no-candidate-routes-found-as