### PR TITLE
Fuzzy search to pools page search - Search matches for coinName in pools page

### DIFF
--- a/packages/server/src/queries/complex/pools/index.ts
+++ b/packages/server/src/queries/complex/pools/index.ts
@@ -111,7 +111,7 @@ export async function getPools(
 
   if (params?.search) {
     // search for an exact match of coinMinimalDenom or pool ID
-    const coinMinimalDemonMatches = search(
+    const coinDenomsOrIdMatches = search(
       denomPools,
       ["coinDenoms", "id"],
       params.search,
@@ -119,8 +119,8 @@ export async function getPools(
     );
 
     // if not exact match for coinMinimalDenom or pool ID, search by poolNameByDenom (ex: OSMO/USDC) or coinName (ex: Bitcoin)
-    if (coinMinimalDemonMatches.length > 0) {
-      denomPools = coinMinimalDemonMatches;
+    if (coinDenomsOrIdMatches.length > 0) {
+      denomPools = coinDenomsOrIdMatches;
     } else {
       const poolNameByDenomMatches = search(
         denomPools,


### PR DESCRIPTION
## What is the purpose of the change:

- add search for pools by coinName matches (ex "Bitcoin")

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-554/add-asset-fuzzy-search-to-pools-page-search-v1)

## Brief Changelog

- add coinName value to search by

## Testing and Verifying

<img width="1158" alt="Screenshot 2024-06-14 at 6 37 25 PM" src="https://github.com/osmosis-labs/osmosis-frontend/assets/30577966/3e556126-9dd7-482f-84b2-2b332eeacdb5">
