### PR TITLE
feat: historical limit orders 

### DIFF
--- a/packages/server/src/queries/complex/orderbooks/active-orders.ts
+++ b/packages/server/src/queries/complex/orderbooks/active-orders.ts
@@ -19,7 +19,7 @@ export function getOrderbookActiveOrders({
   return cachified({
     cache: activeOrdersCache,
     key: `orderbookActiveOrders-${orderbookAddress}-${userOsmoAddress}`,
-    ttl: 1000 * 30, // 30 seconds
+    ttl: 1000 * 3, // 30 seconds
     getFreshValue: () =>
       queryOrderbookActiveOrders({
         orderbookAddress,

--- a/packages/server/src/queries/complex/orderbooks/historical-orders.ts
+++ b/packages/server/src/queries/complex/orderbooks/historical-orders.ts
@@ -1,0 +1,23 @@
+import cachified, { CacheEntry } from "cachified";
+import { LRUCache } from "lru-cache";
+
+import { DEFAULT_LRU_OPTIONS } from "../../../utils/cache";
+import { queryHistoricalOrders } from "../../osmosis";
+
+const orderbookHistoricalOrdersCache = new LRUCache<string, CacheEntry>(
+  DEFAULT_LRU_OPTIONS
+);
+
+export function getOrderbookHistoricalOrders({
+  userOsmoAddress,
+}: {
+  userOsmoAddress: string;
+}) {
+  return cachified({
+    cache: orderbookHistoricalOrdersCache,
+    key: `orderbookHistoricalOrders-${userOsmoAddress}`,
+    ttl: 1000 * 3, // 3 seconds
+    getFreshValue: () =>
+      queryHistoricalOrders(userOsmoAddress).then((data) => data),
+  });
+}

--- a/packages/server/src/queries/complex/orderbooks/index.ts
+++ b/packages/server/src/queries/complex/orderbooks/index.ts
@@ -1,5 +1,6 @@
 export * from "./active-orders";
 export * from "./denoms";
+export * from "./historical-orders";
 export * from "./maker-fee";
 export * from "./spot-price";
 export * from "./tick-state";

--- a/packages/server/src/queries/osmosis/orderbooks.ts
+++ b/packages/server/src/queries/osmosis/orderbooks.ts
@@ -1,3 +1,5 @@
+import dayjs from "dayjs";
+
 import { createNodeQuery } from "../create-node-query";
 
 interface OrderbookMakerFeeResponse {
@@ -168,3 +170,76 @@ export const queryOrderbookDenoms = createNodeQuery<
     return `/cosmwasm/wasm/v1/contract/${orderbookAddress}/smart/${encodedMsg}`;
   },
 });
+
+export interface HistoricalLimitOrder {
+  place_timestamp: string;
+  place_tx_hash: string;
+  order_denom: string;
+  output_denom: string;
+  quantity: string;
+  tick_id: string;
+  order_id: string;
+  order_direction: "ask" | "bid";
+  price: string;
+  status: string;
+  contract: string;
+}
+
+export function queryHistoricalOrders(
+  userOsmoAddress: string
+): Promise<HistoricalLimitOrder[]> {
+  // const url = new URL(
+  //   `/users/limit_orders/history/closed?address=${userOsmoAddress}`,
+  //   NUMIA_BASE_URL
+  // );
+  // return apiClient<HistoricalLimitOrder[]>(url.toString());
+  const placedholders: HistoricalLimitOrder[] = [
+    {
+      place_timestamp: (dayjs().unix() * 1_000_000).toString(),
+      place_tx_hash: "123123",
+      order_denom:
+        "ibc/DE6792CF9E521F6AD6E9A4BDF6225C9571A3B74ACC0A529F92BC5122A39D2E58",
+      output_denom: "uosmo",
+      quantity: "1000000",
+      tick_id: "1",
+      order_id: '1"',
+      order_direction: "bid",
+      price: "1",
+      status: "fullyClaimed",
+      contract:
+        "osmo1kgvlc4gmd9rvxuq2e63m0fn4j58cdnzdnrxx924mrzrjclcgqx5qxn3dga",
+    },
+    {
+      place_timestamp: (dayjs().unix() * 1_000_000).toString(),
+      place_tx_hash: "123123",
+      output_denom:
+        "ibc/DE6792CF9E521F6AD6E9A4BDF6225C9571A3B74ACC0A529F92BC5122A39D2E58",
+      order_denom: "uosmo",
+      quantity: "123123",
+      tick_id: "1",
+      order_id: '1"',
+      order_direction: "ask",
+      price: "0.5",
+      status: "fullyClaimed",
+      contract:
+        "osmo1kgvlc4gmd9rvxuq2e63m0fn4j58cdnzdnrxx924mrzrjclcgqx5qxn3dga",
+    },
+    {
+      place_timestamp: (dayjs().unix() * 1_000_000).toString(),
+      place_tx_hash: "123123",
+      output_denom:
+        "ibc/DE6792CF9E521F6AD6E9A4BDF6225C9571A3B74ACC0A529F92BC5122A39D2E58",
+      order_denom: "uosmo",
+      quantity: "123123",
+      tick_id: "1",
+      order_id: '1"',
+      order_direction: "ask",
+      price: "2.5",
+      status: "cancelled",
+      contract:
+        "osmo1kgvlc4gmd9rvxuq2e63m0fn4j58cdnzdnrxx924mrzrjclcgqx5qxn3dga",
+    },
+  ];
+
+  return new Promise((resolve) => resolve(placedholders));
+}

--- a/packages/server/src/queries/osmosis/orderbooks.ts
+++ b/packages/server/src/queries/osmosis/orderbooks.ts
@@ -1,5 +1,6 @@
-import dayjs from "dayjs";
+import { apiClient } from "@osmosis-labs/utils";
 
+import { NUMIA_BASE_URL } from "../../env";
 import { createNodeQuery } from "../create-node-query";
 
 interface OrderbookMakerFeeResponse {
@@ -188,58 +189,9 @@ export interface HistoricalLimitOrder {
 export function queryHistoricalOrders(
   userOsmoAddress: string
 ): Promise<HistoricalLimitOrder[]> {
-  // const url = new URL(
-  //   `/users/limit_orders/history/closed?address=${userOsmoAddress}`,
-  //   NUMIA_BASE_URL
-  // );
-  // return apiClient<HistoricalLimitOrder[]>(url.toString());
-  const placedholders: HistoricalLimitOrder[] = [
-    {
-      place_timestamp: (dayjs().unix() * 1_000_000).toString(),
-      place_tx_hash: "123123",
-      order_denom:
-        "ibc/DE6792CF9E521F6AD6E9A4BDF6225C9571A3B74ACC0A529F92BC5122A39D2E58",
-      output_denom: "uosmo",
-      quantity: "1000000",
-      tick_id: "1",
-      order_id: '1"',
-      order_direction: "bid",
-      price: "1",
-      status: "fullyClaimed",
-      contract:
-        "osmo1kgvlc4gmd9rvxuq2e63m0fn4j58cdnzdnrxx924mrzrjclcgqx5qxn3dga",
-    },
-    {
-      place_timestamp: (dayjs().unix() * 1_000_000).toString(),
-      place_tx_hash: "123123",
-      output_denom:
-        "ibc/DE6792CF9E521F6AD6E9A4BDF6225C9571A3B74ACC0A529F92BC5122A39D2E58",
-      order_denom: "uosmo",
-      quantity: "123123",
-      tick_id: "1",
-      order_id: '1"',
-      order_direction: "ask",
-      price: "0.5",
-      status: "fullyClaimed",
-      contract:
-        "osmo1kgvlc4gmd9rvxuq2e63m0fn4j58cdnzdnrxx924mrzrjclcgqx5qxn3dga",
-    },
-    {
-      place_timestamp: (dayjs().unix() * 1_000_000).toString(),
-      place_tx_hash: "123123",
-      output_denom:
-        "ibc/DE6792CF9E521F6AD6E9A4BDF6225C9571A3B74ACC0A529F92BC5122A39D2E58",
-      order_denom: "uosmo",
-      quantity: "123123",
-      tick_id: "1",
-      order_id: '1"',
-      order_direction: "ask",
-      price: "2.5",
-      status: "cancelled",
-      contract:
-        "osmo1kgvlc4gmd9rvxuq2e63m0fn4j58cdnzdnrxx924mrzrjclcgqx5qxn3dga",
-    },
-  ];
-
-  return new Promise((resolve) => resolve(placedholders));
+  const url = new URL(
+    `/users/limit_orders/history/closed?address=${userOsmoAddress}`,
+    NUMIA_BASE_URL
+  );
+  return apiClient<HistoricalLimitOrder[]>(url.toString());
 }

--- a/packages/trpc/src/orderbook-router.ts
+++ b/packages/trpc/src/orderbook-router.ts
@@ -4,10 +4,12 @@ import {
   CursorPaginationSchema,
   getOrderbookActiveOrders,
   getOrderbookDenoms,
+  getOrderbookHistoricalOrders,
   getOrderbookMakerFee,
   getOrderbookSpotPrice,
   getOrderbookTickState,
   getOrderbookTickUnrealizedCancels,
+  HistoricalLimitOrder,
   LimitOrder,
   maybeCachePaginatedItems,
 } from "@osmosis-labs/server";
@@ -43,7 +45,7 @@ export type MappedLimitOrder = Omit<
   orderbookAddress: string;
   price: Dec;
   status: OrderStatus;
-  output: number;
+  output: Dec;
   quoteAsset: ReturnType<typeof getAssetFromAssetList>;
   baseAsset: ReturnType<typeof getAssetFromAssetList>;
   placed_at: number;
@@ -99,19 +101,11 @@ async function getTickInfoAndTransformOrders(
       ({ tickId }) => tickId === o.tick_id
     ) ?? { tickState: undefined, unrealizedCancels: undefined };
 
-    const [tokenInAsset, tokenOutAsset] =
-      o.order_direction === "bid"
-        ? [quoteAsset, baseAsset]
-        : [baseAsset, quoteAsset];
-
-    const quantityMin = parseInt(o.quantity);
-    const placedQuantityMin = parseInt(o.placed_quantity);
-    const placedQuantity =
-      placedQuantityMin / 10 ** (tokenInAsset?.decimals ?? 0);
-    const quantity = quantityMin / 10 ** (tokenInAsset?.decimals ?? 0);
+    const quantity = parseInt(o.quantity);
+    const placedQuantity = parseInt(o.placed_quantity);
 
     const percentClaimed = new Dec(
-      (placedQuantityMin - quantityMin) / placedQuantityMin
+      (placedQuantity - quantity) / placedQuantity
     );
     const [tickEtas, tickUnrealizedCancelled] =
       o.order_direction === "bid"
@@ -135,22 +129,17 @@ async function getTickInfoAndTransformOrders(
           ];
     const tickTotalEtas = tickEtas + tickUnrealizedCancelled;
     const totalFilled = Math.max(
-      tickTotalEtas - (parseInt(o.etas) - (placedQuantityMin - quantityMin)),
+      tickTotalEtas - (parseInt(o.etas) - (placedQuantity - quantity)),
       0
     );
-    const percentFilled = new Dec(Math.min(totalFilled / placedQuantityMin, 1));
+    const percentFilled = new Dec(Math.min(totalFilled / placedQuantity, 1));
     const price = tickToPrice(new Int(o.tick_id));
     const status = mapOrderStatus(o, percentFilled);
-    const outputMin =
+    const output =
       o.order_direction === "bid"
-        ? new Dec(placedQuantityMin).quo(price)
-        : new Dec(placedQuantityMin).mul(price);
-    const output = parseInt(
-      outputMin
-        .quo(new Dec(10 ** (tokenOutAsset?.decimals ?? 0)))
-        .truncate()
-        .toString()
-    );
+        ? new Dec(placedQuantity).quo(price)
+        : new Dec(placedQuantity).mul(price);
+    console.log("price", price.toString());
     return {
       ...o,
       price,
@@ -165,6 +154,46 @@ async function getTickInfoAndTransformOrders(
       quoteAsset,
       baseAsset,
       placed_at: parseInt(o.placed_at),
+    };
+  });
+}
+
+function mapHistoricalToMapped(
+  historicalOrders: HistoricalLimitOrder[],
+  userAddress: string,
+  quoteAsset: ReturnType<typeof getAssetFromAssetList>,
+  baseAsset: ReturnType<typeof getAssetFromAssetList>
+): MappedLimitOrder[] {
+  return historicalOrders.map((o) => {
+    const quantityMin = parseInt(o.quantity);
+    const placedQuantityMin = parseInt(o.quantity);
+
+    const price = new Dec(o.price);
+    const percentClaimed = new Dec(1);
+    const output =
+      o.order_direction === "bid"
+        ? new Dec(placedQuantityMin).quo(price)
+        : new Dec(placedQuantityMin).mul(price);
+    return {
+      quoteAsset,
+      baseAsset,
+      etas: "0",
+      order_direction: o.order_direction,
+      order_id: parseInt(o.order_id),
+      owner: userAddress,
+      placed_at: parseInt(o.place_timestamp),
+      placed_quantity: parseInt(o.quantity),
+      placedQuantityMin,
+      quantityMin,
+      quantity: parseInt(o.quantity),
+      price,
+      status: o.status as OrderStatus,
+      tick_id: parseInt(o.tick_id),
+      output,
+      percentClaimed,
+      percentFilled: new Dec(1),
+      totalFilled: parseInt(o.quantity),
+      orderbookAddress: o.contract,
     };
   });
 }
@@ -241,6 +270,10 @@ export const orderbookRouter = createTRPCRouter({
           if (contractAddresses.length === 0 || userOsmoAddress.length === 0)
             return [];
 
+          const historicalOrders = await getOrderbookHistoricalOrders({
+            userOsmoAddress: input.userOsmoAddress,
+          });
+
           const promises = contractAddresses.map(
             async (contractOsmoAddress: string) => {
               const resp = await getOrderbookActiveOrders({
@@ -248,8 +281,15 @@ export const orderbookRouter = createTRPCRouter({
                 userOsmoAddress: userOsmoAddress,
                 chainList: ctx.chainList,
               });
+              const historicalOrdersForContract = historicalOrders.filter(
+                (o) => o.contract === contractOsmoAddress
+              );
 
-              if (resp.orders.length === 0) return [];
+              if (
+                resp.orders.length === 0 &&
+                historicalOrdersForContract.length === 0
+              )
+                return [];
               const { base_denom } = await getOrderbookDenoms({
                 orderbookAddress: contractOsmoAddress,
                 chainList: ctx.chainList,
@@ -270,11 +310,22 @@ export const orderbookRouter = createTRPCRouter({
                 quoteAsset,
                 baseAsset
               );
-              return mappedOrders.sort(defaultSortOrders);
+
+              const mappedHistoricalOrders = mapHistoricalToMapped(
+                historicalOrdersForContract,
+                input.userOsmoAddress,
+                quoteAsset,
+                baseAsset
+              );
+
+              return [...mappedOrders, ...mappedHistoricalOrders].sort(
+                defaultSortOrders
+              );
             }
           );
           const ordersByContracts = await Promise.all(promises);
           const allOrders = ordersByContracts.flatMap((p) => p);
+
           return allOrders;
         },
         cacheKey: JSON.stringify([
@@ -350,5 +401,14 @@ export const orderbookRouter = createTRPCRouter({
       const ordersByContracts = await Promise.all(promises);
       const allOrders = ordersByContracts.flatMap((p) => p);
       return allOrders;
+    }),
+  getHistoricalOrders: publicProcedure
+    .input(UserOsmoAddressSchema.required())
+    .query(async ({ input }) => {
+      const { userOsmoAddress } = input;
+      const historicalOrders = await getOrderbookHistoricalOrders({
+        userOsmoAddress,
+      });
+      return historicalOrders;
     }),
 });

--- a/packages/web/components/complex/orders-history/columns.tsx
+++ b/packages/web/components/complex/orders-history/columns.tsx
@@ -2,6 +2,7 @@ import { PricePretty } from "@keplr-wallet/unit";
 import { DEFAULT_VS_CURRENCY } from "@osmosis-labs/server";
 import { createColumnHelper } from "@tanstack/react-table";
 import classNames from "classnames";
+import dayjs from "dayjs";
 import Image from "next/image";
 
 import { Icon } from "~/components/assets";
@@ -124,11 +125,18 @@ export const tableColumns = [
     header: () => {
       return <small className="body2">Order Placed</small>;
     },
-    cell: () => {
+    cell: ({
+      row: {
+        original: { placed_at },
+      },
+    }) => {
+      const placedAt = dayjs(placed_at / 1000000);
+      const formattedTime = placedAt.format("h:mm A");
+      const formattedDate = placedAt.format("MMM D");
       return (
         <div className="flex flex-col gap-1">
-          <p className="body2 text-osmoverse-300">2:14 PM</p>
-          <p>Apr 1st</p>
+          <p className="body2 text-osmoverse-300">{formattedTime}</p>
+          <p>{formattedDate}</p>
         </div>
       );
     },

--- a/packages/web/components/complex/orders-history/columns.tsx
+++ b/packages/web/components/complex/orders-history/columns.tsx
@@ -1,4 +1,4 @@
-import { PricePretty } from "@keplr-wallet/unit";
+import { CoinPretty, Dec, PricePretty } from "@keplr-wallet/unit";
 import { DEFAULT_VS_CURRENCY } from "@osmosis-labs/server";
 import { createColumnHelper } from "@tanstack/react-table";
 import classNames from "classnames";
@@ -61,8 +61,16 @@ export const tableColumns = [
               )}
             >
               <span>
-                {order_direction === "bid" ? output : placed_quantity}{" "}
-                {baseAsset?.symbol}
+                {formatPretty(
+                  new CoinPretty(
+                    {
+                      coinDecimals: baseAsset?.decimals ?? 0,
+                      coinDenom: baseAsset?.symbol ?? "",
+                      coinMinimalDenom: baseAsset?.coinMinimalDenom ?? "",
+                    },
+                    order_direction === "ask" ? placed_quantity : output
+                  )
+                )}
               </span>
               <Icon
                 id="arrow-right"
@@ -71,8 +79,16 @@ export const tableColumns = [
                 height={16}
               />
               <span>
-                {order_direction === "bid" ? placed_quantity : output}{" "}
-                {quoteAsset?.symbol}
+                {formatPretty(
+                  new CoinPretty(
+                    {
+                      coinDecimals: quoteAsset?.decimals ?? 0,
+                      coinDenom: quoteAsset?.symbol ?? "",
+                      coinMinimalDenom: quoteAsset?.coinMinimalDenom ?? "",
+                    },
+                    order_direction === "ask" ? output : placed_quantity
+                  )
+                )}
               </span>
             </p>
             <div className="inline-flex items-center gap-2">
@@ -81,7 +97,9 @@ export const tableColumns = [
                 {formatPretty(
                   new PricePretty(
                     DEFAULT_VS_CURRENCY,
-                    order_direction === "bid" ? placed_quantity : output
+                    order_direction === "bid"
+                      ? placed_quantity / 1_000_000
+                      : output.quo(new Dec(1_000_000))
                   )
                 )}{" "}
                 of

--- a/packages/web/components/complex/orders-history/columns.tsx
+++ b/packages/web/components/complex/orders-history/columns.tsx
@@ -148,7 +148,7 @@ export const tableColumns = [
         original: { placed_at },
       },
     }) => {
-      const placedAt = dayjs(placed_at / 1000000);
+      const placedAt = dayjs(placed_at);
       const formattedTime = placedAt.format("h:mm A");
       const formattedDate = placedAt.format("MMM D");
       return (

--- a/packages/web/hooks/limit-orders/use-orderbook.ts
+++ b/packages/web/hooks/limit-orders/use-orderbook.ts
@@ -293,6 +293,11 @@ export const useOrderbookAllActiveOrders = ({
     }
   );
 
+  const { data: historicalOrders } =
+    api.edge.orderbooks.getHistoricalOrders.useQuery({
+      userOsmoAddress: userAddress,
+    });
+
   const allOrders = useMemo(() => {
     return orders?.pages.flatMap((page) => page.items) ?? [];
   }, [orders]);

--- a/packages/web/hooks/use-feature-flags.ts
+++ b/packages/web/hooks/use-feature-flags.ts
@@ -45,7 +45,7 @@ const defaultFlags: Record<ModifiedFlags, boolean> = {
   sidebarOsmoChangeAndChart: true,
   multiBridgeProviders: true,
   earnPage: false,
-  transactionsPage: true,
+  transactionsPage: false,
   sidecarRouter: true,
   legacyRouter: true,
   tfmRouter: true,

--- a/packages/web/hooks/use-feature-flags.ts
+++ b/packages/web/hooks/use-feature-flags.ts
@@ -45,7 +45,7 @@ const defaultFlags: Record<ModifiedFlags, boolean> = {
   sidebarOsmoChangeAndChart: true,
   multiBridgeProviders: true,
   earnPage: false,
-  transactionsPage: false,
+  transactionsPage: true,
   sidecarRouter: true,
   legacyRouter: true,
   tfmRouter: true,


### PR DESCRIPTION
## What is the purpose of the change:
These changes add historical data (provided by Numia) on a user's limit orders. Orders are retrieved from Numia and mapped to the expected interface for display and merged with active orders for pagination.

These changes also include fixes for displaying the in/out amount for an order on the order history page.

**Currently data from Numia is replaced by placeholder data.**

### Linear Task

[LIM-136: Add Endpoint to get Past Orders](https://linear.app/osmosis/issue/LIM-136/[services]-add-endpoint-to-get-past-orders)

## Brief Changelog
- Added `queryHistoricalOrders` Numia query
- Renamed unrealized cancels query to `get_unrealized_cancels`
- Added order sorting for active/historical orders
