### PR TITLE
feat: Order price mapping

### DIFF
--- a/packages/math/src/pool/concentrated/__tests__/tick.spec.ts
+++ b/packages/math/src/pool/concentrated/__tests__/tick.spec.ts
@@ -2,7 +2,7 @@ import { Dec, Int } from "@keplr-wallet/unit";
 
 import { approxSqrt } from "../../../utils";
 import { maxSpotPrice, maxTick, minSpotPrice } from "../const";
-import { priceToTick, tickToSqrtPrice } from "../tick";
+import { priceToTick, tickToPrice, tickToSqrtPrice } from "../tick";
 
 // https://github.com/osmosis-labs/osmosis/blob/0f9eb3c1259078035445b3e3269659469b95fd9f/x/concentrated-liquidity/math/tick_test.go#L30
 describe("tickToSqrtPrice", () => {
@@ -213,6 +213,38 @@ describe("priceToTick", () => {
         console.error(e);
         expect(expectedError).toBeDefined();
       }
+    });
+  });
+});
+
+describe("tickToPrice", () => {
+  const testCases: Record<string, { tick: Int; priceExpected: Dec }> = {
+    "Tick Zero": {
+      tick: new Int("0"),
+      priceExpected: new Dec("1"),
+    },
+    "Large Positive Tick": {
+      tick: new Int("1000000"),
+      priceExpected: new Dec("2"),
+    },
+    "Large Negative Tick": {
+      tick: new Int("-5000000"),
+      priceExpected: new Dec("0.5"),
+    },
+    "Max Tick": {
+      tick: new Int("182402823"),
+      priceExpected: new Dec("340282300000000000000"),
+    },
+    "Min Tick": {
+      tick: new Int("-108000000"),
+      priceExpected: new Dec("0.000000000001"),
+    },
+  };
+
+  Object.values(testCases).forEach(({ tick, priceExpected }, i) => {
+    it(Object.keys(testCases)[i], () => {
+      const price = tickToPrice(tick);
+      expect(price.toString()).toEqual(priceExpected.toString());
     });
   });
 });

--- a/packages/math/src/pool/concentrated/tick.ts
+++ b/packages/math/src/pool/concentrated/tick.ts
@@ -66,6 +66,53 @@ export function tickToSqrtPrice(tickIndex: Int): Dec {
   return approxSqrt(price);
 }
 
+export function tickToPrice(tickIndex: Int): Dec {
+  if (tickIndex.isZero()) {
+    return new Dec(1);
+  }
+
+  const geometricExponentIncrementDistanceInTicks = nine.mul(
+    powTenBigDec(new Int(exponentAtPriceOne).neg()).toDec()
+  );
+
+  if (tickIndex.lt(minTick) || tickIndex.gt(maxTick)) {
+    throw new Error(
+      `tickIndex is out of range: ${tickIndex.toString()}, min: ${minTick.toString()}, max: ${maxTick.toString()}`
+    );
+  }
+
+  const geometricExponentDelta = new Dec(tickIndex)
+    .quoTruncate(new Dec(geometricExponentIncrementDistanceInTicks.truncate()))
+    .truncate();
+
+  let exponentAtCurTick = new Int(exponentAtPriceOne).add(
+    geometricExponentDelta
+  );
+  if (tickIndex.lt(new Int(0))) {
+    exponentAtCurTick = exponentAtCurTick.sub(new Int(1));
+  }
+
+  const currentAdditiveIncrementInTicks = powTenBigDec(exponentAtCurTick);
+
+  const numAdditiveTicks = tickIndex.sub(
+    geometricExponentDelta.mul(
+      geometricExponentIncrementDistanceInTicks.truncate()
+    )
+  );
+
+  const price = powTenBigDec(geometricExponentDelta)
+    .add(new BigDec(numAdditiveTicks).mul(currentAdditiveIncrementInTicks))
+    .toDec();
+
+  if (price.gt(maxSpotPrice) || price.lt(minSpotPrice)) {
+    throw new Error(
+      `price is out of range: ${price.toString()}, min: ${minSpotPrice.toString()}, max: ${maxSpotPrice.toString()}`
+    );
+  }
+
+  return price;
+}
+
 /** PriceToTick takes a price and returns the corresponding tick index
  *  This function does not take into consideration tick spacing.
  */

--- a/packages/trpc/src/orderbook-router.ts
+++ b/packages/trpc/src/orderbook-router.ts
@@ -1,4 +1,5 @@
-import { Dec } from "@keplr-wallet/unit";
+import { Dec, Int } from "@keplr-wallet/unit";
+import { tickToPrice } from "@osmosis-labs/math";
 import {
   CursorPaginationSchema,
   getOrderbookActiveOrders,
@@ -28,6 +29,7 @@ type MappedLimitOrder = Omit<LimitOrder, "quantity" | "placed_quantity"> & {
   totalFilled: number;
   percentFilled: Dec;
   orderbookAddress: string;
+  price: Dec;
 };
 
 async function getTickInfoAndTransformOrders(
@@ -94,9 +96,10 @@ async function getTickInfoAndTransformOrders(
         tickEtas + (tickUnrealizedCancelled - tickCumulativeCancelled);
       const totalFilled = Math.max(tickTotalEtas - parseInt(o.etas), 0);
       const percentFilled = new Dec(totalFilled / placedQuantity);
-
+      const price = tickToPrice(new Int(o.tick_id));
       return {
         ...o,
+        price,
         quantity,
         placed_quantity: placedQuantity,
         percentClaimed,


### PR DESCRIPTION
## What is the purpose of the change:
These changes add a `price` field to `MappedLimitOrders` that show a representation of the ratio between the quote and base asset at the tick for the given order.

## Brief Changelog

- Added `tickToPrice` function in the `math` package
- Added price calculation when mapping order info in `getTickInfoAndTransformOrders`

## Testing and Verifying
Added several test cases for `tickToPrice` in `tick.spec.ts`
