### PR TITLE
Use sqs for pools on testnet

### DIFF
--- a/packages/server/src/queries/complex/pools/index.ts
+++ b/packages/server/src/queries/complex/pools/index.ts
@@ -6,6 +6,7 @@ import { IS_TESTNET } from "../../../env";
 import { search, SearchSchema } from "../../../utils/search";
 import { PoolRawResponse } from "../../osmosis";
 import { getPoolsFromIndexer } from "./providers/indexer";
+import { getPoolsFromSidecar } from "./providers";
 
 const allPooltypes = [
   "concentrated",
@@ -73,7 +74,9 @@ export async function getPool({
  *  Params can be used to filter the results by a fuzzy search on the id, type, or coin denoms, as well as a specific id or type. */
 export async function getPools(
   params: Partial<PoolFilter> & { assetLists: AssetList[]; chainList: Chain[] },
-  poolProvider: PoolProvider = getPoolsFromIndexer
+  poolProvider: PoolProvider = IS_TESTNET
+    ? getPoolsFromSidecar
+    : getPoolsFromIndexer
 ): Promise<Pool[]> {
   let pools = await poolProvider({ ...params, poolIds: params?.poolIds });
 


### PR DESCRIPTION
Use SQS as the provider of pools on testnet, as it's more immediately available compared to pools from indexer as we don't have an indexer for testnet yet.