### PR TITLE
Run E2E tests on Production and Preview deployments

### DIFF
--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -2,6 +2,7 @@ name: Frontend E2E tests Workflow
 
 on:
   deployment_status:
+  workflow_dispatch:
 
 jobs:
   verify-environment:

--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -4,6 +4,17 @@ on:
   deployment_status:
 
 jobs:
+  verify-environment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify App url
+        env:
+          BASE_URL: ${{ github.event.deployment_status.environment_url }}
+          DEPLOYMENT_STATUS: ${{toJson(github.event.deployment_status)}}
+        run: |
+          echo "$BASE_URL"
+          echo "$DEPLOYMENT_STATUS"
+
   master-e2e-tests:
     if: github.event_name == 'deployment_status' && github.event.deployment_status.state == 'success' && github.ref == 'refs/heads/master'
     runs-on: macos-latest

--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -2,24 +2,9 @@ name: Frontend E2E tests Workflow
 
 on:
   deployment_status:
-  workflow_dispatch:
 
 jobs:
-  verify-environment:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Verify App url and environment
-        env:
-          BASE_URL: ${{ github.event.deployment_status.environment_url }}
-          DEPLOYMENT_STATUS_ENVIRONMENT: ${{ github.event.deployment_status.environment }}
-          DEPLOYMENT_STATUS: ${{toJson(github.event.deployment_status)}}
-        run: |
-          echo "$BASE_URL"
-          echo "$DEPLOYMENT_STATUS_ENVIRONMENT"
-          echo "$DEPLOYMENT_STATUS"
-
   master-e2e-tests:
-    needs: verify-environment
     if: github.event_name == 'deployment_status' && github.event.deployment_status.state == 'success' && github.event.deployment_status.environment == 'Production – osmosis-frontend'
     runs-on: macos-latest
     environment:
@@ -62,8 +47,7 @@ jobs:
           name: main-e2e-junit-results
           path: packages/web/test-results/test-results.xml
 
-  stage-e2e-tests:
-    needs: verify-environment
+  preview-e2e-tests:
     if: github.event_name == 'deployment_status' && github.event.deployment_status.state == 'success' && github.event.deployment_status.environment == 'Preview – osmosis-frontend'
     runs-on: macos-latest
     environment:
@@ -87,7 +71,7 @@ jobs:
           yarn --cwd packages/web install --frozen-lockfile && npx playwright install --with-deps chromium
       - name: Run Select Swap Pair tests on Stage
         env:
-          BASE_URL: "https://stage.osmosis.zone"
+          BASE_URL: ${{ github.event.deployment_status.environment_url }}
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
         run: |
           cd packages/web
@@ -97,5 +81,5 @@ jobs:
         id: e2e-test-results
         uses: actions/upload-artifact@v4
         with:
-          name: stage-e2e-test-results
+          name: preview-e2e-test-results
           path: packages/web/playwright-report

--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -19,6 +19,7 @@ jobs:
           echo "$DEPLOYMENT_STATUS"
 
   master-e2e-tests:
+    needs: verify-environment
     if: github.event_name == 'deployment_status' && github.event.deployment_status.state == 'success' && github.event.deployment_status.environment == 'Production – osmosis-frontend'
     runs-on: macos-latest
     environment:
@@ -62,6 +63,7 @@ jobs:
           path: packages/web/test-results/test-results.xml
 
   stage-e2e-tests:
+    needs: verify-environment
     if: github.event_name == 'deployment_status' && github.event.deployment_status.state == 'success' && github.event.deployment_status.environment == 'Preview – osmosis-frontend'
     runs-on: macos-latest
     environment:

--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -53,13 +53,13 @@ jobs:
         id: e2e-test-results
         uses: actions/upload-artifact@v4
         with:
-          name: e2e-test-results
+          name: main-e2e-test-results
           path: packages/web/playwright-report
       - name: upload junit test results
         id: e2e-junit-results
         uses: actions/upload-artifact@v4
         with:
-          name: e2e-junit-results
+          name: main-e2e-junit-results
           path: packages/web/test-results/test-results.xml
 
   stage-e2e-tests:
@@ -97,5 +97,5 @@ jobs:
         id: e2e-test-results
         uses: actions/upload-artifact@v4
         with:
-          name: e2e-test-results
+          name: stage-e2e-test-results
           path: packages/web/playwright-report

--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -8,16 +8,18 @@ jobs:
   verify-environment:
     runs-on: ubuntu-latest
     steps:
-      - name: Verify App url
+      - name: Verify App url and environment
         env:
           BASE_URL: ${{ github.event.deployment_status.environment_url }}
+          DEPLOYMENT_STATUS_ENVIRONMENT: ${{ github.event.deployment_status.environment }}
           DEPLOYMENT_STATUS: ${{toJson(github.event.deployment_status)}}
         run: |
           echo "$BASE_URL"
+          echo "$DEPLOYMENT_STATUS_ENVIRONMENT"
           echo "$DEPLOYMENT_STATUS"
 
   master-e2e-tests:
-    if: github.event_name == 'deployment_status' && github.event.deployment_status.state == 'success' && github.ref == 'refs/heads/master'
+    if: github.event_name == 'deployment_status' && github.event.deployment_status.state == 'success' && github.event.deployment_status.environment == 'Production – osmosis-frontend'
     runs-on: macos-latest
     environment:
       name: prod_swap_test
@@ -60,7 +62,7 @@ jobs:
           path: packages/web/test-results/test-results.xml
 
   stage-e2e-tests:
-    if: github.event_name == 'deployment_status' && github.event.deployment_status.state == 'success' && github.ref == 'refs/heads/stage'
+    if: github.event_name == 'deployment_status' && github.event.deployment_status.state == 'success' && github.event.deployment_status.environment == 'Preview – osmosis-frontend'
     runs-on: macos-latest
     environment:
       name: prod_swap_test


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant Linear task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change:

Test workflow now runs on environments:

- Production – osmosis-frontend
- Preview – osmosis-frontend

### Linear Task

[Linear FE-60](https://linear.app/osmosis/issue/FE-60)

## Brief Changelog

Updated E2E test workflow to start on successful deployments to preview or production.

## Testing and Verifying


This change has been tested on branch but must be merged to see how it performs.

