### PR TITLE
Add IBC transfer status provider to store

### DIFF
--- a/packages/bridge/src/ibc/__tests__/ibc-transfer-status.spec.ts
+++ b/packages/bridge/src/ibc/__tests__/ibc-transfer-status.spec.ts
@@ -4,7 +4,7 @@ import { TxTracer } from "@osmosis-labs/tx";
 import { MockAssetLists } from "../../__tests__/mock-asset-lists";
 import { MockChains } from "../../__tests__/mock-chains";
 import { TransferStatusReceiver } from "../../interface";
-import { IBCTransferStatusProvider } from "../transfer-status";
+import { IbcTransferStatusProvider } from "../transfer-status";
 
 const makeRpcStatusResponse = (
   timeoutHeight: string,
@@ -67,8 +67,8 @@ jest.mock("@osmosis-labs/tx", () => ({
   })),
 }));
 
-describe("IBCTransferStatusProvider", () => {
-  let provider: IBCTransferStatusProvider;
+describe("IbcTransferStatusProvider", () => {
+  let provider: IbcTransferStatusProvider;
   let mockReceiver: jest.Mocked<TransferStatusReceiver>;
   let consoleSpy: jest.SpyInstance;
 
@@ -76,7 +76,7 @@ describe("IBCTransferStatusProvider", () => {
     mockReceiver = {
       receiveNewTxStatus: jest.fn(),
     };
-    provider = new IBCTransferStatusProvider(MockChains, MockAssetLists);
+    provider = new IbcTransferStatusProvider(MockChains, MockAssetLists);
     provider.statusReceiverDelegate = mockReceiver;
     // silences console errors and serves as a spy to test for calls
     consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});

--- a/packages/bridge/src/ibc/index.ts
+++ b/packages/bridge/src/ibc/index.ts
@@ -280,3 +280,5 @@ export class IbcBridgeProvider implements BridgeProvider {
     return { urlProviderName: "TFM", url };
   }
 }
+
+export * from "./transfer-status";

--- a/packages/bridge/src/ibc/transfer-status.ts
+++ b/packages/bridge/src/ibc/transfer-status.ts
@@ -13,7 +13,7 @@ import { IbcBridgeProvider } from ".";
 
 export type IbcTransferStatus = "pending" | "complete" | "timeout" | "refunded";
 
-export class IBCTransferStatusProvider implements TransferStatusProvider {
+export class IbcTransferStatusProvider implements TransferStatusProvider {
   readonly keyPrefix = IbcBridgeProvider.ID;
   readonly sourceDisplayName = "IBC Transfer";
   public statusReceiverDelegate?: TransferStatusReceiver;

--- a/packages/bridge/src/index.ts
+++ b/packages/bridge/src/index.ts
@@ -2,6 +2,7 @@ export * from "./axelar";
 export * from "./bridge-providers";
 export * from "./chain";
 export * from "./errors";
+export * from "./ibc";
 export * from "./interface";
 export * from "./skip";
 export * from "./squid";

--- a/packages/web/stores/root.ts
+++ b/packages/web/stores/root.ts
@@ -1,5 +1,6 @@
 import {
   AxelarTransferStatusProvider,
+  IbcTransferStatusProvider,
   SkipTransferStatusProvider,
   SquidTransferStatusProvider,
 } from "@osmosis-labs/bridge";
@@ -256,6 +257,7 @@ export class RootStore {
         new AxelarTransferStatusProvider(IS_TESTNET ? "testnet" : "mainnet"),
         new SquidTransferStatusProvider(IS_TESTNET ? "testnet" : "mainnet"),
         new SkipTransferStatusProvider(IS_TESTNET ? "testnet" : "mainnet"),
+        new IbcTransferStatusProvider(ChainList, AssetLists),
       ]
     );
 


### PR DESCRIPTION
## What is the purpose of the change:

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

We will pass IBC transfers here to be tracked by this provider from IBC transfers initiated by the new deposit/withdraw flow.

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-559/add-ibc-transfer-status-provider-to-status-receiver)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

* Add IBC transfer status provider to our transfer status UI config in root of repo
