### PR TITLE
Pools Search Improvements - Add pool by denom

### DIFF
--- a/packages/server/src/queries/complex/pools/index.ts
+++ b/packages/server/src/queries/complex/pools/index.ts
@@ -48,7 +48,7 @@ export const PoolFilterSchema = z.object({
 /** Params for filtering pools. */
 export type PoolFilter = z.infer<typeof PoolFilterSchema>;
 
-const searchablePoolKeys = ["id", "coinDenoms", "poolNameByDenom"];
+// const searchablePoolKeys = ["id", "coinDenoms", "poolNameByDenom"];
 
 /** Get's an individual pool by ID.
  *  @throws If pool not found. */
@@ -105,10 +105,27 @@ export async function getPools(
     poolNameByDenom: pool.reserveCoins.map(({ denom }) => denom).join("/"),
   }));
 
-  console.log("denomPools[0]: ", denomPools[0]);
-
   if (params?.search) {
-    denomPools = search(denomPools, searchablePoolKeys, params.search);
+    // search for an exact match of coinMinimalDenom or pool ID
+    const coinMinimalDemonMatches = search(
+      denomPools,
+      ["coinDenoms", "id"],
+      params.search,
+      0.0 // Exact match
+    );
+
+    // if not exact match for coinMinimalDenom or pool ID, search by poolNameByDenom (ex: OSMO/USDC)
+    if (coinMinimalDemonMatches.length > 0) {
+      denomPools = coinMinimalDemonMatches;
+    } else {
+      const poolNameByDenomMatches = search(
+        denomPools,
+        ["poolNameByDenom"],
+        params.search
+      );
+
+      denomPools = poolNameByDenomMatches;
+    }
   }
 
   return denomPools;

--- a/packages/web/components/complex/all-pools-table.tsx
+++ b/packages/web/components/complex/all-pools-table.tsx
@@ -109,8 +109,6 @@ export const AllPoolsTable: FunctionComponent<{
 
   const { filters, sortParams, setSortParams } = useAllPoolsTable();
 
-  console.log("filters: ", filters);
-
   /** Won't sort when searching is happening. */
   const sortKey = useMemo(
     () => (Boolean(filters.searchQuery) ? undefined : sortParams.allPoolsSort),


### PR DESCRIPTION
## What is the purpose of the change:

- search improvements for pools page

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-437/pools-search-improvements)

## Brief Changelog

- replaced fuzzy search for coinMinimalDenom / pool ID with exact match search, this otherwise was adding odd searches
- add search by denom/denom "poolNameByDenom" (partial and exact) -> OSMO/USDC returns [OSMO/USDC, OSMO/USDC.axl, WOSMO/USDC, and similar matches]

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

After - can search for OSMO/USDC, searches exact pool match

https://github.com/osmosis-labs/osmosis-frontend/assets/30577966/8ba8964b-4b25-4306-8f50-2b569b50195c

Before - cannot search for OSMO/USDC (empty), searches by pool fuzzy match which doesn't make sense

https://github.com/osmosis-labs/osmosis-frontend/assets/30577966/0665ec49-a7c6-4c92-8983-37ffaa8f8a82


