### PR TITLE
feat: normalised price values against USD for limit orders

### DIFF
--- a/packages/web/hooks/limit-orders/use-place-limit.ts
+++ b/packages/web/hooks/limit-orders/use-place-limit.ts
@@ -108,8 +108,8 @@ export const usePlaceLimit = ({
 
   /**
    * Determines the fiat amount the user will pay for their order.
-   * In the case of an Ask the fiat amount is the amount of tokens the user will sell times the currently selected price.
-   * In the case of a Bid the fiat amount is the amount of tokens the user will buy times the current price of the quote asset.
+   * In the case of an Ask the fiat amount is the amount of tokens the user will sell multiplied by the currently selected price.
+   * In the case of a Bid the fiat amount is the amount of quote asset tokens the user will send multiplied by the current price of the quote asset.
    */
   const paymentFiatValue = useMemo(() => {
     return orderDirection === OrderDirection.Ask

--- a/packages/web/hooks/limit-orders/use-place-limit.ts
+++ b/packages/web/hooks/limit-orders/use-place-limit.ts
@@ -127,10 +127,7 @@ export const usePlaceLimit = ({
       return;
     }
 
-    const paymentDenom =
-      orderDirection === OrderDirection.Bid
-        ? quoteAsset.coinMinimalDenom
-        : baseAsset.coinMinimalDenom;
+    const paymentDenom = paymentTokenValue.toCoin().denom;
 
     // The requested price must account for the ratio between the quote and base asset as the base asset may not be a stablecoin.
     // To account for this we divide by the quote asset price.
@@ -163,8 +160,6 @@ export const usePlaceLimit = ({
   }, [
     orderbookContractAddress,
     account,
-    quoteAsset,
-    baseAsset,
     orderDirection,
     priceState,
     quoteAssetPrice,

--- a/packages/web/hooks/limit-orders/use-place-limit.ts
+++ b/packages/web/hooks/limit-orders/use-place-limit.ts
@@ -80,23 +80,23 @@ export const usePlaceLimit = ({
     if (orderDirection === OrderDirection.Ask) {
       // In the case of an Ask we just return the amount requested to sell
       return baseTokenAmount;
-    } else {
-      // Determine the outgoing fiat amount the user wants to buy
-      const outgoingFiatValue =
-        mulPrice(
-          baseTokenAmount,
-          new PricePretty(DEFAULT_VS_CURRENCY, priceState.price),
-          DEFAULT_VS_CURRENCY
-        ) ?? new PricePretty(DEFAULT_VS_CURRENCY, new Dec(0));
-
-      // Determine the amount of quote asset tokens to send by dividing the outgoing fiat amount by the current quote asset price
-      // Multiply by 10^n where n is the amount of decimals for the quote asset
-      const quoteTokenAmount = outgoingFiatValue!
-        .quo(quoteAssetPrice ?? new Dec(1))
-        .toDec()
-        .mul(new Dec(Math.pow(10, quoteAsset.coinDecimals)));
-      return new CoinPretty(quoteAsset, quoteTokenAmount);
     }
+
+    // Determine the outgoing fiat amount the user wants to buy
+    const outgoingFiatValue =
+      mulPrice(
+        baseTokenAmount,
+        new PricePretty(DEFAULT_VS_CURRENCY, priceState.price),
+        DEFAULT_VS_CURRENCY
+      ) ?? new PricePretty(DEFAULT_VS_CURRENCY, new Dec(0));
+
+    // Determine the amount of quote asset tokens to send by dividing the outgoing fiat amount by the current quote asset price
+    // Multiply by 10^n where n is the amount of decimals for the quote asset
+    const quoteTokenAmount = outgoingFiatValue!
+      .quo(quoteAssetPrice ?? new Dec(1))
+      .toDec()
+      .mul(new Dec(Math.pow(10, quoteAsset.coinDecimals)));
+    return new CoinPretty(quoteAsset, quoteTokenAmount);
   }, [
     quoteAssetPrice,
     baseAsset,


### PR DESCRIPTION
## What is the purpose of the change:
Previous calculations when placing a limit order assumed the quote asset to be a stablecoin. These changes are to adjust for the current quote asset's fiat price for the case where the quote asset is not a stablecoin.

### Linear Task
[LIM-109: Adjust Limited Order to Account for Quote Asset Price](https://linear.app/osmosis/issue/LIM-109/adjust-limit-order-placing-to-account-for-quote-asset-price)


## Brief Changelog
- Adjusted `usePlaceLimit` calculations to account for `quoteAssetPrice` (the current fiat value of the quote denom)
