### PR TITLE
reduce loading toast time to 2 seconds

### DIFF
--- a/packages/web/components/alert/toast.tsx
+++ b/packages/web/components/alert/toast.tsx
@@ -46,7 +46,7 @@ export function displayToast(
       toast(<ErrorToast {...alert} />, toastOptions);
       break;
     case ToastType.LOADING:
-      toast(<LoadingToast {...alert} />, toastOptions);
+      toast(<LoadingToast {...alert} />, { ...toastOptions, autoClose: 2000 });
       break;
   }
 }


### PR DESCRIPTION
## What is the purpose of the change:

Reducing the loading toast time to 2 seconds since it is currently jarring that the loading toast takes so long when the transaction is already complete

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-470/tx-toast-lag)

## Brief Changelog

- change loading toast time to 2000ms

## Testing and Verifying

This change has been tested locally by rebuilding the website and verified content and links are expected

