### PR TITLE
only enable ICNS address check for mainnet

### DIFF
--- a/packages/web/hooks/queries/osmosis/use-icns-name.ts
+++ b/packages/web/hooks/queries/osmosis/use-icns-name.ts
@@ -1,13 +1,14 @@
 import { queryICNSName } from "@osmosis-labs/server";
 import { useQuery } from "@tanstack/react-query";
 
+import { IS_TESTNET } from "~/config";
 import { ChainList } from "~/config/generated/chain-list";
 
 export const useICNSName = ({ address }: { address: string }) => {
   return useQuery({
     queryKey: ["icns-name", address],
     queryFn: () => queryICNSName({ address, chainList: ChainList }),
-    enabled: Boolean(address) && typeof address === "string",
+    enabled: !IS_TESTNET && Boolean(address) && typeof address === "string",
     select: ({ data: { names, primary_name } }) => {
       return {
         names: names,


### PR DESCRIPTION
## What is the purpose of the change:

- only enable ICNS query on mainnet

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-481/testnet-turn-off-or-update-icns-query)

## Brief Changelog

- add !IS_TESTNET check to query
