### PR TITLE
(1CT) Disable and hide 1CT for new users with no funds

### DIFF
--- a/packages/web/components/navbar/index.tsx
+++ b/packages/web/components/navbar/index.tsx
@@ -27,7 +27,7 @@ import { IconButton } from "~/components/buttons/icon-button";
 import { ClientOnly } from "~/components/client-only";
 import { SkeletonLoader } from "~/components/loaders/skeleton-loader";
 import { MainLayoutMenu, MainMenu } from "~/components/main-menu";
-import { useOneClickProfileTooltip } from "~/components/one-click-trading/one-click-floating-banner";
+import { useOneClickProfileTooltip } from "~/components/one-click-trading/one-click-toast";
 import { Tooltip } from "~/components/tooltip";
 import { CustomClasses } from "~/components/types";
 import { Button } from "~/components/ui/button";

--- a/packages/web/components/one-click-trading/introducing-one-click-trading.tsx
+++ b/packages/web/components/one-click-trading/introducing-one-click-trading.tsx
@@ -36,7 +36,9 @@ export const IntroducingOneClick = ({
             className:
               "!inline w-auto !px-0 !text-body2 !font-body2 text-wosmongton-300",
           })}
-          // TODO: Add link
+          href="https://support.osmosis.zone/tutorials/1clicktrading"
+          target="_blank"
+          rel="noopener noreferrer"
         >
           {t("oneClickTrading.introduction.learnMore")} ↗️
         </a>

--- a/packages/web/components/one-click-trading/one-click-toast.tsx
+++ b/packages/web/components/one-click-trading/one-click-toast.tsx
@@ -15,6 +15,7 @@ import {
   useTranslation,
 } from "~/hooks";
 import { useOneClickTradingSession } from "~/hooks/one-click-trading/use-one-click-trading-session";
+import { useIsCosmosNewAccount } from "~/hooks/use-is-new-account";
 import { useGlobalIs1CTIntroModalScreen } from "~/modals";
 import { useStore } from "~/stores";
 
@@ -23,14 +24,20 @@ export const useOneClickProfileTooltip = createGlobalState(false);
 export const OneClickFloatingBannerDoNotShowKey =
   "do-not-show-one-click-trading-floating-notification";
 
