### PR TITLE
Remove lock duration query

### DIFF
--- a/packages/server/src/queries/complex/concentrated-liquidity/index.ts
+++ b/packages/server/src/queries/complex/concentrated-liquidity/index.ts
@@ -244,7 +244,6 @@ export async function mapGetUserPositionDetails({
     : queryAccountPositions({ ...params, bech32Address: userOsmoAddress }).then(
         ({ positions }) => positions
       );
-  const lockableDurationsPromise = getLockableDurations(params);
   const userUnbondingPositionsPromise = getUserUnbondingPositions({
     ...params,
     bech32Address: userOsmoAddress,
@@ -265,7 +264,6 @@ export async function mapGetUserPositionDetails({
 
   const [
     positions,
-    lockableDurations,
     userUnbondingPositions,
     delegatedPositions,
     undelegatingPositions,
@@ -273,13 +271,15 @@ export async function mapGetUserPositionDetails({
     superfluidPoolIds,
   ] = await Promise.all([
     positionsPromise,
-    lockableDurationsPromise,
     userUnbondingPositionsPromise,
     delegatedPositionsPromise,
     undelegatingPositionsPromise,
     stakeCurrencyPromise,
     superfluidPoolIdsPromise,
   ]);
+
+  const lockableDurations = getLockableDurations();
+  const longestLockDuration = lockableDurations[lockableDurations.length - 1];
 
   const pools = await getPools({
     ...params,
@@ -438,8 +438,6 @@ export async function mapGetUserPositionDetails({
       if (isSuperfluidStaked && delegatedSuperfluidPosition) {
         // delegated position info
 
-        const longestLockDuration =
-          lockableDurations[lockableDurations.length - 1];
         const validatorInfo = await getValidatorInfo({
           ...params,
           validatorBech32Address: delegatedSuperfluidPosition.validatorAddress,

--- a/packages/server/src/queries/complex/pools/bonding.ts
+++ b/packages/server/src/queries/complex/pools/bonding.ts
@@ -87,9 +87,6 @@ export async function getSharePoolBondDurations({
   const isSuperfluidPromise = getSuperfluidPoolIds(params).then((ids) =>
     ids.includes(poolId)
   );
-  const longestDurationPromise = getLockableDurations(params).then(
-    (durations) => durations[durations.length - 1]
-  );
   const internalIncentivesPromise = getIncentivizedPools(params).then(
     (incentivizedPools) => incentivizedPools.find((p) => p.pool_id === poolId)
   );
@@ -107,17 +104,18 @@ export async function getSharePoolBondDurations({
     poolGauges,
     poolIncentives,
     isSuperfluid,
-    longestDuration,
     internalIncentives,
     userPoolLocks,
   ] = await Promise.all([
     activeGaugesPromise,
     poolIncentivesPromise,
     isSuperfluidPromise,
-    longestDurationPromise,
     internalIncentivesPromise,
     userPoolLocksPromise,
   ]);
+
+  const lockableDurations = getLockableDurations();
+  const longestDuration = lockableDurations[lockableDurations.length - 1];
 
   /** Set of all available durations. */
   const durationsMsSet = new Set<number>();

--- a/packages/server/src/queries/complex/pools/incentives.ts
+++ b/packages/server/src/queries/complex/pools/incentives.ts
@@ -11,7 +11,7 @@ import { EXCLUDED_EXTERNAL_BOOSTS_POOL_IDS } from "../../../env";
 import { queryPriceRangeApr } from "../../../queries/data-services";
 import { DEFAULT_LRU_OPTIONS } from "../../../utils/cache";
 import { queryPoolAprs } from "../../data-services/pool-aprs";
-import { Gauge, queryGauges, queryLockableDurations } from "../../osmosis";
+import { Gauge, queryGauges } from "../../osmosis";
 import { Epochs } from "../../osmosis/epochs";
 import { queryIncentivizedPools } from "../../osmosis/incentives/incentivized-pools";
 import { getEpochs } from "../osmosis";
@@ -181,25 +181,17 @@ function maybeMakeRatePretty(value: number): RatePretty | undefined {
 
 const incentivesCache = new LRUCache<string, CacheEntry>(DEFAULT_LRU_OPTIONS);
 
-export function getLockableDurations({ chainList }: { chainList: Chain[] }) {
-  return cachified({
-    cache: incentivesCache,
-    key: "lockable-durations",
-    ttl: 1000 * 60 * 10, // 10 mins
-    getFreshValue: async () => {
-      const { lockable_durations } = await queryLockableDurations({
-        chainList,
-      });
+export function getLockableDurations() {
+  // see: https://linear.app/osmosis/issue/FE-302/hardcode-lockable-durations-query-response
+  const lockable_durations = ["86400s", "604800s", "1209600s"];
 
-      return lockable_durations
-        .map((durationStr: string) => {
-          return dayjs.duration(parseInt(durationStr.replace("s", "")) * 1000);
-        })
-        .sort((v1, v2) => {
-          return v1.asMilliseconds() > v2.asMilliseconds() ? 1 : -1;
-        });
-    },
-  });
+  return lockable_durations
+    .map((durationStr: string) => {
+      return dayjs.duration(parseInt(durationStr.replace("s", "")) * 1000);
+    })
+    .sort((v1, v2) => {
+      return v1.asMilliseconds() > v2.asMilliseconds() ? 1 : -1;
+    });
 }
 
 /** Gets internally incentivized pools with gauges that distribute minted staking tokens. */

--- a/packages/server/src/queries/complex/pools/share.ts
+++ b/packages/server/src/queries/complex/pools/share.ts
@@ -62,10 +62,9 @@ export async function getSharePool(params: {
   chainList: Chain[];
   poolId: string;
 }) {
-  const [pool, lockableDurations] = await Promise.all([
-    getPool(params),
-    getLockableDurations(params),
-  ]);
+  const pool = await getPool(params);
+
+  const lockableDurations = getLockableDurations();
 
   const basePool = {
     ...pool,

--- a/packages/server/src/queries/osmosis/incentives/index.ts
+++ b/packages/server/src/queries/osmosis/incentives/index.ts
@@ -1,3 +1,2 @@
 export * from "./gauges";
 export * from "./incentivized-pools";
-export * from "./lockable-durations";

--- a/packages/server/src/queries/osmosis/incentives/lockable-durations.ts
+++ b/packages/server/src/queries/osmosis/incentives/lockable-durations.ts
@@ -1,9 +1,0 @@
-import { createNodeQuery } from "../../../queries/base-utils";
-
-interface LockableDurations {
-  lockable_durations: string[];
-}
-
-export const queryLockableDurations = createNodeQuery<LockableDurations>({
-  path: "/osmosis/pool-incentives/v1beta1/lockable_durations",
-});


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
v    If you are a member of the Osmosis org, please include a link to the relevant Linear task in your PR description!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change:

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

Improve performance by not querying params for lockable durations, which are not expected to change. See linear issue.

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-302/hardcode-lockable-durations-query-response)
