### PR TITLE
Fix z index for mobile nav menu

### DIFF
--- a/packages/web/components/assets/categories.tsx
+++ b/packages/web/components/assets/categories.tsx
@@ -318,7 +318,7 @@ const OverlappingAssetImages: FunctionComponent<
         key={url}
         style={{
           marginLeft: `${index * 24}px`,
-          zIndex: 50 + index,
+          zIndex: 40 + index,
         }}
         className={classNames(
           "absolute flex h-8 w-8 items-center justify-center",

--- a/packages/web/components/navbar/index.tsx
+++ b/packages/web/components/navbar/index.tsx
@@ -506,7 +506,7 @@ const AnnouncementBanner: FunctionComponent<{
   return (
     <div
       className={classNames(
-        "fixed top-[71px] z-[60] float-right my-auto ml-sidebar flex w-[calc(100vw_-_14.58rem)] items-center px-8 py-[14px] md:top-[57px] md:ml-0 md:w-full sm:gap-3 sm:px-2",
+        "fixed top-[71px] z-[51] float-right my-auto ml-sidebar flex w-[calc(100vw_-_14.58rem)] items-center px-8 py-[14px] md:top-[57px] md:ml-0 md:w-full sm:gap-3 sm:px-2",
         {
           "bg-gradient-negative": isWarning,
           "bg-gradient-neutral": !isWarning,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant Linear task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change:
Fix z index for mobile dropdown menu and category sample images:
<img width="273" alt="Screenshot 2024-05-06 at 12 15 06 PM" src="https://github.com/osmosis-labs/osmosis-frontend/assets/4606373/d930defc-d683-491e-93d3-9ce60b17056d">
>
