### PR TITLE
Add 1h, 7d price change to assets table

### DIFF
--- a/packages/server/src/queries/complex/assets/market.ts
+++ b/packages/server/src/queries/complex/assets/market.ts
@@ -18,7 +18,9 @@ import { DEFAULT_VS_CURRENCY } from "./config";
 export type AssetMarketInfo = Partial<{
   marketCap: PricePretty;
   currentPrice: PricePretty;
+  priceChange1h: RatePretty;
   priceChange24h: RatePretty;
+  priceChange7d: RatePretty;
   volume24h: PricePretty;
 }>;
 
@@ -48,7 +50,9 @@ export async function getMarketAsset<TAsset extends Asset>({
         marketCap: marketCap
           ? new PricePretty(DEFAULT_VS_CURRENCY, marketCap)
           : undefined,
+        priceChange1h: assetMarketActivity?.price1hChange,
         priceChange24h: assetMarketActivity?.price24hChange,
+        priceChange7d: assetMarketActivity?.price7dChange,
         volume24h: assetMarketActivity?.volume24h,
       };
     },
@@ -151,9 +155,17 @@ function makeMarketActivityFromTokenData(tokenData: TokenData) {
         ? new RatePretty(new Dec(tokenData.volume_24h_change).quo(new Dec(100)))
         : undefined,
     name: tokenData.name,
+    price1hChange:
+      tokenData.price_1h_change !== null
+        ? new RatePretty(new Dec(tokenData.price_1h_change).quo(new Dec(100)))
+        : undefined,
     price24hChange:
       tokenData.price_24h_change !== null
         ? new RatePretty(new Dec(tokenData.price_24h_change).quo(new Dec(100)))
+        : undefined,
+    price7dChange:
+      tokenData.price_7d_change !== null
+        ? new RatePretty(new Dec(tokenData.price_7d_change).quo(new Dec(100)))
         : undefined,
     exponent: tokenData.exponent,
     display: tokenData.display,

--- a/packages/server/src/queries/data-services/token-data.ts
+++ b/packages/server/src/queries/data-services/token-data.ts
@@ -12,7 +12,9 @@ export interface TokenData {
   volume_24h: number;
   volume_24h_change: number | null;
   name: string;
+  price_1h_change: number | null;
   price_24h_change: number | null;
+  price_7d_change: number | null;
   exponent: number;
   display: string;
 }

--- a/packages/server/src/trpc-routers/assets-router.ts
+++ b/packages/server/src/trpc-routers/assets-router.ts
@@ -24,9 +24,9 @@ import { UserOsmoAddressSchema } from "../queries/complex/parameter-types";
 import {
   AvailableRangeValues,
   AvailableTimeDurations,
+  TimeDuration,
   TimeFrame,
 } from "../queries/data-services";
-import { TimeDuration } from "../queries/data-services";
 import { createTRPCRouter, publicProcedure } from "../trpc";
 import { captureErrorAndReturn } from "../utils/error";
 import { maybeCachePaginatedItems } from "../utils/pagination";
@@ -176,7 +176,9 @@ export const assetsRouter = createTRPCRouter({
         z.object({
           sort: createSortSchema([
             "currentPrice",
+            "priceChange1h",
             "priceChange24h",
+            "priceChange7d",
             "marketCap",
             "volume24h",
           ] as const).optional(),

--- a/packages/web/components/table/asset-info.tsx
+++ b/packages/web/components/table/asset-info.tsx
@@ -245,6 +245,27 @@ export const AssetsInfoTable: FunctionComponent<{
           ),
       }),
       columnHelper.accessor((row) => row, {
+        id: "priceChange1h",
+        header: () => (
+          <SortHeader
+            label="1h"
+            sortKey="priceChange1h"
+            currentSortKey={sortKey}
+            currentDirection={sortDirection}
+            setSortDirection={setSortDirection}
+            setSortKey={setSortKey}
+          />
+        ),
+        cell: ({
+          row: {
+            original: { priceChange1h },
+          },
+        }) =>
+          priceChange1h && (
+            <PriceChange className="justify-end" priceChange={priceChange1h} />
+          ),
+      }),
+      columnHelper.accessor((row) => row, {
         id: "priceChange24h",
         header: () => (
           <SortHeader
@@ -263,6 +284,27 @@ export const AssetsInfoTable: FunctionComponent<{
         }) =>
           priceChange24h && (
             <PriceChange className="justify-end" priceChange={priceChange24h} />
+          ),
+      }),
+      columnHelper.accessor((row) => row, {
+        id: "priceChange7d",
+        header: () => (
+          <SortHeader
+            label="7d"
+            sortKey="priceChange7d"
+            currentSortKey={sortKey}
+            currentDirection={sortDirection}
+            setSortDirection={setSortDirection}
+            setSortKey={setSortKey}
+          />
+        ),
+        cell: ({
+          row: {
+            original: { priceChange7d },
+          },
+        }) =>
+          priceChange7d && (
+            <PriceChange className="justify-end" priceChange={priceChange7d} />
           ),
       }),
       columnHelper.accessor(
@@ -314,6 +356,8 @@ export const AssetsInfoTable: FunctionComponent<{
   /** Columns collapsed for screen size responsiveness. */
   const collapsedColumns = useMemo(() => {
     const collapsedColIds: string[] = [];
+    if (width < Breakpoint.xxl) collapsedColIds.push("priceChange7d");
+    if (width < Breakpoint.xlhalf) collapsedColIds.push("priceChange1h");
     if (width < Breakpoint.xl) collapsedColIds.push("marketCap");
     if (width < Breakpoint.xlg) collapsedColIds.push("priceChart");
     if (width < Breakpoint.lg) collapsedColIds.push("priceChange24h");
@@ -447,7 +491,7 @@ export const AssetsInfoTable: FunctionComponent<{
                     "sm:w-fit ",
                     {
                       // defines column widths after first column
-                      "w-36 xl:w-28": index !== 0,
+                      "w-28": index !== 0,
                     }
                   )}
                   key={header.id}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant Linear task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change:

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->
<img width="1097" alt="Screenshot 2024-05-06 at 10 11 32 AM" src="https://github.com/osmosis-labs/osmosis-frontend/assets/4606373/37075d79-9419-4a5f-910c-73eba04b908c">

Data was added to:
https://stage-proxy-data-api.osmosis-labs.workers.dev/tokens/v2/all


### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-247/add-1h-and-7d-price-change-columns)