### PR TITLE
(Deposit/Withdraw) Fix use of coinMinimalDenom from asset info page

### DIFF
--- a/packages/web/components/bridge/amount-screen.tsx
+++ b/packages/web/components/bridge/amount-screen.tsx
@@ -328,7 +328,9 @@ export const AmountScreen = observer(
       // Use Osmosis Assets to get the source asset
       if (direction === "withdraw") {
         const selectedAsset = assetsInOsmosis?.find(
-          (asset) => asset.coinDenom === selectedDenom
+          (asset) =>
+            asset.coinDenom === selectedDenom ||
+            asset.coinMinimalDenom === selectedDenom
         );
         if (!selectedAsset) return undefined;
         return [


### PR DESCRIPTION
## What is the purpose of the change:

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

For withdraw, it was assumed the symbol was used for jumping to an asset amount screen. Now, the coinMinimalDenom will also be used for finding the initial asset

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-693/fix-flow-from-asset-info-pages)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->
