### PR TITLE
feat: review modal now supports market order info

### DIFF
--- a/packages/web/hooks/limit-orders/use-place-limit.ts
+++ b/packages/web/hooks/limit-orders/use-place-limit.ts
@@ -100,6 +100,14 @@ export const usePlaceLimit = ({
    * @returns The amount of tokens to be sent with the order in base asset amounts for an Ask and quote asset amounts for a Bid.
    */
   const paymentTokenValue = useMemo(() => {
+    if (isMarket)
+      return (
+        marketState.inAmountInput.amount ??
+        new CoinPretty(
+          orderDirection === "ask" ? baseAsset! : quoteAsset!,
+          new Dec(0)
+        )
+      );
     // The amount of tokens the user wishes to buy/sell
     const baseTokenAmount =
       inAmountInput.amount ?? new CoinPretty(baseAsset!, new Dec(0));
@@ -137,22 +145,8 @@ export const usePlaceLimit = ({
     isMarket,
     priceState.askSpotPrice,
     priceState.bidSpotPrice,
+    marketState.inAmountInput.amount,
   ]);
-
-  /**
-   * Determines the fiat amount the user will pay for their order.
-   * In the case of an Ask the fiat amount is the amount of tokens the user will sell multiplied by the currently selected price.
-   * In the case of a Bid the fiat amount is the amount of quote asset tokens the user will send multiplied by the current price of the quote asset.
-   */
-  const paymentFiatValue = useMemo(() => {
-    return orderDirection === "ask"
-      ? mulPrice(
-          paymentTokenValue,
-          new PricePretty(DEFAULT_VS_CURRENCY, priceState.price),
-          DEFAULT_VS_CURRENCY
-        )
-      : mulPrice(paymentTokenValue, quoteAssetPrice, DEFAULT_VS_CURRENCY);
-  }, [paymentTokenValue, orderDirection, quoteAssetPrice, priceState]);
 
   /**
    * When creating a market order we want to update the market state with the input amount
@@ -163,9 +157,36 @@ export const usePlaceLimit = ({
   useEffect(() => {
     if (orderDirection === "bid") return;
 
-    const normalizedAmount = paymentTokenValue.toDec().toString();
+    const normalizedAmount = inAmountInput.amount?.toDec().toString() ?? "0";
     marketState.inAmountInput.setAmount(normalizedAmount);
-  }, [paymentTokenValue, orderDirection, marketState.inAmountInput]);
+  }, [inAmountInput.amount, orderDirection, marketState.inAmountInput]);
+
+  /**
+   * Determines the fiat amount the user will pay for their order.
+   * In the case of an Ask the fiat amount is the amount of tokens the user will sell multiplied by the currently selected price.
+   * In the case of a Bid the fiat amount is the amount of quote asset tokens the user will send multiplied by the current price of the quote asset.
+   */
+  const paymentFiatValue = useMemo(() => {
+    if (isMarket)
+      return (
+        marketState.inAmountInput.fiatValue ??
+        new PricePretty(DEFAULT_VS_CURRENCY, new Dec(0))
+      );
+    return orderDirection === "ask"
+      ? mulPrice(
+          paymentTokenValue,
+          new PricePretty(DEFAULT_VS_CURRENCY, priceState.price),
+          DEFAULT_VS_CURRENCY
+        )
+      : mulPrice(paymentTokenValue, quoteAssetPrice, DEFAULT_VS_CURRENCY);
+  }, [
+    paymentTokenValue,
+    orderDirection,
+    quoteAssetPrice,
+    priceState,
+    isMarket,
+    marketState.inAmountInput.fiatValue,
+  ]);
 
   const placeLimit = useCallback(async () => {
     const quantity = paymentTokenValue.toCoin().amount ?? "0";
@@ -245,6 +266,15 @@ export const usePlaceLimit = ({
           ?.lt(paymentTokenValue.toDec() ?? new Dec(0))) ?? true;
 
   const expectedTokenAmountOut = useMemo(() => {
+    if (isMarket) {
+      return (
+        marketState.quote?.amount ??
+        new CoinPretty(
+          orderDirection === "ask" ? quoteAsset! : baseAsset!,
+          new Dec(0)
+        )
+      );
+    }
     const preFeeAmount =
       orderDirection === "ask"
         ? new CoinPretty(
@@ -262,9 +292,14 @@ export const usePlaceLimit = ({
     makerFee,
     quoteAssetPrice,
     paymentFiatValue,
+    isMarket,
+    marketState.quote?.amount,
   ]);
 
   const expectedFiatAmountOut = useMemo(() => {
+    if (isMarket) {
+      return marketState.tokenOutFiatValue;
+    }
     return orderDirection === "ask"
       ? new PricePretty(
           DEFAULT_VS_CURRENCY,
@@ -279,6 +314,8 @@ export const usePlaceLimit = ({
     expectedTokenAmountOut,
     orderDirection,
     quoteAssetPrice,
+    isMarket,
+    marketState.tokenOutFiatValue,
   ]);
 
   return {

--- a/packages/web/modals/review-limit-order.tsx
+++ b/packages/web/modals/review-limit-order.tsx
@@ -29,15 +29,23 @@ export const ReviewLimitOrderModal: React.FC<ReviewLimitOrderModalProps> = ({
 }) => {
   const { t } = useTranslation();
 
-  //TODO: Retrieve maker fee from contract
   const fee = useMemo(() => {
+    if (placeLimitState.isMarket) {
+      const marketFee = placeLimitState.marketState.totalFee;
+      return marketFee;
+    }
+
     return (
       placeLimitState.paymentFiatValue?.mul(makerFee) ??
       new PricePretty(DEFAULT_VS_CURRENCY, 0)
     );
-  }, [placeLimitState.paymentFiatValue, makerFee]);
+  }, [
+    placeLimitState.paymentFiatValue,
+    makerFee,
+    placeLimitState.isMarket,
+    placeLimitState.marketState,
+  ]);
 
-  //TODO: Normalize price against the dollar
   const total = useMemo(() => {
     if (
       placeLimitState.paymentFiatValue &&
@@ -47,6 +55,18 @@ export const ReviewLimitOrderModal: React.FC<ReviewLimitOrderModalProps> = ({
     }
     return new PricePretty(DEFAULT_VS_CURRENCY, 0);
   }, [placeLimitState.paymentFiatValue, fee]);
+
+  const price = useMemo(() => {
+    if (placeLimitState.isMarket) {
+      const priceState = placeLimitState.priceState;
+      const price =
+        orderDirection === "bid"
+          ? priceState.askSpotPrice
+          : priceState.bidSpotPrice;
+      return price ?? new Dec(0);
+    }
+    return placeLimitState.priceState.price;
+  }, [placeLimitState.isMarket, placeLimitState.priceState, orderDirection]);
 
   const [orderType] = useQueryState("type");
 
@@ -84,14 +104,13 @@ export const ReviewLimitOrderModal: React.FC<ReviewLimitOrderModalProps> = ({
             </div>
             <div className="flex w-full flex-col items-center justify-center">
               <h5>
-                {orderType === "market" && "≈"}{" "}
-                {placeLimitState.inAmountInput.amount
-                  ? formatPretty(placeLimitState.inAmountInput.amount)
+                {placeLimitState.isMarket && "≈"}{" "}
+                {placeLimitState.expectedTokenAmountOut
+                  ? formatPretty(placeLimitState.expectedTokenAmountOut)
                   : "0"}
               </h5>
               <span className="text-body1 text-osmoverse-300">
-                {t("limitOrders.at")} $
-                {formatPretty(placeLimitState.priceState.price)}
+                {t("limitOrders.at")} ${formatPretty(price ?? new Dec(0))}
               </span>
             </div>
           </div>
@@ -118,10 +137,7 @@ export const ReviewLimitOrderModal: React.FC<ReviewLimitOrderModalProps> = ({
             left={t("limitOrders.value")}
             right={
               <span className="text-osmoverse-100">
-                ~
-                {placeLimitState.paymentFiatValue
-                  ? formatPretty(placeLimitState.paymentFiatValue)
-                  : "$0"}
+                ~{total ? formatPretty(total) : "$0"}
               </span>
             }
           />
@@ -132,24 +148,17 @@ export const ReviewLimitOrderModal: React.FC<ReviewLimitOrderModalProps> = ({
           <hr className="my-2 text-osmoverse-700" />
           <RecapRow
             left={t("limitOrders.receive")}
-            right={<>{formatPretty(total)}</>}
+            right={<>{formatPretty(placeLimitState.expectedTokenAmountOut)}</>}
           />
-          {orderType === "market" && (
+          {placeLimitState.isMarket && placeLimitState.marketState.quote && (
             <RecapRow
               left={t("limitOrders.receiveMin")}
               right={
                 <span className="body2 text-osmoverse-100">
-                  {formatPretty(placeLimitState.expectedTokenAmountOut, {
-                    maxDecimals: 2,
-                    minimumFractionDigits: 2,
-                  })}{" "}
+                  {formatPretty(placeLimitState.expectedTokenAmountOut)}{" "}
                   <span className="text-osmoverse-300">
                     (~
-                    {formatPretty(placeLimitState.expectedFiatAmountOut, {
-                      maxDecimals: 2,
-                      minimumFractionDigits: 2,
-                    })}
-                    )
+                    {formatPretty(placeLimitState.expectedFiatAmountOut)})
                   </span>
                 </span>
               }
@@ -187,9 +196,7 @@ export const ReviewLimitOrderModal: React.FC<ReviewLimitOrderModalProps> = ({
               left={t("assets.table.price")}
               right={
                 <span className="text-osmoverse-100">
-                  {placeLimitState.priceState
-                    ? `$${formatPretty(placeLimitState.priceState.price)}`
-                    : "N/D"}
+                  {price ? `$${formatPretty(price)}` : "$0"}
                 </span>
               }
             />


### PR DESCRIPTION
## What is the purpose of the change:
These changes alter the `ReviewLimitOrder` modal in order to accommodate market orders. 

Note: The minimum received amount fiat value looks unusual as it's using the in amount and base asset's fiat value.

### Linear Task

[LIM-166: Fix Review Order for Market Orders](https://linear.app/osmosis/issue/LIM-166/[ui]-fix-review-order-for-market-orders)

## Brief Changelog
- Altered `use-place-limit` fields to return market values as expected
- Updated `ReviewLimitOrder` component for market order values