### PR TITLE
Jon/fe 249 tablet responsiveness

### DIFF
--- a/packages/web/components/complex/portfolio-page.tsx
+++ b/packages/web/components/complex/portfolio-page.tsx
@@ -112,7 +112,7 @@ export const PortfolioPage: FunctionComponent = () => {
             ) : userHasNoAssets ? (
               <UserZeroBalanceTableSplash />
             ) : (
-              <Tab.Panels className="py-3">
+              <Tab.Panels className="py-6">
                 <Tab.Panel>
                   <AssetBalancesTable
                     tableTopPadding={overviewHeight + tabsHeight}
@@ -235,13 +235,17 @@ const UserPositionsSection: FunctionComponent<{ address?: string }> = ({
       <>
         {hasPositions && (
           <section>
-            <h6>{t("portfolio.yourSuperchargedPositions")}</h6>
+            <span className="body2 text-osmoverse-200">
+              {t("portfolio.yourSuperchargedPositions")}
+            </span>
             <MyPositionsSection />
           </section>
         )}
         {hasPools && (
           <section>
-            <h6>{t("portfolio.yourLiquidityPools")}</h6>
+            <span className="body2 text-osmoverse-200">
+              {t("portfolio.yourLiquidityPools")}
+            </span>
             <MyPoolsCardsGrid />
           </section>
         )}

--- a/packages/web/components/table/asset-balances.tsx
+++ b/packages/web/components/table/asset-balances.tsx
@@ -313,7 +313,7 @@ export const AssetBalancesTable: FunctionComponent<{
                 <th
                   className={classNames({
                     // defines column width
-                    "w-56 lg:w-36": index !== 0 && index !== headers.length - 1,
+                    "w-56 xl:w-36": index !== 0 && index !== headers.length - 1,
                     "w-36": index === headers.length - 1,
                   })}
                   key={header.id}

--- a/packages/web/components/table/asset-balances.tsx
+++ b/packages/web/components/table/asset-balances.tsx
@@ -293,7 +293,7 @@ export const AssetBalancesTable: FunctionComponent<{
         }}
       />
       <SearchBox
-        className="my-4 !w-[33.25rem]"
+        className="my-4 !w-[33.25rem] xl:!w-96"
         currentValue={searchQuery?.query ?? ""}
         onInput={onSearchInput}
         placeholder={t("assets.table.search")}
@@ -496,7 +496,7 @@ export const AssetActionsCell: AssetCellComponent<{
         Boolean(counterparty.length) &&
         Boolean(transferMethods.length) && (
           <button
-            className="h-11 w-11 rounded-full bg-osmoverse-825 p-1"
+            className="h-11 w-11 rounded-full bg-osmoverse-825 p-1 transition-[color] duration-150 ease-out hover:bg-osmoverse-800 hover:text-white-full"
             onClick={(e) => {
               e.preventDefault();
 
@@ -507,7 +507,7 @@ export const AssetActionsCell: AssetCellComponent<{
               }
             }}
           >
-            <Icon className="m-auto" id="deposit" width={16} height={16} />
+            <Icon className="m-auto " id="deposit" width={16} height={16} />
           </button>
         )}
       {!needsActivation &&
@@ -515,7 +515,7 @@ export const AssetActionsCell: AssetCellComponent<{
         Boolean(counterparty.length) &&
         Boolean(transferMethods.length) && (
           <button
-            className="h-11 w-11 rounded-full bg-osmoverse-825 p-1"
+            className="h-11 w-11 rounded-full bg-osmoverse-825 p-1 transition-[color] duration-150 ease-out hover:bg-osmoverse-800 hover:text-white-full"
             onClick={(e) => {
               e.preventDefault();
 

--- a/packages/web/components/table/asset-info.tsx
+++ b/packages/web/components/table/asset-info.tsx
@@ -367,7 +367,7 @@ export const AssetsInfoTable: FunctionComponent<{
         />
       </section>
       <SearchBox
-        className="mb-4 !w-[33.25rem]"
+        className="my-4 !w-[33.25rem] xl:!w-96"
         currentValue={searchQuery?.query ?? ""}
         onInput={onSearchInput}
         placeholder={t("assets.table.search")}

--- a/packages/web/components/table/asset-info.tsx
+++ b/packages/web/components/table/asset-info.tsx
@@ -388,7 +388,7 @@ export const AssetsInfoTable: FunctionComponent<{
                 <th
                   className={classNames({
                     // defines column width
-                    "w-36": index !== 0,
+                    "w-36 xl:w-25": index !== 0,
                   })}
                   key={header.id}
                   colSpan={header.colSpan}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant Linear task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change:

Some progress on responsive design:
<img width="874" alt="Screenshot 2024-04-25 at 11 02 52 AM" src="https://github.com/osmosis-labs/osmosis-frontend/assets/4606373/7aae7ccf-d1f9-474f-a1b3-7a34c320dea5">

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-249/tablet-responsiveness)
[Linear Task URL](https://linear.app/osmosis/issue/FE-271/portfolio-headings-in-your-positions-tab-are-too-large)