### PR TITLE
Fix outdated link for App listing application form 

### DIFF
--- a/packages/web/pages/apps.tsx
+++ b/packages/web/pages/apps.tsx
@@ -158,7 +158,7 @@ export const AppStore: React.FC<AppStoreProps> = ({ apps }) => {
         <div className="flex w-48 items-center justify-center pl-6">
           <Button variant="outline" asChild>
             <a
-              href="https://tally.so/r/wge9xO"
+              href="https://github.com/osmosis-labs/fe-content/tree/main/cms/apps"
               target="_blank"
               rel="noreferrer noopener"
               onClick={handleApplyClick}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant Linear task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change:

We have an outdated form for app listing on the apps page. Changes this to the correct link we currently use
## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->
