### PR TITLE
Add transactions link to portoflio page

### DIFF
--- a/packages/web/components/cards/validator-squad-card.tsx
+++ b/packages/web/components/cards/validator-squad-card.tsx
@@ -100,7 +100,7 @@ export const ValidatorSquadCard: React.FC<{
                 <Tooltip
                   content={
                     <div className="flex flex-col gap-1 p-1">
-                      <span className="text-osmoverse-white-100">
+                      <span className="text-osmoverse-100">
                         {validatorName}
                       </span>
                       <span className="text-xs text-osmoverse-200">

--- a/packages/web/components/complex/assets-page-v1.tsx
+++ b/packages/web/components/complex/assets-page-v1.tsx
@@ -1,13 +1,15 @@
 import { PricePretty, RatePretty } from "@keplr-wallet/unit";
 import { ObservableQueryPool } from "@osmosis-labs/stores";
 import { observer } from "mobx-react-lite";
+import Link from "next/link";
 import { FunctionComponent, useCallback, useEffect, useState } from "react";
 
+import { Icon } from "~/components/assets";
 import { PoolCard } from "~/components/cards/";
 import { MetricLoader } from "~/components/loaders";
 import { AssetsTableV1 } from "~/components/table/assets-table-v1";
 import type { Metric } from "~/components/types";
-import { ShowMoreButton } from "~/components/ui/button";
+import { Button, ShowMoreButton } from "~/components/ui/button";
 import { DesktopOnlyPrivateText } from "~/components/your-balance/privacy";
 import { useTranslation } from "~/hooks";
 import {
@@ -22,6 +24,23 @@ import { useStore } from "~/stores";
 import { formatPretty } from "~/utils/formatter";
 
 const INIT_POOL_CARD_COUNT = 6;
+
+const TransactionsLink = () => {
+  const { t } = useTranslation();
+  return (
+    <div className="flex h-12 items-center justify-between rounded-3xl bg-osmoverse-850 px-4">
+      <div className="flex items-center gap-3 p-3">
+        <Icon id="history" />
+        <div className="subtitle1 text-osmoverse-100">
+          {t("transactions.title")}
+        </div>
+      </div>
+      <Button variant="ghost" asChild className="text-wosmongton-200" size="md">
+        <Link href="/transactions">View All</Link>
+      </Button>
+    </div>
+  );
+};
 
 export const AssetsPageV1: FunctionComponent = observer(() => {
   const { isMobile } = useWindowSize();
@@ -70,9 +89,15 @@ export const AssetsPageV1: FunctionComponent = observer(() => {
     [bridgeAsset]
   );
 
+  const flags = useFeatureFlags();
+
   return (
     <main className="mx-auto flex max-w-container flex-col gap-20 bg-osmoverse-900 p-8 pt-4 md:gap-8 md:p-4">
-      <AssetsOverview />
+      <div className="flex flex-col gap-3">
+        <AssetsOverview />
+        {flags.transactionsPage && <TransactionsLink />}
+      </div>
+
       <AssetsTableV1
         nativeBalances={nativeBalances}
         unverifiedNativeBalances={unverifiedNativeBalances}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant Linear task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change:

- add access to transactions page from portfolio page

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/PROD-88/provide-a-link-to-transactions-page-in-portfolio)

## Brief Changelog

- add transactions link to portfolio page
- wrap behind feature flag
- i18n

## Testing and Verifying

<img width="1499" alt="Screenshot 2024-04-30 at 3 48 15 PM" src="https://github.com/osmosis-labs/osmosis-frontend/assets/30577966/038280ff-0303-4277-bf90-0f0a0f31c578">
<img width="495" alt="Screenshot 2024-04-30 at 3 48 26 PM" src="https://github.com/osmosis-labs/osmosis-frontend/assets/30577966/82dbad8b-8a83-4d98-b2a2-e80cefbf8669">
<img width="1496" alt="Screenshot 2024-04-30 at 3 47 49 PM" src="https://github.com/osmosis-labs/osmosis-frontend/assets/30577966/421e6511-5680-4ec2-b74d-9bcbcfc30761">

