### PR TITLE
refactor: replace OrderDirection enum with string literal

### DIFF
--- a/packages/web/components/control/token-select-limit.tsx
+++ b/packages/web/components/control/token-select-limit.tsx
@@ -100,11 +100,11 @@ export const TokenSelectLimit: FunctionComponent<
     );
 
     const showBaseBalance = useMemo(
-      () => orderDirection === OrderDirection.Ask && isWalletConnected,
+      () => orderDirection === "ask" && isWalletConnected,
       [isWalletConnected, orderDirection]
     );
     const showQuoteBalance = useMemo(
-      () => orderDirection === OrderDirection.Bid,
+      () => orderDirection === "bid",
       [orderDirection]
     );
 
@@ -174,7 +174,7 @@ export const TokenSelectLimit: FunctionComponent<
         />
         <TokenSelectModalLimit
           headerTitle={
-            orderDirection === OrderDirection.Ask
+            orderDirection === "ask"
               ? "Select an asset to sell"
               : "Select an asset to buy"
           }

--- a/packages/web/components/place-limit-tool/index.tsx
+++ b/packages/web/components/place-limit-tool/index.tsx
@@ -50,7 +50,7 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
     const setBase = useCallback((base: string) => set({ base }), [set]);
 
     const orderDirection = useMemo(
-      () => (tab === "buy" ? OrderDirection.Bid : OrderDirection.Ask),
+      () => (tab === "buy" ? "bid" : "ask"),
       [tab]
     );
 
@@ -91,8 +91,7 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
           />
           <div className="relative flex flex-col rounded-2xl bg-osmoverse-1000">
             <p className="body2 p-4 text-center font-light text-osmoverse-400">
-              Enter an amount to{" "}
-              {orderDirection === OrderDirection.Bid ? "buy" : "sell"}
+              Enter an amount to {orderDirection === "bid" ? "buy" : "sell"}
             </p>
             <LimitInput
               onChange={swapState.inAmountInput.setAmount}
