### PR TITLE
fix: circulating supply formatting

### DIFF
--- a/packages/web/components/token-details/token-details.tsx
+++ b/packages/web/components/token-details/token-details.tsx
@@ -313,6 +313,7 @@ const TokenStats: FunctionComponent<TokenStatsProps> = observer(
                   maximumSignificantDigits: 3,
                   notation: "compact",
                   compactDisplay: "short",
+                  scientificMagnitudeThreshold: 30,
                 })
               : "-"}
           </h5>


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant Linear task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change:

this pr fixes this formatting error, now a compact form is used by removing the scientific notation.

![image (2) (1)](https://github.com/osmosis-labs/osmosis-frontend/assets/17269969/8106b404-a655-44d8-8bc8-9a1e75d4eb9d)

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-406/fix-circulating-supply-formatting)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->
