### PR TITLE
use nextjs headers to implement caching

### DIFF
--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -9,6 +9,19 @@ const config = {
   images: {
     domains: ["app.osmosis.zone", "raw.githubusercontent.com", "pbs.twimg.com"],
   },
+  async headers() {
+    return [
+      {
+        source: "/favicon.ico",
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=864000", // Cache for 10 days
+          },
+        ],
+      },
+    ];
+  },
   webpack(config) {
     /**
      * Add sprite.svg to bundle and append hash to revalidate cache when content changes.


### PR DESCRIPTION
## What is the purpose of the change:

To make sure favicon is cached for 10 days

This PR should close the bounty https://github.com/osmosis-labs/osmosis-frontend/issues/3357

### Linear Task

[Linear Task URL](https://github.com/osmosis-labs/osmosis-frontend/issues/3357)

## Brief Changelog

Added headers config for nextjs
Reset to stage and applied fix

## Testing and Verifying


This change has been tested locally by rebuilding the website and verified content and links are expected
<img width="1304" alt="Screenshot 2024-06-28 at 09 02 29" src="https://github.com/osmosis-labs/osmosis-frontend/assets/49923152/f39e68cf-3782-4144-b778-4ebb40cbb682">

@MaxMillington please review 