### PR TITLE
Add IBC status provider tests

### DIFF
--- a/packages/bridge/src/__tests__/mock-chains.ts
+++ b/packages/bridge/src/__tests__/mock-chains.ts
@@ -54,7 +54,7 @@ export const MockChains: Chain[] = [
     },
     explorers: [
       {
-        tx_page: "https://www.mintscan.io/cosmos/txs/${txHash}",
+        tx_page: "https://www.mintscan.io/osmosis/txs/{txHash}",
       },
     ],
     features: [
@@ -115,7 +115,7 @@ export const MockChains: Chain[] = [
     },
     explorers: [
       {
-        tx_page: "https://www.mintscan.io/osmosis/txs/${txHash}",
+        tx_page: "https://www.mintscan.io/cosmos/txs/{txHash}",
       },
     ],
     features: ["ibc-go", "ibc-transfer"],
@@ -178,7 +178,7 @@ export const MockChains: Chain[] = [
     },
     explorers: [
       {
-        tx_page: "https://www.mintscan.io/juno/txs/${txHash}",
+        tx_page: "https://www.mintscan.io/juno/txs/{txHash}",
       },
     ],
     features: ["ibc-transfer", "ibc-go", "cosmwasm", "wasmd_0.24+"],
@@ -233,7 +233,7 @@ export const MockChains: Chain[] = [
     },
     explorers: [
       {
-        tx_page: "https://explorer.injective.network/transaction/${txHash}",
+        tx_page: "https://explorer.injective.network/transaction/{txHash}",
       },
     ],
     features: ["ibc-transfer", "ibc-go", "eth-address-gen", "eth-key-sign"],
@@ -290,7 +290,7 @@ export const MockChains: Chain[] = [
     explorers: [
       {
         tx_page:
-          "https://secretnodes.com/secret/chains/secret-4/transactions/${txHash}",
+          "https://secretnodes.com/secret/chains/secret-4/transactions/{txHash}",
       },
     ],
     features: [
@@ -351,7 +351,7 @@ export const MockChains: Chain[] = [
     },
     explorers: [
       {
-        tx_page: "https://axelarscan.io/tx/${txHash}",
+        tx_page: "https://axelarscan.io/tx/{txHash}",
       },
     ],
     features: ["ibc-transfer", "ibc-go", "axelar-evm-bridge"],

--- a/packages/bridge/src/axelar/__tests__/axelar-transfer-status.spec.ts
+++ b/packages/bridge/src/axelar/__tests__/axelar-transfer-status.spec.ts
@@ -18,6 +18,9 @@ jest.mock("@osmosis-labs/utils", () => ({
   }),
 }));
 
+// silence console errors
+jest.spyOn(console, "error").mockImplementation(() => {});
+
 describe("AxelarTransferStatusProvider", () => {
   let provider: AxelarTransferStatusProvider;
   const mockReceiver: TransferStatusReceiver = {

--- a/packages/bridge/src/ibc/__tests__/ibc-transfer-status.spec.ts
+++ b/packages/bridge/src/ibc/__tests__/ibc-transfer-status.spec.ts
@@ -1,0 +1,200 @@
+import { queryRPCStatus, queryTx } from "@osmosis-labs/server";
+
+import { MockAssetLists } from "../../__tests__/mock-asset-lists";
+import { MockChains } from "../../__tests__/mock-chains";
+import { TransferStatusReceiver } from "../../interface";
+import { IBCTransferStatusProvider } from "../transfer-status";
+
+const makeRpcStatusResponse = (timeoutHeight: string) => ({
+  jsonrpc: "2.0",
+  id: 1,
+  result: {
+    validator_info: {
+      address: "mock_address",
+      pub_key: {
+        type: "mock_type",
+        value: "mock_value",
+      },
+      voting_power: "mock_voting_power",
+    },
+    node_info: {
+      protocol_version: {
+        p2p: "mock_p2p",
+        block: "mock_block",
+        app: "mock_app",
+      },
+      id: "mock_id",
+      listen_addr: "mock_listen_addr",
+      network: "mock_network",
+      version: "mock_version",
+      channels: "mock_channels",
+      moniker: "mock_moniker",
+      other: {
+        tx_index: "on" as const,
+        rpc_address: "mock_rpc_address",
+      },
+    },
+    sync_info: {
+      // reasonable time range
+      latest_block_hash: "mock_latest_block_hash",
+      latest_app_hash: "mock_latest_app_hash",
+      earliest_block_hash: "mock_earliest_block_hash",
+      earliest_app_hash: "mock_earliest_app_hash",
+      latest_block_height: timeoutHeight,
+      earliest_block_height: "90",
+      latest_block_time: new Date(Date.now() - 10000).toISOString(),
+      earliest_block_time: new Date(Date.now() - 20000).toISOString(),
+      catching_up: false,
+    },
+  },
+});
+
+jest.mock("@osmosis-labs/server", () => ({
+  queryTx: jest.fn(),
+  queryRPCStatus: jest.fn(),
+  DEFAULT_LRU_OPTIONS: { max: 10 },
+}));
+
+jest.mock("@osmosis-labs/tx", () => ({
+  ...jest.requireActual("@osmosis-labs/tx"),
+  TxTracer: jest.fn().mockImplementation(() => ({
+    traceTx: jest.fn().mockResolvedValue(undefined),
+    close: jest.fn(),
+  })),
+}));
+
+describe("IBCTransferStatusProvider", () => {
+  let provider: IBCTransferStatusProvider;
+  let mockReceiver: jest.Mocked<TransferStatusReceiver>;
+  let consoleSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    mockReceiver = {
+      receiveNewTxStatus: jest.fn(),
+    };
+    provider = new IBCTransferStatusProvider(MockChains, MockAssetLists);
+    provider.statusReceiverDelegate = mockReceiver;
+    // silences console errors and serves as a spy to test for calls
+    consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    jest.clearAllTimers();
+    jest.clearAllMocks();
+  });
+
+  it("should handle numerical chain IDs", async () => {
+    const params = JSON.stringify({
+      sendTxHash: "ABC123",
+      fromChainId: 1,
+      toChainId: "osmosis-1",
+    });
+
+    provider.trackTxStatus(params);
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "Unexpected failure when tracing IBC transfer status",
+      new Error("Unexpected numerical chain ID for cosmos tx: 1")
+    );
+    expect(mockReceiver.receiveNewTxStatus).toHaveBeenCalledWith(
+      `IBC${params}`,
+      "connection-error"
+    );
+  });
+
+  it("should handle failed transactions", async () => {
+    (queryTx as jest.Mock).mockResolvedValue({
+      // positive error code = failed tx on chain
+      tx_response: { code: 1 },
+    });
+
+    const params = JSON.stringify({
+      sendTxHash: "ABC123",
+      fromChainId: "osmosis-1",
+      toChainId: "osmosis-1",
+    });
+
+    await provider.trackTxStatus(params);
+
+    expect(mockReceiver.receiveNewTxStatus).toHaveBeenCalledWith(
+      `IBC${params}`,
+      "failed"
+    );
+  });
+
+  it("should handle missing events", async () => {
+    (queryTx as jest.Mock).mockResolvedValue({
+      tx_response: { code: 0, events: [] },
+    });
+
+    const params = JSON.stringify({
+      sendTxHash: "ABC123",
+      fromChainId: "osmosis-1",
+      toChainId: "osmosis-1",
+    });
+
+    await provider.trackTxStatus(params);
+
+    expect(mockReceiver.receiveNewTxStatus).toHaveBeenCalledWith(
+      `IBC${params}`,
+      "failed"
+    );
+  });
+
+  it("should handle successful trace", async () => {
+    (queryTx as jest.Mock).mockResolvedValue({
+      tx_response: {
+        code: 0,
+        events: [
+          {
+            type: "send_packet",
+            attributes: [
+              { key: "packet_src_channel", value: "channel-0" },
+              { key: "packet_dst_channel", value: "channel-1" },
+              { key: "packet_sequence", value: "1" },
+              { key: "packet_timeout_height", value: "1-100" },
+            ],
+          },
+        ],
+      },
+    });
+    (queryRPCStatus as jest.Mock).mockResolvedValue(
+      // not timed out
+      makeRpcStatusResponse("100000")
+    );
+
+    const params = JSON.stringify({
+      sendTxHash: "ABC123",
+      fromChainId: "osmosis-1",
+      toChainId: "cosmoshub-4",
+    });
+
+    await provider.trackTxStatus(params);
+
+    expect(mockReceiver.receiveNewTxStatus).toHaveBeenCalledWith(
+      `IBC${params}`,
+      "success"
+    );
+  });
+
+  it("should handle unexpected errors", async () => {
+    (queryTx as jest.Mock).mockRejectedValue(new Error("Network error"));
+
+    const params = JSON.stringify({
+      sendTxHash: "ABC123",
+      fromChainId: "osmosis-1",
+      toChainId: "osmosis-1",
+    });
+
+    await provider.trackTxStatus(params);
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "Unexpected failure when tracing IBC transfer status",
+      new Error("Network error")
+    );
+    expect(mockReceiver.receiveNewTxStatus).toHaveBeenCalledWith(
+      `IBC${params}`,
+      "connection-error"
+    );
+  });
+});

