### PR TITLE
Jon/fe 284 search shouldnt be disabled when category filter selected

### DIFF
--- a/packages/web/components/assets/categories.tsx
+++ b/packages/web/components/assets/categories.tsx
@@ -254,7 +254,7 @@ const CategoriesDropdown: FunctionComponent<{
                 "transition-transform duration-150 ease-out",
                 open && "rotate-180"
               )}
-              id="chevron-up"
+              id="chevron-down"
               width={16}
               height={16}
             />

--- a/packages/web/components/table/asset-info.tsx
+++ b/packages/web/components/table/asset-info.tsx
@@ -96,10 +96,6 @@ export const AssetsInfoTable: FunctionComponent<{
   const onSearchInput = useCallback((input: string) => {
     setSearchQuery(input ? { query: input } : undefined);
   }, []);
-  const search = useMemo(
-    () => (Boolean(selectedCategory) ? undefined : searchQuery),
-    [selectedCategory, searchQuery]
-  );
 
   // sorting
   const [sortKey_, setSortKey_] = useState<SortKey>("volume24h");
@@ -132,13 +128,13 @@ export const AssetsInfoTable: FunctionComponent<{
   const sort = useMemo(
     () =>
       // disable sorting while searching on client to remove sort UI while searching
-      !Boolean(search)
+      !Boolean(searchQuery)
         ? {
             keyPath: sortKey,
             direction: sortDirection,
           }
         : undefined,
-    [search, sortKey, sortDirection]
+    [searchQuery, sortKey, sortDirection]
   );
 
   // unverified assets
@@ -166,8 +162,8 @@ export const AssetsInfoTable: FunctionComponent<{
   } = api.edge.assets.getMarketAssets.useInfiniteQuery(
     {
       limit: 50,
-      search,
-      onlyVerified: showUnverifiedAssets === false && !search,
+      search: searchQuery,
+      onlyVerified: showUnverifiedAssets === false && !searchQuery,
       includePreview,
       sort,
       categories,

--- a/packages/web/components/table/asset-info.tsx
+++ b/packages/web/components/table/asset-info.tsx
@@ -409,7 +409,6 @@ export const AssetsInfoTable: FunctionComponent<{
         onInput={onSearchInput}
         placeholder={t("assets.table.search")}
         debounce={500}
-        disabled={Boolean(selectedCategory)}
       />
       <BalancesMoved className="my-3" />
       <table


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant Linear task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change:

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

See issue

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-284/search-shouldnt-be-disabled-when-category-filter-selected)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->
