### PR TITLE
feat: limit orders feature flag 

### DIFF
--- a/packages/web/components/navbar-osmo-price.tsx
+++ b/packages/web/components/navbar-osmo-price.tsx
@@ -26,7 +26,6 @@ export const NavbarOsmoPrice = observer(() => {
   const { t } = useTranslation();
   const flags = useFeatureFlags();
   const { fiatRampSelection } = useBridge();
-
   const { chainId } = chainStore.osmosis;
   const wallet = accountStore.getWallet(chainId);
 

--- a/packages/web/hooks/use-feature-flags.ts
+++ b/packages/web/hooks/use-feature-flags.ts
@@ -28,7 +28,8 @@ export type AvailableFlags =
   | "displayDailyEarn"
   | "newAssetsPage"
   | "newDepositWithdrawFlow"
-  | "oneClickTrading";
+  | "oneClickTrading"
+  | "limitOrders";
 
 type ModifiedFlags =
   | Exclude<AvailableFlags, "mobileNotifications">
@@ -59,6 +60,7 @@ const defaultFlags: Record<ModifiedFlags, boolean> = {
   displayDailyEarn: false,
   newDepositWithdrawFlow: false,
   oneClickTrading: false,
+  limitOrders: true,
   _isInitialized: false,
   _isClientIDPresent: false,
 };

--- a/packages/web/pages/index.tsx
+++ b/packages/web/pages/index.tsx
@@ -1,8 +1,11 @@
 import dayjs from "dayjs";
 import { observer } from "mobx-react-lite";
+import { useLocalStorage } from "react-use";
 
 import { Ad, AdBanners } from "~/components/ad-banner";
 import { ErrorBoundary } from "~/components/error/error-boundary";
+import { ProgressiveSvgImage } from "~/components/progressive-svg-image";
+import { SwapTool } from "~/components/swap-tool";
 import { TradeTool } from "~/components/trade-tool";
 import { EventName } from "~/config";
 import {
@@ -21,6 +24,11 @@ export type PreviousTrade = {
 };
 
 const Home = () => {
+  const featureFlags = useFeatureFlags();
+  return featureFlags.limitOrders ? <HomeNew /> : <HomeV1 />;
+};
+
+const HomeNew = () => {
   const featureFlags = useFeatureFlags();
   // const [previousTrade, setPreviousTrade] =
   //   useLocalStorage<PreviousTrade>(SwapPreviousTradeKey);
@@ -62,7 +70,48 @@ const Home = () => {
       <div className="my-auto flex h-auto w-full items-center justify-center">
         <div className="flex w-[35rem] flex-col gap-4 lg:mx-auto md:mt-mobile-header">
           {featureFlags.swapsAdBanner && <SwapAdsBanner />}
-          {/* <SwapTool
+          <TradeTool />
+        </div>
+      </div>
+    </main>
+  );
+};
+
+const HomeV1 = () => {
+  const featureFlags = useFeatureFlags();
+  const [previousTrade, setPreviousTrade] =
+    useLocalStorage<PreviousTrade>(SwapPreviousTradeKey);
+
+  useAmplitudeAnalytics({
+    onLoadEvent: [EventName.Swap.pageViewed, { isOnHome: true }],
+  });
+
+  return (
+    <main className="relative flex h-full items-center overflow-auto bg-osmoverse-900 py-2">
+      <div className="pointer-events-none fixed h-full w-full bg-home-bg-pattern bg-cover bg-repeat-x">
+        <svg
+          className="absolute h-full w-full lg:hidden"
+          pointerEvents="none"
+          viewBox="0 0 1300 900"
+          height="900"
+          preserveAspectRatio="xMidYMid slice"
+        >
+          <g>
+            <ProgressiveSvgImage
+              lowResXlinkHref="/images/osmosis-home-bg-low.png"
+              xlinkHref="/images/osmosis-home-bg.png"
+              x="56"
+              y="220"
+              width="578.7462"
+              height="725.6817"
+            />
+          </g>
+        </svg>
+      </div>
+      <div className="my-auto flex h-auto w-full items-center">
+        <div className="ml-auto mr-[15%] flex w-[27rem] flex-col gap-4 lg:mx-auto md:mt-mobile-header">
+          {featureFlags.swapsAdBanner && <SwapAdsBanner />}
+          <SwapTool
             useQueryParams
             useOtherCurrencies
             onSwapSuccess={({ sendTokenDenom, outTokenDenom }) => {
@@ -71,8 +120,7 @@ const Home = () => {
             initialSendTokenDenom={previousTrade?.sendTokenDenom}
             initialOutTokenDenom={previousTrade?.outTokenDenom}
             page="Swap Page"
-          /> */}
-          <TradeTool />
+          />
         </div>
       </div>
     </main>

--- a/packages/web/pages/index.tsx
+++ b/packages/web/pages/index.tsx
@@ -25,6 +25,7 @@ export type PreviousTrade = {
 
 const Home = () => {
   const featureFlags = useFeatureFlags();
+  if (!featureFlags._isInitialized) return null;
   return featureFlags.limitOrders ? <HomeNew /> : <HomeV1 />;
 };
 


### PR DESCRIPTION
## What is the purpose of the change:
Adds a feature flag for `limitOrders` that toggles between the current swap page and the new limit orders swap page.

### Linear Task

[LIM-117: Integrate Feature Flags](https://linear.app/osmosis/issue/LIM-117/integrate-feature-flags)

## Brief Changelog
- Added a `limitOrders` feature flag
- Readded old swap page under `HomeV1` and renamed the new component (`Home` -> `HomeNew`)
- Swapping between the two versions can be done by toggling the `limitOrders` feature flag
