### PR TITLE
feat: :lipstick: add asset page max container

### DIFF
--- a/packages/web/pages/assets/[denom].tsx
+++ b/packages/web/pages/assets/[denom].tsx
@@ -216,7 +216,7 @@ const AssetInfoView: FunctionComponent<AssetInfoPageProps> = observer(
           title={`${title ? `${title} (${denom})` : denom} | Osmosis`}
           description={details?.description}
         />
-        <main className="flex flex-col gap-8 p-8 py-4 xs:px-2">
+        <main className="mx-auto flex max-w-7xl flex-col gap-8 px-10 xs:px-2">
           <LinkButton
             className="mr-auto hidden md:flex"
             icon={


### PR DESCRIPTION
## What is the purpose of the change:

Currently full screen which we should move away from. Max width should be 1280px with 40px inner padding.

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-553/adjust-max-width-to-new-standard)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->
