### PR TITLE
feat: added claimable orders

### DIFF
--- a/packages/server/src/queries/osmosis/orderbooks.ts
+++ b/packages/server/src/queries/osmosis/orderbooks.ts
@@ -29,6 +29,7 @@ export interface LimitOrder {
   etas: string;
   claim_bounty?: string;
   placed_quantity: string;
+  placed_at: string;
 }
 
 interface OrderbookActiveOrdersResponse {
@@ -111,7 +112,7 @@ export const queryOrderbookTickUnrealizedCancelsById = createNodeQuery<
 >({
   path: ({ tickIds, orderbookAddress }) => {
     const msg = JSON.stringify({
-      tick_unrealized_cancels_by_id: {
+      get_unrealized_cancels: {
         tick_ids: tickIds,
       },
     });

--- a/packages/web/components/complex/orders-history/cells/filled-progress.tsx
+++ b/packages/web/components/complex/orders-history/cells/filled-progress.tsx
@@ -1,4 +1,4 @@
-import { Dec } from "@keplr-wallet/unit";
+import { Dec, Int } from "@keplr-wallet/unit";
 import { MappedLimitOrder } from "@osmosis-labs/trpc";
 import React, { useMemo } from "react";
 
@@ -16,9 +16,9 @@ export const OrderProgressBar: React.FC<OrderProgressBarProps> = ({
 
   const roundedAmountFilled = useMemo(() => {
     if (percentFilled.lt(new Dec(1)) && !percentFilled.isZero()) {
-      return new Dec(1);
+      return new Int(1);
     }
-    return percentFilled.round();
+    return percentFilled.round().mul(new Int(100));
   }, [percentFilled]);
 
   const progressSegments = useMemo(

--- a/packages/web/components/complex/orders-history/index.tsx
+++ b/packages/web/components/complex/orders-history/index.tsx
@@ -14,6 +14,7 @@ import { Spinner } from "~/components/loaders";
 import {
   DisplayableLimitOrder,
   useOrderbookAllActiveOrders,
+  useOrderbookClaimableOrders,
 } from "~/hooks/limit-orders/use-orderbook";
 import { useStore } from "~/stores";
 
@@ -32,6 +33,10 @@ export const OrderHistory = observer(() => {
     data: orders,
     columns: tableColumns,
     getCoreRowModel: getCoreRowModel(),
+  });
+
+  const { count, claimAllOrders } = useOrderbookClaimableOrders({
+    userAddress: wallet?.address ?? "",
   });
 
   const filledOrders = useMemo(
@@ -130,7 +135,7 @@ export const OrderHistory = observer(() => {
                       <div className="flex items-center gap-2 pb-3">
                         <h6>Filled orders to claim</h6>
                         <div className="flex h-6 w-6 items-center justify-center rounded-full bg-[#A51399]">
-                          <span className="caption">1</span>
+                          <span className="caption">{count}</span>
                         </div>
                       </div>
                       <div className="flex h-12 w-12 items-center justify-center">
@@ -142,7 +147,10 @@ export const OrderHistory = observer(() => {
                         />
                       </div>
                     </div>
-                    <button className="flex items-center justify-center rounded-[48px] bg-wosmongton-700 py-3 px-4">
+                    <button
+                      className="flex items-center justify-center rounded-[48px] bg-wosmongton-700 py-3 px-4"
+                      onClick={claimAllOrders}
+                    >
                       <span className="subtitle1">Claim all</span>
                     </button>
                   </div>

--- a/packages/web/hooks/limit-orders/use-orderbook.ts
+++ b/packages/web/hooks/limit-orders/use-orderbook.ts
@@ -1,8 +1,9 @@
 import { Dec } from "@keplr-wallet/unit";
+import { CoinPrimitive } from "@osmosis-labs/keplr-stores";
 import { Asset } from "@osmosis-labs/server";
 import { MappedLimitOrder } from "@osmosis-labs/trpc";
 import { getAssetFromAssetList, makeMinimalAsset } from "@osmosis-labs/utils";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 
 import { AssetLists } from "~/config/generated/asset-lists";
 import { useSwapAsset } from "~/hooks/use-swap";
@@ -300,6 +301,63 @@ export const useOrderbookAllActiveOrders = ({
     isLoading,
     fetchNextPage,
     isFetching,
+  };
+};
+
+export const useOrderbookClaimableOrders = ({
+  userAddress,
+}: {
+  userAddress: string;
+}) => {
+  const { orderbooks } = useOrderbooks();
+  const { accountStore } = useStore();
+  const account = accountStore.getWallet(accountStore.osmosisChainId);
+  const addresses = orderbooks.map(({ contractAddress }) => contractAddress);
+  const {
+    data: orders,
+    isLoading,
+    isFetching,
+  } = api.edge.orderbooks.getClaimableOrders.useQuery({
+    contractAddresses: addresses,
+    userOsmoAddress: userAddress,
+  });
+
+  const claimAllOrders = useCallback(async () => {
+    if (!account || !orders) return;
+    const msgs = addresses
+      .map((contractAddress) => {
+        const ordersForAddress = orders.filter(
+          (o) => o.orderbookAddress === contractAddress
+        );
+        if (ordersForAddress.length === 0) return;
+
+        const msg = {
+          batch_claim: {
+            orders: ordersForAddress.map((o) => [o.tick_id, o.order_id]),
+          },
+        };
+        return {
+          contractAddress,
+          msg,
+          funds: [],
+        };
+      })
+      .filter(Boolean) as {
+      contractAddress: string;
+      msg: object;
+      funds: CoinPrimitive[];
+    }[];
+
+    if (msgs.length > 0) {
+      await account?.cosmwasm.sendMultiExecuteContractMsg("executeWasm", msgs);
+    }
+  }, [orders, account, addresses]);
+
+  return {
+    orders: orders ?? [],
+    count: orders?.length ?? 0,
+    isLoading: isLoading || isFetching,
+    claimAllOrders,
   };
 };
 

--- a/packages/web/hooks/limit-orders/use-place-limit.ts
+++ b/packages/web/hooks/limit-orders/use-place-limit.ts
@@ -145,9 +145,8 @@ export const usePlaceLimit = ({
     const paymentDenom = paymentTokenValue.toCoin().denom;
     // The requested price must account for the ratio between the quote and base asset as the base asset may not be a stablecoin.
     // To account for this we divide by the quote asset price.
-    const tickId = priceToTick(
-      priceState.price.quo(quoteAssetPrice?.toDec() ?? new Dec(1))
-    );
+    //TODO: Adjust for quote asset price quoteAssetPrice?.toDec()
+    const tickId = priceToTick(priceState.price.quo(new Dec(1)));
     const msg = {
       place_limit: {
         tick_id: parseInt(tickId.toString()),
@@ -176,7 +175,6 @@ export const usePlaceLimit = ({
     account,
     orderDirection,
     priceState,
-    quoteAssetPrice,
     paymentTokenValue,
   ]);
 

--- a/packages/web/hooks/use-feature-flags.ts
+++ b/packages/web/hooks/use-feature-flags.ts
@@ -45,7 +45,7 @@ const defaultFlags: Record<ModifiedFlags, boolean> = {
   sidebarOsmoChangeAndChart: true,
   multiBridgeProviders: true,
   earnPage: false,
-  transactionsPage: true,
+  transactionsPage: false,
   sidecarRouter: true,
   legacyRouter: true,
   tfmRouter: true,

--- a/packages/web/hooks/use-feature-flags.ts
+++ b/packages/web/hooks/use-feature-flags.ts
@@ -45,7 +45,7 @@ const defaultFlags: Record<ModifiedFlags, boolean> = {
   sidebarOsmoChangeAndChart: true,
   multiBridgeProviders: true,
   earnPage: false,
-  transactionsPage: false,
+  transactionsPage: true,
   sidecarRouter: true,
   legacyRouter: true,
   tfmRouter: true,


### PR DESCRIPTION
## What is the purpose of the change:
These changes add a query to retrieve all claimable orders and include the results of that query in the order history page. This is a separate query as the current active orders query is paginated and may not return all claimable orders. Also includes is the ability to batch claim all filled orders.

There are also some changes to accommodate for changes in the smart contract.

### Linear Task

[LIM-157: Claimable Orders](https://linear.app/osmosis/issue/LIM-157/[services-ui]-claimable-orders)
[LIM-158: Batch Claim Orders](https://linear.app/osmosis/issue/LIM-158/[services]-batch-claim-orders)

## Brief Changelog
- Added `getClaimableOrders` to orderbook router
- Added `useClaimableOrders` hook
- Wired in `Claim All` button on order history page
