### PR TITLE
feat: replace vercel kv with upstash

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -36,7 +36,7 @@
     "@osmosis-labs/types": "^1.0.0",
     "@osmosis-labs/utils": "^1.0.0",
     "@sentry/core": "^7.109.0",
-    "@vercel/kv": "^0.2.3",
+    "@upstash/redis": "^1.31.5",
     "axios": "^0.27.2",
     "cachified": "^3.5.4",
     "dataloader": "^2.2.2",

--- a/packages/server/src/queries/twitter/twitter.ts
+++ b/packages/server/src/queries/twitter/twitter.ts
@@ -1,5 +1,5 @@
 import { apiClient } from "@osmosis-labs/utils";
-import { createClient, VercelKV } from "@vercel/kv";
+import { Redis } from "@upstash/redis";
 import { Cache, CacheEntry, cachified } from "cachified";
 
 import {
@@ -50,7 +50,7 @@ export interface RichTweet {
 
 const DEFAULT_TTL = 1000 * 60 * 60 * 24 * 7;
 
-const kvStoreAdapter = (store: VercelKV): Cache => ({
+const kvStoreAdapter = (store: Redis): Cache => ({
   set: <T>(key: string, value: CacheEntry<T>) => {
     value.metadata.ttl;
     return store.set(key, value, {
@@ -75,7 +75,7 @@ export class Twitter {
   private rawUsers: RawUser[] = [];
   private rawMedia: RawMedia[] = [];
 
-  private kvStore: VercelKV;
+  private kvStore: Redis;
   private cache: Cache;
 
   /**
@@ -85,7 +85,7 @@ export class Twitter {
    */
   constructor(cacheExpireTime: number = DEFAULT_TTL) {
     this.cacheExpireTime = cacheExpireTime;
-    this.kvStore = createClient({
+    this.kvStore = new Redis({
       url: KV_STORE_REST_API_URL!,
       token: KV_STORE_REST_API_TOKEN!,
     });

--- a/packages/server/src/utils/remote-cache.ts
+++ b/packages/server/src/utils/remote-cache.ts
@@ -1,5 +1,5 @@
 import { isNil } from "@osmosis-labs/utils";
-import { createClient, VercelKV } from "@vercel/kv";
+import { Redis } from "@upstash/redis";
 import { Cache as CachifiedCache, CacheEntry, totalTtl } from "cachified";
 import { LRUCache } from "lru-cache";
 
@@ -21,7 +21,7 @@ const isTestEnv = process.env.NODE_ENV === "test";
  *  Falls back to in-memory cache if the remote client is not able to be created.
  */
 export class RemoteCache implements CachifiedCache {
-  protected kvStore: VercelKV | null = null;
+  protected kvStore: Redis | null = null;
 
   protected fallbackCache: CachifiedCache | null = null;
 
@@ -59,7 +59,7 @@ export class RemoteCache implements CachifiedCache {
       }
 
       try {
-        this.kvStore = createClient({
+        this.kvStore = new Redis({
           url,
           token,
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -10408,19 +10408,12 @@
     "@typescript-eslint/types" "7.4.0"
     eslint-visitor-keys "^3.4.1"
 
-"@upstash/redis@1.22.0":
-  version "1.22.0"
-  resolved "https://registry.yarnpkg.com/@upstash/redis/-/redis-1.22.0.tgz#3ae3ef056608c8598f46e8bc3b3f405a94781142"
-  integrity sha512-sXoJDoEqqik0HbrNE7yRWckOySEFsoBxfRdCgOqkc0w6py19ZZG50SpGkDDEUXSnBqP8VgGYXhWAiBpqxrt5oA==
+"@upstash/redis@^1.31.5":
+  version "1.31.5"
+  resolved "https://registry.yarnpkg.com/@upstash/redis/-/redis-1.31.5.tgz#8d5fe439a2a28638b3a354a23680ecf7f7eb4f54"
+  integrity sha512-2MatqeqftroSJ9Q+pqbyGAIwXX6KEPtUTUna2c/fq09h12ffwvltDTgfppeF+NzJo/SyZfHY8e1RoflduMbz1A==
   dependencies:
-    isomorphic-fetch "^3.0.0"
-
-"@vercel/kv@^0.2.3":
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/@vercel/kv/-/kv-0.2.3.tgz#182419a8e44fcc7ff1638522f8d79a1846d99795"
-  integrity sha512-Wq1+EsRBQmvLlcqCZeYVg1MAARWrnETgLe3Sy3UCqG+zg7LThpkt0YHZe1NN3Aj4IRmCKQamotWrLDdEx+ZB3w==
-  dependencies:
-    "@upstash/redis" "1.22.0"
+    crypto-js "^4.2.0"
 
 "@virtuoso.dev/react-urx@^0.2.12":
   version "0.2.13"
@@ -14272,7 +14265,7 @@ crypto-hash@^1.3.0:
   resolved "https://registry.yarnpkg.com/crypto-hash/-/crypto-hash-1.3.0.tgz#b402cb08f4529e9f4f09346c3e275942f845e247"
   integrity sha512-lyAZ0EMyjDkVvz8WOeVnuCPvKVBXcMv1l5SVqO1yC7PzTwrD/pPje/BIRbWhMoPe436U+Y2nD7f5bFx0kt+Sbg==
 
-crypto-js@^4.0.0, crypto-js@^4.1.1:
+crypto-js@^4.0.0, crypto-js@^4.1.1, crypto-js@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.2.0.tgz#4d931639ecdfd12ff80e8186dba6af2c2e856631"
   integrity sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==


### PR DESCRIPTION
## What is the purpose of the change:

Replace vercel kv with upstash for twitter cache and generic remote cache.

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-520/change-vercel-kv-to-upstash)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->
