### PR TITLE
feat: Current orderbook spot price hook

### DIFF
--- a/packages/server/src/queries/complex/orderbooks/index.ts
+++ b/packages/server/src/queries/complex/orderbooks/index.ts
@@ -1,1 +1,2 @@
 export * from "./maker-fee";
+export * from "./spot-price";

--- a/packages/server/src/queries/complex/orderbooks/spot-price.ts
+++ b/packages/server/src/queries/complex/orderbooks/spot-price.ts
@@ -1,0 +1,35 @@
+import { Chain } from "@osmosis-labs/types";
+import cachified, { CacheEntry } from "cachified";
+import { LRUCache } from "lru-cache";
+
+import { DEFAULT_LRU_OPTIONS } from "../../../utils/cache";
+import { queryOrderbookSpotPrice } from "../../osmosis";
+
+const orderbookSpotPriceCache = new LRUCache<string, CacheEntry>(
+  DEFAULT_LRU_OPTIONS
+);
+
+export function getOrderbookSpotPrice({
+  orderbookAddress,
+  chainList,
+  quoteAssetDenom,
+  baseAssetDenom,
+}: {
+  orderbookAddress: string;
+  quoteAssetDenom: string;
+  baseAssetDenom: string;
+  chainList: Chain[];
+}) {
+  return cachified({
+    cache: orderbookSpotPriceCache,
+    key: `orderbookSpotPrice-${orderbookAddress}-${quoteAssetDenom}-${baseAssetDenom}`,
+    ttl: 1000 * 60 * 2, // 2 minutes
+    getFreshValue: () =>
+      queryOrderbookSpotPrice({
+        orderbookAddress,
+        chainList,
+        quoteAssetDenom,
+        baseAssetDenom,
+      }).then(({ data }) => data.spot_price),
+  });
+}

--- a/packages/server/src/queries/osmosis/orderbooks.ts
+++ b/packages/server/src/queries/osmosis/orderbooks.ts
@@ -52,3 +52,29 @@ export const queryOrderbookActiveOrders = createNodeQuery<
     return `/cosmwasm/wasm/v1/contract/${orderbookAddress}/smart/${encodedMsg}`;
   },
 });
+
+interface OrderbookSpotPriceResponse {
+  data: {
+    spot_price: string;
+  };
+}
+
+export const queryOrderbookSpotPrice = createNodeQuery<
+  OrderbookSpotPriceResponse,
+  {
+    orderbookAddress: string;
+    quoteAssetDenom: string;
+    baseAssetDenom: string;
+  }
+>({
+  path: ({ orderbookAddress, quoteAssetDenom, baseAssetDenom }) => {
+    const msg = JSON.stringify({
+      spot_price: {
+        quote_asset_denom: quoteAssetDenom,
+        base_asset_denom: baseAssetDenom,
+      },
+    });
+    const encodedMsg = Buffer.from(msg).toString("base64");
+    return `/cosmwasm/wasm/v1/contract/${orderbookAddress}/smart/${encodedMsg}`;
+  },
+});

--- a/packages/server/src/trpc-routers/orderbook-router.ts
+++ b/packages/server/src/trpc-routers/orderbook-router.ts
@@ -2,7 +2,10 @@ import { Dec } from "@keplr-wallet/unit";
 import { z } from "zod";
 
 import { queryOrderbookActiveOrders } from "../queries";
-import { getOrderbookMakerFee } from "../queries/complex/orderbooks";
+import {
+  getOrderbookMakerFee,
+  getOrderbookSpotPrice,
+} from "../queries/complex/orderbooks";
 import { OsmoAddressSchema } from "../queries/complex/parameter-types";
 import { createTRPCRouter, publicProcedure } from "../trpc";
 
@@ -36,5 +39,25 @@ export const orderbookRouter = createTRPCRouter({
         chainList: ctx.chainList,
       });
       return resp.data;
+    }),
+  getSpotPrice: publicProcedure
+    .input(
+      z
+        .object({
+          quoteAssetDenom: z.string(),
+          baseAssetDenom: z.string(),
+        })
+        .required()
+        .and(OsmoAddressSchema.required())
+    )
+    .query(async ({ input, ctx }) => {
+      const { quoteAssetDenom, baseAssetDenom, osmoAddress } = input;
+      const spotPrice = await getOrderbookSpotPrice({
+        orderbookAddress: osmoAddress,
+        quoteAssetDenom: quoteAssetDenom,
+        baseAssetDenom: baseAssetDenom,
+        chainList: ctx.chainList,
+      });
+      return new Dec(spotPrice);
     }),
 });

