### PR TITLE
improvement: Enable TSC Declaration Maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ src/styles/index.scss
 .turbo
 
 lerna-debug.log
+
+tsconfig.tsbuildinfo

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,12 +11,12 @@
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "react",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
-    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    "declarationMap": true /* Generates a sourcemap for each corresponding '.d.ts' file. */,
     "sourceMap": true /* Generates corresponding '.map' file. */,
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     // "outDir": "./",                        /* Redirect output structure to the directory. */
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-    // "composite": true,                     /* Enable project compilation */
+    "composite": true /* Enable project compilation */,
     // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
     // "removeComments": true,                /* Do not emit comments to output. */
     // "noEmit": true,                        /* Do not emit outputs. */


### PR DESCRIPTION
## What is the purpose of the change:

This PR improves the development workflow by enabling TypeScript declaration maps. This enhancement allows for better debugging and navigation by linking declaration files back to their original source files.

## Brief Changelog

- Enabled TypeScript declaration maps in the `tsconfig.json` file.

## Testing and Verifying

This change has been tested locally by rebuilding the website and verified content and links are expected
