### PR TITLE
Display latest price from pool instead of historical price data

### DIFF
--- a/packages/server/src/queries/complex/assets/price/historical.ts
+++ b/packages/server/src/queries/complex/assets/price/historical.ts
@@ -98,7 +98,7 @@ export function getPoolAssetPairHistoricalPrice({
   return cachified({
     cache: tokenPairPriceCache,
     key: `token-pair-historical-price-${poolId}-${quoteCoinMinimalDenom}-${baseCoinMinimalDenom}-${timeDuration}`,
-    ttl: 1000 * 10, // 10 seconds
+    ttl: 1000 * 60 * 3, // 3 minutes
     getFreshValue: () =>
       queryTokenPairHistoricalChart(
         poolId,

--- a/packages/server/src/queries/complex/assets/price/historical.ts
+++ b/packages/server/src/queries/complex/assets/price/historical.ts
@@ -98,7 +98,7 @@ export function getPoolAssetPairHistoricalPrice({
   return cachified({
     cache: tokenPairPriceCache,
     key: `token-pair-historical-price-${poolId}-${quoteCoinMinimalDenom}-${baseCoinMinimalDenom}-${timeDuration}`,
-    ttl: 1000 * 60 * 3, // 3 minutes
+    ttl: 1000 * 10, // 10 seconds
     getFreshValue: () =>
       queryTokenPairHistoricalChart(
         poolId,

--- a/packages/web/components/cards/my-position/expanded.tsx
+++ b/packages/web/components/cards/my-position/expanded.tsx
@@ -537,8 +537,14 @@ const Chart: FunctionComponent<{
   config: ObservableHistoricalAndLiquidityData;
   position: UserPosition;
 }> = observer(({ config, position: { isFullRange } }) => {
-  const { historicalChartData, yRange, setHoverPrice, lastChartData, range } =
-    config;
+  const {
+    historicalChartData,
+    yRange,
+    setHoverPrice,
+    lastChartData,
+    range,
+    currentPrice,
+  } = config;
 
   return (
     <HistoricalPriceChart
@@ -551,7 +557,9 @@ const Chart: FunctionComponent<{
       domain={yRange}
       onPointerHover={(price) => setHoverPrice(price)}
       onPointerOut={
-        lastChartData ? () => setHoverPrice(lastChartData.close) : undefined
+        lastChartData
+          ? () => setHoverPrice(Number(currentPrice.toString()))
+          : undefined
       }
     />
   );

--- a/packages/web/components/pool-detail/concentrated.tsx
+++ b/packages/web/components/pool-detail/concentrated.tsx
@@ -430,8 +430,6 @@ const Chart: FunctionComponent<{
     currentPrice,
   } = config;
 
-  console.log({ currentPrice: Number(currentPrice.toString()) });
-
   return (
     <HistoricalPriceChart
       data={historicalChartData}

--- a/packages/web/components/pool-detail/concentrated.tsx
+++ b/packages/web/components/pool-detail/concentrated.tsx
@@ -422,7 +422,15 @@ const ChartHeader: FunctionComponent<{
 const Chart: FunctionComponent<{
   config: ObservableHistoricalAndLiquidityData;
 }> = observer(({ config }) => {
-  const { historicalChartData, yRange, setHoverPrice, lastChartData } = config;
+  const {
+    historicalChartData,
+    yRange,
+    setHoverPrice,
+    lastChartData,
+    currentPrice,
+  } = config;
+
+  console.log({ currentPrice: Number(currentPrice.toString()) });
 
   return (
     <HistoricalPriceChart
@@ -432,7 +440,7 @@ const Chart: FunctionComponent<{
       onPointerHover={setHoverPrice}
       onPointerOut={() => {
         if (lastChartData) {
-          setHoverPrice(Number(lastChartData.close));
+          setHoverPrice(Number(currentPrice.toString()));
         }
       }}
     />


### PR DESCRIPTION
Adjust TTL values for price chart since the last closing price is used for current price display.