### PR TITLE
Deposit Overrides for Ethereum Assets via Picasso

### DIFF
--- a/packages/web/config/ibc-overrides.ts
+++ b/packages/web/config/ibc-overrides.ts
@@ -618,35 +618,35 @@ const MainnetIBCAdditionalData: Partial<
   CROWDP: {
     depositUrlOverride: "https://app.evmos.org/assets",
   },
-  'ETH.pica': {
+  "ETH.pica": {
     depositUrlOverride: "https://games.mantis.app/?from=ETHEREUM&to=OSMOSIS",
     withdrawUrlOverride: "https://games.mantis.app/?from=OSMOSIS&to=ETHEREUM",
   },
-  'DAI.pica': {
+  "DAI.pica": {
     depositUrlOverride: "https://games.mantis.app/?from=ETHEREUM&to=OSMOSIS",
     withdrawUrlOverride: "https://games.mantis.app/?from=OSMOSIS&to=ETHEREUM",
   },
-  'FXS.pica': {
+  "FXS.pica": {
     depositUrlOverride: "https://games.mantis.app/?from=ETHEREUM&to=OSMOSIS",
     withdrawUrlOverride: "https://games.mantis.app/?from=OSMOSIS&to=ETHEREUM",
   },
-  'FRAX.pica': {
+  "FRAX.pica": {
     depositUrlOverride: "https://games.mantis.app/?from=ETHEREUM&to=OSMOSIS",
     withdrawUrlOverride: "https://games.mantis.app/?from=OSMOSIS&to=ETHEREUM",
   },
-  'USDT.pica': {
+  "USDT.pica": {
     depositUrlOverride: "https://games.mantis.app/?from=ETHEREUM&to=OSMOSIS",
     withdrawUrlOverride: "https://games.mantis.app/?from=OSMOSIS&to=ETHEREUM",
   },
-  'sFRAX.pica': {
+  "sFRAX.pica": {
     depositUrlOverride: "https://games.mantis.app/?from=ETHEREUM&to=OSMOSIS",
     withdrawUrlOverride: "https://games.mantis.app/?from=OSMOSIS&to=ETHEREUM",
   },
-  'frxETH.pica': {
+  "frxETH.pica": {
     depositUrlOverride: "https://games.mantis.app/?from=ETHEREUM&to=OSMOSIS",
     withdrawUrlOverride: "https://games.mantis.app/?from=OSMOSIS&to=ETHEREUM",
   },
-  'sfrxETH.pica': {
+  "sfrxETH.pica": {
     depositUrlOverride: "https://games.mantis.app/?from=ETHEREUM&to=OSMOSIS",
     withdrawUrlOverride: "https://games.mantis.app/?from=OSMOSIS&to=ETHEREUM",
   },

--- a/packages/web/config/ibc-overrides.ts
+++ b/packages/web/config/ibc-overrides.ts
@@ -117,8 +117,8 @@ const MainnetIBCAdditionalData: Partial<
     withdrawUrlOverride: "/wormhole?from=osmosis&to=solana&token=SOL",
   },
   DOT: {
-    depositUrlOverride: "https://app.trustless.zone/?from=PICASSO&to=OSMOSIS",
-    withdrawUrlOverride: "https://app.trustless.zone/?from=OSMOSIS&to=PICASSO",
+    depositUrlOverride: "https://games.mantis.app/?from=PICASSO&to=OSMOSIS",
+    withdrawUrlOverride: "https://games.mantis.app/?from=OSMOSIS&to=PICASSO",
   },
   MATIC: {
     sourceChainNameOverride: "Polygon",
@@ -294,8 +294,8 @@ const MainnetIBCAdditionalData: Partial<
       "https://pro.osmosis.zone/ibc?chainFrom=osmosis-1&chainTo=pacific-1&token0=ibc%2F71F11BC0AF8E526B80E44172EBA9D3F0A8E03950BB882325435691EBC9450B1D&token1=usei",
   },
   KSM: {
-    depositUrlOverride: "https://app.trustless.zone/?from=PICASSO&to=OSMOSIS",
-    withdrawUrlOverride: "https://app.trustless.zone/?from=OSMOSIS&to=PICASSO",
+    depositUrlOverride: "https://games.mantis.app/?from=PICASSO&to=OSMOSIS",
+    withdrawUrlOverride: "https://games.mantis.app/?from=OSMOSIS&to=PICASSO",
   },
   LUNC: {
     depositUrlOverride: "https://bridge.terra.money",
@@ -411,8 +411,8 @@ const MainnetIBCAdditionalData: Partial<
       "https://pro.osmosis.zone/ibc?chainFrom=planq_7070-2&chainTo=osmosis-1&token0=aplanq&token1=ibc%2FB1E0166EA0D759FDF4B207D1F5F12210D8BFE36F2345CEFC76948CE2B36DFBAF",
   },
   PICA: {
-    depositUrlOverride: "https://app.trustless.zone/?from=PICASSO&to=OSMOSIS",
-    withdrawUrlOverride: "https://app.trustless.zone/?from=OSMOSIS&to=PICASSO",
+    depositUrlOverride: "https://games.mantis.app/?from=PICASSO&to=OSMOSIS",
+    withdrawUrlOverride: "https://games.mantis.app/?from=OSMOSIS&to=PICASSO",
   },
   "WBTC.grv": {
     depositUrlOverride:
@@ -596,8 +596,8 @@ const MainnetIBCAdditionalData: Partial<
       "https://pro.osmosis.zone/ibc?chainFrom=osmosis-1&chainTo=injective-1&token0=ibc%2FB84F8CC583A54DA8173711C0B66B22FDC1954FEB1CA8DBC66C89919DAFE02000&token1=peggy0xA4426666addBE8c4985377d36683D17FB40c31Be",
   },
   TNKR: {
-    depositUrlOverride: "https://app.trustless.zone/?from=PICASSO&to=OSMOSIS",
-    withdrawUrlOverride: "https://app.trustless.zone/?from=OSMOSIS&to=PICASSO",
+    depositUrlOverride: "https://games.mantis.app/?from=PICASSO&to=OSMOSIS",
+    withdrawUrlOverride: "https://games.mantis.app/?from=OSMOSIS&to=PICASSO",
   },
   SAYVE: {
     depositUrlOverride:
@@ -617,6 +617,38 @@ const MainnetIBCAdditionalData: Partial<
   },
   CROWDP: {
     depositUrlOverride: "https://app.evmos.org/assets",
+  },
+  'ETH.pica': {
+    depositUrlOverride: "https://games.mantis.app/?from=ETHEREUM&to=OSMOSIS",
+    withdrawUrlOverride: "https://games.mantis.app/?from=OSMOSIS&to=ETHEREUM",
+  },
+  'DAI.pica': {
+    depositUrlOverride: "https://games.mantis.app/?from=ETHEREUM&to=OSMOSIS",
+    withdrawUrlOverride: "https://games.mantis.app/?from=OSMOSIS&to=ETHEREUM",
+  },
+  'FXS.pica': {
+    depositUrlOverride: "https://games.mantis.app/?from=ETHEREUM&to=OSMOSIS",
+    withdrawUrlOverride: "https://games.mantis.app/?from=OSMOSIS&to=ETHEREUM",
+  },
+  'FRAX.pica': {
+    depositUrlOverride: "https://games.mantis.app/?from=ETHEREUM&to=OSMOSIS",
+    withdrawUrlOverride: "https://games.mantis.app/?from=OSMOSIS&to=ETHEREUM",
+  },
+  'USDT.pica': {
+    depositUrlOverride: "https://games.mantis.app/?from=ETHEREUM&to=OSMOSIS",
+    withdrawUrlOverride: "https://games.mantis.app/?from=OSMOSIS&to=ETHEREUM",
+  },
+  'sFRAX.pica': {
+    depositUrlOverride: "https://games.mantis.app/?from=ETHEREUM&to=OSMOSIS",
+    withdrawUrlOverride: "https://games.mantis.app/?from=OSMOSIS&to=ETHEREUM",
+  },
+  'frxETH.pica': {
+    depositUrlOverride: "https://games.mantis.app/?from=ETHEREUM&to=OSMOSIS",
+    withdrawUrlOverride: "https://games.mantis.app/?from=OSMOSIS&to=ETHEREUM",
+  },
+  'sfrxETH.pica': {
+    depositUrlOverride: "https://games.mantis.app/?from=ETHEREUM&to=OSMOSIS",
+    withdrawUrlOverride: "https://games.mantis.app/?from=OSMOSIS&to=ETHEREUM",
   },
 };
 


### PR DESCRIPTION
## What is the purpose of the change:

Adding pica assets deposit overrides

## Brief Changelog

adds deposit and withdraw URLs for new PICA assets to Update ibc-overrides.ts

## Testing and Verifying

This change has been tested locally by rebuilding the website and verified content and links are expected