### PR TITLE
Add random and specific transactions tests

### DIFF
--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -166,7 +166,7 @@ jobs:
       - name: Install Playwright
         run: |
           yarn --cwd packages/web install --frozen-lockfile && npx playwright install --with-deps chromium
-      - name: Run Portfolio tests
+      - name: Run Transactions tests
         env:
           BASE_URL: "https://${{ needs.wait-for-deployment.outputs.environment_url }}"
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}

--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -143,3 +143,40 @@ jobs:
         with:
           name: preview-pools-test-results
           path: packages/web/playwright-report
+
+  preview-transactions-tests:
+    needs: wait-for-deployment
+    runs-on: macos-latest
+    environment:
+      name: prod_swap_test
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.OS }}-20.x-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.OS }}-20.x-
+      - name: Install Playwright
+        run: |
+          yarn --cwd packages/web install --frozen-lockfile && npx playwright install --with-deps chromium
+      - name: Run Portfolio tests
+        env:
+          BASE_URL: "https://${{ needs.wait-for-deployment.outputs.environment_url }}"
+          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+        run: |
+          cd packages/web
+          npx playwright test -g "Test Transactions feature"
+      - name: upload transactions test results
+        if: always()
+        id: transactions-test-results
+        uses: actions/upload-artifact@v4
+        with:
+          name: preview-transactions-test-results
+          path: packages/web/playwright-report

