### PR TITLE
Swap failed events: only reject committed txs with code !== 0

### DIFF
--- a/packages/web/components/swap-tool/index.tsx
+++ b/packages/web/components/swap-tool/index.tsx
@@ -223,7 +223,6 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
           }
         })
         .catch((error) => {
-          console.error("swap failed", error);
           if (error instanceof Error && error.message === "Request rejected") {
             // don't log when the user rejects in wallet
             return;

--- a/packages/web/components/swap-tool/index.tsx
+++ b/packages/web/components/swap-tool/index.tsx
@@ -222,9 +222,10 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
             });
           }
         })
-        .catch(() => {
-          console.log("reject sig");
-          logEvent([EventName.Swap.swapFailed, baseEvent]);
+        .catch((e) => {
+          if (e instanceof Error && e.message.includes("Failed to send")) {
+            logEvent([EventName.Swap.swapFailed, baseEvent]);
+          }
         })
         .finally(() => {
           setIsSendingTx(false);

--- a/packages/web/components/swap-tool/index.tsx
+++ b/packages/web/components/swap-tool/index.tsx
@@ -222,11 +222,8 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
             });
           }
         })
-        .catch((error) => {
-          if (error instanceof Error && error.message === "Request rejected") {
-            // don't log when the user rejects in wallet
-            return;
-          }
+        .catch(() => {
+          console.log("reject sig");
           logEvent([EventName.Swap.swapFailed, baseEvent]);
         })
         .finally(() => {

--- a/packages/web/hooks/use-swap.tsx
+++ b/packages/web/hooks/use-swap.tsx
@@ -269,12 +269,16 @@ export function useSwap(
     () =>
       new Promise<"multiroute" | "multihop" | "exact-in">(
         async (resolve, reject) => {
-          if (!maxSlippage) return reject(new Error("No max slippage"));
+          if (!maxSlippage)
+            return reject(new Error("Max slippage is not defined."));
           if (!inAmountInput.amount)
-            return reject(new Error("No input amount"));
-          if (!account) return reject(new Error("No account"));
-          if (!swapAssets.fromAsset) return reject(new Error("No from asset"));
-          if (!swapAssets.toAsset) return reject(new Error("No to asset"));
+            return reject(new Error("Input amount is not specified."));
+          if (!account)
+            return reject(new Error("Account information is missing."));
+          if (!swapAssets.fromAsset)
+            return reject(new Error("From asset is not specified."));
+          if (!swapAssets.toAsset)
+            return reject(new Error("To asset is not specified."));
 
           let txParams: ReturnType<typeof getSwapTxParameters>;
           try {
@@ -287,7 +291,9 @@ export function useSwap(
             });
           } catch (e) {
             const error = e as Error;
-            return reject(error);
+            return reject(
+              new Error(`Transaction preparation failed: ${error.message}`)
+            );
           }
 
           const { routes, tokenIn, tokenOutMinAmount } = txParams;

--- a/packages/web/hooks/use-swap.tsx
+++ b/packages/web/hooks/use-swap.tsx
@@ -380,7 +380,8 @@ export function useSwap(
                 }
               )
               .catch((reason) => {
-                reject(reason);
+                // broadcast error or tx rejection
+                console.error(reason);
               });
             return pools.length === 1 ? "exact-in" : "multihop";
           } else if (routes.length > 1) {
@@ -400,9 +401,11 @@ export function useSwap(
                 }
               )
               .catch((reason) => {
-                reject(reason);
+                // broadcast error or tx rejection
+                console.error(reason);
               });
           } else {
+            // should not be possible because button should be disabled
             reject("No routes given");
           }
         }

--- a/packages/web/hooks/use-swap.tsx
+++ b/packages/web/hooks/use-swap.tsx
@@ -373,8 +373,10 @@ export function useSwap(
                 tokenOutMinAmount,
                 undefined,
                 signOptions,
-                () => {
-                  resolve(pools.length === 1 ? "exact-in" : "multihop");
+                ({ code }) => {
+                  if (code)
+                    reject("Failed to send swap exact amount in message");
+                  else resolve(pools.length === 1 ? "exact-in" : "multihop");
                 }
               )
               .catch((reason) => {
@@ -389,8 +391,12 @@ export function useSwap(
                 tokenOutMinAmount,
                 undefined,
                 signOptions,
-                () => {
-                  resolve("multiroute");
+                ({ code }) => {
+                  if (code)
+                    reject(
+                      "Failed to send split route swap exact amount in message"
+                    );
+                  else resolve("multiroute");
                 }
               )
               .catch((reason) => {


### PR DESCRIPTION
Before, we logged events if the broadcast failed (could be network error or signature rejection). Now, the promise that rejects that causes the error to be logged should largely come from failed txs on chain. Other lower priority errors, like random network errors or signature rejections, should be ignored.