### PR TITLE
Show 1 IBC complete toast

### DIFF
--- a/packages/stores/src/ibc-history/index.ts
+++ b/packages/stores/src/ibc-history/index.ts
@@ -32,9 +32,9 @@ export class IBCTransferHistoryStore {
   @observable
   protected _histories: IBCTransferHistory[] = [];
 
-  protected onHistoryChangedHandlers: ((
-    history: IBCTransferHistory
-  ) => void)[] = [];
+  protected onHistoryChangedHandler:
+    | ((history: IBCTransferHistory) => void)
+    | null = null;
 
   // Key is chain id.
   // No need to be observable
@@ -54,7 +54,7 @@ export class IBCTransferHistoryStore {
   }
 
   addHistoryChangedHandler(handler: (history: IBCTransferHistory) => void) {
-    this.onHistoryChangedHandlers.push(handler);
+    this.onHistoryChangedHandler = handler;
   }
 
   get histories(): IBCTransferHistory[] {
@@ -460,9 +460,7 @@ export class IBCTransferHistoryStore {
     if (history.status !== status) {
       history.status = status;
 
-      for (const handler of this.onHistoryChangedHandlers) {
-        handler(history);
-      }
+      this.onHistoryChangedHandler?.(history);
 
       yield this.save();
 

--- a/packages/web/stores/ibc-notifier.tsx
+++ b/packages/web/stores/ibc-notifier.tsx
@@ -1,7 +1,8 @@
 import { ChainIdHelper } from "@keplr-wallet/cosmos";
 import { CoinPretty, Dec } from "@keplr-wallet/unit";
 import { observer } from "mobx-react-lite";
-import { FunctionComponent, useEffect, useState } from "react";
+import { FunctionComponent } from "react";
+import { useMount } from "react-use";
 
 import { displayToast, ToastType } from "~/components/alert";
 import { useStore } from "~/stores";
@@ -9,105 +10,93 @@ import { api } from "~/utils/trpc";
 
 /**
  * IbcNotifier hook tracks the changes of the IBC Transfer history on the IBCTransferHistoryStore.
- * And, if the changes are detected, this will notify the success or failure to the users, and update the balances.
+ * And, if the changes are detected, this will notify the success or failure to the users and update the balances.
  * XXX: `IbcNotifier` doesn't render anything.
  */
 export const IbcNotifier: FunctionComponent = observer(() => {
   const { chainStore, queriesStore, ibcTransferHistoryStore, accountStore } =
     useStore();
   const { chainId } = chainStore.osmosis;
-  const [historyHandlerAdded, setHistoryHandlerAdded] = useState(false);
   const apiUtils = api.useUtils();
 
-  useEffect(() => {
-    if (!historyHandlerAdded) {
-      ibcTransferHistoryStore.addHistoryChangedHandler((history) => {
-        if (chainStore.hasChain(history.destChainId)) {
-          const transferAmount = new CoinPretty(
-            history.amount.currency,
-            new Dec(history.amount.amount)
-          ).moveDecimalPointRight(history.amount.currency.coinDecimals);
-          const isWithdraw =
-            ChainIdHelper.parse(chainId).identifier !==
-            ChainIdHelper.parse(history.destChainId).identifier;
+  useMount(() => {
+    ibcTransferHistoryStore.addHistoryChangedHandler((history) => {
+      if (chainStore.hasChain(history.destChainId)) {
+        const transferAmount = new CoinPretty(
+          history.amount.currency,
+          new Dec(history.amount.amount)
+        ).moveDecimalPointRight(history.amount.currency.coinDecimals);
+        const isWithdraw =
+          ChainIdHelper.parse(chainId).identifier !==
+          ChainIdHelper.parse(history.destChainId).identifier;
 
+        if (history.status === "complete") {
+          console.log("complete", history);
+          displayToast(
+            {
+              message: "IBC Transfer Complete",
+              caption: isWithdraw
+                ? `${transferAmount
+                    .maxDecimals(6)
+                    .trim(true)
+                    .shrink(true)} has been successfully withdrawn`
+                : `${transferAmount
+                    .maxDecimals(6)
+                    .trim(true)
+                    .shrink(true)} has been successfully deposited`,
+            },
+            ToastType.SUCCESS
+          );
+        } else if (history.status === "timeout") {
+          displayToast(
+            {
+              message: "IBC Transfer Timeout",
+              caption: isWithdraw
+                ? `${transferAmount
+                    .maxDecimals(6)
+                    .trim(true)
+                    .shrink(true)} has failed to withdraw`
+                : `${transferAmount
+                    .maxDecimals(6)
+                    .trim(true)
+                    .shrink(true)} has failed to deposit`,
+            },
+            ToastType.ERROR
+          );
+        } else if (history.status === "refunded") {
+          displayToast(
+            {
+              message: "IBC Transfer Refunded",
+              caption: `${transferAmount
+                .maxDecimals(6)
+                .trim(true)
+                .shrink(true)} has been successfully refunded`,
+            },
+            ToastType.SUCCESS
+          );
+        }
+
+        const account = accountStore.getWallet(chainId);
+        if (
+          history.sender === account?.address ||
+          history.recipient === account?.address
+        ) {
           if (history.status === "complete") {
-            displayToast(
-              {
-                message: "IBC Transfer Complete",
-                caption: isWithdraw
-                  ? `${transferAmount
-                      .maxDecimals(6)
-                      .trim(true)
-                      .shrink(true)} has been successfully withdrawn`
-                  : `${transferAmount
-                      .maxDecimals(6)
-                      .trim(true)
-                      .shrink(true)} has been successfully deposited`,
-              },
-              ToastType.SUCCESS
-            );
-          } else if (history.status === "timeout") {
-            displayToast(
-              {
-                message: "IBC Transfer Timeout",
-                caption: isWithdraw
-                  ? `${transferAmount
-                      .maxDecimals(6)
-                      .trim(true)
-                      .shrink(true)} has failed to withdraw`
-                  : `${transferAmount
-                      .maxDecimals(6)
-                      .trim(true)
-                      .shrink(true)} has failed to deposit`,
-              },
-              ToastType.ERROR
-            );
+            apiUtils.invalidate();
+            queriesStore
+              .get(history.destChainId)
+              .queryBalances.getQueryBech32Address(history.recipient)
+              .fetch();
           } else if (history.status === "refunded") {
-            displayToast(
-              {
-                message: "IBC Transfer Refunded",
-                caption: `${transferAmount
-                  .maxDecimals(6)
-                  .trim(true)
-                  .shrink(true)} has been successfully refunded`,
-              },
-              ToastType.SUCCESS
-            );
-          }
-
-          const account = accountStore.getWallet(chainId);
-          if (
-            history.sender === account?.address ||
-            history.recipient === account?.address
-          ) {
-            if (history.status === "complete") {
-              apiUtils.invalidate();
-              queriesStore
-                .get(history.destChainId)
-                .queryBalances.getQueryBech32Address(history.recipient)
-                .fetch();
-            } else if (history.status === "refunded") {
-              queriesStore
-                .get(history.sourceChainId)
-                .queryBalances.getQueryBech32Address(history.recipient)
-                .fetch();
-            }
+            queriesStore
+              .get(history.sourceChainId)
+              .queryBalances.getQueryBech32Address(history.recipient)
+              .fetch();
           }
         }
-      });
-      setHistoryHandlerAdded(true);
-    }
-  }, [
-    ibcTransferHistoryStore,
-    chainId,
-    queriesStore,
-    accountStore,
-    chainStore,
-    historyHandlerAdded,
-    apiUtils,
-    setHistoryHandlerAdded,
-  ]);
+      }
+    });
+  });
 
   return null;
 });

--- a/packages/web/stores/ibc-notifier.tsx
+++ b/packages/web/stores/ibc-notifier.tsx
@@ -31,7 +31,6 @@ export const IbcNotifier: FunctionComponent = observer(() => {
           ChainIdHelper.parse(history.destChainId).identifier;
 
         if (history.status === "complete") {
-          console.log("complete", history);
           displayToast(
             {
               message: "IBC Transfer Complete",


### PR DESCRIPTION
Only use one handler in the IBC history store to ensure only one callback is called even if multiple mount cycles occur on the component that adds the handler.