### PR TITLE
feat: add price axis to charts

### DIFF
--- a/packages/web/components/chart/light-weight-charts/chart.tsx
+++ b/packages/web/components/chart/light-weight-charts/chart.tsx
@@ -1,7 +1,6 @@
 import {
   ColorType,
   DeepPartial,
-  isBusinessDay,
   LineStyle,
   MouseEventParams,
   TickMarkType,
@@ -17,7 +16,10 @@ import React, {
   useSyncExternalStore,
 } from "react";
 
-import { priceFormatter } from "~/components/chart/light-weight-charts/utils";
+import {
+  priceFormatter,
+  timepointToString,
+} from "~/components/chart/light-weight-charts/utils";
 import { theme } from "~/tailwind.config";
 
 import {
@@ -33,38 +35,6 @@ function resizeSubscribe(callback: (this: Window, ev: UIEvent) => unknown) {
     window.removeEventListener("resize", callback);
   };
 }
-
-const timepointToString = (
-  timePoint: Time,
-  formatOptions: Intl.DateTimeFormatOptions,
-  locale?: string
-) => {
-  let date = new Date();
-
-  if (typeof timePoint === "string") {
-    date = new Date(timePoint);
-  } else if (!isBusinessDay(timePoint)) {
-    date = new Date((timePoint as number) * 1000);
-  } else {
-    date = new Date(
-      Date.UTC(timePoint.year, timePoint.month - 1, timePoint.day)
-    );
-  }
-
-  // from given date we should use only as UTC date or timestamp
-  // but to format as locale date we can convert UTC date to local date
-  const localDateFromUtc = new Date(
-    date.getUTCFullYear(),
-    date.getUTCMonth(),
-    date.getUTCDate(),
-    date.getUTCHours(),
-    date.getUTCMinutes(),
-    date.getUTCSeconds(),
-    date.getUTCMilliseconds()
-  );
-
-  return localDateFromUtc.toLocaleString(locale, formatOptions);
-};
 
 export const defaultOptions: DeepPartial<TimeChartOptions> = {
   layout: {

--- a/packages/web/components/chart/light-weight-charts/chart.tsx
+++ b/packages/web/components/chart/light-weight-charts/chart.tsx
@@ -90,6 +90,10 @@ export const defaultOptions: DeepPartial<TimeChartOptions> = {
     autoScale: true,
     borderVisible: false,
     ticksVisible: false,
+    scaleMargins: {
+      top: 0.25,
+      bottom: 0,
+    },
   },
   crosshair: {
     horzLine: {
@@ -97,12 +101,14 @@ export const defaultOptions: DeepPartial<TimeChartOptions> = {
       style: LineStyle.LargeDashed,
       width: 2,
       color: `${theme.colors.osmoverse[300]}33`,
+      labelVisible: false,
     },
     vertLine: {
       labelBackgroundColor: theme.colors.osmoverse[850],
       style: LineStyle.LargeDashed,
       width: 2,
       color: `${theme.colors.osmoverse[300]}33`,
+      labelVisible: false,
     },
   },
   handleScroll: false,

--- a/packages/web/components/chart/light-weight-charts/chart.tsx
+++ b/packages/web/components/chart/light-weight-charts/chart.tsx
@@ -92,7 +92,12 @@ export const defaultOptions: DeepPartial<TimeChartOptions> = {
     ticksVisible: false,
   },
   crosshair: {
-    horzLine: { visible: false },
+    horzLine: {
+      labelBackgroundColor: theme.colors.osmoverse[850],
+      style: LineStyle.LargeDashed,
+      width: 2,
+      color: `${theme.colors.osmoverse[300]}33`,
+    },
     vertLine: {
       labelBackgroundColor: theme.colors.osmoverse[850],
       style: LineStyle.LargeDashed,

--- a/packages/web/components/chart/light-weight-charts/chart.tsx
+++ b/packages/web/components/chart/light-weight-charts/chart.tsx
@@ -17,6 +17,7 @@ import React, {
   useSyncExternalStore,
 } from "react";
 
+import { priceFormatter } from "~/components/chart/light-weight-charts/utils";
 import { theme } from "~/tailwind.config";
 
 import {
@@ -76,8 +77,20 @@ export const defaultOptions: DeepPartial<TimeChartOptions> = {
     fontSize: 14,
   },
   grid: { horzLines: { visible: false }, vertLines: { visible: false } },
-  rightPriceScale: { visible: false },
-  leftPriceScale: { visible: false },
+  rightPriceScale: {
+    autoScale: true,
+    borderVisible: false,
+    ticksVisible: false,
+    scaleMargins: {
+      top: 0.25,
+      bottom: 0,
+    },
+  },
+  leftPriceScale: {
+    autoScale: true,
+    borderVisible: false,
+    ticksVisible: false,
+  },
   crosshair: {
     horzLine: { visible: false },
     vertLine: {
@@ -94,6 +107,7 @@ export const defaultOptions: DeepPartial<TimeChartOptions> = {
     mouse: false,
   },
   localization: {
+    priceFormatter,
     timeFormatter: (timePoint: Time) => {
       const formatOptions: Intl.DateTimeFormatOptions = {
         year: "numeric",
@@ -206,7 +220,7 @@ export const Chart = memo(
     }, []);
 
     return (
-      <div className="relative h-full" ref={setContainer}>
+      <div className="relative h-full [&_table]:table-auto" ref={setContainer}>
         {children}
       </div>
     );

--- a/packages/web/components/chart/light-weight-charts/linear-chart.ts
+++ b/packages/web/components/chart/light-weight-charts/linear-chart.ts
@@ -63,10 +63,11 @@ export class LinearChartController extends AreaChartController {
 
           return `
             <h6 class="text-h6 font-semibold text-white-full whitespace-nowrap">
-              $
               ${
                 formatPretty(closeDec, {
                   maxDecimals,
+                  currency: "USD",
+                  style: "currency",
                   ...formatOpts,
                 }) || ""
               }

--- a/packages/web/components/chart/light-weight-charts/utils.ts
+++ b/packages/web/components/chart/light-weight-charts/utils.ts
@@ -1,15 +1,20 @@
 import { Dec } from "@keplr-wallet/unit";
 
-import { formatPretty } from "~/utils/formatter";
+import { formatPretty, getPriceExtendedFormatOptions } from "~/utils/formatter";
+import { getDecimalCount } from "~/utils/number";
 
 export const priceFormatter = (price: number) => {
+  const minimumDecimals = 2;
+  const maxDecimals = Math.max(getDecimalCount(price), minimumDecimals);
+
   const priceDec = new Dec(price);
 
+  const formatOpts = getPriceExtendedFormatOptions(priceDec);
+
   return formatPretty(priceDec, {
+    maxDecimals,
     currency: "USD",
     style: "currency",
-    maxDecimals: 3,
-    minimumSignificantDigits: 3,
-    disabledTrimZeros: true,
+    ...formatOpts,
   });
 };

--- a/packages/web/components/chart/light-weight-charts/utils.ts
+++ b/packages/web/components/chart/light-weight-charts/utils.ts
@@ -37,17 +37,5 @@ export const timepointToString = (
     );
   }
 
-  // from given date we should use only as UTC date or timestamp
-  // but to format as locale date we can convert UTC date to local date
-  const localDateFromUtc = new Date(
-    date.getUTCFullYear(),
-    date.getUTCMonth(),
-    date.getUTCDate(),
-    date.getUTCHours(),
-    date.getUTCMinutes(),
-    date.getUTCSeconds(),
-    date.getUTCMilliseconds()
-  );
-
-  return localDateFromUtc.toLocaleString(locale, formatOptions);
+  return date.toLocaleString(locale, formatOptions);
 };

--- a/packages/web/components/chart/light-weight-charts/utils.ts
+++ b/packages/web/components/chart/light-weight-charts/utils.ts
@@ -1,4 +1,5 @@
 import { Dec } from "@keplr-wallet/unit";
+import { isBusinessDay, Time } from "lightweight-charts";
 
 import { formatPretty, getPriceExtendedFormatOptions } from "~/utils/formatter";
 import { getDecimalCount } from "~/utils/number";
@@ -17,4 +18,36 @@ export const priceFormatter = (price: number) => {
     style: "currency",
     ...formatOpts,
   });
+};
+
+export const timepointToString = (
+  timePoint: Time,
+  formatOptions: Intl.DateTimeFormatOptions,
+  locale?: string
+) => {
+  let date = new Date();
+
+  if (typeof timePoint === "string") {
+    date = new Date(timePoint);
+  } else if (!isBusinessDay(timePoint)) {
+    date = new Date((timePoint as number) * 1000);
+  } else {
+    date = new Date(
+      Date.UTC(timePoint.year, timePoint.month - 1, timePoint.day)
+    );
+  }
+
+  // from given date we should use only as UTC date or timestamp
+  // but to format as locale date we can convert UTC date to local date
+  const localDateFromUtc = new Date(
+    date.getUTCFullYear(),
+    date.getUTCMonth(),
+    date.getUTCDate(),
+    date.getUTCHours(),
+    date.getUTCMinutes(),
+    date.getUTCSeconds(),
+    date.getUTCMilliseconds()
+  );
+
+  return localDateFromUtc.toLocaleString(locale, formatOptions);
 };

--- a/packages/web/components/chart/light-weight-charts/utils.ts
+++ b/packages/web/components/chart/light-weight-charts/utils.ts
@@ -1,0 +1,15 @@
+import { Dec } from "@keplr-wallet/unit";
+
+import { formatPretty } from "~/utils/formatter";
+
+export const priceFormatter = (price: number) => {
+  const priceDec = new Dec(price);
+
+  return formatPretty(priceDec, {
+    currency: "USD",
+    style: "currency",
+    maxDecimals: 3,
+    minimumSignificantDigits: 3,
+    disabledTrimZeros: true,
+  });
+};

--- a/packages/web/components/chart/price-historical-v2.tsx
+++ b/packages/web/components/chart/price-historical-v2.tsx
@@ -7,17 +7,24 @@ import {
 import React, { FunctionComponent, memo } from "react";
 
 import { LinearChartController } from "~/components/chart/light-weight-charts/linear-chart";
+import { theme } from "~/tailwind.config";
 
 import { Chart } from "./light-weight-charts/chart";
 
 const seriesOpt: DeepPartial<AreaSeriesOptions> = {
-  lineColor: "#8C8AF9",
-  topColor: "rgba(60, 53, 109, 1)",
-  bottomColor: "rgba(32, 27, 67, 1)",
+  lineColor: theme.colors.wosmongton[300],
+  topColor: theme.colors.osmoverse[700],
+  bottomColor: theme.colors.osmoverse[850],
   priceLineVisible: false,
-  priceScaleId: "left",
+  lastValueVisible: false,
+  priceScaleId: "right",
   crosshairMarkerBorderWidth: 0,
   crosshairMarkerRadius: 8,
+  priceFormat: {
+    type: "price",
+    precision: 4,
+    minMove: 0.0001,
+  },
 };
 
 const HistoricalPriceChartV2: FunctionComponent<{

--- a/packages/web/components/chart/price-historical-v2.tsx
+++ b/packages/web/components/chart/price-historical-v2.tsx
@@ -22,8 +22,8 @@ const seriesOpt: DeepPartial<AreaSeriesOptions> = {
   crosshairMarkerRadius: 8,
   priceFormat: {
     type: "price",
-    precision: 4,
-    minMove: 0.0001,
+    precision: 10,
+    minMove: 0.0000001,
   },
 };
 

--- a/packages/web/components/chart/price-historical-v2.tsx
+++ b/packages/web/components/chart/price-historical-v2.tsx
@@ -6,7 +6,7 @@ import {
 } from "lightweight-charts";
 import React, { FunctionComponent, memo } from "react";
 
-import { LinearChartController } from "~/components/chart/light-weight-charts/linear-chart";
+import { AreaChartController } from "~/components/chart/light-weight-charts/area-chart";
 import { theme } from "~/tailwind.config";
 
 import { Chart } from "./light-weight-charts/chart";
@@ -34,7 +34,7 @@ const HistoricalPriceChartV2: FunctionComponent<{
 }> = memo(({ data = [], onPointerHover, onPointerOut }) => {
   return (
     <Chart
-      Controller={LinearChartController}
+      Controller={AreaChartController}
       series={[
         {
           type: "Area",

--- a/packages/web/components/chart/price-historical-v2.tsx
+++ b/packages/web/components/chart/price-historical-v2.tsx
@@ -2,6 +2,7 @@ import {
   AreaData,
   AreaSeriesOptions,
   DeepPartial,
+  Time,
   UTCTimestamp,
 } from "lightweight-charts";
 import React, { FunctionComponent, memo } from "react";
@@ -29,7 +30,7 @@ const seriesOpt: DeepPartial<AreaSeriesOptions> = {
 
 const HistoricalPriceChartV2: FunctionComponent<{
   data: { close: number; time: number }[];
-  onPointerHover?: (price: number) => void;
+  onPointerHover?: (price: number, time: Time) => void;
   onPointerOut?: () => void;
 }> = memo(({ data = [], onPointerHover, onPointerOut }) => {
   return (
@@ -49,7 +50,7 @@ const HistoricalPriceChartV2: FunctionComponent<{
         if (params.seriesData.size > 0) {
           const [data] = [...params.seriesData.values()] as AreaData[];
 
-          onPointerHover?.(data.value);
+          onPointerHover?.(data.value, data.time);
         } else {
           onPointerOut?.();
         }

--- a/packages/web/components/chart/price-historical.tsx
+++ b/packages/web/components/chart/price-historical.tsx
@@ -252,6 +252,7 @@ export const PriceChartHeader: FunctionComponent<{
   historicalRange: PriceRange;
   setHistoricalRange: (pr: PriceRange) => void;
   hoverPrice: number;
+  hoverDate?: string;
   decimal: number;
   formatOpts?: FormatOptions;
   fiatSymbol?: string;
@@ -274,6 +275,7 @@ export const PriceChartHeader: FunctionComponent<{
     setHistoricalRange,
     baseDenom,
     quoteDenom,
+    hoverDate,
     hoverPrice,
     formatOpts,
     decimal,
@@ -320,29 +322,38 @@ export const PriceChartHeader: FunctionComponent<{
             classes?.pricesHeaderContainerClass
           )}
         >
-          <SkeletonLoader isLoaded={!isLoading}>
-            <h4
-              className={classNames(
-                "row-span-2 pr-1 font-caption sm:text-h5",
-                classes?.priceHeaderClass
-              )}
-            >
-              {fiatSymbol}
-              {compactZeros ? (
-                <>
-                  {significantDigits}.
-                  {Boolean(zeros) && (
-                    <>
-                      0<sub title={`${getFormattedPrice()}USD`}>{zeros}</sub>
-                    </>
-                  )}
-                  {decimalDigits}
-                </>
-              ) : (
-                getFormattedPrice()
-              )}
-            </h4>
-          </SkeletonLoader>
+          <div>
+            <SkeletonLoader isLoaded={!isLoading}>
+              <h4
+                className={classNames(
+                  "row-span-2 pr-1 font-caption sm:text-h5",
+                  classes?.priceHeaderClass
+                )}
+              >
+                {fiatSymbol}
+                {compactZeros ? (
+                  <>
+                    {significantDigits}.
+                    {Boolean(zeros) && (
+                      <>
+                        0<sub title={`${getFormattedPrice()}USD`}>{zeros}</sub>
+                      </>
+                    )}
+                    {decimalDigits}
+                  </>
+                ) : (
+                  getFormattedPrice()
+                )}
+              </h4>
+            </SkeletonLoader>
+            {hoverDate ? (
+              <p className="flex flex-1 flex-col justify-center font-caption text-wosmongton-200">
+                {hoverDate}
+              </p>
+            ) : (
+              false
+            )}
+          </div>
           {baseDenom && quoteDenom ? (
             <div
               className={classNames(

--- a/packages/web/components/chart/price-historical.tsx
+++ b/packages/web/components/chart/price-historical.tsx
@@ -252,7 +252,7 @@ export const PriceChartHeader: FunctionComponent<{
   historicalRange: PriceRange;
   setHistoricalRange: (pr: PriceRange) => void;
   hoverPrice: number;
-  hoverDate?: string;
+  hoverDate?: string | null;
   decimal: number;
   formatOpts?: FormatOptions;
   fiatSymbol?: string;
@@ -346,8 +346,15 @@ export const PriceChartHeader: FunctionComponent<{
                 )}
               </h4>
             </SkeletonLoader>
-            {hoverDate ? (
-              <p className="flex flex-1 flex-col justify-center font-caption text-wosmongton-200">
+            {hoverDate !== undefined ? (
+              <p
+                className={classNames(
+                  "flex flex-1 flex-col justify-center font-caption text-wosmongton-200",
+                  {
+                    "invisible h-6": hoverDate === null,
+                  }
+                )}
+              >
                 {hoverDate}
               </p>
             ) : (

--- a/packages/web/hooks/ui-config/use-asset-info-config.ts
+++ b/packages/web/hooks/ui-config/use-asset-info-config.ts
@@ -285,11 +285,9 @@ export class ObservableAssetInfoConfig {
   }
 
   @computed
-  get hoverDate(): string | undefined {
-    let date = this._hoverDate;
-
+  get hoverDate(): string | null {
     if (!this._hoverDate) {
-      date = new Date().toISOString();
+      return null;
     }
 
     const formatOptions: Intl.DateTimeFormatOptions = {
@@ -300,7 +298,7 @@ export class ObservableAssetInfoConfig {
       minute: "numeric",
     };
 
-    return timepointToString(date!, formatOptions, "en-US");
+    return timepointToString(this._hoverDate, formatOptions, "en-US");
   }
 
   @computed

--- a/packages/web/hooks/ui-config/use-asset-info-config.ts
+++ b/packages/web/hooks/ui-config/use-asset-info-config.ts
@@ -4,9 +4,11 @@ import {
   type TokenHistoricalPrice,
 } from "@osmosis-labs/server";
 import dayjs from "dayjs";
+import { Time } from "lightweight-charts";
 import { action, computed, makeObservable, observable } from "mobx";
 import { useEffect, useMemo } from "react";
 
+import { timepointToString } from "~/components/chart/light-weight-charts/utils";
 import { api } from "~/utils/trpc";
 
 export const useAssetInfoConfig = (
@@ -206,6 +208,9 @@ export class ObservableAssetInfoConfig {
   protected _hoverPrice: number = 0;
 
   @observable
+  protected _hoverDate?: Time = undefined;
+
+  @observable
   protected _historicalData: TokenHistoricalPrice[] = [];
 
   @observable
@@ -275,7 +280,27 @@ export class ObservableAssetInfoConfig {
     if (!fiat) {
       return undefined;
     }
+
     return new PricePretty(fiat, this._hoverPrice);
+  }
+
+  @computed
+  get hoverDate(): string | undefined {
+    let date = this._hoverDate;
+
+    if (!this._hoverDate) {
+      date = new Date().toISOString();
+    }
+
+    const formatOptions: Intl.DateTimeFormatOptions = {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "numeric",
+    };
+
+    return timepointToString(date!, formatOptions, "en-US");
   }
 
   @computed
@@ -307,8 +332,9 @@ export class ObservableAssetInfoConfig {
   };
 
   @action
-  readonly setHoverPrice = (price: number) => {
+  readonly setHoverPrice = (price: number, time?: Time) => {
     this._hoverPrice = price;
+    this._hoverDate = time;
   };
 
   @action

--- a/packages/web/pages/assets/[denom].tsx
+++ b/packages/web/pages/assets/[denom].tsx
@@ -480,6 +480,7 @@ const TokenChartHeader = observer(() => {
         decimal={maxDecimals}
         showAllRange
         hoverPrice={hoverPrice}
+        hoverDate={assetInfoConfig.hoverDate}
         historicalRange={assetInfoConfig.historicalRange}
         setHistoricalRange={assetInfoConfig.setHistoricalRange}
         fiatSymbol={fiatSymbol}
@@ -507,7 +508,7 @@ const TokenChart = observer(() => {
             data={assetInfoConfig.historicalChartData}
             onPointerHover={assetInfoConfig.setHoverPrice}
             onPointerOut={() => {
-              assetInfoConfig.setHoverPrice(0);
+              assetInfoConfig.setHoverPrice(0, undefined);
             }}
           />
         </>


### PR DESCRIPTION
## What is the purpose of the change:

This PR introduce a price axis on the right for the token info page chart.

<img width="715" alt="Screenshot 2024-06-06 alle 09 59 18" src="https://github.com/osmosis-labs/osmosis-frontend/assets/17269969/8462cd23-004e-4b12-94d0-6137b1170dfc">

### Linear Task

[Linear Task](https://linear.app/osmosis/issue/FE-505/add-price-axis-to-charts)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->
