### PR TITLE
Update BERLIN symbol to match the assetlist

### DIFF
--- a/packages/web/config/ibc-overrides.ts
+++ b/packages/web/config/ibc-overrides.ts
@@ -621,7 +621,7 @@ const MainnetIBCAdditionalData: Partial<
     depositUrlOverride: "https://portalbridge.com/cosmos/",
     withdrawUrlOverride: "https://portalbridge.com/cosmos/",
   },
-  BERLIN: {
+  "BERLIN-legacy": {
     depositUrlOverride: "https://app.evmos.org/assets",
   },
   BMOS: {


### PR DESCRIPTION
## What is the purpose of the change:

Update BERLIN to "BERLIN-legacy" because it was hardcoded and now doesn't match the assetlist.

## Brief Changelog

Update BERLIN to "BERLIN-legacy" in ibc-overrides.ts

## Testing and Verifying


This change has been tested locally by rebuilding the website and verified content and links are expected
