### PR TITLE
Make tests setup wallet just once

### DIFF
--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Playwright
         run: |
           yarn --cwd packages/web install --frozen-lockfile && npx playwright install --with-deps chromium
-      - name: Run Select Swap Pair tests on Master
+      - name: Run Swap Pair tests on Master
         env:
           BASE_URL: "https://app.osmosis.zone"
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
@@ -63,7 +63,7 @@ jobs:
       - name: Install Playwright
         run: |
           yarn --cwd packages/web install --frozen-lockfile && npx playwright install --with-deps chromium
-      - name: Run Select Swap Pair tests on Stage
+      - name: Run Swap Pair tests on Stage
         env:
           BASE_URL: ${{ github.event.deployment_status.environment_url }}
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}

--- a/packages/web/e2e/pages/swap-page.ts
+++ b/packages/web/e2e/pages/swap-page.ts
@@ -127,7 +127,7 @@ export class SwapPage {
 
     if (fromTokenText == from && toTokenText == to) {
       console.log(
-        "Current pair:" + fromTokenText + toTokenText + " is already matching."
+        "Current pair: " + fromTokenText + toTokenText + " is already matching."
       );
       return;
     }
@@ -135,7 +135,7 @@ export class SwapPage {
     if (fromTokenText == to && toTokenText == from) {
       await this.flipTokenPair();
       console.log(
-        "Current pair:" + fromTokenText + toTokenText + " is fliped."
+        "Current pair: " + fromTokenText + toTokenText + " is fliped."
       );
       return;
     }

--- a/packages/web/e2e/tests/swap.stables.spec.ts
+++ b/packages/web/e2e/tests/swap.stables.spec.ts
@@ -22,7 +22,7 @@ test.describe("Test Swap Stables feature", () => {
   let USDT =
     "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB";
 
-  test.beforeEach(async () => {
+  test.beforeAll(async () => {
     console.log("Before test setup Wallet Extension.");
     // Launch Chrome with a Keplr wallet extension
     const pathToExtension = path.join(__dirname, "../keplr-extension");
@@ -51,7 +51,7 @@ test.describe("Test Swap Stables feature", () => {
     expect(await swapPage.isError(), "Swap is not available!").toBeFalsy();
   });
 
-  test.afterEach(async () => {
+  test.afterAll(async () => {
     await context.close();
   });
 

--- a/packages/web/e2e/tests/swap.wallet.spec.ts
+++ b/packages/web/e2e/tests/swap.wallet.spec.ts
@@ -24,8 +24,8 @@ test.describe("Test Swap feature", () => {
   let AKT =
     "ibc/1480B8FD20AD5FCAE81EA87584D269547DD4D436843C1D20F15E00EB64743EF4";
 
-  test.beforeEach(async () => {
-    console.log("Before test setup Wallet Extension.");
+  test.beforeAll(async () => {
+    console.log("\nBefore test setup Wallet Extension.");
     // Launch Chrome with a Keplr wallet extension
     const pathToExtension = path.join(__dirname, "../keplr-extension");
     context = await chromium.launchPersistentContext("", {
@@ -53,7 +53,7 @@ test.describe("Test Swap feature", () => {
     expect(await swapPage.isError(), "Swap is not available!").toBeFalsy();
   });
 
-  test.afterEach(async () => {
+  test.afterAll(async () => {
     await context.close();
   });
 


### PR DESCRIPTION
## What is the purpose of the change:

Make e2e workflow run faster by re-using wallet between tests.

## Brief Changelog:

- Make tests setup wallet just once
- Fix some typos