### PR TITLE
disable ICNS query on testnet

### DIFF
--- a/packages/web/hooks/queries/osmosis/use-icns-name.ts
+++ b/packages/web/hooks/queries/osmosis/use-icns-name.ts
@@ -1,13 +1,17 @@
 import { queryICNSName } from "@osmosis-labs/server";
 import { useQuery } from "@tanstack/react-query";
 
+import { IS_TESTNET } from "~/config";
 import { ChainList } from "~/config/generated/chain-list";
 
 export const useICNSName = ({ address }: { address: string }) => {
+  const enabled =
+    !!IS_TESTNET && Boolean(address) && typeof address === "string";
+
   return useQuery({
     queryKey: ["icns-name", address],
     queryFn: () => queryICNSName({ address, chainList: ChainList }),
-    enabled: Boolean(address) && typeof address === "string",
+    enabled,
     select: ({ data: { names, primary_name } }) => {
       return {
         names: names,


### PR DESCRIPTION
## What is the purpose of the change:

- disable icns query on testnet

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-481/testnet-turn-off-or-update-icns-query)

## Brief Changelog

- disable icns query on testnet

## Testing and Verifying

1. set testnet env variable to true
2. verify icns name isn't pulled, and wallet address is shown

https://github.com/osmosis-labs/osmosis-frontend/assets/30577966/be647016-6f3c-4b2e-94d1-89f8bc308bfa