--- a/packages/bridge/src/ibc/__tests__/ibc-transfer-status.spec.ts
+++ b/packages/bridge/src/ibc/__tests__/ibc-transfer-status.spec.ts
@@ -352,6 +352,6 @@ describe("IBCTransferStatusProvider", () => {
 
     const url = provider.makeExplorerUrl(params);
 
-    expect(url).toBe(`https://www.mintscan.io/osmosis-1/txs/ABC123`);
+    expect(url).toBe(`https://www.mintscan.io/osmosis/txs/ABC123`);
   });
 });

--- a/packages/bridge/src/skip/__tests__/skip-transfer-status.spec.ts
+++ b/packages/bridge/src/skip/__tests__/skip-transfer-status.spec.ts
@@ -5,21 +5,21 @@ import { server } from "../../__tests__/msw";
 import { BridgeEnvironment, TransferStatusReceiver } from "../../interface";
 import { SkipTransferStatusProvider } from "../transfer-status";
 
-jest.mock("@osmosis-labs/utils", () => {
-  const originalModule = jest.requireActual("@osmosis-labs/utils");
-  return {
-    ...originalModule,
-    poll: jest.fn(({ fn, validate }) => {
-      const pollFn = async () => {
-        const result = await fn();
-        if (validate(result)) {
-          return result;
-        }
-      };
-      return pollFn();
-    }),
-  };
-});
+jest.mock("@osmosis-labs/utils", () => ({
+  ...jest.requireActual("@osmosis-labs/utils"),
+  poll: jest.fn(({ fn, validate }) => {
+    const pollFn = async () => {
+      const result = await fn();
+      if (validate(result)) {
+        return result;
+      }
+    };
+    return pollFn();
+  }),
+}));
+
+// silence console errors
+jest.spyOn(console, "error").mockImplementation(() => {});
 
 describe("SkipTransferStatusProvider", () => {
   let provider: SkipTransferStatusProvider;
@@ -54,12 +54,12 @@ describe("SkipTransferStatusProvider", () => {
       })
     );
 
-    await provider.trackTxStatus(
-      JSON.stringify({ sendTxHash: "testTxHash", fromChainId: 1 })
-    );
+    const params = JSON.stringify({ sendTxHash: "testTxHash", fromChainId: 1 });
+
+    await provider.trackTxStatus(params);
 
     expect(mockReceiver.receiveNewTxStatus).toHaveBeenCalledWith(
-      `Skip${JSON.stringify({ sendTxHash: "testTxHash", fromChainId: 1 })}`,
+      `Skip${params}`,
       "success",
       undefined
     );
@@ -72,12 +72,12 @@ describe("SkipTransferStatusProvider", () => {
       })
     );
 
