### PR TITLE
Add alt fee token feature to wallets

### DIFF
--- a/packages/stores/src/account/base.ts
+++ b/packages/stores/src/account/base.ts
@@ -1273,6 +1273,10 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
           })
         : undefined;
 
+      const walletSupportsAltFeeTokens = Boolean(
+        wallet.walletInfo.features?.includes("alt-fee-tokens")
+      );
+
       const estimate = await apiClient<QuoteStdFee>("/api/estimate-gas-fee", {
         data: {
           chainId: wallet.chainId,
@@ -1280,7 +1284,8 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
           nonCriticalExtensionOptions:
             nonCriticalExtensionOptions?.map(encodeAnyBase64),
           bech32Address: wallet.address,
-          onlyDefaultFeeDenom: signOptions.useOneClickTrading,
+          onlyDefaultFeeDenom:
+            signOptions.useOneClickTrading || !walletSupportsAltFeeTokens,
           gasMultiplier: GasMultiplier,
         },
       });

--- a/packages/stores/src/account/types.ts
+++ b/packages/stores/src/account/types.ts
@@ -73,7 +73,7 @@ export type CosmosRegistryWallet = Omit<Wallet, "logo"> & {
    * For example, if "notifications" is included in the array, the app will display
    * the notifications button.
    */
-  features: Array<"notifications">;
+  features: Array<"notifications" | "alt-fee-tokens">;
 
   signOptions?: SignOptions;
 };

--- a/packages/web/config/wallet-registry.ts
+++ b/packages/web/config/wallet-registry.ts
@@ -17,7 +17,7 @@ export const CosmosWalletRegistry: CosmosRegistryWallet[] = [
     windowPropertyName: "keplr",
     stakeUrl: "https://wallet.keplr.app/chains/osmosis?tab=staking",
     governanceUrl: "https://wallet.keplr.app/chains/osmosis?tab=governance",
-    features: ["notifications"],
+    features: ["notifications", "alt-fee-tokens"],
   },
   {
     ...CosmosKitWalletList["keplr-mobile"],
@@ -60,7 +60,7 @@ export const CosmosWalletRegistry: CosmosRegistryWallet[] = [
     },
     stakeUrl: "https://wallet.keplr.app/chains/osmosis?tab=staking",
     governanceUrl: "https://wallet.keplr.app/chains/osmosis?tab=governance",
-    features: [],
+    features: ["alt-fee-tokens"],
   },
   {
     ...CosmosKitWalletList["leap-extension"],
@@ -71,7 +71,7 @@ export const CosmosWalletRegistry: CosmosRegistryWallet[] = [
     windowPropertyName: "leap",
     stakeUrl: "https://cosmos.leapwallet.io/transact/stake/plain?chain=osmosis",
     governanceUrl: "https://cosmos.leapwallet.io/portfolio/gov?chain=osmosis",
-    features: ["notifications"],
+    features: ["notifications", "alt-fee-tokens"],
   },
   {
     ...CosmosKitWalletList["leap-cosmos-mobile"],
@@ -152,7 +152,7 @@ export const CosmosWalletRegistry: CosmosRegistryWallet[] = [
 
     stakeUrl: "https://cosmos.leapwallet.io/transact/stake/plain?chain=osmosis",
     governanceUrl: "https://cosmos.leapwallet.io/portfolio/gov?chain=osmosis",
-    features: [],
+    features: ["alt-fee-tokens"],
   },
   {
     ...CosmosKitWalletList["okxwallet-extension"],


### PR DESCRIPTION
## What is the purpose of the change:

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

Some wallets don't support alt fee tokens. This adds an `"alt-fee-tokens"` flag that can be specified in the wallet registry for determining if a wallet accepts a token other than the default gas fee token on chains.
