### PR TITLE
feat: all active limit orders hook

### DIFF
--- a/packages/server/src/queries/complex/orderbooks/active-orders.ts
+++ b/packages/server/src/queries/complex/orderbooks/active-orders.ts
@@ -1,0 +1,32 @@
+import { Chain } from "@osmosis-labs/types";
+import cachified, { CacheEntry } from "cachified";
+import { LRUCache } from "lru-cache";
+
+import { DEFAULT_LRU_OPTIONS } from "../../../utils/cache";
+import { LimitOrder, queryOrderbookActiveOrders } from "../../osmosis";
+
+const activeOrdersCache = new LRUCache<string, CacheEntry>(DEFAULT_LRU_OPTIONS);
+
+export function getOrderbookActiveOrders({
+  orderbookAddress,
+  userOsmoAddress,
+  chainList,
+}: {
+  orderbookAddress: string;
+  userOsmoAddress: string;
+  chainList: Chain[];
+}) {
+  return cachified({
+    cache: activeOrdersCache,
+    key: `orderbookActiveOrders-${orderbookAddress}-${userOsmoAddress}`,
+    ttl: 1000 * 60 * 2, // 2 minutes
+    getFreshValue: () =>
+      queryOrderbookActiveOrders({
+        orderbookAddress,
+        userAddress: userOsmoAddress,
+        chainList,
+      }).then(
+        ({ data }: { data: { count: number; orders: LimitOrder[] } }) => data
+      ),
+  });
+}

--- a/packages/server/src/queries/complex/orderbooks/index.ts
+++ b/packages/server/src/queries/complex/orderbooks/index.ts
@@ -1,1 +1,3 @@
+export * from "./active-orders";
 export * from "./maker-fee";
+export * from "./tick-state";

--- a/packages/server/src/queries/complex/orderbooks/tick-state.ts
+++ b/packages/server/src/queries/complex/orderbooks/tick-state.ts
@@ -1,0 +1,57 @@
+import { Chain } from "@osmosis-labs/types";
+import cachified, { CacheEntry } from "cachified";
+import { LRUCache } from "lru-cache";
+
+import { DEFAULT_LRU_OPTIONS } from "../../../utils/cache";
+import {
+  queryOrderbookTicks,
+  queryOrderbookTickUnrealizedCancelsById,
+} from "../../osmosis";
+
+const tickInfoCache = new LRUCache<string, CacheEntry>(DEFAULT_LRU_OPTIONS);
+
+export function getOrderbookTickState({
+  orderbookAddress,
+  chainList,
+  tickIds,
+}: {
+  orderbookAddress: string;
+  chainList: Chain[];
+  tickIds: number[];
+}) {
+  return cachified({
+    cache: tickInfoCache,
+    key: `orderbookTickInfo-${orderbookAddress}-${tickIds
+      .sort((a, b) => a - b)
+      .join(",")}`,
+    ttl: 1000 * 60 * 2, // 2 minutes
+    getFreshValue: () =>
+      queryOrderbookTicks({ orderbookAddress, chainList, tickIds }).then(
+        ({ data }) => data.ticks
+      ),
+  });
+}
+
+export function getOrderbookTickUnrealizedCancels({
+  orderbookAddress,
+  chainList,
+  tickIds,
+}: {
+  orderbookAddress: string;
+  chainList: Chain[];
+  tickIds: number[];
+}) {
+  return cachified({
+    cache: tickInfoCache,
+    key: `orderbookTickUnrealizedCancels-${orderbookAddress}-${tickIds
+      .sort((a, b) => a - b)
+      .join(",")}`,
+    ttl: 1000 * 60 * 2, // 2 minutes
+    getFreshValue: () =>
+      queryOrderbookTickUnrealizedCancelsById({
+        orderbookAddress,
+        chainList,
+        tickIds,
+      }).then(({ data }) => data.ticks),
+  });
+}

--- a/packages/server/src/queries/osmosis/orderbooks.ts
+++ b/packages/server/src/queries/osmosis/orderbooks.ts
@@ -32,7 +32,7 @@ export interface LimitOrder {
 }
 
 interface OrderbookActiveOrdersResponse {
-  data: LimitOrder[];
+  data: { orders: LimitOrder[]; count: number };
 }
 
 export const queryOrderbookActiveOrders = createNodeQuery<
