### PR TITLE
Add Deposit IBC Overrides for Solana Assets via Picasso

### DIFF
--- a/packages/web/config/ibc-overrides.ts
+++ b/packages/web/config/ibc-overrides.ts
@@ -720,24 +720,24 @@ const MainnetIBCAdditionalData: Partial<
       "https://app.picasso.network/?from=OSMOSIS&to=ETHEREUM",
   },
   "solana.USDT.pica": {
-    depositUrlOverride: "https://app.picasso.network/?from=ETHEREUM&to=OSMOSIS",
-    withdrawUrlOverride:
-      "https://app.picasso.network/?from=OSMOSIS&to=ETHEREUM",
+    depositUrlOverride: "https://app.picasso.network/?from=SOLANA&to=OSMOSIS",
+    withdrawUrlOverride: "https://app.picasso.network/?from=OSMOSIS&to=SOLANA",
   },
   "edgeSOL.pica": {
-    depositUrlOverride: "https://app.picasso.network/?from=ETHEREUM&to=OSMOSIS",
-    withdrawUrlOverride:
-      "https://app.picasso.network/?from=OSMOSIS&to=ETHEREUM",
+    depositUrlOverride: "https://app.picasso.network/?from=SOLANA&to=OSMOSIS",
+    withdrawUrlOverride: "https://app.picasso.network/?from=OSMOSIS&to=SOLANA",
   },
   "LST.pica": {
-    depositUrlOverride: "https://app.picasso.network/?from=ETHEREUM&to=OSMOSIS",
-    withdrawUrlOverride:
-      "https://app.picasso.network/?from=OSMOSIS&to=ETHEREUM",
+    depositUrlOverride: "https://app.picasso.network/?from=SOLANA&to=OSMOSIS",
+    withdrawUrlOverride: "https://app.picasso.network/?from=OSMOSIS&to=SOLANA",
   },
   "jitoSOL.pica": {
     depositUrlOverride: "https://app.picasso.network/?from=SOLANA&to=OSMOSIS",
-    withdrawUrlOverride:
-      "https://app.picasso.network/?from=OSMOSIS&to=SOLANA",
+    withdrawUrlOverride: "https://app.picasso.network/?from=OSMOSIS&to=SOLANA",
+  },
+  "wSOL.pica": {
+    depositUrlOverride: "https://app.picasso.network/?from=SOLANA&to=OSMOSIS",
+    withdrawUrlOverride: "https://app.picasso.network/?from=OSMOSIS&to=SOLANA",
   },
 };
 

--- a/packages/web/config/ibc-overrides.ts
+++ b/packages/web/config/ibc-overrides.ts
@@ -719,6 +719,26 @@ const MainnetIBCAdditionalData: Partial<
     withdrawUrlOverride:
       "https://app.picasso.network/?from=OSMOSIS&to=ETHEREUM",
   },
+  "solana.USDT.pica": {
+    depositUrlOverride: "https://app.picasso.network/?from=ETHEREUM&to=OSMOSIS",
+    withdrawUrlOverride:
+      "https://app.picasso.network/?from=OSMOSIS&to=ETHEREUM",
+  },
+  "edgeSOL.pica": {
+    depositUrlOverride: "https://app.picasso.network/?from=ETHEREUM&to=OSMOSIS",
+    withdrawUrlOverride:
+      "https://app.picasso.network/?from=OSMOSIS&to=ETHEREUM",
+  },
+  "LST.pica": {
+    depositUrlOverride: "https://app.picasso.network/?from=ETHEREUM&to=OSMOSIS",
+    withdrawUrlOverride:
+      "https://app.picasso.network/?from=OSMOSIS&to=ETHEREUM",
+  },
+  "jitoSOL.pica": {
+    depositUrlOverride: "https://app.picasso.network/?from=SOLANA&to=OSMOSIS",
+    withdrawUrlOverride:
+      "https://app.picasso.network/?from=OSMOSIS&to=SOLANA",
+  },
 };
 
 export const IBCAdditionalData: AdditionalData = IS_TESTNET


### PR DESCRIPTION
## What is the purpose of the change:

Add Deposit IBC Overrides for Solana Assets via Picasso

## Brief Changelog

-add LST, jitoSOL, edgeSOL, wSOL, solana.USDT, to ibc-overrides, with deposit and withdraw URL going to Picasso App (transfers with Solana)

## Testing and Verifying

This change has been tested locally by rebuilding the website and verified content and links are expected
