### PR TITLE
Fix asset list build: get chain name from first counterparty (IBC)

### DIFF
--- a/packages/web/config/generate-lists.ts
+++ b/packages/web/config/generate-lists.ts
@@ -187,11 +187,8 @@ async function generateAssetListFile({
   const osmosisChainId = getOsmosisChainId(environment);
 
   const assetLists = assetList.assets.reduce<AssetList[]>((acc, asset) => {
-    /** If there are no traces, assume it's an Osmosis asset */
-    if (
-      asset.transferMethods.length === 0 ||
-      !asset.transferMethods.some(({ type }) => type === "ibc")
-    ) {
+    /** If it's from the first chain, assume it's an Osmosis asset */
+    if (asset.chainName === chains[0].chain_name) {
       const chain = chains.find((chain) => chain.chain_id === osmosisChainId);
 
       if (!chain) {

--- a/packages/web/config/generate-lists.ts
+++ b/packages/web/config/generate-lists.ts
@@ -11,13 +11,7 @@
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { queryGithubFile, queryLatestCommitHash } from "@osmosis-labs/server";
-import type {
-  Asset,
-  AssetList,
-  Chain,
-  ChainList,
-  IbcTransferMethod,
-} from "@osmosis-labs/types";
+import type { Asset, AssetList, Chain, ChainList } from "@osmosis-labs/types";
 
 import { generateTsFile } from "~/utils/codegen";
 
@@ -199,17 +193,11 @@ async function generateAssetListFile({
     }
 
     /** Otherwise, assume IBC asset 1 hop counterparty. */
-    const cosmosCounterparty = [...asset.transferMethods]
-      .reverse()
-      .find(({ type }) => type === "ibc") as IbcTransferMethod | undefined;
+    const counterpartyChainName = asset.counterparty[0]?.chainName;
 
-    if (!cosmosCounterparty) {
-      throw new Error(
-        "Failed to find cosmos counterparty for IBC asset: " + asset.symbol
-      );
+    if (!counterpartyChainName) {
+      throw new Error("Failed to find counterparty for asset: " + asset.symbol);
     }
-
-    const counterpartyChainName = cosmosCounterparty.counterparty.chainName;
 
     const chain = chains.find(
       (chain) => chain.chain_name === counterpartyChainName

--- a/packages/web/stores/assets/assets-store.ts
+++ b/packages/web/stores/assets/assets-store.ts
@@ -156,7 +156,10 @@ export class ObservableAssets {
     sourceChainNameOverride?: string;
   })[] {
     return this.assets
-      .filter((asset) => asset.transferMethods.length > 0) // Filter osmosis native assets
+      .filter((asset) =>
+        // Filter osmosis native assets
+        asset.transferMethods.some(({ type }) => type === "ibc")
+      )
       .filter((asset) => {
         // Remove preview assets if preview assets is disabled
         if (typeof window === "undefined") return true;
@@ -167,11 +170,12 @@ export class ObservableAssets {
         return !asset.preview;
       })
       .map((ibcAsset) => {
-        const cosmosCounterparty = ibcAsset
-          .counterparty[0] as CosmosCounterparty;
+        const cosmosCounterparty = ibcAsset.counterparty[0] as
+          | CosmosCounterparty
+          | undefined;
         const chainInfo = this.chainStore.getChain(
           // first counterparty should be cosmos counterparty where it is bridged
-          cosmosCounterparty?.chainId ?? ""
+          cosmosCounterparty?.chainId ?? "no-counterparty-found"
         );
 
         const ibcAssetSourceDenom = ibcAsset.sourceDenom;

--- a/packages/web/stores/assets/assets-store.ts
+++ b/packages/web/stores/assets/assets-store.ts
@@ -173,10 +173,12 @@ export class ObservableAssets {
         const cosmosCounterparty = ibcAsset.counterparty[0] as
           | CosmosCounterparty
           | undefined;
-        const chainInfo = this.chainStore.getChain(
-          // first counterparty should be cosmos counterparty where it is bridged
-          cosmosCounterparty?.chainId ?? "no-counterparty-found"
-        );
+
+        if (!cosmosCounterparty)
+          throw new Error("Counterparty chain information not found");
+
+        // first counterparty should be cosmos counterparty where it is bridged
+        const chainInfo = this.chainStore.getChain(cosmosCounterparty.chainId);
 
         const ibcAssetSourceDenom = ibcAsset.sourceDenom;
         const originCurrency = chainInfo.currencies.find((cur) => {


### PR DESCRIPTION
Use `counterparty` instead of `transferMethod` for getting the chain name