### PR TITLE
Add $WHINE Deposit/Withdraw URL Override

### DIFF
--- a/packages/web/config/ibc-overrides.ts
+++ b/packages/web/config/ibc-overrides.ts
@@ -739,6 +739,10 @@ const MainnetIBCAdditionalData: Partial<
     depositUrlOverride: "https://app.picasso.network/?from=SOLANA&to=OSMOSIS",
     withdrawUrlOverride: "https://app.picasso.network/?from=OSMOSIS&to=SOLANA",
   },
+  WHINE: {
+    depositUrlOverride: "https://app.picasso.network/?from=SOLANA&to=OSMOSIS",
+    withdrawUrlOverride: "https://app.picasso.network/?from=OSMOSIS&to=SOLANA",
+  },
 };
 
 export const IBCAdditionalData: AdditionalData = IS_TESTNET


### PR DESCRIPTION
## What is the purpose of the change:

$WHINE deposit and withdraw URL overrides to Picasso bridging interface

[Linear Task URL](PASTE_LINEAR_TASK_URL_HERE)

## Brief Changelog

Update ibc-overrides.ts to include $WHINE deposit and withdraw URL overrides to Picasso bridging interface

## Testing and Verifying

This change has been tested locally by rebuilding the website and verified content and links are expected
