### PR TITLE
Clean and cache output of tx project build output

### DIFF
--- a/packages/bridge/package.json
+++ b/packages/bridge/package.json
@@ -16,7 +16,7 @@
   ],
   "license": "Apache-2.0",
   "scripts": {
-    "clean": "rm -rf node_modules; rm -rf build",
+    "clean": "rm -rf node_modules; rm -rf build; rm tsconfig.tsbuildinfo",
     "build": "tsc",
     "dev": "tsc -w",
     "test": "jest --passWithNoTests",

--- a/packages/keplr-hooks/package.json
+++ b/packages/keplr-hooks/package.json
@@ -19,7 +19,7 @@
     "access": "public"
   },
   "scripts": {
-    "clean": "rm -rf node_modules; rm -rf build",
+    "clean": "rm -rf node_modules; rm -rf build; rm tsconfig.tsbuildinfo",
     "build": "tsc",
     "dev": "tsc -w",
     "test": "jest --passWithNoTests",

--- a/packages/keplr-stores/package.json
+++ b/packages/keplr-stores/package.json
@@ -18,7 +18,7 @@
     "access": "public"
   },
   "scripts": {
-    "clean": "rm -rf node_modules; rm -rf build",
+    "clean": "rm -rf node_modules; rm -rf build; rm tsconfig.tsbuildinfo",
     "build": "tsc",
     "dev": "tsc -w",
     "test": "jest --passWithNoTests",

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -21,7 +21,7 @@
     "access": "public"
   },
   "scripts": {
-    "clean": "rm -rf node_modules; rm -rf build",
+    "clean": "rm -rf node_modules; rm -rf build; rm tsconfig.tsbuildinfo",
     "build": "tsc",
     "dev": "tsc -w",
     "test": "jest --passWithNoTests",

--- a/packages/pools/package.json
+++ b/packages/pools/package.json
@@ -21,7 +21,7 @@
     "access": "public"
   },
   "scripts": {
-    "clean": "rm -rf node_modules; rm -rf build",
+    "clean": "rm -rf node_modules; rm -rf build; rm tsconfig.tsbuildinfo",
     "build": "tsc",
     "dev": "tsc -w",
     "test": "jest --passWithNoTests",

--- a/packages/proto-codecs/package.json
+++ b/packages/proto-codecs/package.json
@@ -22,7 +22,7 @@
     "access": "public"
   },
   "scripts": {
-    "clean": "rm -rf node_modules; rm -rf build",
+    "clean": "rm -rf node_modules; rm -rf build; rm tsconfig.tsbuildinfo",
     "build": "tsc",
     "dev": "tsc --watch",
     "test:regression": "jest --passWithNoTests --runInBand",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -20,7 +20,7 @@
     "./build/utils/dayjs.js"
   ],
   "scripts": {
-    "clean": "rm -rf node_modules; rm -rf build",
+    "clean": "rm -rf node_modules; rm -rf build; rm tsconfig.tsbuildinfo",
     "build": "tsc",
     "dev": "tsc -w",
     "test": "jest --passWithNoTests",

--- a/packages/stores/package.json
+++ b/packages/stores/package.json
@@ -22,7 +22,7 @@
     "access": "public"
   },
   "scripts": {
-    "clean": "rm -rf node_modules; rm -rf build",
+    "clean": "rm -rf node_modules; rm -rf build; rm tsconfig.tsbuildinfo",
     "build": "tsc",
     "dev": "tsc -w",
     "test": "jest --passWithNoTests",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -15,7 +15,7 @@
   ],
   "license": "Apache-2.0",
   "scripts": {
-    "clean": "rm -rf node_modules; rm -rf build",
+    "clean": "rm -rf node_modules; rm -rf build; rm tsconfig.tsbuildinfo",
     "build": "tsc",
     "dev": "tsc -w",
     "test": "jest --passWithNoTests",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "sideEffects": false,
   "scripts": {
-    "clean": "rm -rf node_modules; rm -rf build",
+    "clean": "rm -rf node_modules; rm -rf build; rm tsconfig.tsbuildinfo",
     "build": "tsc",
     "dev": "tsc -w",
     "test": "jest --passWithNoTests",

--- a/turbo.json
+++ b/turbo.json
@@ -9,7 +9,8 @@
         "src/codegen/**",
         "scripts/generated/**",
         "config/generated/**",
-        "public/tokens/generated/**"
+        "public/tokens/generated/**",
+        "tsconfig.tsbuildinfo"
       ],
       "dependsOn": ["^build"]
     },


### PR DESCRIPTION
The ts config for project references was recently added to allow IDEs to reference the source folder as the definition instead of the build folders. So, f12 now works across packages.

However, for turbo build caching to work properly the output of the recently added tsproject build needs to be included in build output for each package. Also, for local development to work better, the file needs to be deleted when cleaning.