@@ -63,7 +63,7 @@ interface TickValues {
 
 export interface TickState {
   ask_values: TickValues;
-  vid_values: TickValues;
+  bid_values: TickValues;
 }
 
 interface OrderbookTicksResponse {
@@ -76,13 +76,13 @@ export const queryOrderbookTicks = createNodeQuery<
   OrderbookTicksResponse,
   {
     orderbookAddress: string;
-    ticks: number[];
+    tickIds: number[];
   }
 >({
-  path: ({ ticks, orderbookAddress }) => {
+  path: ({ tickIds, orderbookAddress }) => {
     const msg = JSON.stringify({
       ticks_by_id: {
-        tick_ids: ticks,
+        tick_ids: tickIds,
       },
     });
     const encodedMsg = Buffer.from(msg).toString("base64");
@@ -90,16 +90,15 @@ export const queryOrderbookTicks = createNodeQuery<
   },
 });
 
-export interface TickState {
-  ask_values: TickValues;
-  vid_values: TickValues;
+export interface TickUnrealizedCancelsState {
+  ask_unrealized_cancels: string;
+  bid_unrealized_cancels: string;
 }
-
 interface OrderbookTickUnrealizedCancelsResponse {
   data: {
     ticks: {
       tick_id: number;
-      unrealized_cancels: string;
+      unrealized_cancels: TickUnrealizedCancelsState;
     }[];
   };
 }
@@ -108,13 +107,13 @@ export const queryOrderbookTickUnrealizedCancelsById = createNodeQuery<
   OrderbookTickUnrealizedCancelsResponse,
   {
     orderbookAddress: string;
-    ticks: number[];
+    tickIds: number[];
   }
 >({
-  path: ({ ticks, orderbookAddress }) => {
+  path: ({ tickIds, orderbookAddress }) => {
     const msg = JSON.stringify({
       tick_unrealized_cancels_by_id: {
-        tick_ids: ticks,
+        tick_ids: tickIds,
       },
     });
     const encodedMsg = Buffer.from(msg).toString("base64");

--- a/packages/server/src/queries/osmosis/orderbooks.ts
+++ b/packages/server/src/queries/osmosis/orderbooks.ts
@@ -52,3 +52,72 @@ export const queryOrderbookActiveOrders = createNodeQuery<
     return `/cosmwasm/wasm/v1/contract/${orderbookAddress}/smart/${encodedMsg}`;
   },
 });
+
+interface TickValues {
+  total_amount_of_liquidity: string;
+  cumulative_total_value: string;
+  effective_total_amount_swapped: string;
+  cumulative_realized_cancels: string;
+  last_tick_sync_etas: string;
+}
+
+export interface TickState {
+  ask_values: TickValues;
+  vid_values: TickValues;
+}
+
+interface OrderbookTicksResponse {
+  data: {
+    ticks: { tick_id: number; tick_state: TickState }[];
+  };
+}
+
+export const queryOrderbookTicks = createNodeQuery<
+  OrderbookTicksResponse,
+  {
+    orderbookAddress: string;
+    ticks: number[];
+  }
+>({
+  path: ({ ticks, orderbookAddress }) => {
+    const msg = JSON.stringify({
+      ticks_by_id: {
+        tick_ids: ticks,
+      },
+    });
+    const encodedMsg = Buffer.from(msg).toString("base64");
+    return `/cosmwasm/wasm/v1/contract/${orderbookAddress}/smart/${encodedMsg}`;
+  },
+});
+
+export interface TickState {
+  ask_values: TickValues;
+  vid_values: TickValues;
+}
+
+interface OrderbookTickUnrealizedCancelsResponse {
+  data: {
+    ticks: {
+      tick_id: number;
+      unrealized_cancels: string;
+    }[];
+  };
+}
+
+export const queryOrderbookTickUnrealizedCancelsById = createNodeQuery<
+  OrderbookTickUnrealizedCancelsResponse,
+  {
+    orderbookAddress: string;
+    ticks: number[];
+  }
+>({
+  path: ({ ticks, orderbookAddress }) => {
+    const msg = JSON.stringify({
+      tick_unrealized_cancels_by_id: {
+        tick_ids: ticks,
+      },
+    });
+    const encodedMsg = Buffer.from(msg).toString("base64");
+    return `/cosmwasm/wasm/v1/contract/${orderbookAddress}/smart/${encodedMsg}`;
+  },
+});

--- a/packages/web/components/place-limit-tool/index.tsx
+++ b/packages/web/components/place-limit-tool/index.tsx
@@ -1,7 +1,13 @@
 import { Dec } from "@keplr-wallet/unit";
 import { observer } from "mobx-react-lite";
 import { parseAsString, parseAsStringLiteral, useQueryStates } from "nuqs";
-import { FunctionComponent, useCallback, useMemo, useState } from "react";
+import {
+  FunctionComponent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 
 import { Icon } from "~/components/assets";
 import { TokenSelectLimit } from "~/components/control/token-select-limit";
@@ -57,6 +63,13 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
       baseDenom: base,
       quoteDenom: quote,
     });
+
+    // Adjust price to base price if the type changes to "market"
+    useEffect(() => {
+      if (type === "market") {
+        swapState.priceState.adjustByPercentage(new Dec(0));
+      }
+    }, [swapState.priceState, type]);
 
     const account = accountStore.getWallet(accountStore.osmosisChainId);
 

--- a/packages/web/components/place-limit-tool/index.tsx
+++ b/packages/web/components/place-limit-tool/index.tsx
@@ -66,7 +66,10 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
 
     // Adjust price to base price if the type changes to "market"
     useEffect(() => {
-      if (type === "market") {
+      if (
+        type === "market" &&
+        swapState.priceState.percentAdjusted.abs().gt(new Dec(0))
+      ) {
         swapState.priceState.adjustByPercentage(new Dec(0));
       }
     }, [swapState.priceState, type]);

--- a/packages/web/components/swap-tool/price-selector.tsx
+++ b/packages/web/components/swap-tool/price-selector.tsx
@@ -79,12 +79,6 @@ export const PriceSelector = memo(
                 usdValue: walletAsset.usdValue,
               };
 
-              /**
-               * TEMP
-               *
-               * Waiting for fix on the assetlist for USDC not
-               * having "stablecoin" value in the "categories" array
-               */
               if (asset?.symbol === "USDC") return returnAsset;
 
               // In the future, we might want to pass every coin instead of just stables.

--- a/packages/web/hooks/limit-orders/use-orderbook.ts
+++ b/packages/web/hooks/limit-orders/use-orderbook.ts
@@ -243,23 +243,57 @@ const useMakerFee = ({ orderbookAddress }: { orderbookAddress: string }) => {
   };
 };
 
-// export const useActiveLimitOrdersByOrderbook = ({
-//   orderbookAddress,
-//   userAddress,
-// }: {
-//   orderbookAddress: string;
-//   userAddress: string;
-// }) => {
-//   const { data: orders, isLoading } =
-//     api.edge.orderbooks.getActiveOrders.useQuery({
-//       contractOsmoAddress: orderbookAddress,
-//       userOsmoAddress: userAddress,
-//     });
-//   return {
-//     orders,
-//     isLoading,
-//   };
-// };
+export const useActiveLimitOrdersByOrderbook = ({
+  orderbookAddress,
+  userAddress,
+}: {
+  orderbookAddress: string;
+  userAddress: string;
+}) => {
+  const { data: orders, isLoading } =
+    api.edge.orderbooks.getActiveOrders.useQuery({
+      contractOsmoAddress: orderbookAddress,
+      userOsmoAddress: userAddress,
+    });
+  console.log("ORDERS", orders);
+  return {
+    orders,
+    isLoading,
+  };
+};
+
+export const useOrderbookAllActiveOrders = ({
+  userAddress,
+}: {
+  userAddress: string;
+}) => {
+  const { orderbooks } = useOrderbooks();
+  const addresses = orderbooks.map(({ contractAddress }) => contractAddress);
+  const { data: orders, isLoading } =
+    api.edge.orderbooks.getAllActiveOrders.useQuery({
+      contractAddresses: addresses,
+      userOsmoAddress: userAddress,
+    });
+  const ordersWithDenoms = useMemo(() => {
+    return (
+      orders?.map((o) => {
+        const orderbook = orderbooks.find(
+          (ob) => ob.contractAddress === o.orderbookAddress
+        );
+        return {
+          ...o,
+          baseDenom: orderbook?.baseDenom ?? "",
+          quoteDenom: orderbook?.quoteDenom ?? "",
+        };
+      }) ?? []
+    );
+  }, [orders, orderbooks]);
+
+  return {
+    orders: ordersWithDenoms,
+    isLoading,
+  };
+};
 
 /**
  * Hook to fetch the current spot price of a given pair from an orderbook.


### PR DESCRIPTION
## What is the purpose of the change:
These changes add the required queries and hooks to get all active limit orders for a user.

### Linear Task

[LIM-137: Tick Info Query](https://linear.app/osmosis/issue/LIM-137/[services]-tick-info-query)
[LIM-138: Query for all Active Orders Info](https://linear.app/osmosis/issue/LIM-138/[services]-query-for-all-active-orders-info)

## Brief Changelog
- Added the following queries:
  - `queryOrderbookTicks`: Gets tick state for the provided tick IDs
  - `queryOrderbookTickUnrealizedCancelsById`: Gets the amount of unrealized cancels for the given tick IDs
- Exposed the above queries via cached complex server functions
- Exposed the above queries via two orderbook router methods 

## Note
Pagination will be added in a following PR
