### PR TITLE
Swap tool gas estimation: add more checks to query enabled

### DIFF
--- a/packages/web/hooks/use-swap.tsx
+++ b/packages/web/hooks/use-swap.tsx
@@ -127,7 +127,7 @@ export function useSwap(
     // with the input amount when switching assets
     inAmountInput.debouncedInAmount?.currency.coinMinimalDenom ===
       swapAssets.fromAsset?.coinMinimalDenom &&
-    !Boolean(account?.txTypeInProgress) &&
+    !account?.txTypeInProgress &&
     !isWalletLoading;
 
   const {
@@ -789,6 +789,7 @@ function useSwapAmountInput({
     !isLoadingWallet &&
     Boolean(swapAssets.fromAsset) &&
     Boolean(swapAssets.toAsset) &&
+    // since the in amount is debounced, the asset could be wrong when switching assets
     inAmountInput.debouncedInAmount?.currency.coinMinimalDenom ===
       swapAssets.fromAsset!.coinMinimalDenom &&
     !!inAmountInput.balance &&
@@ -817,7 +818,7 @@ function useSwapAmountInput({
     // includes check for balanceQuoteQueryEnabled
     !isQuoteForCurrentBalanceLoading &&
     Boolean(quoteForCurrentBalance) &&
-    !Boolean(account?.txTypeInProgress);
+    !account?.txTypeInProgress;
   const {
     data: currentBalanceNetworkFee,
     isLoading: isLoadingCurrentBalanceNetworkFee_,

--- a/packages/web/hooks/use-swap.tsx
+++ b/packages/web/hooks/use-swap.tsx
@@ -102,6 +102,7 @@ export function useSwap(
   const { isOneClickTradingEnabled, oneClickTradingInfo } =
     useOneClickTradingSession();
   const { t } = useTranslation();
+  const { isLoading: isWalletLoading } = useWalletSelect();
 
   const swapAssets = useSwapAssets({
     initialFromDenom,
@@ -119,14 +120,15 @@ export function useSwap(
   // load flags
   const isToFromAssets =
     Boolean(swapAssets.fromAsset) && Boolean(swapAssets.toAsset);
-  const canLoadQuote =
+  const quoteQueryEnabled =
     isToFromAssets &&
     Boolean(inAmountInput.debouncedInAmount?.toDec().isPositive()) &&
     // since input is debounced there could be the wrong asset associated
     // with the input amount when switching assets
     inAmountInput.debouncedInAmount?.currency.coinMinimalDenom ===
       swapAssets.fromAsset?.coinMinimalDenom &&
-    !Boolean(account?.txTypeInProgress);
+    !Boolean(account?.txTypeInProgress) &&
+    !isWalletLoading;
 
   const {
     data: quote,
@@ -140,11 +142,11 @@ export function useSwap(
       forcePoolId: forceSwapInPoolId,
       maxSlippage,
     },
-    canLoadQuote
+    quoteQueryEnabled
   );
   /** If a query is not enabled, it is considered loading.
    *  Work around this by checking if the query is enabled and if the query is loading to be considered loading. */
-  const isQuoteLoading = isQuoteLoading_ && canLoadQuote;
+  const isQuoteLoading = isQuoteLoading_ && quoteQueryEnabled;
 
   const {
     data: spotPriceQuote,
@@ -196,6 +198,7 @@ export function useSwap(
   const networkFeeQueryEnabled =
     featureFlags.swapToolSimulateFee &&
     !Boolean(precedentError) &&
+    // includes check for quoteQueryEnabled
     !isQuoteLoading &&
     Boolean(quote) &&
     Boolean(account?.address);
@@ -211,10 +214,7 @@ export function useSwap(
       useOneClickTrading: isOneClickTradingEnabled,
     },
   });
-  const isLoadingNetworkFee =
-    featureFlags.swapToolSimulateFee &&
-    isLoadingNetworkFee_ &&
-    networkFeeQueryEnabled;
+  const isLoadingNetworkFee = isLoadingNetworkFee_ && networkFeeQueryEnabled;
 
   const hasExceededOneClickTradingGasLimit = useMemo(() => {
     if (
@@ -774,6 +774,7 @@ function useSwapAmountInput({
 }) {
   const { chainStore, accountStore } = useStore();
   const account = accountStore.getWallet(chainStore.osmosis.chainId);
+  const { isLoading: isLoadingWallet } = useWalletSelect();
 
   const featureFlags = useFeatureFlags();
 
@@ -785,10 +786,15 @@ function useSwapAmountInput({
   });
 
   const balanceQuoteQueryEnabled =
-    !!inAmountInput.balance &&
-    !inAmountInput.balance?.toDec().isZero() &&
+    !isLoadingWallet &&
     Boolean(swapAssets.fromAsset) &&
-    Boolean(swapAssets.toAsset);
+    Boolean(swapAssets.toAsset) &&
+    inAmountInput.debouncedInAmount?.currency.coinMinimalDenom ===
+      swapAssets.fromAsset!.coinMinimalDenom &&
+    !!inAmountInput.balance &&
+    !inAmountInput.balance.toDec().isZero() &&
+    inAmountInput.balance.currency.coinMinimalDenom ===
+      swapAssets.fromAsset?.coinMinimalDenom;
   const {
     data: quoteForCurrentBalance,
     isLoading: isQuoteForCurrentBalanceLoading_,
@@ -806,8 +812,9 @@ function useSwapAmountInput({
   const isQuoteForCurrentBalanceLoading =
     isQuoteForCurrentBalanceLoading_ && balanceQuoteQueryEnabled;
 
-  const networkQueryEnabled =
+  const networkFeeQueryEnabled =
     featureFlags.swapToolSimulateFee &&
+    // includes check for balanceQuoteQueryEnabled
     !isQuoteForCurrentBalanceLoading &&
     Boolean(quoteForCurrentBalance) &&
     !Boolean(account?.txTypeInProgress);
@@ -818,10 +825,10 @@ function useSwapAmountInput({
   } = useEstimateTxFees({
     chainId: chainStore.osmosis.chainId,
     messages: quoteForCurrentBalance?.messages,
-    enabled: networkQueryEnabled,
+    enabled: networkFeeQueryEnabled,
   });
   const isLoadingCurrentBalanceNetworkFee =
-    networkQueryEnabled && isLoadingCurrentBalanceNetworkFee_;
+    networkFeeQueryEnabled && isLoadingCurrentBalanceNetworkFee_;
 
   const hasErrorWithCurrentBalanceQuote = useMemo(() => {
     return !!currentBalanceNetworkFeeError || !!quoteForCurrentBalanceError;


### PR DESCRIPTION
## What is the purpose of the change:

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

[Vercel Logs](https://vercel.com/osmo-labs/osmosis-frontend/logs?slug=app-future&slug=en-US&slug=osmo-labs&slug=osmosis-frontend&slug=logs&page=1&timeline=past30Minutes&startDate=1717521244055&endDate=1717523044055&levels=error&selectedLogId=1717522995240299524043600000&selectedLogTimestamp=1717522995240&forceEndDate=1717523032957)

I've noticed an increase in failed gas estimation queries in Vercel logs. Our UI gracefully handles these failed queries but it should still be prevented.

It's hard to reproduce but it might be a race condition where an estimation query is enabled when it shouldn't be. I added more checks to the query enabled flags to ensure the quote and estimation queries are only sent when current state is valid.
