### PR TITLE
fix: Re-Enable Token Select in Token Info

### DIFF
--- a/packages/web/pages/assets/[denom].tsx
+++ b/packages/web/pages/assets/[denom].tsx
@@ -239,7 +239,7 @@ const AssetInfoView: FunctionComponent<AssetInfoPageProps> = observer(
                 <SwapTool
                   fixedWidth
                   useQueryParams={false}
-                  useOtherCurrencies={false}
+                  useOtherCurrencies={true}
                   initialSendTokenDenom={denom === "USDC" ? "OSMO" : "USDC"}
                   initialOutTokenDenom={denom}
                   page="Token Info Page"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enabled support for multiple currencies in the `SwapTool` on the asset information page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->