### PR TITLE
fix: insufficient funds now correctly uses quote asset balance on buy

### DIFF
--- a/packages/web/hooks/limit-orders/use-place-limit.ts
+++ b/packages/web/hooks/limit-orders/use-place-limit.ts
@@ -232,19 +232,17 @@ export const usePlaceLimit = ({
       {
         enabled: !!account?.address,
         select: (balances) =>
-          balances.find(({ denom }) => denom === baseAsset?.coinMinimalDenom)
+          balances.find(({ denom }) => denom === quoteAsset?.coinMinimalDenom)
             ?.coin,
       }
     );
 
   const insufficientFunds =
     (orderDirection === "bid"
-      ? quoteTokenBalance
-          ?.toDec()
-          ?.lt(inAmountInput.amount?.toDec() ?? new Dec(0))
+      ? quoteTokenBalance?.toDec()?.lt(paymentTokenValue.toDec() ?? new Dec(0))
       : baseTokenBalance
           ?.toDec()
-          ?.lt(inAmountInput.amount?.toDec() ?? new Dec(0))) ?? true;
+          ?.lt(paymentTokenValue.toDec() ?? new Dec(0))) ?? true;
 
   const expectedTokenAmountOut = useMemo(() => {
     const preFeeAmount =


### PR DESCRIPTION
## What is the purpose of the change:
On limit/market order inputs for the "buy" tab the balance check was using base asset instead of the quote asset. These changes correct that.

### Linear Task

[LIM-169: Use Fiat Balance for Buy Tab Input Calculation](https://linear.app/osmosis/issue/LIM-169/[ui]-use-fiat-balance-for-buy-tab-input-calculation)

## Brief Changelog
- `quoteAssetBalance` now correctly uses the quote asset