-    await provider.trackTxStatus(
-      JSON.stringify({ sendTxHash: "testTxHash", fromChainId: 1 })
-    );
+    const params = JSON.stringify({ sendTxHash: "testTxHash", fromChainId: 1 });
+
+    await provider.trackTxStatus(params);
 
     expect(mockReceiver.receiveNewTxStatus).toHaveBeenCalledWith(
-      `Skip${JSON.stringify({ sendTxHash: "testTxHash", fromChainId: 1 })}`,
+      `Skip${params}`,
       "failed",
       undefined
     );

--- a/packages/bridge/src/squid/__tests__/squid-transfer-status.spec.ts
+++ b/packages/bridge/src/squid/__tests__/squid-transfer-status.spec.ts
@@ -21,6 +21,9 @@ jest.mock("@osmosis-labs/utils", () => {
   };
 });
 
+// silence console errors
+jest.spyOn(console, "error").mockImplementation(() => {});
+
 describe("SquidTransferStatusProvider", () => {
   let provider: SquidTransferStatusProvider;
   const mockReceiver: TransferStatusReceiver = {

--- a/packages/tx/src/tracer.ts
+++ b/packages/tx/src/tracer.ts
@@ -57,7 +57,7 @@ export class TxTracer {
 
   constructor(
     protected readonly url: string,
-    protected readonly wsEndpoint: string,
+    protected readonly wsEndpoint: string = "/websocket",
     protected readonly options: {
       wsObject?: new (url: string, protocols?: string | string[]) => WebSocket;
     } = {}


### PR DESCRIPTION
## What is the purpose of the change:

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

I accidentally committed the IBC provider tests to stage in the past, but they are quite simple.

This PR introduces the test suite for the IBC status provider, which has quite a few async operations. In short, it sets up a Promise.wait to either wait for an IBC ack confirming the transfer, or for the IBC timeout height to be reached on the counterparty chain from polling.

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-473/add-unit-tests-for-ibc-bridge-provider-and-transfer-status)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

* Adds unit tests for IBC transfer status provider
* Makes minor improvements to the status provider and providers it uses

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

* All tests pass
