### PR TITLE
feat: added indicator for claimable order amount to swap page

### DIFF
--- a/packages/web/components/trade-tool/index.tsx
+++ b/packages/web/components/trade-tool/index.tsx
@@ -12,6 +12,7 @@ import {
   SwapToolTab,
   SwapToolTabs,
 } from "~/components/swap-tool/swap-tool-tabs";
+import { useOrderbookClaimableOrders } from "~/hooks/limit-orders/use-orderbook";
 import { useStore } from "~/stores";
 
 export interface TradeToolProps {}
@@ -30,13 +31,10 @@ export const TradeTool: FunctionComponent<TradeToolProps> = observer(() => {
   )?.isWalletConnected;
 
   // Mock
-  const unclaimedOrders = useMemo(
-    () =>
-      Array(0)
-        .fill(null)
-        .map((i) => i + 1),
-    []
-  );
+  const { count } = useOrderbookClaimableOrders({
+    userAddress:
+      accountStore.getWallet(accountStore.osmosisChainId)?.address ?? "",
+  });
 
   return (
     <ClientOnly>
@@ -56,11 +54,9 @@ export const TradeTool: FunctionComponent<TradeToolProps> = observer(() => {
                   height={24}
                   className="h-6 w-6 text-wosmongton-200"
                 />
-                {unclaimedOrders.length > 0 && (
+                {count > 0 && (
                   <div className="absolute -top-1 -right-1 flex h-6 w-6 items-center justify-center rounded-full bg-[#A51399]">
-                    <span className="text-xs leading-[14px]">
-                      {unclaimedOrders.length}
-                    </span>
+                    <span className="text-xs leading-[14px]">{count}</span>
                   </div>
                 )}
               </Link>


### PR DESCRIPTION
## What is the purpose of the change:
These changes add an indicator to the swap page when the use has a fully claimable order.

### Linear Task

[LIM-168: Add Claimable Orders Indicator to Order History Link](https://linear.app/osmosis/issue/LIM-168/[ui]-add-claimable-orders-indicator-to-order-history-link)

## Brief Changelog
- Replaced mock data in `trade-tool/index.tsx` with query data
