### PR TITLE
Swap tool: fix button disabled

### DIFF
--- a/packages/web/components/swap-tool/index.tsx
+++ b/packages/web/components/swap-tool/index.tsx
@@ -918,9 +918,9 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
             <Button
               disabled={
                 isWalletLoading ||
-                !Boolean(swapState.quote) ||
                 (account?.walletStatus === WalletStatus.Connected &&
                   (swapState.inAmountInput.isEmpty ||
+                    !Boolean(swapState.quote) ||
                     Boolean(swapState.error) ||
                     account?.txTypeInProgress !== ""))
               }


### PR DESCRIPTION
I updated it to rely on missing quotes instead of just loading state (which is conditional, therefore less reliable), but missed the disconnected wallet state.