-export const OneClickFloatingBanner = observer(() => {
+export const OneClickToast = observer(() => {
   const { accountStore, chainStore } = useStore();
   const featureFlags = useFeatureFlags();
   const account = accountStore.getWallet(chainStore.osmosis.chainId);
   const isConnected = !!account?.address;
   const { isOneClickTradingEnabled } = useOneClickTradingSession();
+  const { isNewAccount } = useIsCosmosNewAccount({ address: account?.address });
 
-  if (!isConnected || !featureFlags.oneClickTrading || isOneClickTradingEnabled)
+  if (
+    !isConnected ||
+    !featureFlags.oneClickTrading ||
+    isOneClickTradingEnabled ||
+    isNewAccount
+  )
     return null;
 
   return <OneClickFloatingBannerContent />;

--- a/packages/web/components/one-click-trading/one-click-trading-settings.tsx
+++ b/packages/web/components/one-click-trading/one-click-trading-settings.tsx
@@ -257,7 +257,9 @@ export const OneClickTradingSettings = ({
                           className:
                             "!inline w-auto !px-0 !text-body2 !font-body2 text-wosmongton-300",
                         })}
-                        // TODO: Add link
+                        href="https://support.osmosis.zone/tutorials/1clicktrading"
+                        target="_blank"
+                        rel="noopener noreferrer"
                       >
                         {t("oneClickTrading.introduction.learnMore")} ↗️
                       </a>

--- a/packages/web/hooks/mutations/one-click-trading/use-create-one-click-trading-session.tsx
+++ b/packages/web/hooks/mutations/one-click-trading/use-create-one-click-trading-session.tsx
@@ -21,7 +21,7 @@ import dayjs from "dayjs";
 import { useLocalStorage } from "react-use";
 
 import { displayToast, ToastType } from "~/components/alert";
-import { OneClickFloatingBannerDoNotShowKey } from "~/components/one-click-trading/one-click-floating-banner";
+import { OneClickFloatingBannerDoNotShowKey } from "~/components/one-click-trading/one-click-toast";
 import { EventName, SPEND_LIMIT_CONTRACT_ADDRESS } from "~/config";
 import { useTranslation } from "~/hooks/language";
 import { useAmplitudeAnalytics } from "~/hooks/use-amplitude-analytics";

--- a/packages/web/hooks/queries/osmosis/use-icns-name.ts
+++ b/packages/web/hooks/queries/osmosis/use-icns-name.ts
@@ -1,17 +1,13 @@
 import { queryICNSName } from "@osmosis-labs/server";
 import { useQuery } from "@tanstack/react-query";
 
-import { IS_TESTNET } from "~/config";
 import { ChainList } from "~/config/generated/chain-list";
 
 export const useICNSName = ({ address }: { address: string }) => {
-  const enabled =
-    !!IS_TESTNET && Boolean(address) && typeof address === "string";
-
   return useQuery({
     queryKey: ["icns-name", address],
     queryFn: () => queryICNSName({ address, chainList: ChainList }),
-    enabled,
+    enabled: Boolean(address) && typeof address === "string",
     select: ({ data: { names, primary_name } }) => {
       return {
         names: names,

--- a/packages/web/hooks/use-is-new-account.ts
+++ b/packages/web/hooks/use-is-new-account.ts
@@ -1,0 +1,25 @@
+import { api } from "~/utils/trpc";
+
+export const useIsCosmosNewAccount = ({
+  address,
+}: {
+  address: string | undefined;
+}) => {
+  const { data, isLoading: isLoadingBalances } =
+    api.local.balances.getUserBalances.useQuery(
+      {
+        bech32Address: address!,
+      },
+      {
+        enabled: !!address,
+      }
+    );
+
+  return {
+    isNewAccount: isLoadingBalances
+      ? true
+      : !data ||
+        data.length === 0 || // If there are no balances, don't show the floating toast
+        !data.some(({ amount }) => amount !== "0"),
+  };
+};

--- a/packages/web/localizations/de.json
+++ b/packages/web/localizations/de.json
@@ -512,13 +512,8 @@
       "introducingSubtitle": "Führen Sie schnellere und einfachere Geschäfte durch, ohne den Aufwand mehrerer Wallet-Genehmigungen.",
       "learnMore": "Erfahren Sie mehr",
       "startTradingButton": "Starten Sie den 1-Klick-Handel",
-      "defaultParameters": "1-Click Trading ist auf diesem Gerät 1 Stunde lang aktiv, mit einem Ausgabenlimit von 5.000 USD",
-      "changeButton": "Ändern"
-    },
-    "swapRotatingBanner": {
-      "tradeQuickerAndEasier": "Handeln Sie schneller und einfacher",
-      "startOneClickTradingNow": "Starten Sie jetzt mit dem 1-Click-Trading",
-      "iconAlt": "1-Click Trading Kleines Logo"
+      "defaultParameters": "Die Standardeinstellungen sind auf 1 Stunde mit einem Verlustschutzlimit von 5.000 USD festgelegt.",
+      "changeButton": "Einstellungen bearbeiten"
     },
     "floatingBanner": {
       "newPill": "Neu",

--- a/packages/web/localizations/en.json
+++ b/packages/web/localizations/en.json
@@ -512,13 +512,8 @@
       "introducingSubtitle": "Make quicker, easier trades without the hassle of multiple wallet approvals.",
       "learnMore": "Learn more",
       "startTradingButton": "Start 1-Click Trading",
-      "defaultParameters": "1-Click Trading will be active for 1 hour on this device with a $5,000 USD spend limit",
-      "changeButton": "Change"
-    },
-    "swapRotatingBanner": {
-      "tradeQuickerAndEasier": "Trade quicker and easier",
-      "startOneClickTradingNow": "Start 1-Click Trading now",
-      "iconAlt": "1-Click Trading Small Logo"
+      "defaultParameters": "Default settings are set to 1 hour with a $5,000 USD Loss Protection limit.",
+      "changeButton": "Edit settings"
     },
     "floatingBanner": {
       "newPill": "New",

--- a/packages/web/localizations/es.json
+++ b/packages/web/localizations/es.json
@@ -512,13 +512,8 @@
       "introducingSubtitle": "Realice transacciones más rápidas y sencillas sin la molestia de múltiples aprobaciones de billetera.",
       "learnMore": "Aprende más",
       "startTradingButton": "Comience a operar con 1 clic",
-      "defaultParameters": "El comercio con 1 clic estará activo durante 1 hora en este dispositivo con un límite de gasto de $5,000 USD",
-      "changeButton": "Cambiar"
-    },
-    "swapRotatingBanner": {
-      "tradeQuickerAndEasier": "Opere más rápido y más fácilmente",
-      "startOneClickTradingNow": "Comience a operar con 1 clic ahora",
-      "iconAlt": "Logotipo pequeño comercial con 1 clic"
+      "defaultParameters": "La configuración predeterminada está establecida en 1 hora con un límite de protección contra pérdidas de $5,000 USD.",
+      "changeButton": "Editar ajustes"
     },
     "floatingBanner": {
       "newPill": "Nuevo",

--- a/packages/web/localizations/fa.json
+++ b/packages/web/localizations/fa.json
@@ -512,13 +512,8 @@
       "introducingSubtitle": "بدون دردسر تأییدیه های کیف پول های متعدد، معاملات سریع تر و آسان تر انجام دهید.",
       "learnMore": "بیشتر بدانید",
       "startTradingButton": "شروع تجارت با 1 کلیک",
-      "defaultParameters": "1-Click Trading به مدت 1 ساعت در این دستگاه با محدودیت هزینه 5000 دلاری فعال خواهد بود.",
-      "changeButton": "تغییر دادن"
-    },
-    "swapRotatingBanner": {
-      "tradeQuickerAndEasier": "تجارت سریعتر و آسان تر",
-      "startOneClickTradingNow": "اکنون تجارت 1-کلیک کنید",
-      "iconAlt": "1-روی نماد تجاری کوچک کلیک کنید"
+      "defaultParameters": "تنظیمات پیش‌فرض روی 1 ساعت با محدودیت محافظت از ضرر 5000 دلار آمریکا تنظیم شده است.",
+      "changeButton": "ویرایش تنظیمات"
     },
     "floatingBanner": {
       "newPill": "جدید",

--- a/packages/web/localizations/fr.json
+++ b/packages/web/localizations/fr.json
@@ -512,13 +512,8 @@
       "introducingSubtitle": "Effectuez des transactions plus rapides et plus faciles sans les tracas liés aux approbations multiples de portefeuilles.",
       "learnMore": "Apprendre encore plus",
       "startTradingButton": "Commencez le trading en 1 clic",
-      "defaultParameters": "Le trading en 1 clic sera actif pendant 1 heure sur cet appareil avec une limite de dépenses de 5 000 USD.",
-      "changeButton": "Changement"
-    },
-    "swapRotatingBanner": {
-      "tradeQuickerAndEasier": "Tradez plus rapidement et plus facilement",
-      "startOneClickTradingNow": "Commencez le trading en 1 clic maintenant",
-      "iconAlt": "Petit logo de trading en 1 clic"
+      "defaultParameters": "Les paramètres par défaut sont définis sur 1 heure avec une limite de protection contre les pertes de 5 000 USD.",
+      "changeButton": "Modifier les paramètres"
     },
     "floatingBanner": {
       "newPill": "Nouveau",

--- a/packages/web/localizations/gu.json
+++ b/packages/web/localizations/gu.json
@@ -512,13 +512,8 @@
       "introducingSubtitle": "બહુવિધ વૉલેટ મંજૂરીઓની ઝંઝટ વિના ઝડપી, સરળ વેપાર કરો.",
       "learnMore": "વધુ શીખો",
       "startTradingButton": "1-ક્લિક ટ્રેડિંગ શરૂ કરો",
-      "defaultParameters": "1-ક્લિક ટ્રેડિંગ $5,000 USD ખર્ચ મર્યાદા સાથે આ ઉપકરણ પર 1 કલાક માટે સક્રિય રહેશે",
-      "changeButton": "બદલો"
-    },
-    "swapRotatingBanner": {
-      "tradeQuickerAndEasier": "ઝડપી અને સરળ વેપાર કરો",
-      "startOneClickTradingNow": "હવે 1-ક્લિક ટ્રેડિંગ શરૂ કરો",
-      "iconAlt": "1- ટ્રેડિંગ સ્મોલ લોગો પર ક્લિક કરો"
+      "defaultParameters": "ડિફોલ્ટ સેટિંગ્સ $5,000 USD નુકશાન સંરક્ષણ મર્યાદા સાથે 1 કલાક પર સેટ છે.",
+      "changeButton": "સેટિંગ્સ સંપાદિત કરો"
     },
     "floatingBanner": {
       "newPill": "નવી",

--- a/packages/web/localizations/hi.json
+++ b/packages/web/localizations/hi.json
@@ -512,13 +512,8 @@
       "introducingSubtitle": "एकाधिक वॉलेट अनुमोदन की परेशानी के बिना त्वरित, आसान व्यापार करें।",
       "learnMore": "और अधिक जानें",
       "startTradingButton": "1-क्लिक ट्रेडिंग प्रारंभ करें",
-      "defaultParameters": "1-क्लिक ट्रेडिंग इस डिवाइस पर $5,000 USD की खर्च सीमा के साथ 1 घंटे के लिए सक्रिय रहेगी",
-      "changeButton": "परिवर्तन"
-    },
-    "swapRotatingBanner": {
-      "tradeQuickerAndEasier": "जल्दी और आसानी से व्यापार करें",
-      "startOneClickTradingNow": "अभी 1-क्लिक ट्रेडिंग शुरू करें",
-      "iconAlt": "1-क्लिक ट्रेडिंग छोटा लोगो"
+      "defaultParameters": "डिफ़ॉल्ट सेटिंग $5,000 USD हानि संरक्षण सीमा के साथ 1 घंटे पर सेट की गई है।",
+      "changeButton": "विन्यास बदलें"
     },
     "floatingBanner": {
       "newPill": "नया",

--- a/packages/web/localizations/ja.json
+++ b/packages/web/localizations/ja.json
@@ -512,13 +512,8 @@
       "introducingSubtitle": "複数のウォレット承認の手間を省き、より迅速かつ簡単な取引を行うことができます。",
       "learnMore": "もっと詳しく知る",
       "startTradingButton": "1-Click取引を開始する",
-      "defaultParameters": "1-Click 取引は、このデバイスで 1 時間有効になり、使用制限は 5,000 米ドルになります。",
-      "changeButton": "変化"
-    },
-    "swapRotatingBanner": {
-      "tradeQuickerAndEasier": "取引をより迅速かつ簡単に",
-      "startOneClickTradingNow": "今すぐ1-Click取引を始めましょう",
-      "iconAlt": "1-Click 取引の小さなロゴ"
+      "defaultParameters": "デフォルト設定は 1 時間に設定されており、損失保護の限度額は 5,000 米ドルです。",
+      "changeButton": "編集の設定"
     },
     "floatingBanner": {
       "newPill": "新しい",

--- a/packages/web/localizations/ko.json
+++ b/packages/web/localizations/ko.json
@@ -512,13 +512,8 @@
       "introducingSubtitle": "여러 번 지갑을 승인해야 하는 번거로움 없이 더 빠르고 쉽게 거래하세요.",
       "learnMore": "더 알아보기",
       "startTradingButton": "1-클릭 거래 시작",
-      "defaultParameters": "1-클릭 거래는 $5,000 USD 지출 한도로 이 기기에서 1시간 동안 활성화됩니다.",
-      "changeButton": "변화"
-    },
-    "swapRotatingBanner": {
-      "tradeQuickerAndEasier": "더 빠르고 쉽게 거래하세요",
-      "startOneClickTradingNow": "지금 1-클릭 거래를 시작하세요",
-      "iconAlt": "1-클릭 거래 작은 로고"
+      "defaultParameters": "기본 설정은 1시간으로 설정되어 있으며 손실 보호 한도는 USD 5,000입니다.",
+      "changeButton": "설정 수정"
     },
     "floatingBanner": {
       "newPill": "새로운",

--- a/packages/web/localizations/pl.json
+++ b/packages/web/localizations/pl.json
@@ -512,13 +512,8 @@
       "introducingSubtitle": "Dokonuj szybszych i łatwiejszych transakcji bez konieczności zatwierdzania wielu portfeli.",
       "learnMore": "Ucz się więcej",
       "startTradingButton": "Rozpocznij handel jednym kliknięciem",
-      "defaultParameters": "Handel jednym kliknięciem będzie aktywny przez 1 godzinę na tym urządzeniu z limitem wydatków wynoszącym 5000 USD",
-      "changeButton": "Zmiana"
-    },
-    "swapRotatingBanner": {
-      "tradeQuickerAndEasier": "Handluj szybciej i łatwiej",
-      "startOneClickTradingNow": "Rozpocznij handel jednym kliknięciem już teraz",
-      "iconAlt": "Handel małym logo jednym kliknięciem"
+      "defaultParameters": "Ustawienia domyślne są ustawione na 1 godzinę z limitem ochrony przed stratą w wysokości 5000 USD.",
+      "changeButton": "Edytuj ustawienia"
     },
     "floatingBanner": {
       "newPill": "Nowy",

--- a/packages/web/localizations/pt-br.json
+++ b/packages/web/localizations/pt-br.json
@@ -512,13 +512,8 @@
       "introducingSubtitle": "Faça negociações mais rápidas e fáceis sem o incômodo de múltiplas aprovações de carteira.",
       "learnMore": "Saber mais",
       "startTradingButton": "Comece a negociação com 1 clique",
-      "defaultParameters": "A negociação em 1 clique ficará ativa por 1 hora neste dispositivo com um limite de gastos de US$ 5.000.",
-      "changeButton": "Mudar"
-    },
-    "swapRotatingBanner": {
-      "tradeQuickerAndEasier": "Negocie de forma mais rápida e fácil",
-      "startOneClickTradingNow": "Comece a negociação com 1 clique agora",
-      "iconAlt": "Logotipo pequeno de negociação em 1 clique"
+      "defaultParameters": "As configurações padrão são definidas para 1 hora com um limite de proteção contra perdas de US$ 5.000.",
+      "changeButton": "Editar Configurações"
     },
     "floatingBanner": {
       "newPill": "Novo",

--- a/packages/web/localizations/ro.json
+++ b/packages/web/localizations/ro.json
@@ -512,13 +512,8 @@
       "introducingSubtitle": "Efectuați tranzacții mai rapide și mai ușoare, fără bătaia de cap a aprobărilor multiple pentru portofel.",
       "learnMore": "Află mai multe",
       "startTradingButton": "Începeți tranzacționarea cu 1 clic",
-      "defaultParameters": "Tranzacționarea cu 1 clic va fi activă timp de 1 oră pe acest dispozitiv, cu o limită de cheltuieli de 5.000 USD",
-      "changeButton": "Schimbare"
-    },
-    "swapRotatingBanner": {
-      "tradeQuickerAndEasier": "Comerț mai rapid și mai ușor",
-      "startOneClickTradingNow": "Începeți acum tranzacționarea cu 1 clic",
-      "iconAlt": "1-Click Trading Small Logo"
+      "defaultParameters": "Setările implicite sunt setate la 1 oră cu o limită de protecție împotriva pierderilor de 5.000 USD.",
+      "changeButton": "Editeaza setarile"
     },
     "floatingBanner": {
       "newPill": "Nou",

--- a/packages/web/localizations/ru.json
+++ b/packages/web/localizations/ru.json
@@ -512,13 +512,8 @@
       "introducingSubtitle": "Совершайте сделки быстрее и проще без хлопот, требующих одобрения нескольких кошельков.",
       "learnMore": "Узнать больше",
       "startTradingButton": "Начать торговлю в 1 клик",
-      "defaultParameters": "На этом устройстве функция «1-Click Trading» будет активна в течение 1 часа с лимитом расходов в 5,000 долларов США.",
-      "changeButton": "Изменять"
-    },
-    "swapRotatingBanner": {
-      "tradeQuickerAndEasier": "Торгуйте быстрее и проще",
-      "startOneClickTradingNow": "Начните торговлю в 1 клик прямо сейчас",
-      "iconAlt": "Маленький логотип «1-Click Trading»"
+      "defaultParameters": "Настройки по умолчанию установлены на 1 час с лимитом защиты от потерь в размере 5000 долларов США.",
+      "changeButton": "Изменить настройки"
     },
     "floatingBanner": {
       "newPill": "Новый",

--- a/packages/web/localizations/tr.json
+++ b/packages/web/localizations/tr.json
@@ -512,13 +512,8 @@
       "introducingSubtitle": "Birden fazla cüzdan onayıyla uğraşmadan daha hızlı ve daha kolay işlemler yapın.",
       "learnMore": "Daha fazla bilgi edin",
       "startTradingButton": "Tek Tıklamayla Ticareti Başlatın",
-      "defaultParameters": "Tek Tıklamayla Ticaret bu cihazda 1 saat boyunca 5.000 ABD Doları harcama sınırıyla etkin olacak",
-      "changeButton": "Değiştirmek"
-    },
-    "swapRotatingBanner": {
-      "tradeQuickerAndEasier": "Daha hızlı ve daha kolay ticaret yapın",
-      "startOneClickTradingNow": "Şimdi Tek Tıkla Ticarete Başlayın",
-      "iconAlt": "Tek Tıklamayla Ticaret Küçük Logosu"
+      "defaultParameters": "Varsayılan ayarlar 5.000 USD Kayıp Koruma limitiyle 1 saate ayarlanmıştır.",
+      "changeButton": "Ayarları düzenle"
     },
     "floatingBanner": {
       "newPill": "Yeni",

--- a/packages/web/localizations/zh-cn.json
+++ b/packages/web/localizations/zh-cn.json
@@ -512,13 +512,8 @@
       "introducingSubtitle": "进行更快、更轻松的交易，无需多个钱包批准的麻烦。",
       "learnMore": "了解更多",
       "startTradingButton": "开始一键交易",
-      "defaultParameters": "一键交易将在此设备上激活 1 小时，支出限额为 5,000 美元",
-      "changeButton": "改变"
-    },
-    "swapRotatingBanner": {
-      "tradeQuickerAndEasier": "交易更快捷、更轻松",
-      "startOneClickTradingNow": "立即开始一键交易",
-      "iconAlt": "一键交易小徽标"
+      "defaultParameters": "默认设置为 1 小时，损失保护限额为 5,000 美元。",
+      "changeButton": "编辑设置"
     },
     "floatingBanner": {
       "newPill": "新的",

--- a/packages/web/localizations/zh-hk.json
+++ b/packages/web/localizations/zh-hk.json
@@ -512,13 +512,8 @@
       "introducingSubtitle": "進行更快、更輕鬆的交易，無需多個錢包批准的麻煩。",
       "learnMore": "了解更多",
       "startTradingButton": "開始一鍵交易",
-      "defaultParameters": "一鍵交易將在此裝置上啟動 1 小時，支出限額為 5,000 美元",
-      "changeButton": "改變"
-    },
-    "swapRotatingBanner": {
-      "tradeQuickerAndEasier": "交易更快、更輕鬆",
-      "startOneClickTradingNow": "立即開始一鍵交易",
-      "iconAlt": "一鍵交易小徽標"
+      "defaultParameters": "預設為 1 小時，損失保護限額為 5,000 美元。",
+      "changeButton": "編輯設定"
     },
     "floatingBanner": {
       "newPill": "新的",

--- a/packages/web/localizations/zh-tw.json
+++ b/packages/web/localizations/zh-tw.json
@@ -512,13 +512,8 @@
       "introducingSubtitle": "進行更快、更輕鬆的交易，無需多個錢包批准的麻煩。",
       "learnMore": "了解更多",
       "startTradingButton": "開始一鍵交易",
-      "defaultParameters": "一鍵交易將在此裝置上啟動 1 小時，支出限額為 5,000 美元",
-      "changeButton": "改變"
-    },
-    "swapRotatingBanner": {
-      "tradeQuickerAndEasier": "交易更快、更輕鬆",
-      "startOneClickTradingNow": "立即開始一鍵交易",
-      "iconAlt": "一鍵交易小徽標"
+      "defaultParameters": "預設為 1 小時，損失保護限額為 5,000 美元。",
+      "changeButton": "編輯設定"
     },
     "floatingBanner": {
       "newPill": "新的",

--- a/packages/web/pages/_app.tsx
+++ b/packages/web/pages/_app.tsx
@@ -28,7 +28,7 @@ import { ErrorFallback } from "~/components/error/error-fallback";
 import { Pill } from "~/components/indicators/pill";
 import { MainLayout } from "~/components/layouts";
 import { MainLayoutMenu } from "~/components/main-menu";
-import { OneClickFloatingBanner } from "~/components/one-click-trading/one-click-floating-banner";
+import { OneClickToast } from "~/components/one-click-trading/one-click-toast";
 import { AmplitudeEvent, EventName } from "~/config";
 import { wagmiConfig } from "~/config/wagmi";
 import {
@@ -332,7 +332,7 @@ const MainLayoutWrapper: FunctionComponent<{
       {flags.oneClickTrading && (
         <>
           <OneClickTradingIntroModal />
-          <OneClickFloatingBanner />
+          <OneClickToast />
         </>
       )}
     </MainLayout>


### PR DESCRIPTION
## What is the purpose of the change:

Currently we're showing 1CT for new users/wallets that don't have funds, but this causes a dead end when they try to connect and start a 1CT session. We should simply disable and hide the feature for these users until they've deposited funds.

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-751/disabled-and-hide-1ct-for-new-users-with-no-funds)

## Testing and Verifying

- [ ] Wallet with no funds will not see 1-Click Trading. Please note that intro wallet select sections will still be visible