### PR TITLE
Update ibc-overrides.ts

### DIFF
--- a/packages/web/config/ibc-overrides.ts
+++ b/packages/web/config/ibc-overrides.ts
@@ -267,10 +267,8 @@ const MainnetIBCAdditionalData: Partial<
     },
   },
   INJ: {
-    depositUrlOverride:
-      "https://hub.injective.network/bridge/?destination=osmosis&origin=injective&token=inj",
-    withdrawUrlOverride:
-      "https://hub.injective.network/bridge/?destination=injective&origin=osmosis&token=inj",
+    depositUrlOverride: "https://bridge.injective.network/",
+    withdrawUrlOverride: "https://bridge.injective.network/",
   },
   FTM: {
     sourceChainNameOverride: "Fantom",


### PR DESCRIPTION
## What is the purpose of the change:

The old URLs to https://hub.injective.network/bridge no longer work. Now they have a new bridge site: https://bridge.injective.network/

## Brief Changelog

Update ibc-overrides.ts for Injective $INJ
depositUrlOverride: "https://bridge.injective.network/",
    withdrawUrlOverride: "https://bridge.injective.network/",

## Testing and Verifying

This change has been tested locally by rebuilding the website and verified content and links are expected
