### PR TITLE
Run Server E2E Workflow every 30 minutes

### DIFF
--- a/.github/workflows/server-e2e-tests.yml
+++ b/.github/workflows/server-e2e-tests.yml
@@ -70,13 +70,13 @@ jobs:
         with:
           payload: |
             {
-              "text": "🚨 Frontend Server E2E Tests Failure Alert 🚨",
+              "text": "🚨 Server to SQS E2E Tests Failure Alert 🚨",
               "blocks": [
                 {
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": "Frontend Server E2E Tests Failure"
+                    "text": "Server to SQS E2E Tests Failure"
                   }
                 },
                 {

--- a/.github/workflows/server-e2e-tests.yml
+++ b/.github/workflows/server-e2e-tests.yml
@@ -1,6 +1,10 @@
 name: Server E2E Workflow
 
-on: [push]
+on:
+  workflow_dispatch:
+  push:
+  schedule:
+    - cron: "*/15 * * * *"
 
 jobs:
   setup-matrix:

--- a/.github/workflows/server-e2e-tests.yml
+++ b/.github/workflows/server-e2e-tests.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
   schedule:
-    - cron: "*/15 * * * *"
+    - cron: "*/30 * * * *"
 
 jobs:
   setup-matrix:

--- a/packages/server/src/trpc-routers/__tests_e2e__/swap-router.test.ts
+++ b/packages/server/src/trpc-routers/__tests_e2e__/swap-router.test.ts
@@ -305,13 +305,17 @@ it("Sidecar — USDC.axl <> USDC — Should return valid quote for possible allo
     router: preferredRouter,
   });
 
-  const amountDec = reply.amount.toDec();
-  const tokenInAmountDec = new Dec(tokenInAmount).quo(
+  const amountDec: Dec = reply.amount.toDec();
+  const tokenInAmountDec: Dec = new Dec(tokenInAmount).quo(
+    DecUtils.getTenExponentN(tokenIn.decimals)
+  );
+  const tokenOutAmountDec: Dec = amountDec.quo(
     DecUtils.getTenExponentN(tokenIn.decimals)
   );
 
-  // Token out amount should be the greater or equal to in amount
-  expect(amountDec.gte(tokenInAmountDec)).toBeTruthy();
+  // Token out amount should be the near or equal to in amount
+  const diff: Dec = tokenInAmountDec.sub(tokenOutAmountDec);
+  expect(diff.lte(new Dec(10000))).toBeTruthy();
 
   // Price impact should be less than 0.5%
   expect(reply.priceImpactTokenOut?.toDec().lte(new Dec(0.05))).toBeTruthy();


### PR DESCRIPTION
## What is the purpose of the change:

- Run Server E2E Workflow every 30 minutes
- Changed Alert name
- Fix USDC/USDC.axl test

### Linear Task

[Linear Task FE-455](https://linear.app/osmosis/issue/FE-455/remove-low-liquidity-e2e-tests)

## Brief Changelog

Added schedule:
    - cron: "*/30 * * * *"

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->
