### PR TITLE
feat: add token chart queries by denom

### DIFF
--- a/packages/server/src/queries/complex/assets/price/historical.ts
+++ b/packages/server/src/queries/complex/assets/price/historical.ts
@@ -36,7 +36,7 @@ export function getAssetHistoricalPrice({
   /**
    * Major (symbol) denom to fetch historical price data for.
    *
-   * Note: this can be both a symbol or a denom (coinMinimaldenom)
+   * Note: this can be both a symbol or a denom (coinMinimalDenom)
    * */
   coinDenom: string;
   /** Number of minutes per bar. So 60 refers to price every hour. */

--- a/packages/server/src/queries/complex/assets/price/historical.ts
+++ b/packages/server/src/queries/complex/assets/price/historical.ts
@@ -33,7 +33,11 @@ export function getAssetHistoricalPrice({
   timeFrame,
   numRecentFrames,
 }: {
-  /** Major (symbol) denom to fetch historical price data for. */
+  /**
+   * Major (symbol) denom to fetch historical price data for.
+   *
+   * Note: this can be both a symbol or a denom (coinMinimaldenom)
+   * */
   coinDenom: string;
   /** Number of minutes per bar. So 60 refers to price every hour. */
   timeFrame: TimeFrame | CommonPriceChartTimeFrame;

--- a/packages/server/src/queries/data-services/token-historical-chart.ts
+++ b/packages/server/src/queries/data-services/token-historical-chart.ts
@@ -42,14 +42,20 @@ export async function queryTokenHistoricalChart({
   coinDenom,
   timeFrameMinutes,
 }: {
-  /** Major (symbol) denom to fetch historical price data for. */
+  /**
+   * Major (symbol) denom to fetch historical price data for.
+   *
+   * Note: this can be both a symbol or a denom (coinMinimaldenom)
+   * */
   coinDenom: string;
   /** Number of minutes per bar. So 60 refers to price every 60 minutes. */
   timeFrameMinutes: TimeFrame;
 }): Promise<TokenHistoricalPrice[]> {
   // collect params
   const url = new URL(
-    `/tokens/v2/historical/${coinDenom}/chart?tf=${timeFrameMinutes}`,
+    `/tokens/v2/historical/${encodeURIComponent(
+      coinDenom
+    )}/chart?tf=${timeFrameMinutes}`,
     TIMESERIES_DATA_URL
   );
   try {

--- a/packages/server/src/queries/data-services/token-historical-chart.ts
+++ b/packages/server/src/queries/data-services/token-historical-chart.ts
@@ -45,7 +45,7 @@ export async function queryTokenHistoricalChart({
   /**
    * Major (symbol) denom to fetch historical price data for.
    *
-   * Note: this can be both a symbol or a denom (coinMinimaldenom)
+   * Note: this can be both a symbol or a denom (coinMinimalDenom)
    * */
   coinDenom: string;
   /** Number of minutes per bar. So 60 refers to price every 60 minutes. */

--- a/packages/web/hooks/ui-config/use-asset-info-config.ts
+++ b/packages/web/hooks/ui-config/use-asset-info-config.ts
@@ -70,13 +70,13 @@ export const useAssetInfoConfig = (
     isError,
   } = api.edge.assets.getAssetHistoricalPrice.useQuery(
     {
-      coinDenom: denom,
+      coinDenom: coinMinimalDenom ?? denom,
       timeFrame: {
         custom: customTimeFrame,
       },
     },
     {
-      enabled: Boolean(denom),
+      enabled: Boolean(coinMinimalDenom ?? denom),
       staleTime: 1000 * 60 * 3, // 3 minutes
       cacheTime: 1000 * 60 * 6, // 6 minutes
       trpc: {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant Linear task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change:

Migrate to the new numia service to get the chart, instead of using the token symbol we can now use the denom, this should reduce the errors of searching for a token.

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-310/migrate-from-tokensv2symbol-to-tokensv2denom)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->
