### PR TITLE
feat: remove token holding filter and minor ui bug

### DIFF
--- a/packages/web/components/earn/filters/filters-modal.tsx
+++ b/packages/web/components/earn/filters/filters-modal.tsx
@@ -111,14 +111,18 @@ const FiltersModal = (
             containerClassName="hidden w-full max-w-sm items-center gap-7 2xl:flex"
           />
         </div>
-        <RadioWithOptions
-          disabled={props.isMyAllSwitchDisabled}
-          mode="primary"
-          variant="large"
-          value={tokenHolder}
-          onChange={(value) => setFilter("tokenHolder", value)}
-          options={props.tokenFilterOptions}
-        />
+        {!props.isMyAllSwitchDisabled ? (
+          <RadioWithOptions
+            disabled={props.isMyAllSwitchDisabled}
+            mode="primary"
+            variant="large"
+            value={tokenHolder}
+            onChange={(value) => setFilter("tokenHolder", value)}
+            options={props.tokenFilterOptions}
+          />
+        ) : (
+          false
+        )}
       </div>
       <Button onClick={props.onRequestClose} className="mt-16 max-h-11">
         {t("earnPage.saveFilters")}

--- a/packages/web/components/earn/filters/top-filters.tsx
+++ b/packages/web/components/earn/filters/top-filters.tsx
@@ -123,14 +123,18 @@ export const TopFilters = ({
   return (
     <div className="flex flex-col gap-5 px-10 py-8 1.5xs:px-7 1.5xs:py-7">
       <div className="flex flex-wrap items-center justify-between gap-7 2xl:gap-10 1.5xl:gap-4 lg:hidden">
-        <RadioWithOptions
-          disabled={tokenHolderSwitchDisabled}
-          mode="primary"
-          variant="large"
-          value={tokenHolder}
-          onChange={(value) => setFilter("tokenHolder", value)}
-          options={tokenFilterOptions}
-        />
+        {!tokenHolderSwitchDisabled ? (
+          <RadioWithOptions
+            disabled={tokenHolderSwitchDisabled}
+            mode="primary"
+            variant="large"
+            value={tokenHolder}
+            onChange={(value) => setFilter("tokenHolder", value)}
+            options={tokenFilterOptions}
+          />
+        ) : (
+          false
+        )}
         <DropdownWithLabel<string>
           label={t("earnPage.strategyMethod")}
           allLabel={t("earnPage.allMethods")}

--- a/packages/web/components/earn/filters/top-filters.tsx
+++ b/packages/web/components/earn/filters/top-filters.tsx
@@ -219,19 +219,24 @@ export const TopFilters = ({
       </div>
       {/** 512 - 1024 */}
       <div className="hidden items-center justify-between gap-4 lg:flex 1.5xs:hidden">
-        <RadioWithOptions
-          disabled={tokenHolderSwitchDisabled}
-          mode="primary"
-          variant="large"
-          value={tokenHolder}
-          onChange={(value) => setFilter("tokenHolder", value)}
-          options={tokenFilterOptions}
-        />
+        {!tokenHolderSwitchDisabled ? (
+          <RadioWithOptions
+            disabled={tokenHolderSwitchDisabled}
+            mode="primary"
+            variant="large"
+            value={tokenHolder}
+            onChange={(value) => setFilter("tokenHolder", value)}
+            options={tokenFilterOptions}
+          />
+        ) : (
+          false
+        )}
         <SearchBox
           onInput={(value) => setFilter("search", String(value))}
           currentValue={search ?? ""}
           placeholder={t("store.searchPlaceholder")}
-          size={"full"}
+          size="full"
+          variant="outline"
         />
       </div>
       <div className="hidden flex-wrap items-center justify-between gap-4 lg:flex 1.5xs:hidden">
@@ -288,7 +293,8 @@ export const TopFilters = ({
           onInput={(value) => setFilter("search", String(value))}
           currentValue={search ?? ""}
           placeholder={t("store.searchPlaceholder")}
-          size={"full"}
+          size="full"
+          variant="outline"
         />
         <Button onClick={() => setIsModalOpen(true)} className="max-w-[110px]">
           {t("earnPage.filters")}


### PR DESCRIPTION
removed token holding filter if we're using yout strategy tab.

## What is the purpose of the change:

Inside the earn page we are going to remove "token holding" filter if you're inside "your strategies" tab, because the data is already filtered for the tokens you have.

 
<img width="1154" alt="Screenshot 2024-05-22 alle 10 26 23" src="https://github.com/osmosis-labs/osmosis-frontend/assets/17269969/c7912392-a833-492d-9115-0b467c81e0e8">

This PR also ensure that we render `<SearchBox />` using `outline` variant everywhere inside the earn page.

### Linear Task

[Linear Task URL](PASTE_LINEAR_TASK_URL_HERE)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->
