### PR TITLE
fix: :bug: transmuter pool liquidity percentage calc

### DIFF
--- a/packages/server/src/queries/complex/pools/transmuter.ts
+++ b/packages/server/src/queries/complex/pools/transmuter.ts
@@ -1,4 +1,4 @@
-import { CoinPretty, Dec, RatePretty } from "@keplr-wallet/unit";
+import { CoinPretty, Dec, DecUtils, RatePretty } from "@keplr-wallet/unit";
 import { AssetList, Chain } from "@osmosis-labs/types";
 import cachified, { CacheEntry } from "cachified";
 import { LRUCache } from "lru-cache";
@@ -46,12 +46,11 @@ export async function getCachedTransmuterTotalPoolLiquidity(
         );
 
         if (asset) {
-          const coinPretty = new CoinPretty(
-            asset,
-            coin.amount
-          ).moveDecimalPointLeft(asset.coinDecimals);
+          const amount = new Dec(coin.amount);
 
-          return acc.add(coinPretty.toDec());
+          return acc.add(
+            amount.quo(DecUtils.getTenExponentN(asset.coinDecimals))
+          );
         }
 
         return acc;
@@ -63,15 +62,16 @@ export async function getCachedTransmuterTotalPoolLiquidity(
         );
 
         if (asset) {
-          const coinPretty = new CoinPretty(
-            asset,
-            coin.amount
-          ).moveDecimalPointLeft(asset.coinDecimals);
+          const coinPretty = new CoinPretty(asset, coin.amount);
+
+          const amount = new Dec(coin.amount).quo(
+            DecUtils.getTenExponentN(asset.coinDecimals)
+          );
 
           poolLiquidityAssets.push({
             asset,
             coin: coinPretty,
-            percentage: new RatePretty(coinPretty.toDec().quo(totalLiquidity)),
+            percentage: new RatePretty(amount.quo(totalLiquidity)),
           });
         }
       }


### PR DESCRIPTION
## What is the purpose of the change:

Right now there is a bug on production, the percentage we show in the alloyed asset is miscalculated because it does not take into account that each asset has different decimals.

### Linear Task

[Linear Task URL](PASTE_LINEAR_TASK_URL_HERE)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->
