### PR TITLE
[Limit Orders]: Disable input switching on market orders

### DIFF
--- a/packages/web/components/input/limit-input.tsx
+++ b/packages/web/components/input/limit-input.tsx
@@ -48,6 +48,7 @@ export const LimitInput: FC<LimitInputProps> = ({
 }) => {
   const [fiatAmount, setFiatAmount] = useState<string>("");
   const [tab] = useQueryState("tab");
+  const [type] = useQueryState("type");
   const [focused, setFocused] = useState<FocusedInput>(
     tab === "buy" ? FocusedInput.FIAT : FocusedInput.TOKEN
   );
@@ -60,6 +61,13 @@ export const LimitInput: FC<LimitInputProps> = ({
 
   // Swap focus every time the tab changes
   useEffect(() => swapFocus(), [swapFocus, tab]);
+
+  // Set focus to Fiat / Token on type/tab change
+  useEffect(() => {
+    if (type === "market") {
+      setFocused(tab === "buy" ? FocusedInput.FIAT : FocusedInput.TOKEN);
+    }
+  }, [tab, type]);
 
   const setFiatAmountSafe = useCallback(
     (value: string) => {

--- a/packages/web/components/input/limit-input.tsx
+++ b/packages/web/components/input/limit-input.tsx
@@ -13,6 +13,7 @@ export interface LimitInputProps {
   tokenAmount: string;
   price: Dec;
   insufficentFunds?: boolean;
+  disableSwitching?: boolean;
 }
 
 export enum FocusedInput {
@@ -43,6 +44,7 @@ export const LimitInput: FC<LimitInputProps> = ({
   tokenAmount,
   price,
   insufficentFunds,
+  disableSwitching,
 }) => {
   const [fiatAmount, setFiatAmount] = useState<string>("");
   const [tab] = useQueryState("tab");
@@ -114,6 +116,7 @@ export const LimitInput: FC<LimitInputProps> = ({
           insufficentFunds={insufficentFunds}
           amount={type === "fiat" ? fiatAmount : tokenAmount}
           setter={type === "fiat" ? setFiatAmountSafe : setTokenAmountSafe}
+          disableSwitching={disableSwitching}
         />
       ))}
       <button className="absolute right-4 top-3 flex items-center justify-center rounded-5xl border border-osmoverse-700 py-1.5 px-3 opacity-50 transition-opacity hover:opacity-100">
@@ -139,6 +142,7 @@ function AutoInput({
   amount,
   setter,
   type,
+  disableSwitching,
 }: AutoInputProps) {
   const currentTypeEnum = useMemo(
     () => (type === "fiat" ? FocusedInput.FIAT : FocusedInput.TOKEN),
@@ -167,8 +171,13 @@ function AutoInput({
           "text-white-full": isFocused && +amount > 0,
         }
       )}
-      onClick={focused === oppositeTypeEnum ? swapFocus : undefined}
+      onClick={
+        !disableSwitching && focused === oppositeTypeEnum
+          ? swapFocus
+          : undefined
+      }
     >
+      {disableSwitching && !isFocused && <span>~</span>}
       {type === "fiat" && (
         <span className={classNames({ "font-normal": !isFocused })}>$</span>
       )}
@@ -194,7 +203,7 @@ function AutoInput({
           {baseAsset ? baseAsset.denom : ""}
         </span>
       )}
-      {focused === oppositeTypeEnum && <SwapArrows />}
+      {!disableSwitching && focused === oppositeTypeEnum && <SwapArrows />}
     </div>
   );
 }

--- a/packages/web/components/place-limit-tool/index.tsx
+++ b/packages/web/components/place-limit-tool/index.tsx
@@ -110,6 +110,7 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
               tokenAmount={swapState.inAmountInput.inputAmount}
               price={swapState.priceState.price}
               insufficentFunds={swapState.insufficientFunds}
+              disableSwitching={type === "market"}
             />
           </div>
           {type === "limit" ? (


### PR DESCRIPTION
## What is the purpose of the change:

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->
Disable input switching on market orders and just show fiat/token est. conversion

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/LIM-144/[ui]-disable-input-switching-on-market-orders)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->
