### PR TITLE
Use 1ct flag when estimating max balance gas

### DIFF
--- a/packages/web/.env
+++ b/packages/web/.env
@@ -45,4 +45,4 @@ TWITTER_API_URL=https://api.twitter.com/
 # Pools that are excluded from showing external boost incentives APRs.
 # NEXT_PUBLIC_EXCLUDED_EXTERNAL_BOOSTS_POOL_IDS=
 
-# NEXT_PUBLIC_SPEND_LIMIT_CONTRACT_ADDRESS=
+NEXT_PUBLIC_SPEND_LIMIT_CONTRACT_ADDRESS=osmo10xqv8rlpkflywm92k5wdmplzy7khtasl9c2c08psmvlu543k724sy94k74

--- a/packages/web/hooks/use-swap.tsx
+++ b/packages/web/hooks/use-swap.tsx
@@ -827,6 +827,8 @@ function useSwapAmountInput({
   const isQuoteForCurrentBalanceLoading =
     isQuoteForCurrentBalanceLoading_ && balanceQuoteQueryEnabled;
 
+  const { isOneClickTradingEnabled } = useOneClickTradingSession();
+
   const networkFeeQueryEnabled =
     !isQuoteForCurrentBalanceLoading &&
     balanceQuoteQueryEnabled &&
@@ -839,6 +841,9 @@ function useSwapAmountInput({
     chainId: chainStore.osmosis.chainId,
     messages: quoteForCurrentBalance?.messages,
     enabled: networkFeeQueryEnabled,
+    signOptions: {
+      useOneClickTrading: isOneClickTradingEnabled,
+    },
   });
   const isLoadingCurrentBalanceNetworkFee =
     networkFeeQueryEnabled && isLoadingCurrentBalanceNetworkFee_;

--- a/packages/web/stores/index.tsx
+++ b/packages/web/stores/index.tsx
@@ -49,9 +49,7 @@ export const StoreProvider = ({ children }: PropsWithChildren) => {
           onExceeds1CTNetworkFeeLimit: ({ finish, continueTx }) => {
             displayToast(
               {
-                titleTranslationKey: t(
-                  "oneClickTrading.toast.networkFeeTooHigh"
-                ),
+                titleTranslationKey: "oneClickTrading.toast.networkFeeTooHigh",
                 captionElement: (
                   <div className="flex flex-col items-start gap-2">
                     <Button


### PR DESCRIPTION
## What is the purpose of the change:

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

Pass `isOneClickTradingEnabled` flag to the max balance gas estimation query to ensure the extension options are included
