### PR TITLE
Stepper: respect order of children

### DIFF
--- a/packages/web/components/cards/stake-learn-more.tsx
+++ b/packages/web/components/cards/stake-learn-more.tsx
@@ -97,7 +97,6 @@ export const StakeLearnMore: React.FC<StakeLearnMoreProps> = ({
       className="relative flex flex-1 flex-col text-center text-osmoverse-100"
       autoplay={{ stopOnHover: true, delayInMs: 4000, stopOnLastSlide: true }}
     >
-      <StepsIndicator className="order-1 mt-8" />
       {steps.map(({ title, bodyText, image }, index) => {
         const isFirstStep = index === 0;
         const isLastStep = index === steps.length - 1;
@@ -122,6 +121,7 @@ export const StakeLearnMore: React.FC<StakeLearnMoreProps> = ({
           </Step>
         );
       })}
+      <StepsIndicator className="mt-8" />
     </Stepper>
   );
 

--- a/packages/web/components/stepper/index.tsx
+++ b/packages/web/components/stepper/index.tsx
@@ -199,7 +199,7 @@ export const StepperLeftChevronNavigation: FunctionComponent<{
  * It includes an autoplay feature, which allows automatic progression to the
  * next step after a specified delay, providing a smooth, hands-free navigation experience.
  *
- * The Stepper is a headless component and requires multiple children to work:
+ * The Stepper is a headless component and requires multiple direct children to work:
  *  - the `Step` serves to identify and render individual steps within the Stepper.
  *    Each instance of Step corresponds to one stage in the sequential navigation.
  *  - the `StepsIndicator` is responsible for generating a series of navigation buttons.
@@ -221,8 +221,6 @@ export const StepperLeftChevronNavigation: FunctionComponent<{
 const Stepper: FunctionComponent<StepsProps> = (props) => {
   const { children, autoplay } = props;
 
-  const timerTimeInMs = useRef(0);
-
   const stepElements = Children.toArray(children).filter((child) => {
     if (!child) return false;
     return (child as ReactElement)?.props?.__TYPE === "Step";
@@ -236,6 +234,7 @@ const Stepper: FunctionComponent<StepsProps> = (props) => {
     [autoplay?.isStopped, autoplay?.stopOnHover, isHovering]
   );
 
+  const timerTimeInMs = useRef(0);
   useEffect(() => {
     if (autoplay && Boolean(autoplay?.delayInMs)) {
       const IntervalTimeIncrements = 1000;
@@ -294,6 +293,21 @@ const Stepper: FunctionComponent<StepsProps> = (props) => {
     [autoplay, isStopped, stepsContext]
   );
 
+  // Since child indices includes non-Step children, convert
+  // child index to only the index relative to other Steps.
+  // This allows us to headlessly support the given order of children relative
+  // to the active Step (with inactive steps hidden by CSS).
+  const stepIndices = useMemo(
+    () =>
+      Children.toArray(children).reduce((map, child, index) => {
+        if ((child as ReactElement)?.props?.__TYPE === "Step") {
+          map.set(index, map.size);
+        }
+        return map;
+      }, new Map<number, number>()),
+    [children]
+  );
+
   return (
     <StepperContextProvider value={context}>
       <div
@@ -305,7 +319,9 @@ const Stepper: FunctionComponent<StepsProps> = (props) => {
           <StepContextProvider
             key={index}
             value={{
-              index,
+              // only relevant indices of Steps will match the values returned
+              // from the context
+              index: stepIndices.get(index) ?? -1,
             }}
           >
             {child}

--- a/packages/web/components/stepper/index.tsx
+++ b/packages/web/components/stepper/index.tsx
@@ -299,12 +299,15 @@ const Stepper: FunctionComponent<StepsProps> = (props) => {
   // to the active Step (with inactive steps hidden by CSS).
   const stepIndices = useMemo(
     () =>
-      Children.toArray(children).reduce((map, child, index) => {
-        if ((child as ReactElement)?.props?.__TYPE === "Step") {
-          map.set(index, map.size);
-        }
-        return map;
-      }, new Map<number, number>()),
+      Children.toArray(children).reduce(
+        (map: Map<number, number>, child, index) => {
+          if ((child as ReactElement)?.props?.__TYPE === "Step") {
+            return map.set(index, map.size);
+          }
+          return map;
+        },
+        new Map<number, number>()
+      ),
     [children]
   );
 

--- a/packages/web/modals/wallet-select.tsx
+++ b/packages/web/modals/wallet-select.tsx
@@ -632,7 +632,6 @@ const RightModalContent: FunctionComponent<
           className="relative flex flex-col gap-2"
           autoplay={{ stopOnHover: true, delayInMs: 4000 }}
         >
-          <StepsIndicator className="order-1 mt-16" />
           <StepperLeftChevronNavigation className="absolute left-0 top-1/2 z-50 -translate-y-1/2 transform" />
           {OnboardingSteps(t).map(({ title, content }) => (
             <Step key={title}>
@@ -654,6 +653,7 @@ const RightModalContent: FunctionComponent<
             </Step>
           ))}
           <StepperRightChevronNavigation className="absolute right-0 top-1/2 z-50 -translate-y-1/2 transform" />
+          <StepsIndicator className="mt-16" />
         </Stepper>
       </div>
     );


### PR DESCRIPTION
Fixes stepper, to respect given children of headless component, removing the need for CSS hacks to dictate the order of the components in a stepper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved the placement and rendering logic of the `<StepsIndicator>` component in the `StakeLearnMore` and `WalletSelect` modules.
	- Enhanced the `Stepper` component to more accurately manage child indices, ensuring steps are handled and displayed in the correct order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->