### PR TITLE
feat: Take Into Account Spread Factor for Token Out Value

### DIFF
--- a/packages/web/components/swap-tool/index.tsx
+++ b/packages/web/components/swap-tool/index.tsx
@@ -103,8 +103,10 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
 
       // Compute out amount less slippage
       const outAmountLessSlippage =
-        swapState.quote && swapState.toAsset
-          ? new IntPretty(swapState.quote.amount.toDec().mul(oneMinusSlippage))
+        swapState.tokenOutAmountMinusSwapFee && swapState.toAsset
+          ? new IntPretty(
+              swapState.tokenOutAmountMinusSwapFee.toDec().mul(oneMinusSlippage)
+            )
           : undefined;
 
       // Compute out fiat amount less slippage
@@ -117,9 +119,9 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
 
       return { outAmountLessSlippage, outFiatAmountLessSlippage };
     }, [
-      swapState.quote,
-      swapState.toAsset,
       slippageConfig.slippage,
+      swapState.tokenOutAmountMinusSwapFee,
+      swapState.toAsset,
       swapState.tokenOutFiatValue,
     ]);
 
@@ -641,7 +643,9 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
                   <h5
                     className={classNames(
                       "md:subtitle1 whitespace-nowrap text-right transition-opacity",
-                      swapState.quote?.amount.toDec().isPositive() &&
+                      swapState.tokenOutAmountMinusSwapFee
+                        ?.toDec()
+                        .isPositive() &&
                         !swapState.inAmountInput.isTyping &&
                         !swapState.isQuoteLoading
                         ? "text-white-full"
@@ -655,8 +659,8 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
                     )}
                   >
                     {`≈ ${formatPretty(
-                      swapState.quote?.amount
-                        ? swapState.quote.amount.toDec()
+                      swapState.tokenOutAmountMinusSwapFee
+                        ? swapState.tokenOutAmountMinusSwapFee.toDec()
                         : new Dec(0),
                       {
                         maxDecimals: 8,
@@ -860,8 +864,8 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
                   >
                     <span className="caption whitespace-nowrap text-osmoverse-200">
                       {`≈ ${
-                        swapState.quote?.amount
-                          ? formatPretty(swapState.quote.amount, {
+                        swapState.tokenOutAmountMinusSwapFee
+                          ? formatPretty(swapState.tokenOutAmountMinusSwapFee, {
                               maxDecimals: 8,
                             })
                           : ""

--- a/packages/web/hooks/__tests__/use-swap.spec.ts
+++ b/packages/web/hooks/__tests__/use-swap.spec.ts
@@ -1,6 +1,10 @@
+import { CoinPretty, Dec, DecUtils, Int } from "@keplr-wallet/unit";
+import { Currency } from "@osmosis-labs/types";
+
 import {
   determineNextFallbackFromDenom,
   determineNextFallbackToDenom,
+  getTokenOutMinusSwapFee,
 } from "../use-swap";
 
 describe("determineNextFromDenom", () => {
@@ -104,5 +108,153 @@ describe("determineNextToDenom", () => {
         DefaultDenoms,
       })
     ).toBe("ATOM");
+  });
+});
+
+describe("getTokenOutMinusSwapFee", () => {
+  const osmoMockCurrency: Currency = {
+    coinDenom: "OSMO",
+    coinMinimalDenom: "uosmo",
+    coinDecimals: 6,
+  };
+  const atomMockCurrency: Currency = {
+    coinDenom: "ATOM",
+    coinMinimalDenom: "uatom",
+    coinDecimals: 6,
+  };
+  const randomDecimalsMockCurrency: Currency = {
+    coinDenom: "RANDOM",
+    coinMinimalDenom: "urandom",
+    coinDecimals: 12,
+  };
+
+  it("returns undefined if any input is undefined", () => {
+    const tokenOut = new CoinPretty(osmoMockCurrency, new Dec(100));
+    const tokenInFeeAmount = new Int(10);
+    expect(
+      getTokenOutMinusSwapFee({
+        tokenOut,
+        tokenInFeeAmount,
+        quoteBaseOutSpotPrice: undefined,
+      })
+    ).toBeUndefined();
+    expect(
+      getTokenOutMinusSwapFee({
+        tokenOut: undefined,
+        tokenInFeeAmount,
+        quoteBaseOutSpotPrice: undefined,
+      })
+    ).toBeUndefined();
+    expect(
+      getTokenOutMinusSwapFee({
+        tokenOut,
+        tokenInFeeAmount: undefined,
+        quoteBaseOutSpotPrice: undefined,
+      })
+    ).toBeUndefined();
+  });
+
+  it("calculates the token out amount minus the swap fee correctly", () => {
+    // We get 87930.043 OSMO
+    const tokenOut = new CoinPretty(
+      osmoMockCurrency,
+      new Dec(87930.043).mul(
+        DecUtils.getTenExponentN(osmoMockCurrency.coinDecimals)
+      )
+    );
+
+    // 23 ATOM fee = 202.288404 OSMO
+    const tokenInFeeAmount = new Dec(23)
+      .mul(DecUtils.getTenExponentN(atomMockCurrency.coinDecimals))
+      .truncate();
+
+    // 1 ATOM = 8.795148 OSMO
+    const quoteBaseOutSpotPrice = new CoinPretty(
+      osmoMockCurrency,
+      new Dec(8.795148).mul(
+        DecUtils.getTenExponentN(osmoMockCurrency.coinDecimals)
+      )
+    );
+
+    const result = getTokenOutMinusSwapFee({
+      tokenOut,
+      tokenInFeeAmount,
+      quoteBaseOutSpotPrice,
+    });
+
+    /**
+     *  Using the formula
+     *  Token Out Minus Swap Fee = Token Out − (Token In Fee Amount × Quote Base Out Spot Price)
+     *
+     * Token In = 10000 ATOM
+     * Swap Fee = 0.0023 or 0.23%
+     * Token Out = 87930.043 OSMO
+     * Token In Fee Amount = 23 ATOM
+     * Quote Base Out Spot Price = 8.795148 OSMO/ATOM
+     *
+     * Token Out Minus Swap Fee = 87930.043 - (23 * 8.795148)
+     * Token Out Minus Swap Fee = 87930.043 OSMO - 202.288404 OSMO
+     * Token Out Minus Swap Fee = 87727.754596 OSMO
+     */
+    expect(result?.toDec().toString()).toBe("87727.754596000000000000");
+  });
+
+  it("calculates the token out amount minus the swap fee correctly for a currency with different decimals", () => {
+    // Assume we get 500000.123456789012 RANDOM
+    const tokenOut = new CoinPretty(
+      randomDecimalsMockCurrency,
+      new Dec(500000.123456789012).mul(
+        DecUtils.getTenExponentN(randomDecimalsMockCurrency.coinDecimals)
+      )
+    );
+
+    // 15 RANDOM = 11.25 OSMO
+    const tokenInFeeAmount = new Dec(15)
+      .mul(DecUtils.getTenExponentN(randomDecimalsMockCurrency.coinDecimals))
+      .truncate();
+
+    // 1 RANDOM = 0.75 OSMO
+    const quoteBaseOutSpotPrice = new CoinPretty(
+      osmoMockCurrency,
+      new Dec(0.75).mul(DecUtils.getTenExponentN(osmoMockCurrency.coinDecimals))
+    );
+
+    const result = getTokenOutMinusSwapFee({
+      tokenOut,
+      tokenInFeeAmount,
+      quoteBaseOutSpotPrice,
+    });
+
+    /**
+     * Using the formula
+     * Token Out Minus Swap Fee = Token Out − (Token In Fee Amount × Quote Base Out Spot Price)
+     *
+     * Token Out = 500000.123456789012 RANDOM
+     * Token In Fee Amount = 15 RANDOM
+     * Quote Base Out Spot Price = 0.75 OSMO/RANDOM
+     *
+     * Token Out Minus Swap Fee = 500000.123456789012 - (15 * 0.75)
+     * Token Out Minus Swap Fee = 500000.123456789012 - 11.25
+     * Token Out Minus Swap Fee = 499988.873456789012 RANDOM
+     */
+    expect(result?.toDec().toString()).toBe("499988.873456789000000000");
+  });
+
+  it("returns zero if the swap fee is greater than the output token amount", () => {
+    const tokenOut = new CoinPretty(osmoMockCurrency, new Dec(100));
+    const tokenInFeeAmount = new Dec(60)
+      .mul(DecUtils.getTenExponentN(osmoMockCurrency.coinDecimals))
+      .truncate();
+    const quoteBaseOutSpotPrice = new Dec(2);
+
+    const result = getTokenOutMinusSwapFee({
+      tokenOut,
+      tokenInFeeAmount,
+      quoteBaseOutSpotPrice: new CoinPretty(
+        osmoMockCurrency,
+        quoteBaseOutSpotPrice
+      ),
+    });
+    expect(result?.toDec().toString()).toBe("0.000000000000000000"); // 100 - (60 * 2) = -20, but returns 0 since it's negative
   });
 });

--- a/packages/web/hooks/__tests__/use-swap.spec.ts
+++ b/packages/web/hooks/__tests__/use-swap.spec.ts
@@ -266,7 +266,7 @@ describe("getTokenOutMinusSwapFee", () => {
       new Dec(100).mul(DecUtils.getTenExponentN(osmoMockCurrency.coinDecimals))
     );
 
-    // We'll get 75 RANDOM before the fee
+    // We get 75 RANDOM before the fee
     const tokenOut = new CoinPretty(
       randomDecimalsMockCurrency,
       new Dec(75).mul(

--- a/packages/web/hooks/__tests__/use-swap.spec.ts
+++ b/packages/web/hooks/__tests__/use-swap.spec.ts
@@ -128,7 +128,7 @@ describe("getTokenOutMinusSwapFee", () => {
     coinDecimals: 12,
   };
 
-  it("returns undefined when token out is undefined otherwise, return token out without subtracting fee", () => {
+  it("returns undefined when token out is undefined. Otherwise, return token out without subtracting fee", () => {
     const tokenOut = new CoinPretty(osmoMockCurrency, new Dec(100));
     const tokenInFeeAmount = new Int(10);
     expect(
@@ -165,7 +165,7 @@ describe("getTokenOutMinusSwapFee", () => {
       )
     );
 
-    // We get 87,951.48 OSMO
+    // We get 87,951.48 OSMO before the fee
     const tokenOut = new CoinPretty(
       osmoMockCurrency,
       new Dec(87951.48).mul(
@@ -194,8 +194,8 @@ describe("getTokenOutMinusSwapFee", () => {
     });
 
     /**
-     *  Using the formula
-     *  Token Out Minus Swap Fee = Token Out − (Token In Fee Amount × Quote Base Out Spot Price)
+     * Using the formula
+     * Token Out Minus Swap Fee = Token Out − (Token In Fee Amount × Quote Base Out Spot Price)
      *
      * Token In = 10000 ATOM
      * Swap Fee = 0.0023 or 0.23%
@@ -216,7 +216,7 @@ describe("getTokenOutMinusSwapFee", () => {
       new Dec(100).mul(DecUtils.getTenExponentN(osmoMockCurrency.coinDecimals))
     );
 
-    // We'll get 75 RANDOM before the fee
+    // We get 75 RANDOM before the fee
     const tokenOut = new CoinPretty(
       randomDecimalsMockCurrency,
       new Dec(75).mul(

--- a/packages/web/hooks/use-swap.ts
+++ b/packages/web/hooks/use-swap.ts
@@ -413,10 +413,12 @@ export function useSwap(
 const DefaultDenoms = ["ATOM", "OSMO"];
 
 // getTokenOutAmountMinusSwapFee calculates the token out amount after subtracting the swap fee.
-// If any of the input values are undefined, it returns undefined.
+// If the token out is undefined, it returns undefined.
+// If any of the input values are undefined, it return the token out.
 // This function is used to determine the net amount of tokens received after accounting for the swap fee.
 //
 // - outToken: the token being output from the swap
+// - tokenInAsset: the input token asset
 // - tokenInFeeAmount: the fee amount in the input token
 // - quoteBaseOutSpotPrice: the spot price of the output token in terms of the base token
 //

--- a/packages/web/hooks/use-swap.ts
+++ b/packages/web/hooks/use-swap.ts
@@ -445,7 +445,9 @@ export function getTokenOutMinusSwapFee({
     return tokenOut;
   }
 
-  // Swap Fee = Token In Fee Amount × Quote Base Out Spot Price
+  /**
+   * Swap Fee calculation = (Token In Fee Amount / Precision Exponent) × Quote Base Out Spot Price × 10^Coin Decimals
+   */
   const outTokenSwapFee = tokenInFeeAmount
     .toDec()
     .quo(precisionExponent)
@@ -454,7 +456,7 @@ export function getTokenOutMinusSwapFee({
 
   /**
    *  Formula
-   *  Token Out Minus Swap Fee = Token Out − (Token In Fee Amount × Quote Base Out Spot Price)
+   *  Token Out Minus Swap Fee = Token Out − Swap Fee
    */
   const outTokenMinusSwapFee = tokenOut.sub(outTokenSwapFee);
 

--- a/packages/web/hooks/use-swap.ts
+++ b/packages/web/hooks/use-swap.ts
@@ -449,7 +449,8 @@ export function getTokenOutMinusSwapFee({
   const outTokenSwapFee = tokenInFeeAmount
     .toDec()
     .quo(precisionExponent)
-    .mul(quoteBaseOutSpotPrice.toDec());
+    .mul(quoteBaseOutSpotPrice.toDec())
+    .mul(DecUtils.getTenExponentN(quoteBaseOutSpotPrice.currency.coinDecimals));
 
   /**
    *  Formula
@@ -459,7 +460,7 @@ export function getTokenOutMinusSwapFee({
 
   // If the swap fee is greater than the output token amount, return 0
   if (outTokenMinusSwapFee.toDec().isNegative()) {
-    return new CoinPretty(tokenOut.currency, new Dec(0));
+    return tokenOut;
   }
 
   return outTokenMinusSwapFee;


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant Linear task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change:

This PR modifies the token out value by subtracting the swap fee, so users can see the true expected outcome of their swap.

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/STABI-113/token-out-fiat-value-does-not-account-for-spread-factor)

## Testing and Verifying

- [ ] Subtracts swap fee from token out and token out fiat value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Updated the `SwapTool` component to enhance the accuracy of displayed values by incorporating swap fees into the calculation of token out amounts.
- **Tests**
	- Added tests for the new `getTokenOutMinusSwapFee` function to ensure reliable calculation of token amounts post-swap fees.
- **Refactor**
	- Refined the logic in the `use-swap` hook to improve the consistency and precision in fee and token value calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->