### PR TITLE
Handle 0 fee amount estimations

### DIFF
--- a/packages/tx/src/__tests__/gas.spec.ts
+++ b/packages/tx/src/__tests__/gas.spec.ts
@@ -740,8 +740,6 @@ describe("getGasFeeAmount", () => {
       })
     )[0];
 
-    console.log({ gasAmount });
-
     const expectedGasAmount = new Dec(baseFee)
       .mul(new Dec(gasMultiplier))
       .quo(new Dec(lowEnoughSpotPrice))

--- a/packages/tx/src/__tests__/gas.spec.ts
+++ b/packages/tx/src/__tests__/gas.spec.ts
@@ -660,7 +660,133 @@ describe("getGasFeeAmount", () => {
     expect(gasAmount.isNeededForTx).toBe(false);
   });
 
-  it("should the correct gas amount with an alternative fee token that is the lesser of the spent amounts", async () => {
+  // Scenario: base fee token goes down in price and a very expensive (i.e. WBTC) alternative fee token is checked but resulting fee amount is <= 0
+  it("should skip an alternative fee token that has a spot price that results in too little precision for 1 unit of fee amount", async () => {
+    const gasLimit = 1000;
+    const chainId = "osmosis-1";
+    const address = "osmo1...";
+    const baseFee = "0.002500000000000000";
+    /** Spot price low enough to yield a positive gas fee amount */
+    const lowEnoughSpotPrice = "1";
+    const veryHighSpotPrice = "1095.350087822065970161";
+
+    (queryBalances as jest.Mock).mockResolvedValue({
+      balances: [
+        {
+          denom: "uosmo",
+          amount: "1",
+        },
+        {
+          // ATOM
+          denom:
+            "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+          amount: "1000",
+        },
+        {
+          denom: "uion",
+          amount: "1000000",
+        },
+      ],
+    } as Awaited<ReturnType<typeof queryBalances>>);
+    (queryFeesBaseGasPrice as jest.Mock).mockResolvedValue({
+      base_fee: baseFee,
+    } as Awaited<ReturnType<typeof queryFeesBaseGasPrice>>);
+    (queryFeeTokens as jest.Mock).mockResolvedValue({
+      fee_tokens: [
+        {
+          denom: "uion",
+          poolID: 2,
+        },
+        {
+          // ATOM
+          denom:
+            "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+          poolID: 1,
+        },
+      ],
+    } as Awaited<ReturnType<typeof queryFeeTokens>>);
+    (queryFeesBaseDenom as jest.Mock).mockResolvedValue({
+      base_denom: "uosmo",
+    } as Awaited<ReturnType<typeof queryFeesBaseDenom>>);
+    (queryFeeTokenSpotPrice as jest.Mock).mockImplementation(({ denom }) => {
+      // uion should be checked but is skipped due to low precision
+      if (denom === "uion") {
+        return Promise.resolve({
+          pool_id: "2",
+          spot_price: veryHighSpotPrice,
+        } as Awaited<ReturnType<typeof queryFeeTokenSpotPrice>>);
+      }
+      if (
+        denom ===
+        "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+      ) {
+        return Promise.resolve({
+          pool_id: "1",
+          spot_price: lowEnoughSpotPrice,
+        } as Awaited<ReturnType<typeof queryFeeTokenSpotPrice>>);
+      }
+      throw new Error("Mocked implementation got an unexpected fee denom");
+    });
+
+    const gasMultiplier = 1.5;
+
+    const gasAmount = (
+      await getGasFeeAmount({
+        chainId,
+        chainList: MockChains,
+        gasLimit: gasLimit.toString(),
+        bech32Address: address,
+        gasMultiplier,
+      })
+    )[0];
+
+    console.log({ gasAmount });
+
+    const expectedGasAmount = new Dec(baseFee)
+      .mul(new Dec(gasMultiplier))
+      .quo(new Dec(lowEnoughSpotPrice))
+      .mul(new Dec(1.01))
+      .mul(new Dec(gasLimit))
+      .truncate()
+      .toString();
+
+    expect(queryBalances).toBeCalledWith({
+      chainId,
+      bech32Address: address,
+      chainList: MockChains,
+    });
+    expect(queryFeesBaseGasPrice).toBeCalledWith({
+      chainId,
+      chainList: MockChains,
+    });
+    expect(queryFeeTokens).toBeCalledWith({
+      chainId,
+      chainList: MockChains,
+    });
+    expect(queryFeesBaseDenom).toBeCalledWith({
+      chainId,
+      chainList: MockChains,
+    });
+    expect(queryFeeTokenSpotPrice).toBeCalledWith({
+      chainId,
+      chainList: MockChains,
+      denom: "uion",
+    });
+    expect(queryFeeTokenSpotPrice).toBeCalledWith({
+      chainId,
+      chainList: MockChains,
+      denom:
+        "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+    });
+
+    expect(gasAmount.denom).toBe(
+      "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+    );
+    expect(gasAmount.amount).toBe(expectedGasAmount);
+    expect(gasAmount.isNeededForTx).toBeUndefined();
+  });
+
+  it("should return the correct gas amount with an alternative fee token that is the lesser of the spent amounts", async () => {
     const gasLimit = 1000;
     const chainId = "osmosis-1";
     const address = "osmo1...";

--- a/packages/tx/src/gas.ts
+++ b/packages/tx/src/gas.ts
@@ -332,8 +332,12 @@ export async function getGasFeeAmount({
       .truncate()
       .toString();
 
-    // Check if this balance is not enough to pay the fee, if so skip.
-    if (new Dec(feeAmount).gt(new Dec(unspentFeeBalance.amount))) continue;
+    // Check if this balance is not enough or fee amount is too little (not enough precision) to pay the fee, if so skip.
+    if (
+      new Dec(feeAmount).gt(new Dec(unspentFeeBalance.amount)) ||
+      new Dec(feeAmount).lte(new Dec(0))
+    )
+      continue;
 
     // found enough to pay the fee that is not spent
     return [
@@ -377,6 +381,9 @@ export async function getGasFeeAmount({
     .sort((a, b) => (new Int(a.feeAmount).lt(new Int(b.feeAmount)) ? -1 : 1));
 
   for (const spentFeeAmount of spentFees) {
+    // check for gas price conversion having too little precision
+    if (new Dec(spentFeeAmount.feeAmount).lte(new Dec(0))) continue;
+
     const spentAmount =
       coinsSpent.find(({ denom }) => denom === spentFeeAmount.denom)?.amount ||
       "0";

--- a/packages/tx/src/gas.ts
+++ b/packages/tx/src/gas.ts
@@ -320,11 +320,11 @@ export async function getGasFeeAmount({
     (balance) => !feeDenomsSpent.includes(balance.denom)
   );
 
-  for (const unspentFeeBalance of unspentFeeBalances) {
+  for (const { denom, amount } of unspentFeeBalances) {
     const { gasPrice: feeDenomGasPrice } = await getGasPriceByFeeDenom({
       chainId,
       chainList,
-      feeDenom: unspentFeeBalance.denom,
+      feeDenom: denom,
       gasMultiplier,
     });
     const feeAmount = feeDenomGasPrice
@@ -334,7 +334,7 @@ export async function getGasFeeAmount({
 
     // Check if this balance is not enough or fee amount is too little (not enough precision) to pay the fee, if so skip.
     if (
-      new Dec(feeAmount).gt(new Dec(unspentFeeBalance.amount)) ||
+      new Dec(feeAmount).gt(new Dec(amount)) ||
       new Dec(feeAmount).lte(new Dec(0))
     )
       continue;
@@ -343,7 +343,7 @@ export async function getGasFeeAmount({
     return [
       {
         amount: feeAmount,
-        denom: unspentFeeBalance.denom,
+        denom,
       },
     ];
   }
@@ -380,22 +380,19 @@ export async function getGasFeeAmount({
     )
     .sort((a, b) => (new Int(a.feeAmount).lt(new Int(b.feeAmount)) ? -1 : 1));
 
-  for (const spentFeeAmount of spentFees) {
+  for (const { amount, feeAmount, denom } of spentFees) {
     // check for gas price conversion having too little precision
-    if (new Dec(spentFeeAmount.feeAmount).lte(new Dec(0))) continue;
+    if (new Dec(feeAmount).lte(new Dec(0))) continue;
 
     const spentAmount =
-      coinsSpent.find(({ denom }) => denom === spentFeeAmount.denom)?.amount ||
-      "0";
-    const totalSpent = new Dec(spentAmount).add(
-      new Dec(spentFeeAmount.feeAmount)
-    );
-    const isBalanceNeededForTx = totalSpent.gte(new Dec(spentFeeAmount.amount));
+      coinsSpent.find((coinSpent) => coinSpent.denom === denom)?.amount || "0";
+    const totalSpent = new Dec(spentAmount).add(new Dec(feeAmount));
+    const isBalanceNeededForTx = totalSpent.gte(new Dec(amount));
 
     return [
       {
-        amount: spentFeeAmount.feeAmount,
-        denom: spentFeeAmount.denom,
+        amount: feeAmount,
+        denom,
         isNeededForTx: isBalanceNeededForTx,
       },
     ];

--- a/packages/web/components/pool-detail/share.tsx
+++ b/packages/web/components/pool-detail/share.tsx
@@ -216,8 +216,6 @@ export const SharePool: FunctionComponent<{ pool: Pool }> = observer(
           unbondingPeriod: duration.asDays(),
         };
 
-        console.log({ electSuperfluid });
-
         logEvent([E.bondingStarted, lockInfo]);
 
         if (electSuperfluid) {
@@ -258,10 +256,6 @@ export const SharePool: FunctionComponent<{ pool: Pool }> = observer(
     );
     const handleSuperfluidDelegateToValidator = useCallback(
       (validatorAddress: string) => {
-        console.log("handleSuperfluidDelegateToValidator", {
-          validatorAddress,
-          isSuperfluid,
-        });
         if (!isSuperfluid || !pool.id) return;
 
         const poolInfo = {
@@ -303,8 +297,6 @@ export const SharePool: FunctionComponent<{ pool: Pool }> = observer(
       (setter: Function, show: boolean) => () => setter(show),
       []
     );
-
-    console.log("parentBalance", lockLPTokensConfig?.balance?.toString());
 
     return (
       <main className="m-auto flex min-h-screen max-w-container flex-col gap-8 bg-osmoverse-900 px-8 py-4 md:gap-4 md:p-4">


### PR DESCRIPTION
## What is the purpose of the change:

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

Currently, the WBTC spot price is too high relative to OSMO. This causes a 0 amount of WBTC to be calculated as an alternative fee amount. We need to handle this by ensuring the alternative fee token amount is greater than 0, and otherwise searching for other fee tokens.

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

* Check for 0 alternative fee token amount, continue if <= 0
* Add test case

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

* Unit tests pass
* 0 fee amounts are not suggested when estimating a tx execution