### PR TITLE
Increase check for low precision

### DIFF
--- a/packages/tx/src/gas.ts
+++ b/packages/tx/src/gas.ts
@@ -335,8 +335,8 @@ export async function getGasFeeAmount({
 
     // Check if this balance is not enough or fee amount is too little (not enough precision) to pay the fee, if so skip.
     if (
-      new Dec(feeAmount).gt(new Dec(amount)) ||
-      new Dec(feeAmount).lte(new Dec(0))
+      new Int(feeAmount).gt(new Int(amount)) ||
+      new Int(feeAmount).lte(new Int(1))
     )
       continue;
 
@@ -383,7 +383,7 @@ export async function getGasFeeAmount({
 
   for (const { amount, feeAmount, denom } of spentFees) {
     // check for gas price conversion having too little precision
-    if (new Dec(feeAmount).lte(new Dec(0))) continue;
+    if (new Int(feeAmount).lte(new Int(1))) continue;
 
     const spentAmount =
       coinsSpent.find((coinSpent) => coinSpent.denom === denom)?.amount || "0";


### PR DESCRIPTION
Got reports that people are still having issues with 1 uwbtc amounts being used for gas, resulting in a chain error. This adds a check to also ensure that more than 1 unit of gas is estimated, otherwise other fee tokens will be tried.

Also changes unit type to `Int` as it gets truncated into a string integer value above.