--- a/packages/web/components/place-limit-tool/index.tsx
+++ b/packages/web/components/place-limit-tool/index.tsx
@@ -51,7 +51,11 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
       }
     }, [selectableBaseDenoms, selectableQuoteDenoms]);
     useEffect(() => {
-      if (Object.keys(selectableQuoteDenoms).length > 0) {
+      if (
+        Object.keys(selectableQuoteDenoms).length > 0 &&
+        selectableQuoteDenoms[baseDenom] &&
+        selectableQuoteDenoms[baseDenom].length > 0
+      ) {
         const quoteDenom = selectableQuoteDenoms[baseDenom][0];
         setQuoteDenom(quoteDenom);
       }

--- a/packages/web/components/place-limit-tool/index.tsx
+++ b/packages/web/components/place-limit-tool/index.tsx
@@ -196,7 +196,11 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
               !swapState.inAmountInput.inputAmount ||
               swapState.inAmountInput.inputAmount === "0"
             }
-            isLoading={!swapState.isBalancesFetched || isMakerFeeLoading}
+            isLoading={
+              !swapState.isBalancesFetched ||
+              isMakerFeeLoading ||
+              swapState.priceState.isLoading
+            }
             loadingText={"Loading..."}
             onClick={() => setReviewOpen(true)}
           >

--- a/packages/web/hooks/limit-orders/use-orderbook.ts
+++ b/packages/web/hooks/limit-orders/use-orderbook.ts
@@ -14,14 +14,15 @@ interface Orderbook {
 
 const testnetOrderbooks: Orderbook[] = [
   {
-    baseDenom: "OSMO",
-    quoteDenom: "USDC",
+    baseDenom: "uosmo",
+    quoteDenom:
+      "ibc/DE6792CF9E521F6AD6E9A4BDF6225C9571A3B74ACC0A529F92BC5122A39D2E58",
     contractAddress:
       "osmo1kgvlc4gmd9rvxuq2e63m0fn4j58cdnzdnrxx924mrzrjclcgqx5qxn3dga",
   },
   {
-    baseDenom: "ION",
-    quoteDenom: "OSMO",
+    baseDenom: "uion",
+    quoteDenom: "uosmo",
     contractAddress:
       "osmo1ruxn39qj6x44gms8pfzw22kd7kemslc5fahgua3wuz0tkyks0uhq2f25wh",
   },

--- a/packages/web/hooks/limit-orders/use-orderbook.ts
+++ b/packages/web/hooks/limit-orders/use-orderbook.ts
@@ -152,6 +152,15 @@ export const useOrderbook = ({
   };
 };
 
+/**
+ * Hook to fetch the maker fee for a given orderbook.
+ *
+ * Queries the maker fee using the orderbook's address.
+ * If the data is still loading, it returns a default value of Dec(0) for the maker fee.
+ * Once the data is loaded, it returns the actual maker fee if available, or Dec(0) if not.
+ * @param {string} orderbookAddress - The contract address of the orderbook.
+ * @returns {Object} An object containing the maker fee and the loading state.
+ */
 const useMakerFee = ({ orderbookAddress }: { orderbookAddress: string }) => {
   const { data: makerFeeData, isLoading } =
     api.edge.orderbooks.getMakerFee.useQuery({
@@ -162,6 +171,7 @@ const useMakerFee = ({ orderbookAddress }: { orderbookAddress: string }) => {
     if (isLoading) return new Dec(0);
     return makerFeeData?.makerFee ?? new Dec(0);
   }, [isLoading, makerFeeData]);
+
   return {
     makerFee,
     isLoading,
@@ -186,6 +196,20 @@ export const useActiveLimitOrdersByOrderbook = ({
   };
 };
 
+/**
+ * Hook to fetch the current spot price of a given pair from an orderbook.
+ *
+ * The spot price is determined by the provided quote asset and base asset.
+ *
+ * For a BID the quote asset is the base asset and the base asset is the quote asset of the orderbook.
+ *
+ * For an ASK the quote asset is the quote asset and the base asset is the base asset of the orderbook.
+ *
+ * @param {string} orderbookAddress - The contract address of the orderbook.
+ * @param {string} quoteAssetDenom - The token out asset denom.
+ * @param {string} baseAssetDenom - The token in asset denom.
+ * @returns {Object} An object containing the spot price and the loading state.
+ */
 export const useOrderbookSpotPrice = ({
   orderbookAddress,
   quoteAssetDenom,

--- a/packages/web/hooks/limit-orders/use-orderbook.ts
+++ b/packages/web/hooks/limit-orders/use-orderbook.ts
@@ -184,3 +184,24 @@ export const useActiveLimitOrdersByOrderbook = ({
     isLoading,
   };
 };
+
+export const useOrderbookSpotPrice = ({
+  orderbookAddress,
+  quoteAssetDenom,
+  baseAssetDenom,
+}: {
+  orderbookAddress: string;
+  quoteAssetDenom: string;
+  baseAssetDenom: string;
+}) => {
+  const { data: spotPrice, isLoading } =
+    api.edge.orderbooks.getSpotPrice.useQuery({
+      osmoAddress: orderbookAddress,
+      quoteAssetDenom,
+      baseAssetDenom,
+    });
+  return {
+    spotPrice,
+    isLoading,
+  };
+};

--- a/packages/web/hooks/limit-orders/use-place-limit.ts
+++ b/packages/web/hooks/limit-orders/use-place-limit.ts
@@ -234,7 +234,6 @@ const useLimitPrice = ({
   tokenIn: string;
   tokenOut: string;
 }) => {
-  // TODO: Fetch spot price from SQS
   const { spotPrice, isLoading } = useOrderbookSpotPrice({
     orderbookAddress: contractAddress,
     quoteAssetDenom: tokenOut,


### PR DESCRIPTION
## What is the purpose of the change:
This change adds spot price data from the orderbook smart contract. The price is determined by the provided smart contract address and the token in/out pairing (this will swap depending on the order direction).

**Spot price is cached for 2 minutes**

### Linear Task

[ LIM-123: Current Orderbook Spot Price](https://linear.app/osmosis/issue/LIM-123/[services]-current-orderbook-spot-price)

## Brief Changelog
- Added `useOrderbookSpotPrice` hook that returns spot price data from the provided orderbook smart contract
- Added loading state for spot price loading condition
