### PR TITLE
Bridge Providers: add gas estimation for cosmos txs

### DIFF
--- a/packages/bridge/jest.config.js
+++ b/packages/bridge/jest.config.js
@@ -19,6 +19,7 @@ module.exports = {
       },
     ],
   },
+  transformIgnorePatterns: ["node_modules/(?!(superjson)/)"],
   watchPlugins: [
     "jest-watch-typeahead/filename",
     "jest-watch-typeahead/testname",

--- a/packages/bridge/src/axelar/__tests__/axelar-bridge-provider.spec.ts
+++ b/packages/bridge/src/axelar/__tests__/axelar-bridge-provider.spec.ts
@@ -3,6 +3,7 @@ import {
   AxelarAssetTransfer,
   AxelarQueryAPI,
 } from "@axelar-network/axelarjs-sdk";
+import { estimateGasFee } from "@osmosis-labs/tx";
 import { CacheEntry } from "cachified";
 import { LRUCache } from "lru-cache";
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -24,6 +25,15 @@ jest.mock("viem", function () {
     http: jest.fn(),
   };
 });
+
+jest.mock("@osmosis-labs/tx");
+
+jest.mock("@cosmjs/proto-signing", () => ({
+  ...jest.requireActual("@cosmjs/proto-signing"),
+  Registry: jest.fn().mockReturnValue({
+    encodeAsAny: jest.fn().mockReturnValue("any"),
+  }),
+}));
 
 beforeEach(() => {
   server.use(
@@ -150,6 +160,55 @@ describe("AxelarBridgeProvider", () => {
     expect(gasCost?.denom).toBe("ETH");
     expect(gasCost?.sourceDenom).toBe("ETH");
     expect(gasCost?.decimals).toBe(18);
+  });
+
+  it("should estimate gas cost for Cosmos transactions", async () => {
+    (estimateGasFee as jest.Mock).mockResolvedValue({
+      gas: "1000",
+      amount: [
+        {
+          denom: "uosmo",
+          amount: "1000",
+        },
+      ],
+    });
+
+    const gasCost = await provider.estimateGasCost({
+      fromChain: {
+        chainId: "osmosis-1",
+        chainName: "Osmosis",
+        chainType: "cosmos",
+      },
+      toChain: {
+        chainId: 1,
+        chainName: "Ethereum",
+        chainType: "evm",
+      },
+      fromAsset: {
+        denom: "USDC.axl",
+        address:
+          "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
+        decimals: 6,
+        sourceDenom: "uusdc",
+      },
+      toAsset: {
+        denom: "USDc",
+        address: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        decimals: 6,
+        sourceDenom: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+      },
+      fromAmount: "1",
+      fromAddress: "cosmos1ABC123",
+      toAddress: "0x123ABC",
+    });
+
+    expect(gasCost).toBeDefined();
+    expect(gasCost!.amount).toBeDefined();
+    // Should be a string representation of a number
+    expect(gasCost!.amount).toBe("1000");
+    expect(gasCost!.denom).toBe("OSMO");
+    expect(gasCost!.sourceDenom).toBe("uosmo");
+    expect(gasCost!.decimals).toBe(6);
   });
 
   it("should create an EVM transaction", async () => {
@@ -285,7 +344,8 @@ describe("AxelarBridgeProvider", () => {
       toChain: { chainId: 1, chainName: "Ethereum", chainType: "evm" },
       fromAsset: {
         denom: "USDC.axl",
-        address: "cosmos1...",
+        address:
+          "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
         decimals: 6,
         sourceDenom: "uusdc",
       },
@@ -316,7 +376,8 @@ describe("AxelarBridgeProvider", () => {
         timeoutTimestamp: "0",
         token: {
           amount: "1000000",
-          denom: "cosmos1...",
+          denom:
+            "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
         },
       },
     });

--- a/packages/bridge/src/axelar/index.ts
+++ b/packages/bridge/src/axelar/index.ts
@@ -2,7 +2,10 @@ import type {
   AxelarAssetTransfer,
   AxelarQueryAPI,
 } from "@axelar-network/axelarjs-sdk";
+import { Registry } from "@cosmjs/proto-signing";
 import { CoinPretty, Dec } from "@keplr-wallet/unit";
+import { ibcProtoRegistry } from "@osmosis-labs/proto-codecs";
+import { estimateGasFee } from "@osmosis-labs/tx";
 import type { IbcTransferMethod } from "@osmosis-labs/types";
 import { getAssetFromAssetList, getKeyByValue } from "@osmosis-labs/utils";
 import { cachified } from "cachified";
@@ -44,6 +47,7 @@ export class AxelarBridgeProvider implements BridgeProvider {
   // initialized via dynamic import
   protected _queryClient: AxelarQueryAPI | null = null;
   protected _assetTransferClient: AxelarAssetTransfer | null = null;
+  protected protoRegistry = new Registry(ibcProtoRegistry);
 
   protected readonly axelarScanBaseUrl: string;
   protected readonly axelarApiBaseUrl: string;
@@ -253,50 +257,71 @@ export class AxelarBridgeProvider implements BridgeProvider {
   async estimateGasCost(
     params: GetBridgeQuoteParams
   ): Promise<BridgeCoin | undefined> {
-    try {
-      const transactionData = await this.getTransactionData({
-        ...params,
-        fromAmount: "0",
-        simulated: true,
+    const transactionData = await this.getTransactionData({
+      ...params,
+      fromAmount: "0",
+      simulated: true,
+    });
+
+    if (transactionData.type === "evm") {
+      const evmChain = Object.values(EthereumChainInfo).find(
+        ({ id: chainId }) =>
+          String(chainId) === String(params.fromChain.chainId)
+      );
+
+      if (!evmChain) throw new Error("Could not find EVM chain");
+
+      const fromProvider = createPublicClient({
+        chain: evmChain,
+        transport: http(evmChain.rpcUrls.default.http[0]),
       });
 
-      if (transactionData.type === "evm") {
-        const evmChain = Object.values(EthereumChainInfo).find(
-          ({ id: chainId }) =>
-            String(chainId) === String(params.fromChain.chainId)
-        );
-
-        if (!evmChain) throw new Error("Could not find EVM chain");
-
-        const fromProvider = createPublicClient({
-          chain: evmChain,
-          transport: http(evmChain.rpcUrls.default.http[0]),
-        });
-
-        const gasAmountUsed = String(
-          await fromProvider.estimateGas({
-            account: params.fromAddress as Address,
-            to: transactionData.to,
-            value: BigInt(transactionData.value ?? ""),
-            data: transactionData.data,
-          })
-        );
-
-        const gasPrice = (await fromProvider.getGasPrice()).toString();
-
-        const gasCost = new Dec(gasAmountUsed).mul(new Dec(gasPrice));
-        return {
-          amount: gasCost.truncate().toString(),
-          sourceDenom: evmChain.nativeCurrency.symbol,
-          decimals: evmChain.nativeCurrency.decimals,
-          denom: evmChain.nativeCurrency.symbol,
-        };
-      }
-    } catch (e) {
-      console.warn(
-        `Failed to estimate gas fees for ${params.fromAsset.denom}:${params.fromChain.chainName} -> ${params.toAsset.denom}:${params.toChain.chainName}. Reason: ${e}`
+      const gasAmountUsed = String(
+        await fromProvider.estimateGas({
+          account: params.fromAddress as Address,
+          to: transactionData.to,
+          value: BigInt(transactionData.value ?? ""),
+          data: transactionData.data,
+        })
       );
-      return undefined;
+
+      const gasPrice = (await fromProvider.getGasPrice()).toString();
+
+      const gasCost = new Dec(gasAmountUsed).mul(new Dec(gasPrice));
+      return {
+        amount: gasCost.truncate().toString(),
+        sourceDenom: evmChain.nativeCurrency.symbol,
+        decimals: evmChain.nativeCurrency.decimals,
+        denom: evmChain.nativeCurrency.symbol,
+      };
+    }
+
+    if (transactionData.type === "cosmos") {
+      const txSimulation = await estimateGasFee({
+        chainId: params.fromChain.chainId.toString(),
+        chainList: this.ctx.chainList,
+        body: {
+          messages: [
+            this.protoRegistry.encodeAsAny({
+              typeUrl: transactionData.msgTypeUrl,
+              value: transactionData.msg,
+            }),
+          ],
+        },
+        bech32Address: params.fromAddress,
+      });
+
+      const gasFee = txSimulation.amount[0];
+      const gasAsset = this.ctx.assetLists
+        .flatMap((list) => list.assets)
+        .find((asset) => asset.coinMinimalDenom === gasFee.denom);
+
+      return {
+        amount: gasFee.amount,
+        denom: gasFee.denom,
+        decimals: gasAsset?.decimals ?? 0,
+        sourceDenom: gasAsset?.sourceDenom ?? gasFee.denom,
+      };
     }
   }
 

--- a/packages/bridge/src/axelar/index.ts
+++ b/packages/bridge/src/axelar/index.ts
@@ -318,9 +318,9 @@ export class AxelarBridgeProvider implements BridgeProvider {
 
       return {
         amount: gasFee.amount,
-        denom: gasFee.denom,
+        denom: gasAsset?.symbol ?? gasFee.denom,
         decimals: gasAsset?.decimals ?? 0,
-        sourceDenom: gasAsset?.sourceDenom ?? gasFee.denom,
+        sourceDenom: gasAsset?.coinMinimalDenom ?? gasFee.denom,
       };
     }
   }
@@ -451,12 +451,12 @@ export class AxelarBridgeProvider implements BridgeProvider {
         destinationAddress: depositAddress,
       });
 
-      const ibcAssetInfo = getAssetFromAssetList({
+      const ibcAsset = getAssetFromAssetList({
         assetLists: this.ctx.assetLists,
-        sourceDenom: toAsset.sourceDenom,
+        coinMinimalDenom: fromAsset.address,
       });
 
-      if (!ibcAssetInfo) {
+      if (!ibcAsset) {
         throw new BridgeQuoteError([
           {
             errorType: BridgeError.CreateCosmosTxError,
@@ -465,7 +465,7 @@ export class AxelarBridgeProvider implements BridgeProvider {
         ]);
       }
 
-      const ibcTransferMethod = ibcAssetInfo.rawAsset.transferMethods.find(
+      const ibcTransferMethod = ibcAsset.rawAsset.transferMethods.find(
         ({ type }) => type === "ibc"
       ) as IbcTransferMethod | undefined;
 

--- a/packages/bridge/src/ibc/index.ts
+++ b/packages/bridge/src/ibc/index.ts
@@ -62,9 +62,11 @@ export class IbcBridgeProvider implements BridgeProvider {
       .find((asset) => asset.coinMinimalDenom === gasFee.denom);
 
     /** If the sent tokens are needed for fees, account for that in expected output. */
-    const toAmount = gasFee.isNeededForTx
-      ? new Int(params.fromAmount).sub(new Int(gasFee.amount)).toString()
-      : params.fromAmount;
+    const toAmount =
+      gasFee.isNeededForTx &&
+      gasFee.denom.toLowerCase() === params.fromAsset.address.toLowerCase()
+        ? new Int(params.fromAmount).sub(new Int(gasFee.amount)).toString()
+        : params.fromAmount;
 
     if (new Int(toAmount).lte(new Int(0))) {
       throw new BridgeQuoteError([

--- a/packages/bridge/src/skip/__tests__/skip-bridge-provider.spec.ts
+++ b/packages/bridge/src/skip/__tests__/skip-bridge-provider.spec.ts
@@ -383,7 +383,8 @@ describe("SkipBridgeProvider", () => {
 
     expect(gasCost).toBeDefined();
     expect(gasCost?.amount).toBe("1000");
-    expect(gasCost?.denom).toBe("uosmo");
+    expect(gasCost?.denom).toBe("OSMO");
+    expect(gasCost?.sourceDenom).toBe("uosmo");
   });
 
   it("should fetch and return the correct skip asset", async () => {

--- a/packages/bridge/src/skip/__tests__/skip-bridge-provider.spec.ts
+++ b/packages/bridge/src/skip/__tests__/skip-bridge-provider.spec.ts
@@ -1,3 +1,4 @@
+import { estimateGasFee } from "@osmosis-labs/tx";
 import { CacheEntry } from "cachified";
 import { LRUCache } from "lru-cache";
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -27,6 +28,15 @@ jest.mock("viem", () => ({
   encodeFunctionData: jest.fn().mockReturnValue("0xabcdef"),
   encodePacked: jest.fn().mockReturnValue("0xabcdef"),
   keccak256: jest.fn().mockReturnValue("0xabcdef"),
+}));
+
+jest.mock("@osmosis-labs/tx");
+
+jest.mock("@cosmjs/proto-signing", () => ({
+  ...jest.requireActual("@cosmjs/proto-signing"),
+  Registry: jest.fn().mockReturnValue({
+    encodeAsAny: jest.fn().mockReturnValue("any"),
+  }),
 }));
 
 beforeEach(() => {
@@ -127,9 +137,6 @@ beforeEach(() => {
       );
     })
   );
-});
-
-afterEach(() => {
   jest.clearAllMocks();
 });
 
@@ -286,7 +293,7 @@ describe("SkipBridgeProvider", () => {
     expect(txRequest.value).toBe("0x3e8"); // 1000 in hex
   });
 
-  it("should estimate gas cost", async () => {
+  it("should estimate gas cost - EVM transactions", async () => {
     const params: GetBridgeQuoteParams = {
       fromAmount: "1000",
       fromAsset: {
@@ -320,6 +327,63 @@ describe("SkipBridgeProvider", () => {
     expect(gasCost).toBeDefined();
     expect(gasCost?.amount).toBeDefined();
     expect(gasCost?.denom).toBe("ETH");
+  });
+
+  it("should estimate gas cost - Cosmos transactions", async () => {
+    const params: GetBridgeQuoteParams = {
+      fromAmount: "1000",
+      fromAsset: {
+        denom: "asset1",
+        address: "ibc/123",
+        decimals: 6,
+        sourceDenom: "asset1",
+      },
+      fromChain: {
+        chainId: "osmosis-1",
+        chainName: "Osmosis",
+        chainType: "cosmos",
+      },
+      toAsset: {
+        denom: "asset2",
+        address: "0x456",
+        decimals: 6,
+        sourceDenom: "asset2",
+      },
+      toChain: { chainId: 1, chainName: "Ethereum", chainType: "evm" },
+      fromAddress: "osmo1ABC123",
+      toAddress: "0xdef",
+      slippage: 0.01,
+    };
+
+    const txData: BridgeTransactionRequest = {
+      type: "cosmos",
+      msgTypeUrl: "cosmos-sdk/MsgTransfer",
+      msg: {
+        // mock data
+        source_channel: "channel-123",
+        source_port: "port-123",
+        sender: "osmo1ABC123",
+        receiver: "0xdef",
+        denom: "asset1",
+        amount: "1000",
+      },
+    };
+
+    (estimateGasFee as jest.Mock).mockResolvedValue({
+      gas: "1000",
+      amount: [
+        {
+          denom: "uosmo",
+          amount: "1000",
+        },
+      ],
+    });
+
+    const gasCost = await provider.estimateGasCost(params, txData);
+
+    expect(gasCost).toBeDefined();
+    expect(gasCost?.amount).toBe("1000");
+    expect(gasCost?.denom).toBe("uosmo");
   });
 
   it("should fetch and return the correct skip asset", async () => {

--- a/packages/bridge/src/skip/index.ts
+++ b/packages/bridge/src/skip/index.ts
@@ -1,5 +1,8 @@
 import { fromBech32, toBech32 } from "@cosmjs/encoding";
+import { Registry } from "@cosmjs/proto-signing";
 import { CoinPretty } from "@keplr-wallet/unit";
+import { ibcProtoRegistry } from "@osmosis-labs/proto-codecs";
+import { estimateGasFee } from "@osmosis-labs/tx";
 import { isNil } from "@osmosis-labs/utils";
 import cachified from "cachified";
 import {
@@ -37,6 +40,7 @@ export class SkipBridgeProvider implements BridgeProvider {
   readonly providerName = SkipBridgeProvider.ID;
 
   protected readonly skipClient = new SkipApiClient();
+  protected protoRegistry = new Registry(ibcProtoRegistry);
 
   constructor(protected readonly ctx: BridgeProviderContext) {}
 
@@ -497,44 +501,70 @@ export class SkipBridgeProvider implements BridgeProvider {
     params: GetBridgeQuoteParams,
     txData: BridgeTransactionRequest
   ) {
-    if (txData.type !== "evm") {
-      return;
+    if (txData.type === "evm") {
+      const evmChain = Object.values(EthereumChainInfo).find(
+        ({ id: chainId }) => chainId === params.fromChain.chainId
+      );
+
+      if (!evmChain) throw new Error("Could not find EVM chain");
+
+      const provider = createPublicClient({
+        chain: evmChain,
+        transport: http(evmChain.rpcUrls.default.http[0]),
+      });
+
+      const estimatedGas = await this.estimateEvmGasWithStateOverrides(
+        provider,
+        params,
+        txData
+      );
+      if (estimatedGas === BigInt(0)) {
+        return;
+      }
+
+      const gasPrice = await provider.getGasPrice();
+
+      if (!gasPrice) {
+        throw new Error("Failed to get gas price");
+      }
+
+      const gasCost = estimatedGas * gasPrice;
+
+      return {
+        amount: gasCost.toString(),
+        sourceDenom: evmChain.nativeCurrency.symbol,
+        decimals: evmChain.nativeCurrency.decimals,
+        denom: evmChain.nativeCurrency.symbol,
+      };
     }
 
-    const evmChain = Object.values(EthereumChainInfo).find(
-      ({ id: chainId }) => chainId === params.fromChain.chainId
-    );
+    if (txData.type === "cosmos") {
+      const txSimulation = await estimateGasFee({
+        chainId: params.fromChain.chainId.toString(),
+        chainList: this.ctx.chainList,
+        body: {
+          messages: [
+            this.protoRegistry.encodeAsAny({
+              typeUrl: txData.msgTypeUrl,
+              value: txData.msg,
+            }),
+          ],
+        },
+        bech32Address: params.fromAddress,
+      });
 
-    if (!evmChain) throw new Error("Could not find EVM chain");
+      const gasFee = txSimulation.amount[0];
+      const gasAsset = this.ctx.assetLists
+        .flatMap((list) => list.assets)
+        .find((asset) => asset.coinMinimalDenom === gasFee.denom);
 
-    const provider = createPublicClient({
-      chain: evmChain,
-      transport: http(evmChain.rpcUrls.default.http[0]),
-    });
-
-    const estimatedGas = await this.estimateEvmGasWithStateOverrides(
-      provider,
-      params,
-      txData
-    );
-    if (estimatedGas === BigInt(0)) {
-      return;
+      return {
+        amount: gasFee.amount,
+        denom: gasFee.denom,
+        decimals: gasAsset?.decimals ?? 0,
+        sourceDenom: gasAsset?.sourceDenom ?? gasFee.denom,
+      };
     }
-
-    const gasPrice = await provider.getGasPrice();
-
-    if (!gasPrice) {
-      throw new Error("Failed to get gas price");
-    }
-
-    const gasCost = estimatedGas * gasPrice;
-
-    return {
-      amount: gasCost.toString(),
-      sourceDenom: evmChain.nativeCurrency.symbol,
-      decimals: evmChain.nativeCurrency.decimals,
-      denom: evmChain.nativeCurrency.symbol,
-    };
   }
 
   async estimateEvmGasWithStateOverrides(

--- a/packages/bridge/src/skip/index.ts
+++ b/packages/bridge/src/skip/index.ts
@@ -560,9 +560,9 @@ export class SkipBridgeProvider implements BridgeProvider {
 
       return {
         amount: gasFee.amount,
-        denom: gasFee.denom,
+        denom: gasAsset?.symbol ?? gasFee.denom,
         decimals: gasAsset?.decimals ?? 0,
-        sourceDenom: gasAsset?.sourceDenom ?? gasFee.denom,
+        sourceDenom: gasAsset?.coinMinimalDenom ?? gasFee.denom,
       };
     }
   }

--- a/packages/tx/src/gas.ts
+++ b/packages/tx/src/gas.ts
@@ -49,6 +49,14 @@ export type QuoteStdFee = {
   }[];
 };
 
+/** Tx body portions relevant for simulation */
+export type SimBody = Partial<
+  Pick<
+    TxBody,
+    "messages" | "memo" | "extensionOptions" | "nonCriticalExtensionOptions"
+  >
+>;
+
 /**
  * Estimates the full gas fee payment for the given encoded messages on the chain specified by given chain ID.
  * Useful for providing the user with an accurate and dynamic fee amount estimate before sending a transaction.
@@ -122,13 +130,6 @@ export async function estimateGasFee({
 }
 
 export class SimulateNotAvailableError extends Error {}
-/** Tx body portions relevant for simulation */
-export type SimBody = Partial<
-  Pick<
-    TxBody,
-    "messages" | "memo" | "extensionOptions" | "nonCriticalExtensionOptions"
-  >
->;
 
 /**
  * Attempts to estimate gas amount of the given messages in a tx via a POST to the


### PR DESCRIPTION
## What is the purpose of the change:

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

Applies our new gas estimation function to existing bridge providers for Cosmos transactions. Includes the advanced features included in the new function, such as fee markets and alternative fee tokens.

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-521/add-gas-estimation-to-existing-bridge-providers)

## Brief Changelog

* Skip provider: estimate cosmos txs
* Axelar provider: estimate cosmos txs

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

- [ ] TODO: add unit tests
