### PR TITLE
(Wallet Addition) Display Crypto.com Wallet in App Browser

### DIFF
--- a/packages/web/config/wallet-registry.ts
+++ b/packages/web/config/wallet-registry.ts
@@ -261,6 +261,7 @@ export const CosmosWalletRegistry: CosmosRegistryWallet[] = [
       import("@cosmos-kit/cdcwallet-extension").then(
         (m) => m.CdcwalletExtensionWallet
       ),
+    mobileDisabled: false,
     async supportsChain(chainId) {
       const cdcAvailableChains: MainnetChainIds[] = [
         "cosmoshub-4",

--- a/packages/web/modals/wallet-select/use-selectable-wallets.ts
+++ b/packages/web/modals/wallet-select/use-selectable-wallets.ts
@@ -75,6 +75,23 @@ export const useSelectableWallets = ({
              * the frontend from Leap's app in app browser. So, there is no need
              * to use wallet connect, as it resembles the extension's usage.
              */
+            if (
+              _window?.cdc_wallet?.cosmos &&
+              _window?.cdc_wallet?.cosmos.mode === mobileWebModeName
+            ) {
+              return array
+                .filter(
+                  (wallet) =>
+                    wallet.name === AvailableCosmosWallets.CryptocomWallet
+                )
+                .map((wallet) => ({ ...wallet, mobileDisabled: false }));
+            }
+
+            /**
+             * If on mobile and `leap` is in `window`, it means that the user enters
+             * the frontend from Leap's app in app browser. So, there is no need
+             * to use wallet connect, as it resembles the extension's usage.
+             */
             if (_window?.leap && _window?.leap?.mode === mobileWebModeName) {
               return array
                 .filter((wallet) => wallet.name === AvailableCosmosWallets.Leap)


### PR DESCRIPTION
### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-592/implement-cryptocom-mobile-wallet)

## Testing and Verifying

- [ ] Can see the Crypto.com wallet in its mobile app browser