### PR TITLE
(Deposit/Withdraw) Generate correct explorer URL for IBC transfers

### DIFF
--- a/packages/bridge/src/squid/__tests__/squid-transfer-status.spec.ts
+++ b/packages/bridge/src/squid/__tests__/squid-transfer-status.spec.ts
@@ -1,6 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { rest } from "msw";
 
+import { MockChains } from "../../__tests__/mock-chains";
 import { server } from "../../__tests__/msw";
 import { BridgeEnvironment, TransferStatusReceiver } from "../../interface";
 import { SquidTransferStatusProvider } from "../transfer-status";
@@ -35,19 +36,15 @@ describe("SquidTransferStatusProvider", () => {
   };
 
   beforeEach(() => {
-    provider = new SquidTransferStatusProvider("mainnet" as BridgeEnvironment);
+    provider = new SquidTransferStatusProvider(
+      "mainnet" as BridgeEnvironment,
+      MockChains
+    );
     provider.statusReceiverDelegate = mockReceiver;
   });
 
   it("should initialize with correct URLs", () => {
     expect(provider.squidScanBaseUrl).toBe("https://axelarscan.io");
-  });
-
-  it("should generate correct explorer URL", () => {
-    const url = provider.makeExplorerUrl(
-      JSON.stringify({ sendTxHash: "testTxHash" })
-    );
-    expect(url).toBe("https://axelarscan.io/gmp/testTxHash");
   });
 
   it("should handle successful transfer status", async () => {
@@ -104,13 +101,40 @@ describe("SquidTransferStatusProvider", () => {
     expect(mockReceiver.receiveNewTxStatus).not.toHaveBeenCalled();
   });
 
+  it("should generate correct explorer URL", () => {
+    const url = provider.makeExplorerUrl(
+      JSON.stringify({ sendTxHash: "testTxHash", fromChainId: 1, toChainId: 2 })
+    );
+    expect(url).toBe("https://axelarscan.io/gmp/testTxHash");
+  });
+
   it("should generate correct explorer URL for testnet", () => {
     const testnetProvider = new SquidTransferStatusProvider(
-      "testnet" as BridgeEnvironment
+      "testnet" as BridgeEnvironment,
+      MockChains
     );
     const url = testnetProvider.makeExplorerUrl(
-      JSON.stringify({ sendTxHash: "testTxHash" })
+      JSON.stringify({
+        sendTxHash: "testTxHash",
+        fromChainId: 1,
+        toChainId: 2,
+      })
     );
     expect(url).toBe("https://testnet.axelarscan.io/gmp/testTxHash");
+  });
+
+  it("should generate correct explorer URL for a cosmos chain", () => {
+    const cosmosProvider = new SquidTransferStatusProvider(
+      "mainnet" as BridgeEnvironment,
+      MockChains
+    );
+    const url = cosmosProvider.makeExplorerUrl(
+      JSON.stringify({
+        sendTxHash: "cosmosTxHash",
+        fromChainId: "cosmoshub-4",
+        toChainId: "osmosis-1",
+      })
+    );
+    expect(url).toBe("https://www.mintscan.io/cosmos/txs/cosmosTxHash");
   });
 });

--- a/packages/web/stores/root.ts
+++ b/packages/web/stores/root.ts
@@ -253,8 +253,14 @@ export class RootStore {
 
     const transferStatusProviders = [
       new AxelarTransferStatusProvider(IS_TESTNET ? "testnet" : "mainnet"),
-      new SquidTransferStatusProvider(IS_TESTNET ? "testnet" : "mainnet"),
-      new SkipTransferStatusProvider(IS_TESTNET ? "testnet" : "mainnet"),
+      new SquidTransferStatusProvider(
+        IS_TESTNET ? "testnet" : "mainnet",
+        ChainList
+      ),
+      new SkipTransferStatusProvider(
+        IS_TESTNET ? "testnet" : "mainnet",
+        ChainList
+      ),
       new IbcTransferStatusProvider(ChainList, AssetLists),
     ];
 


### PR DESCRIPTION
## What is the purpose of the change:

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

For Skip and Squid, they linked to axelar scan for all transfers. If it's a basic IBC transfer (which we now support), axelarscan would yield no results. Now, we detect if it's a basic IBC transfer and link to mintscan instead.

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-741/skip-status-source-fix-links-to-ibc-txs)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

* Use chain list and chain ID types to determine if a transfer is a basic IBC transfer

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->
* Use Squid or Skip to initiate an IBC transfer. Confirm that it links to mintscan instead of axelarscan.