### PR TITLE
Split E2E workflow per stage/master branch

### DIFF
--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -76,3 +76,10 @@ jobs:
         run: |
           cd packages/web
           npx playwright test -g "Test Swap feature"
+      - name: upload test results
+        if: always()
+        id: e2e-test-results
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-test-results
+          path: packages/web/playwright-report

--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -1,11 +1,11 @@
-name: Frontend E2E Workflow
+name: Frontend E2E tests Workflow
 
 on:
   deployment_status:
 
 jobs:
-  fe-e2e-tests:
-    if: github.event_name == 'deployment_status' && github.event.deployment_status.state == 'success' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/stage')
+  master-e2e-tests:
+    if: github.event_name == 'deployment_status' && github.event.deployment_status.state == 'success' && github.ref == 'refs/heads/master'
     runs-on: macos-latest
     environment:
       name: prod_swap_test
@@ -30,15 +30,6 @@ jobs:
         env:
           BASE_URL: "https://app.osmosis.zone"
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
-        if: github.ref == 'refs/heads/master'
-        run: |
-          cd packages/web
-          npx playwright test -g "Test Swap feature"
-      - name: Run Select Swap Pair tests on Stage
-        env:
-          BASE_URL: "https://stage.osmosis.zone"
-          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
-        if: github.ref == 'refs/heads/stage'
         run: |
           cd packages/web
           npx playwright test -g "Test Swap feature"
@@ -55,3 +46,33 @@ jobs:
         with:
           name: e2e-junit-results
           path: packages/web/test-results/test-results.xml
+
+  stage-e2e-tests:
+    if: github.event_name == 'deployment_status' && github.event.deployment_status.state == 'success' && github.ref == 'refs/heads/stage'
+    runs-on: macos-latest
+    environment:
+      name: prod_swap_test
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.OS }}-20.x-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.OS }}-20.x-
+      - name: Install Playwright
+        run: |
+          yarn --cwd packages/web install --frozen-lockfile && npx playwright install --with-deps chromium
+      - name: Run Select Swap Pair tests on Stage
+        env:
+          BASE_URL: "https://stage.osmosis.zone"
+          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+        run: |
+          cd packages/web
+          npx playwright test -g "Test Swap feature"


### PR DESCRIPTION
## What is the purpose of the change:

Need to split e2e tests between stage and master branches. Workflow is initiated upon on successful deployment.
Looks like at that point of time GitHub does not recognize a branch inside the test step.

## Brief Changelog

- Separate job for master e2e tests
- Separate job for stage e2e tests

## Testing and Verifying

...
