### PR TITLE
Change Prod tests to run on push

### DIFF
--- a/.github/await_deployment.py
+++ b/.github/await_deployment.py
@@ -9,10 +9,11 @@ def wait_for_deployment(timeout):
     time.sleep(30)
     bearer_token = os.getenv('VERCEL_TOKEN')
     project_id = os.getenv('VERCEL_PROJECT')
+    target = os.getenv('VERCEL_TARGET', 'preview')
     headers = {
         "Authorization": f"Bearer {bearer_token}"
     }
-    url = f"https://api.vercel.com/v6/deployments?projectId={project_id}&target=preview&state=BUILDING"
+    url = f"https://api.vercel.com/v6/deployments?projectId={project_id}&target={target}&state=BUILDING"
     response = requests.get(url, headers=headers)
     deployments = response.json()['deployments']
     print(f"Found {len(deployments)} deployments.")

--- a/.github/workflows/prod-frontend-e2e-tests.yml
+++ b/.github/workflows/prod-frontend-e2e-tests.yml
@@ -1,13 +1,37 @@
 name: Production frontend E2E tests
 
 on:
-  deployment_status:
+  push:
+    branches:
+      - master
   workflow_dispatch:
 
 jobs:
+  wait-for-deployment:
+    runs-on: ubuntu-latest
+    outputs:
+      environment_url: ${{steps.vercel.outputs.environment_url}}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - id: vercel
+        env:
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_PROJECT: ${{ secrets.VERCEL_PROJECT }}
+          VERCEL_TARGET: "production"
+        run: |
+          echo "$BRANCH_NAME"
+          python -m pip install requests
+          cd .github && python await_deployment.py
+      - name: Echo GITHUB_OUTPUT environment_url
+        env:
+          environment_url: ${{ steps.vercel.outputs.environment_url }}
+        run: echo "$environment_url"
+
   prod-e2e-tests:
-    if: github.event.deployment_status.state == 'success' && github.event.deployment_status.environment == 'Production – osmosis-frontend'
     runs-on: macos-latest
+    needs: wait-for-deployment
     environment:
       name: prod_swap_test
     steps:


### PR DESCRIPTION
## What is the purpose of the change:

Change Production frontend E2E tests to run on push to reduce spam deployments and events.

### Linear Task

[Change Production frontend E2E tests to run on push](https://linear.app/osmosis/issue/FE-719)
