### PR TITLE
Asset list type: counterparty optional logoURIs

### DIFF
--- a/packages/types/src/asset-types.ts
+++ b/packages/types/src/asset-types.ts
@@ -90,7 +90,7 @@ export interface CosmosCounterparty {
   sourceDenom: string;
   symbol: string;
   decimals: number;
-  logoURIs: LogoURIs;
+  logoURIs?: LogoURIs;
 }
 
 export interface EVMCounterparty {
@@ -101,7 +101,7 @@ export interface EVMCounterparty {
   address: string;
   symbol: string;
   decimals: number;
-  logoURIs: LogoURIs;
+  logoURIs?: LogoURIs;
 }
 
 export interface NonCosmosCounterparty {
@@ -110,7 +110,7 @@ export interface NonCosmosCounterparty {
   sourceDenom: string;
   decimals: number;
   symbol: string;
-  logoURIs: LogoURIs;
+  logoURIs?: LogoURIs;
 }
 
 export type Counterparty =


### PR DESCRIPTION
Make logoURIs optional in cosmos counterparty.