### PR TITLE
feat: :sparkles: add new cms config

### DIFF
--- a/packages/server/src/queries/github/token-info.ts
+++ b/packages/server/src/queries/github/token-info.ts
@@ -22,9 +22,16 @@ export interface TokenCMSData {
 export const getTokenInfo = (denom: string, lang: string) => {
   const fileName = `${denom.toLowerCase()}_asset_detail_${lang.toLowerCase()}.json`;
 
-  if (!CMS_REPOSITORY_PATH)
-    throw new Error("Forgot to set CMS_REPOSITORY_PATH env var");
-  if (!GITHUB_URL) throw new Error("Forgot to set GITHUB_URL env var");
+  if (!CMS_REPOSITORY_PATH || !GITHUB_URL) {
+    const missingVars = [
+      !CMS_REPOSITORY_PATH ? "CMS_REPOSITORY_PATH" : "",
+      !GITHUB_URL ? "GITHUB_URL" : "",
+    ]
+      .filter(Boolean)
+      .join(", ");
+    console.error(`Missing environment variables: ${missingVars}`);
+    throw new Error(`Missing environment variables: ${missingVars}`);
+  }
 
   return githubApi
     .get<TokenCMSData>(`${CMS_REPOSITORY_PATH}/${fileName}`)

--- a/packages/server/src/queries/github/token-info.ts
+++ b/packages/server/src/queries/github/token-info.ts
@@ -20,13 +20,13 @@ export interface TokenCMSData {
 }
 
 export const getTokenInfo = (denom: string, lang: string) => {
-  const fileName = `${denom.toLowerCase()}_token_info_${lang.toLowerCase()}.json`;
+  const fileName = `${denom.toLowerCase()}_asset_detail_${lang.toLowerCase()}.json`;
 
   if (!CMS_REPOSITORY_PATH)
     throw new Error("Forgot to set CMS_REPOSITORY_PATH env var");
   if (!GITHUB_URL) throw new Error("Forgot to set GITHUB_URL env var");
 
   return githubApi
-    .get<TokenCMSData>(`${CMS_REPOSITORY_PATH}/tokens/${fileName}`)
+    .get<TokenCMSData>(`${CMS_REPOSITORY_PATH}/${fileName}`)
     .then((r) => r.data);
 };

--- a/packages/web/.env
+++ b/packages/web/.env
@@ -6,7 +6,7 @@
 
 
 GITHUB_URL=https://raw.githubusercontent.com/osmosis-labs/
-CMS_REPOSITORY_PATH=token-info/main/contents
+CMS_REPOSITORY_PATH=assetlists/main/osmosis-1/generated/asset_detail
 NEXT_PUBLIC_TFM_API_BASE_URL=https://api.tfm.com
 SENTRY_IGNORE_API_RESOLUTION_ERROR=1
 NEXT_PUBLIC_SQUID_INTEGRATOR_ID=osmosis-api


### PR DESCRIPTION
## What is the purpose of the change:

This PR changes the pointing of the CMS api from the old deprecated CMS repo to the assetlist repo.

> Note: we should change env vars from this one:
> `CMS_REPOSITORY_PATH=token-info/main/contents`
> To this one:
> `CMS_REPOSITORY_PATH=assetlists/main/osmosis-1/generated/asset_detail`

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-538/migrate-from-cms-repo-to-assetlist-repo)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->
