### PR TITLE
Add NEXT_PUBLIC_NUMIA_BASE_URL env var

### DIFF
--- a/packages/server/src/env.ts
+++ b/packages/server/src/env.ts
@@ -20,10 +20,15 @@ export const TIMESERIES_DATA_URL =
 export const INDEXER_DATA_URL =
   process.env.NEXT_PUBLIC_INDEXER_DATA_URL ??
   "https://stage-proxy-data-indexer.osmosis-labs.workers.dev";
+export const NUMIA_BASE_URL =
+  process.env.NEXT_PUBLIC_NUMIA_BASE_URL ??
+  "https://public-osmosis-api.numia.xyz";
+
+// sqs
 export const SIDECAR_BASE_URL =
   process.env.NEXT_PUBLIC_SIDECAR_BASE_URL ?? "https://sqs.osmosis.zone/";
 export const TFM_BASE_URL = process.env.NEXT_PUBLIC_TFM_API_BASE_URL;
-export const NUMIA_BASE_URL = "https://public-osmosis-api.numia.xyz";
+
 export const KEYBASE_BASE_URL = "https://keybase.io/";
 export const KV_STORE_REST_API_URL = process.env.KV_STORE_REST_API_URL;
 export const KV_STORE_REST_API_TOKEN = process.env.KV_STORE_REST_API_TOKEN;


### PR DESCRIPTION
## What is the purpose of the change:

This PR allows to override `NUMIA_BASE_URL` via an env variable.
This is needed to support different network (e.g. testnet)

In the future we could merge all the data services env vars into one.
