### PR TITLE
Added Slack alerts for FE E2E tests

### DIFF
--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -40,6 +40,41 @@ jobs:
         with:
           name: main-e2e-test-results
           path: packages/web/playwright-report
+      - name: Send Slack alert if test fails
+        id: slack
+        if: failure()
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "text": "🚨 FE E2E Tests Failure Alert 🚨",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "FE E2E Tests Failure"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Environment:* production\n*App URL:* https://app.osmosis.zone"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Click here to view the run: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|GitHub Actions Run>"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SERVER_E2E_TESTS_SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
   preview-e2e-tests:
     if: github.event.deployment_status.state == 'success' && github.event.deployment_status.environment == 'Preview – osmosis-frontend'
@@ -77,3 +112,38 @@ jobs:
         with:
           name: preview-e2e-test-results
           path: packages/web/playwright-report
+      - name: Send Slack alert if test fails
+        id: slack
+        if: failure()
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "text": "🚨 FE E2E Tests Failure Alert 🚨",
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "FE E2E Tests Failure"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Environment:* preview\n*App URL:* ${{ github.event.deployment_status.environment_url }}"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Click here to view the run: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|GitHub Actions Run>"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SERVER_E2E_TESTS_SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/server-e2e-tests.yml
+++ b/.github/workflows/server-e2e-tests.yml
@@ -55,17 +55,14 @@ jobs:
       - name: Run Tests
         id: tests
         run: yarn test:e2e --filter=server
-        continue-on-error: ${{ matrix.env == 'staging' }}
         env:
           NEXT_PUBLIC_SIDECAR_BASE_URL: ${{ matrix.server-url }}
           NEXT_PUBLIC_TIMESERIES_DATA_URL: ${{ matrix.timeseries-url }}
 
       # Send Slack alert if 'tests' job fails
-      # Here we include the 'steps.tests.outcome != 'success'' function to check if the job failed
-      # even after the 'continue-on-error' flag is set to true.
       - name: Send Slack alert if test fails
         id: slack
-        if: ${{ steps.tests.outcome != 'success' || failure() }}
+        if: failure()
         uses: slackapi/slack-github-action@v1.26.0
         with:
           payload: |


### PR DESCRIPTION
## What is the purpose of the change:

Added Slack alerts for FE E2E tests

[Linear Task FE-536 URL](https://linear.app/osmosis/issue/FE-536)
