### PR TITLE
Always run delete-deployments for Synt Monitoring

### DIFF
--- a/.github/workflows/monitoring-e2e-tests.yml
+++ b/.github/workflows/monitoring-e2e-tests.yml
@@ -208,7 +208,7 @@ jobs:
   delete-deployments:
     runs-on: ubuntu-latest
     if: always()
-    needs: [frontend-e2e-tests, frontend-e2e-tests]
+    needs: [frontend-e2e-tests, fe-quote-tests]
     steps:
       - name: Delete Previous deployments
         uses: actions/github-script@v7

--- a/.github/workflows/monitoring-e2e-tests.yml
+++ b/.github/workflows/monitoring-e2e-tests.yml
@@ -207,7 +207,8 @@ jobs:
 
   delete-deployments:
     runs-on: ubuntu-latest
-    needs: frontend-e2e-tests
+    if: always()
+    needs: [frontend-e2e-tests, frontend-e2e-tests]
     steps:
       - name: Delete Previous deployments
         uses: actions/github-script@v7

--- a/packages/web/e2e/tests/portfolio.wallet.spec.ts
+++ b/packages/web/e2e/tests/portfolio.wallet.spec.ts
@@ -8,11 +8,11 @@ import { WalletPage } from "../pages/wallet-page";
 
 test.describe("Test Portfolio feature", () => {
   let context: BrowserContext;
-  const privateKey =
-    process.env.PRIVATE_KEY ??
-    "0x9866a7f11faf50d5ccc36b0ce57e6fa72c5032367c44279b9ca829713c78bab8";
+  const privateKey = process.env.PRIVATE_KEY ?? "private_key";
   const password = process.env.PASSWORD ?? "TestPassword2024.";
   let portfolioPage: PortfolioPage;
+  let dollarBalanceRegEx = /\$\d+/;
+  let digitBalanceRegEx = /\d+\.\d+/;
 
   test.beforeAll(async () => {
     console.log("\nBefore test setup Wallet Extension.");
@@ -52,27 +52,28 @@ test.describe("Test Portfolio feature", () => {
 
   test("User should be able to see native balances", async () => {
     const osmoBalance = await portfolioPage.getBalanceFor("OSMO");
-    expect(osmoBalance).toMatch(/\$\d+\.\d+/);
+    expect(osmoBalance).toMatch(dollarBalanceRegEx);
     const atomBalance = await portfolioPage.getBalanceFor("ATOM");
-    expect(atomBalance).toMatch(/\$\d+\.\d+/);
+    expect(atomBalance).toMatch(dollarBalanceRegEx);
     const usdtBalance = await portfolioPage.getBalanceFor("USDT");
-    expect(usdtBalance).toMatch(/\$\d+\.\d+/);
+    expect(usdtBalance).toMatch(dollarBalanceRegEx);
     const usdcBalance = await portfolioPage.getBalanceFor("USDC");
-    expect(usdcBalance).toMatch(/\$\d+\.\d+/);
+    expect(usdcBalance).toMatch(dollarBalanceRegEx);
     const tiaBalance = await portfolioPage.getBalanceFor("TIA");
-    expect(tiaBalance).toMatch(/\$\d+\.\d+/);
+    expect(tiaBalance).toMatch(dollarBalanceRegEx);
     const daiBalance = await portfolioPage.getBalanceFor("DAI");
-    expect(daiBalance).toMatch(/\$\d+\.\d/);
+    expect(daiBalance).toMatch(dollarBalanceRegEx);
   });
 
   test("User should be able to see bridged balances", async () => {
     const injBalance = await portfolioPage.getBalanceFor("INJ");
-    expect(injBalance).toMatch(/\$\d+\.\d+/);
+    expect(injBalance).toMatch(dollarBalanceRegEx);
     const ethBalance = await portfolioPage.getBalanceFor("ETH");
-    expect(ethBalance).toMatch(/\$\d+\.\d+/);
+    expect(ethBalance).toMatch(dollarBalanceRegEx);
     const kujiBalance = await portfolioPage.getBalanceFor("KUJI");
-    expect(kujiBalance).toMatch(/\$\d+\.\d/);
+    expect(kujiBalance).toMatch(dollarBalanceRegEx);
     const abtcBalance = await portfolioPage.getBalanceFor("allBTC");
-    expect(abtcBalance).toMatch(/\d+\.\d+/);
+    // allBTC has not $ price atm
+    expect(abtcBalance).toMatch(digitBalanceRegEx);
   });
 });


### PR DESCRIPTION
## What is the purpose of the change:

Always run delete-deployments for Synthetic Monitoring E2E tests workflow