### PR TITLE
feat: added placed at info for active orders

### DIFF
--- a/packages/web/components/complex/orders-history/columns.tsx
+++ b/packages/web/components/complex/orders-history/columns.tsx
@@ -2,6 +2,7 @@ import { PricePretty } from "@keplr-wallet/unit";
 import { DEFAULT_VS_CURRENCY } from "@osmosis-labs/server";
 import { createColumnHelper } from "@tanstack/react-table";
 import classNames from "classnames";
+import dayjs from "dayjs";
 import Image from "next/image";
 
 import { Icon } from "~/components/assets";
@@ -124,11 +125,18 @@ export const tableColumns = [
     header: () => {
       return <small className="body2">Order Placed</small>;
     },
-    cell: () => {
+    cell: ({
+      row: {
+        original: { placed_at },
+      },
+    }) => {
+      const placedAt = dayjs(placed_at / 1000000);
+      const formattedTime = placedAt.format("h:mm A");
+      const formattedDate = placedAt.format("MMM D");
       return (
         <div className="flex flex-col gap-1">
-          <p className="body2 text-osmoverse-300">2:14 PM</p>
-          <p>Apr 1st</p>
+          <p className="body2 text-osmoverse-300">{formattedTime}</p>
+          <p>{formattedDate}</p>
         </div>
       );
     },

--- a/packages/web/hooks/use-feature-flags.ts
+++ b/packages/web/hooks/use-feature-flags.ts
@@ -45,7 +45,7 @@ const defaultFlags: Record<ModifiedFlags, boolean> = {
   sidebarOsmoChangeAndChart: true,
   multiBridgeProviders: true,
   earnPage: false,
-  transactionsPage: false,
+  transactionsPage: true,
   sidecarRouter: true,
   legacyRouter: true,
   tfmRouter: true,


### PR DESCRIPTION
## What is the purpose of the change:
These changes wire in the actual placed at datetime for active orders.

### Linear Task

[LIM-160: Active Order Placed at Date](https://linear.app/osmosis/issue/LIM-160/[services-ui]-active-order-placed-at-date)
