### PR TITLE
Fix quote loading state when wallet disconnected

### DIFF
--- a/packages/web/components/swap-tool/index.tsx
+++ b/packages/web/components/swap-tool/index.tsx
@@ -242,6 +242,8 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
       swapState.isQuoteLoading ||
       swapState.isLoadingNetworkFee;
 
+    console.log(swapState.isLoadingNetworkFee, swapState.isQuoteLoading);
+
     let buttonText: string;
     if (swapState.error) {
       buttonText = t(...tError(swapState.error));
@@ -985,8 +987,7 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
               loadingText={buttonText}
               onClick={sendSwapTx}
             >
-              {account?.walletStatus === WalletStatus.Connected ||
-              isSwapToolLoading ? (
+              {account?.walletStatus === WalletStatus.Connected ? (
                 buttonText
               ) : (
                 <h6 className="flex items-center gap-3">

--- a/packages/web/components/swap-tool/index.tsx
+++ b/packages/web/components/swap-tool/index.tsx
@@ -242,8 +242,6 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
       swapState.isQuoteLoading ||
       swapState.isLoadingNetworkFee;
 
-    console.log(swapState.isLoadingNetworkFee, swapState.isQuoteLoading);
-
     let buttonText: string;
     if (swapState.error) {
       buttonText = t(...tError(swapState.error));

--- a/packages/web/hooks/use-swap.tsx
+++ b/packages/web/hooks/use-swap.tsx
@@ -197,7 +197,8 @@ export function useSwap(
     featureFlags.swapToolSimulateFee &&
     !Boolean(precedentError) &&
     !isQuoteLoading &&
-    Boolean(quote);
+    Boolean(quote) &&
+    Boolean(account?.address);
   const {
     data: networkFee,
     error: networkFeeError,
@@ -783,9 +784,14 @@ function useSwapAmountInput({
     gasAmount: gasAmount,
   });
 
+  const balanceQuoteQueryEnabled =
+    !!inAmountInput.balance &&
+    !inAmountInput.balance?.toDec().isZero() &&
+    Boolean(swapAssets.fromAsset) &&
+    Boolean(swapAssets.toAsset);
   const {
     data: quoteForCurrentBalance,
-    isLoading: isQuoteForCurrentBalanceLoading,
+    isLoading: isQuoteForCurrentBalanceLoading_,
     error: quoteForCurrentBalanceError,
   } = useQueryRouterBestQuote(
     {
@@ -795,11 +801,10 @@ function useSwapAmountInput({
       forcePoolId: forceSwapInPoolId,
       maxSlippage,
     },
-    !!inAmountInput.balance &&
-      !inAmountInput.balance?.toDec().isZero() &&
-      Boolean(swapAssets.fromAsset) &&
-      Boolean(swapAssets.toAsset)
+    balanceQuoteQueryEnabled
   );
+  const isQuoteForCurrentBalanceLoading =
+    isQuoteForCurrentBalanceLoading_ && balanceQuoteQueryEnabled;
 
   const networkQueryEnabled =
     featureFlags.swapToolSimulateFee &&


### PR DESCRIPTION
When wallet is disconnected and there's no account, disable gas fee queries and only show connect wallet button