--- a/packages/web/e2e/pages/base-page.ts
+++ b/packages/web/e2e/pages/base-page.ts
@@ -42,6 +42,9 @@ export class BasePage {
 
   async gotoPortfolio() {
     await this.portfolioLink.click();
+    // we expect that after 2 seconds tokens are loaded and any failure after this point should be considered a bug.
+    await this.page.waitForTimeout(2000);
+    await this.printUrl();
   }
 
   async gotoPools() {

--- a/packages/web/e2e/pages/portfolio-page.ts
+++ b/packages/web/e2e/pages/portfolio-page.ts
@@ -2,11 +2,13 @@
 import { Locator, Page } from "@playwright/test";
 
 import { BasePage } from "~/e2e/pages/base-page";
+import { TransactionsPage } from "~/e2e/pages/transactions-page";
 
 export class PortfolioPage extends BasePage {
   readonly hideZeros: Locator;
   readonly viewMore: Locator;
   readonly portfolioLink: Locator;
+  readonly viewTransactions: Locator;
 
   constructor(page: Page) {
     super(page);
@@ -17,6 +19,7 @@ export class PortfolioPage extends BasePage {
     this.portfolioLink = page.locator(
       '//a//div[contains(text(), "Portfolio")]'
     );
+    this.viewTransactions = page.locator('//div/a[.="View all"]');
   }
 
   async goto() {
@@ -45,5 +48,11 @@ export class PortfolioPage extends BasePage {
     let tokenBalance: string = await bal.innerText();
     console.log(`Balance for ${token}: ${tokenBalance}`);
     return tokenBalance;
+  }
+
+  async viewTransactionsPage() {
+    await this.viewTransactions.click();
+    await this.page.waitForTimeout(1000);
+    return new TransactionsPage(this.page);
   }
 }

--- a/packages/web/e2e/pages/transactions-page.ts
+++ b/packages/web/e2e/pages/transactions-page.ts
@@ -1,0 +1,30 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { expect, Locator, Page } from "@playwright/test";
+
+import { BasePage } from "~/e2e/pages/base-page";
+
+export class TransactionsPage extends BasePage {
+  readonly transactionRow: Locator;
+  readonly viewExplorerLink: Locator;
+  readonly closeTransactionBtn: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.transactionRow = page.locator('//div/p[.="Swapped"]');
+    this.viewExplorerLink = page.locator('//a/span["View on explorer"]');
+    this.closeTransactionBtn = page.locator('//button[@aria-label="Close"]');
+  }
+
+  async viewTransactionByNumber(number: number) {
+    await this.transactionRow.nth(number).click();
+    await this.page.waitForTimeout(1000);
+  }
+
+  async closeTransaction() {
+    await this.closeTransactionBtn.click();
+  }
+
+  async viewOnExplorerIsVisible() {
+    expect(this.viewExplorerLink.isVisible).toBeTruthy();
+  }
+}

--- a/packages/web/e2e/pages/transactions-page.ts
+++ b/packages/web/e2e/pages/transactions-page.ts
@@ -11,7 +11,7 @@ export class TransactionsPage extends BasePage {
   constructor(page: Page) {
     super(page);
     this.transactionRow = page.locator('//div/p[.="Swapped"]');
-    this.viewExplorerLink = page.locator('//a/span["View on explorer"]');
+    this.viewExplorerLink = page.locator('//a/span["View on explorer"]/..');
     this.closeTransactionBtn = page.locator('//button[@aria-label="Close"]');
   }
 
@@ -20,11 +20,25 @@ export class TransactionsPage extends BasePage {
     await this.page.waitForTimeout(1000);
   }
 
+  async viewBySwapAmount(amount: any) {
+    // Transactions need some time to get loaded.
+    await this.page.waitForTimeout(5000);
+    await this.page.reload();
+    const loc = `//div/div[@class="subtitle1 text-osmoverse-100" and contains(text(), "${amount}")]`;
+    await this.page.locator(loc).click();
+  }
+
   async closeTransaction() {
     await this.closeTransactionBtn.click();
   }
 
   async viewOnExplorerIsVisible() {
     expect(this.viewExplorerLink.isVisible).toBeTruthy();
+  }
+
+  async getOnExplorerLink() {
+    const trxUrl = await this.viewExplorerLink.getAttribute("href");
+    console.log("Trx url: " + trxUrl);
+    return trxUrl;
   }
 }

--- a/packages/web/e2e/tests/transactions.wallet.spec.ts
+++ b/packages/web/e2e/tests/transactions.wallet.spec.ts
@@ -1,0 +1,64 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { BrowserContext, chromium, test } from "@playwright/test";
+import process from "process";
+
+import { TransactionsPage } from "~/e2e/pages/transactions-page";
+import { UnzipExtension } from "~/e2e/unzip-extension";
+
+import { PortfolioPage } from "../pages/portfolio-page";
+import { WalletPage } from "../pages/wallet-page";
+
+test.describe("Test Transactions feature", () => {
+  let context: BrowserContext;
+  const privateKey = process.env.PRIVATE_KEY ?? "private_key";
+  const password = process.env.PASSWORD ?? "TestPassword2024.";
+  let portfolioPage: PortfolioPage;
+  let transactionsPage: TransactionsPage;
+
+  test.beforeAll(async () => {
+    const pathToExtension = new UnzipExtension().getPathToExtension();
+    console.log("\nSetup Wallet Extension before tests.");
+    // Launch Chrome with a Keplr wallet extension
+    context = await chromium.launchPersistentContext("", {
+      headless: false,
+      args: [
+        "--headless=new",
+        `--disable-extensions-except=${pathToExtension}`,
+        `--load-extension=${pathToExtension}`,
+      ],
+      viewport: { width: 1280, height: 1024 },
+      slowMo: 300,
+    });
+    // Get all new pages (including Extension) in the context and wait
+    const emptyPage = context.pages()[0];
+    await emptyPage.waitForTimeout(2000);
+    const page = context.pages()[1];
+    const walletPage = new WalletPage(page);
+    // Import existing Wallet (could be aggregated in one function).
+    await walletPage.importWalletWithPrivateKey(privateKey);
+    await walletPage.setWalletNameAndPassword("Test Transactions", password);
+    await walletPage.selectChainsAndSave();
+    await walletPage.finish();
+    // Switch to Application
+    portfolioPage = new PortfolioPage(context.pages()[0]);
+    await portfolioPage.goto();
+    await portfolioPage.connectWallet();
+    transactionsPage = await portfolioPage.viewTransactionsPage();
+  });
+
+  test.afterAll(async () => {
+    await context.close();
+  });
+
+  test("User should be able to see a transaction", async () => {
+    await transactionsPage.viewTransactionByNumber(10);
+    await transactionsPage.viewOnExplorerIsVisible();
+    await transactionsPage.closeTransaction();
+    await transactionsPage.viewTransactionByNumber(20);
+    await transactionsPage.viewOnExplorerIsVisible();
+    await transactionsPage.closeTransaction();
+    await transactionsPage.viewTransactionByNumber(55);
+    await transactionsPage.viewOnExplorerIsVisible();
+    await transactionsPage.closeTransaction();
+  });
+});


### PR DESCRIPTION
## What is the purpose of the change:

- Add random transactions test, to make sure transaction details page is displayed.
- Add a specific transaction test, to make sure it is displayed in reasonable time.

### Linear Task

[Linear Task Add Transactions page tests](https://linear.app/osmosis/issue/FE-696)