@@ -115,8 +114,7 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
                       .abs()}%`}
                   </span>
                   <span>
-                    {orderDirection === OrderDirection.Bid ? "below" : "above"}{" "}
-                    current price
+                    {orderDirection === "bid" ? "below" : "above"} current price
                   </span>
                   <Icon
                     id="arrows-swap-16"
@@ -144,15 +142,13 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
                       key={`limit-price-adjust-${label}`}
                       onClick={() =>
                         swapState.priceState.adjustByPercentage(
-                          orderDirection == OrderDirection.Bid
-                            ? value.neg()
-                            : value
+                          orderDirection == "bid" ? value.neg() : value
                         )
                       }
                     >
                       <span className="body2 text-wosmongton-200">
                         {label !== "0%" &&
-                          (orderDirection === OrderDirection.Bid ? "-" : "+")}
+                          (orderDirection === "bid" ? "-" : "+")}
                         {label}
                       </span>
                     </button>
@@ -202,9 +198,7 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
                   loadingText={"Loading..."}
                   onClick={() => setReviewOpen(true)}
                 >
-                  <h6>
-                    {orderDirection === OrderDirection.Bid ? "Buy" : "Sell"}
-                  </h6>
+                  <h6>{orderDirection === "bid" ? "Buy" : "Sell"}</h6>
                 </Button>
               ) : (
                 <Button onClick={() => setReviewOpen(true)}>

--- a/packages/web/components/trade-tool/index.tsx
+++ b/packages/web/components/trade-tool/index.tsx
@@ -12,7 +12,6 @@ import {
   SwapToolTab,
   SwapToolTabs,
 } from "~/components/swap-tool/swap-tool-tabs";
-import { OrderDirection } from "~/hooks/limit-orders";
 import { useStore } from "~/stores";
 
 export interface TradeToolProps {}
@@ -71,9 +70,9 @@ export const TradeTool: FunctionComponent<TradeToolProps> = observer(() => {
         {useMemo(() => {
           switch (tab) {
             case SwapToolTab.BUY:
-              return <PlaceLimitTool orderDirection={OrderDirection.Bid} />;
+              return <PlaceLimitTool orderDirection={"bid"} />;
             case SwapToolTab.SELL:
-              return <PlaceLimitTool orderDirection={OrderDirection.Ask} />;
+              return <PlaceLimitTool orderDirection={"ask"} />;
             case SwapToolTab.SWAP:
             default:
               return (

--- a/packages/web/hooks/limit-orders/use-place-limit.ts
+++ b/packages/web/hooks/limit-orders/use-place-limit.ts
@@ -10,10 +10,7 @@ import { useSwapAmountInput, useSwapAssets } from "~/hooks/use-swap";
 import { useStore } from "~/stores";
 import { api } from "~/utils/trpc";
 
-export enum OrderDirection {
-  Bid = "bid",
-  Ask = "ask",
-}
+export type OrderDirection = "bid" | "ask";
 
 export interface UsePlaceLimitParams {
   osmosisChainId: string;
@@ -83,7 +80,7 @@ export const usePlaceLimit = ({
     // The amount of tokens the user wishes to buy/sell
     const baseTokenAmount =
       inAmountInput.amount ?? new CoinPretty(baseAsset!, new Dec(0));
-    if (orderDirection === OrderDirection.Ask) {
+    if (orderDirection === "ask") {
       // In the case of an Ask we just return the amount requested to sell
       return baseTokenAmount;
     }
@@ -118,7 +115,7 @@ export const usePlaceLimit = ({
    * In the case of a Bid the fiat amount is the amount of quote asset tokens the user will send multiplied by the current price of the quote asset.
    */
   const paymentFiatValue = useMemo(() => {
-    return orderDirection === OrderDirection.Ask
+    return orderDirection === "ask"
       ? mulPrice(
           paymentTokenValue,
           new PricePretty(DEFAULT_VS_CURRENCY, priceState.price),
@@ -193,7 +190,7 @@ export const usePlaceLimit = ({
     );
 
   const insufficientFunds =
-    (orderDirection === OrderDirection.Bid
+    (orderDirection === "bid"
       ? quoteTokenBalance
           ?.toDec()
           ?.lt(inAmountInput.amount?.toDec() ?? new Dec(0))
@@ -203,7 +200,7 @@ export const usePlaceLimit = ({
 
   const expectedTokenAmountOut = useMemo(() => {
     const preFeeAmount =
-      orderDirection === OrderDirection.Ask
+      orderDirection === "ask"
         ? new CoinPretty(
             quoteAsset!,
             paymentFiatValue?.quo(quoteAssetPrice?.toDec() ?? new Dec(1)) ??
@@ -222,7 +219,7 @@ export const usePlaceLimit = ({
   ]);
 
   const expectedFiatAmountOut = useMemo(() => {
-    return orderDirection === OrderDirection.Ask
+    return orderDirection === "ask"
       ? new PricePretty(
           DEFAULT_VS_CURRENCY,
           quoteAssetPrice?.mul(expectedTokenAmountOut.toDec()) ?? new Dec(0)

--- a/packages/web/modals/review-limit-order.tsx
+++ b/packages/web/modals/review-limit-order.tsx
@@ -56,7 +56,7 @@ export const ReviewLimitOrderModal: React.FC<ReviewLimitOrderModalProps> = ({
     >
       <div className="relative flex h-20 w-full items-center justify-center p-4">
         <h6>
-          {orderDirection === OrderDirection.Bid ? "Buy" : "Sell"}{" "}
+          {orderDirection === "bid" ? "Buy" : "Sell"}{" "}
           {placeLimitState.baseAsset?.coinName}
         </h6>
         <button
@@ -91,24 +91,23 @@ export const ReviewLimitOrderModal: React.FC<ReviewLimitOrderModalProps> = ({
           </div>
         )}
         <div className="flex w-full flex-col pt-3">
-          {placeLimitState.quoteAsset &&
-            orderDirection === OrderDirection.Bid && (
-              <RecapRow
-                left="Pay With"
-                right={
-                  <span className="text-osmoverse-100">
-                    <Image
-                      width={24}
-                      height={24}
-                      src={placeLimitState.quoteAsset.coinImageUrl!}
-                      alt={placeLimitState.quoteAsset.coinDenom}
-                      className="inline"
-                    />{" "}
-                    {placeLimitState.quoteAsset.coinDenom}
-                  </span>
-                }
-              />
-            )}
+          {placeLimitState.quoteAsset && orderDirection === "bid" && (
+            <RecapRow
+              left="Pay With"
+              right={
+                <span className="text-osmoverse-100">
+                  <Image
+                    width={24}
+                    height={24}
+                    src={placeLimitState.quoteAsset.coinImageUrl!}
+                    alt={placeLimitState.quoteAsset.coinDenom}
+                    className="inline"
+                  />{" "}
+                  {placeLimitState.quoteAsset.coinDenom}
+                </span>
+              }
+            />
+          )}
           <RecapRow
             left="Value"
             right={
@@ -147,24 +146,23 @@ export const ReviewLimitOrderModal: React.FC<ReviewLimitOrderModalProps> = ({
               }
             />
           )}
-          {placeLimitState.quoteAsset &&
-            orderDirection === OrderDirection.Ask && (
-              <RecapRow
-                left="Recieve asset"
-                right={
-                  <span className="text-osmoverse-100">
-                    <Image
-                      width={24}
-                      height={24}
-                      src={placeLimitState.quoteAsset.coinImageUrl!}
-                      alt={placeLimitState.quoteAsset.coinDenom}
-                      className="inline"
-                    />{" "}
-                    {placeLimitState.quoteAsset.coinDenom}
-                  </span>
-                }
-              />
-            )}
+          {placeLimitState.quoteAsset && orderDirection === "ask" && (
+            <RecapRow
+              left="Recieve asset"
+              right={
+                <span className="text-osmoverse-100">
+                  <Image
+                    width={24}
+                    height={24}
+                    src={placeLimitState.quoteAsset.coinImageUrl!}
+                    alt={placeLimitState.quoteAsset.coinDenom}
+                    className="inline"
+                  />{" "}
+                  {placeLimitState.quoteAsset.coinDenom}
+                </span>
+              }
+            />
+          )}
           <RecapRow
             left="Order Type"
             right={


### PR DESCRIPTION
## What is the purpose of the change:
Replaced `OrderDirection` enum with a `type` that can be either `"bid"` or `"ask"`

## Brief Changelog
- `OrderDirection` is now a `type` instead of an `enum`