### PR TITLE
fix: default platforms

### DIFF
--- a/packages/server/src/queries/complex/earn/strategies.ts
+++ b/packages/server/src/queries/complex/earn/strategies.ts
@@ -114,12 +114,14 @@ export async function getStrategies({
     getFreshValue: async (): Promise<{
       riskReportUrl?: string;
       categories: StategyCMSCategory[];
+      platforms: StategyCMSCategory[];
       strategies: StrategyCMSData[];
     }> => {
       try {
         const cmsData = await queryOsmosisCMS<{
           strategies: RawStrategyCMSData[];
           categories: StategyCMSCategory[];
+          platforms: StategyCMSCategory[];
           riskReportUrl: string;
         }>({ filePath: `cms/earn/strategies.json` });
 
@@ -172,6 +174,7 @@ export async function getStrategies({
         return {
           riskReportUrl: cmsData.riskReportUrl,
           categories: cmsData.categories,
+          platforms: cmsData.platforms,
           strategies: aggregatedStrategies.filter((strat) => !strat.unlisted),
         };
       } catch (error) {

--- a/packages/web/hooks/use-get-earn-strategies.ts
+++ b/packages/web/hooks/use-get-earn-strategies.ts
@@ -214,6 +214,7 @@ export const useGetEarnStrategies = (
 
   return {
     strategies,
+    cmsData,
     ...additionalBalanceData,
     holdenDenoms,
     areBalancesLoading,

--- a/packages/web/pages/earn/index.tsx
+++ b/packages/web/pages/earn/index.tsx
@@ -53,6 +53,7 @@ function Earn() {
   useNavBar({ title: t("earnPage.title") });
 
   const {
+    cmsData,
     strategies,
     myStrategies,
     totalBalance,
@@ -78,18 +79,18 @@ function Earn() {
         { label: "Perps LP", value: "Perps LP" },
         { label: "Lending", value: "Lending" },
       ],
-      platform: [
-        { label: "Osmosis", value: "Osmosis" },
-        { label: "Quasar", value: "Quasar" },
-        { label: "Levana", value: "Levana" },
-        { label: "Mars", value: "Mars" },
-      ],
+      platform: cmsData?.platforms
+        ? cmsData.platforms.map((platform) => ({
+            label: platform.name,
+            value: platform.name,
+          }))
+        : [],
       lockDurationType: "all",
       search: "",
       specialTokens: [],
       rewardType: "all",
     }),
-    [holdenDenoms?.length, isWalletConnected]
+    [holdenDenoms?.length, cmsData, isWalletConnected]
   );
 
   useEffect(() => {


### PR DESCRIPTION
## What is the purpose of the change:

By default, platforms are now set according to CMS data

### Linear Task

[Linear Task URL](PASTE_LINEAR_TASK_URL_HERE)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->
