### PR TITLE
feat: added input validation for limit input

### DIFF
--- a/packages/web/components/input/limit-input.tsx
+++ b/packages/web/components/input/limit-input.tsx
@@ -6,6 +6,7 @@ import { FC, useCallback, useEffect, useMemo, useState } from "react";
 import AutosizeInput from "react-input-autosize";
 
 import { Icon } from "~/components/assets";
+import { isValidNumericalRawInput } from "~/hooks/input/use-amount-input";
 import { formatPretty } from "~/utils/formatter";
 
 export interface LimitInputProps {
@@ -78,7 +79,11 @@ export const LimitInput: FC<LimitInputProps> = ({
     (value: string) => {
       const updatedValue = transformAmount(value);
       const isFocused = focused === FocusedInput.FIAT;
-      if (updatedValue.length > 0 && new Dec(updatedValue).isNegative()) {
+      if (
+        !isValidNumericalRawInput(updatedValue) ||
+        updatedValue.length > 26 ||
+        (updatedValue.length > 0 && updatedValue.startsWith("-"))
+      ) {
         return;
       }
 
@@ -99,7 +104,11 @@ export const LimitInput: FC<LimitInputProps> = ({
       const updatedValue = transformAmount(value);
       const isFocused = focused === FocusedInput.TOKEN;
 
-      if (updatedValue.length > 0 && new Dec(updatedValue).isNegative()) {
+      if (
+        !isValidNumericalRawInput(updatedValue) ||
+        updatedValue.length > 26 ||
+        (updatedValue.length > 0 && updatedValue.startsWith("-"))
+      ) {
         return;
       }
       isFocused


### PR DESCRIPTION
## What is the purpose of the change:
These changes prevent a user's input in the buy/sell tab from causing an overflow error.

### Linear Task

[LIM-167: Input Cap for Buy/Sell Tab](https://linear.app/osmosis/issue/LIM-167/[ui]-input-cap-for-buysell-tab)

