### PR TITLE
Add builjet and parallelize docker builds

### DIFF
--- a/.github/workflows/push-docker-images.yaml
+++ b/.github/workflows/push-docker-images.yaml
@@ -23,8 +23,8 @@ env:
   TESTNET_DOCKER_REPOSITORY: osmolabs/osmosis-frontend-testnet
 
 jobs:
-  docker:
-    runs-on: ubuntu-latest
+  push-docker-image:
+    runs-on: buildjet-2vcpu-ubuntu-2204
     steps:
       -
         name: Check out repository
@@ -60,6 +60,32 @@ jobs:
             ${{ env.FRONTEND_DOCKER_REPOSITORY }}:${{ github.ref_name }}-${{ env.SHA }}
             ${{ env.FRONTEND_DOCKER_REPOSITORY }}:${{ github.ref_name }}-${{ env.SHA }}-${{ env.DATE }}
             ${{ env.FRONTEND_DOCKER_REPOSITORY }}:latest
+
+  push-docker-image-testnet:
+    runs-on: buildjet-2vcpu-ubuntu-2204
+    steps:
+      -
+        name: Check out repository
+        uses: actions/checkout@v4
+      -
+        name: Get Short SHA
+        uses: benjlevesque/short-sha@v2.1
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Get current date
+        run: |
+          echo "DATE=$(date +%s)" >> $GITHUB_ENV
       -
         name: Build and push (testnet)
         uses: docker/build-push-action@v5


### PR DESCRIPTION
## What is the purpose of the change:

This PR parallilize the docker build for mainnet and testnet. It also adds support for Buildkite for faster builds.

## Testing and Verifying

Improvements should be seen on the next merge to stage or master.
