### PR TITLE
(1CT) Default 1CT toggle and Display 1CT Onboarding Depending on the Previous Connected Account

### DIFF
--- a/packages/tx/src/__tests__/error.spec.ts
+++ b/packages/tx/src/__tests__/error.spec.ts
@@ -1,0 +1,19 @@
+import { isInsufficientFeeError } from "../error";
+
+describe("isInsufficientFeeError", () => {
+  it("should return true for a valid insufficient fee error message", () => {
+    const message =
+      "Insufficient balance for transaction fees. Please add funds to continue.";
+    expect(isInsufficientFeeError(message)).toBeTruthy();
+  });
+
+  it("should return false for an invalid insufficient fee error message", () => {
+    const message = "Some other error message.";
+    expect(isInsufficientFeeError(message)).toBeFalsy();
+  });
+
+  it("should return false for an empty message", () => {
+    const message = "";
+    expect(isInsufficientFeeError(message)).toBeFalsy();
+  });
+});

--- a/packages/tx/src/__tests__/error.spec.ts
+++ b/packages/tx/src/__tests__/error.spec.ts
@@ -1,4 +1,4 @@
-import { isInsufficientFeeError } from "../error";
+import { isAccountNotFoundError, isInsufficientFeeError } from "../error";
 
 describe("isInsufficientFeeError", () => {
   it("should return true for a valid insufficient fee error message", () => {
@@ -15,5 +15,35 @@ describe("isInsufficientFeeError", () => {
   it("should return false for an empty message", () => {
     const message = "";
     expect(isInsufficientFeeError(message)).toBeFalsy();
+  });
+});
+
+describe("isAccountNotFoundError", () => {
+  it("should return true for a valid account not found error message with address 1", () => {
+    const message =
+      "account abcdefghijklmnopqrstuvwxyz1234567890abcdef not found";
+    expect(isAccountNotFoundError(message)).toBeTruthy();
+  });
+
+  it("should return true for a valid account not found error message with address 2", () => {
+    const message =
+      "account 1234567890abcdefghijklmnopqrstuvwxyz1234567890 not found";
+    expect(isAccountNotFoundError(message)).toBeTruthy();
+  });
+
+  it("should return true for a valid account not found error message with address 3", () => {
+    const message =
+      "account zyxwvutsrqponmlkjihgfedcba0987654321zyxwvutsrq not found";
+    expect(isAccountNotFoundError(message)).toBeTruthy();
+  });
+
+  it("should return false for an invalid account not found error message", () => {
+    const message = "Some other error message.";
+    expect(isAccountNotFoundError(message)).toBeFalsy();
+  });
+
+  it("should return false for an empty message", () => {
+    const message = "";
+    expect(isAccountNotFoundError(message)).toBeFalsy();
   });
 });

--- a/packages/tx/src/error.ts
+++ b/packages/tx/src/error.ts
@@ -30,3 +30,9 @@ export function isSlippageErrorMessage(msg: string) {
     msg.includes("price impact protection")
   );
 }
+
+export function isInsufficientFeeError(message: string) {
+  const regexInsufficientFeeError =
+    /Insufficient balance for transaction fees. Please add funds to continue./;
+  return regexInsufficientFeeError.test(message);
+}

--- a/packages/tx/src/error.ts
+++ b/packages/tx/src/error.ts
@@ -36,3 +36,8 @@ export function isInsufficientFeeError(message: string) {
     /Insufficient balance for transaction fees. Please add funds to continue./;
   return regexInsufficientFeeError.test(message);
 }
+
+export function isAccountNotFoundError(message: string) {
+  const regexAccountNotFoundError = /account [a-zA-Z0-9]{39,} not found/;
+  return regexAccountNotFoundError.test(message);
+}

--- a/packages/utils/src/__tests__/api-client.spec.ts
+++ b/packages/utils/src/__tests__/api-client.spec.ts
@@ -96,4 +96,38 @@ describe("apiClient", () => {
       );
     });
   });
+
+  it("should handle messages ending with a dot correctly", async () => {
+    (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: "Bad Request." }), {
+        status: 400,
+      })
+    );
+
+    await apiClient("http://example.com").catch((error) => {
+      expect(error).toBeInstanceOf(ApiClientError);
+      expect(error.message).toEqual("Fetch error. Bad Request.");
+      expect(error.status).toEqual(400);
+      expect(error.data).toEqual({
+        message: "Bad Request.",
+      });
+    });
+  });
+
+  it("should handle messages starting with 'Fetch error.' correctly", async () => {
+    (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: "Fetch error. Something went wrong" }), {
+        status: 500,
+      })
+    );
+
+    await apiClient("http://example.com").catch((error) => {
+      expect(error).toBeInstanceOf(ApiClientError);
+      expect(error.message).toEqual("Fetch error. Something went wrong.");
+      expect(error.status).toEqual(500);
+      expect(error.data).toEqual({
+        message: "Fetch error. Something went wrong",
+      });
+    });
+  });
 });

--- a/packages/utils/src/__tests__/api-client.spec.ts
+++ b/packages/utils/src/__tests__/api-client.spec.ts
@@ -116,9 +116,12 @@ describe("apiClient", () => {
 
   it("should handle messages starting with 'Fetch error.' correctly", async () => {
     (fetch as jest.MockedFunction<typeof fetch>).mockResolvedValueOnce(
-      new Response(JSON.stringify({ message: "Fetch error. Something went wrong" }), {
-        status: 500,
-      })
+      new Response(
+        JSON.stringify({ message: "Fetch error. Something went wrong" }),
+        {
+          status: 500,
+        }
+      )
     );
 
     await apiClient("http://example.com").catch((error) => {

--- a/packages/utils/src/api-client.ts
+++ b/packages/utils/src/api-client.ts
@@ -42,6 +42,12 @@ function getErrorMessage({
 }: {
   message?: string;
 } = {}) {
+  if (message.endsWith(".")) {
+    message = message.slice(0, -1);
+  }
+  if (message.startsWith("Fetch error. ")) {
+    message = message.replace("Fetch error. ", "").trim();
+  }
   return `Fetch error. ${message}.`;
 }
 

--- a/packages/web/components/alert/prettify.ts
+++ b/packages/web/components/alert/prettify.ts
@@ -1,6 +1,9 @@
 import { AppCurrency } from "@keplr-wallet/types";
 import { CoinPretty, Int } from "@keplr-wallet/unit";
-import { isSlippageErrorMessage } from "@osmosis-labs/tx";
+import {
+  isInsufficientFeeError,
+  isSlippageErrorMessage,
+} from "@osmosis-labs/tx";
 
 import { MultiLanguageT } from "~/hooks";
 
@@ -18,9 +21,6 @@ const regexInvalidClPositionAmounts =
 
 const regexFailedSwapSlippage =
   /failed to execute message; message index: \d+: (.*?) token is lesser than min amount: calculated amount is lesser than min amount: invalid request/;
-
-const regexInsufficientFeeError =
-  /Insufficient balance for transaction fees. Please add funds to continue./;
 
 const regexRejectedTx = /Request rejected/;
 
@@ -114,8 +114,7 @@ export function prettifyTxError(
       }
     }
 
-    const matchInsufficientFeeError = message.match(regexInsufficientFeeError);
-    if (matchInsufficientFeeError) {
+    if (isInsufficientFeeError(message)) {
       return ["errors.insufficientFee"];
     }
 

--- a/packages/web/components/alert/tx-event-toast.ts
+++ b/packages/web/components/alert/tx-event-toast.ts
@@ -13,7 +13,8 @@ import { prettifyTxError } from "./prettify";
 // https://github.com/cosmos/cosmos-sdk/blob/8f6a94cd1f9f1c6bf1ad83a751da86270db92e02/types/errors/errors.go#L129
 const txTimeoutHeightReachedErrorCode = 30;
 
-const BROADCASTING_TOAST_ID = "broadcast-failed";
+const BROADCASTING_TOAST_ID = "broadcast";
+export const BROADCASTING_FAILED_TOAST_ID = "broadcast-failed";
 
 export function toastOnBroadcastFailed(
   getChain: (chainId: string) => ChainInfoInner<ChainInfoWithExplorer>
@@ -32,7 +33,10 @@ export function toastOnBroadcastFailed(
         captionTranslationKey:
           prettifyTxError(caption, getChain(chainId).currencies) ?? caption,
       },
-      ToastType.ERROR
+      ToastType.ERROR,
+      {
+        toastId: BROADCASTING_FAILED_TOAST_ID,
+      }
     );
   };
 }

--- a/packages/web/components/one-click-trading/one-click-trading-toast.tsx
+++ b/packages/web/components/one-click-trading/one-click-trading-toast.tsx
@@ -13,9 +13,10 @@ import {
   useAmplitudeAnalytics,
   useFeatureFlags,
   useTranslation,
+  useWalletSelect,
 } from "~/hooks";
 import { useOneClickTradingSession } from "~/hooks/one-click-trading/use-one-click-trading-session";
-import { useIsCosmosNewAccount } from "~/hooks/use-is-new-account";
+import { useIsCosmosNewAccount } from "~/hooks/use-is-cosmos-new-account";
 import { useGlobalIs1CTIntroModalScreen } from "~/modals";
 import { useStore } from "~/stores";
 
@@ -31,12 +32,14 @@ export const OneClickToast = observer(() => {
   const isConnected = !!account?.address;
   const { isOneClickTradingEnabled } = useOneClickTradingSession();
   const { isNewAccount } = useIsCosmosNewAccount({ address: account?.address });
+  const { isOpen: isWalletSelectOpen } = useWalletSelect();
 
   if (
     !isConnected ||
     !featureFlags.oneClickTrading ||
     isOneClickTradingEnabled ||
-    isNewAccount
+    isNewAccount ||
+    isWalletSelectOpen
   )
     return null;
 

--- a/packages/web/hooks/mutations/one-click-trading/use-create-one-click-trading-session.tsx
+++ b/packages/web/hooks/mutations/one-click-trading/use-create-one-click-trading-session.tsx
@@ -21,7 +21,7 @@ import dayjs from "dayjs";
 import { useLocalStorage } from "react-use";
 
 import { displayToast, ToastType } from "~/components/alert";
-import { OneClickFloatingBannerDoNotShowKey } from "~/components/one-click-trading/one-click-toast";
+import { OneClickFloatingBannerDoNotShowKey } from "~/components/one-click-trading/one-click-trading-toast";
 import { EventName, SPEND_LIMIT_CONTRACT_ADDRESS } from "~/config";
 import { useTranslation } from "~/hooks/language";
 import { useAmplitudeAnalytics } from "~/hooks/use-amplitude-analytics";

--- a/packages/web/hooks/use-is-cosmos-new-account.ts
+++ b/packages/web/hooks/use-is-cosmos-new-account.ts
@@ -5,7 +5,7 @@ export const useIsCosmosNewAccount = ({
 }: {
   address: string | undefined;
 }) => {
-  const { data, isLoading: isLoadingBalances } =
+  const { data, isLoading: areLoadingBalances } =
     api.local.balances.getUserBalances.useQuery(
       {
         bech32Address: address!,
@@ -16,10 +16,10 @@ export const useIsCosmosNewAccount = ({
     );
 
   return {
-    isNewAccount: isLoadingBalances
+    isNewAccount: areLoadingBalances
       ? true
       : !data ||
-        data.length === 0 || // If there are no balances, don't show the floating toast
+        data.length === 0 ||
         !data.some(({ amount }) => amount !== "0"),
   };
 };

--- a/packages/web/hooks/use-previous-connected-cosmos-account.ts
+++ b/packages/web/hooks/use-previous-connected-cosmos-account.ts
@@ -5,7 +5,7 @@ import { api } from "~/utils/trpc";
 
 export const usePreviousConnectedCosmosAccount = () => {
   const [previousConnectedCosmosAccount, setPreviousConnectedCosmosAccount] =
-    useLocalStorage<string>("previous-connected-account");
+    useLocalStorage<string>("previous-connected-cosmos-account");
 
   const { data, isLoading: areLoadingBalances } =
     api.local.balances.getUserBalances.useQuery(

--- a/packages/web/hooks/use-previous-connected-cosmos-account.ts
+++ b/packages/web/hooks/use-previous-connected-cosmos-account.ts
@@ -1,0 +1,35 @@
+import { isCosmosAddressValid, isNil } from "@osmosis-labs/utils";
+import { useLocalStorage } from "react-use";
+
+import { api } from "~/utils/trpc";
+
+export const usePreviousConnectedCosmosAccount = () => {
+  const [previousConnectedCosmosAccount, setPreviousConnectedCosmosAccount] =
+    useLocalStorage<string>("previous-connected-account");
+
+  const { data, isLoading: areLoadingBalances } =
+    api.local.balances.getUserBalances.useQuery(
+      {
+        bech32Address: previousConnectedCosmosAccount!,
+      },
+      {
+        enabled:
+          !isNil(previousConnectedCosmosAccount) &&
+          isCosmosAddressValid({
+            address: previousConnectedCosmosAccount,
+            bech32Prefix: "osmo",
+          }),
+      }
+    );
+
+  return {
+    previousConnectedCosmosAccount,
+    setPreviousConnectedCosmosAccount,
+    areLoadingBalances,
+    hasFunds: areLoadingBalances
+      ? false
+      : !isNil(data) &&
+        data.length > 0 &&
+        data.some(({ amount }) => amount !== "0"),
+  };
+};

--- a/packages/web/hooks/use-wallet-select.tsx
+++ b/packages/web/hooks/use-wallet-select.tsx
@@ -46,12 +46,7 @@ export interface WalletSelectParams {
 
 export const WalletSelectProvider: FunctionComponent<{ children: ReactNode }> =
   observer(({ children }) => {
-    const {
-      accountStore,
-      chainStore: {
-        osmosis: { chainId },
-      },
-    } = useStore();
+    const { accountStore } = useStore();
 
     const [walletSelectParams, setWalletSelectParams] =
       useState<WalletSelectParams | null>(null);
@@ -61,7 +56,7 @@ export const WalletSelectProvider: FunctionComponent<{ children: ReactNode }> =
     const { setUserProperty } = useAmplitudeAnalytics();
 
     const setUserAmplitudeProperties = useCallback(() => {
-      const wallet = accountStore.getWallet(chainId);
+      const wallet = accountStore.getWallet(accountStore.osmosisChainId);
       if (wallet) {
         setUserProperty("isWalletConnected", true);
         setUserProperty(
@@ -69,7 +64,7 @@ export const WalletSelectProvider: FunctionComponent<{ children: ReactNode }> =
           wallet?.walletInfo?.name ?? "unknown"
         );
       }
-    }, [setUserProperty, accountStore, chainId]);
+    }, [accountStore, setUserProperty]);
 
     useEffect(() => {
       const installPrevSessionWallet = async () => {

--- a/packages/web/localizations/de.json
+++ b/packages/web/localizations/de.json
@@ -863,6 +863,7 @@
     "approveOneClickTradingSession": "Genehmigen Sie den 1-Klick-Handel in {walletName} .",
     "errorInitializingOneClickTradingSession": "1-Click-Handel konnte nicht aktiviert werden.",
     "retryInWalletOrContinue": "Versuchen Sie es erneut in {walletName} oder fahren Sie ohne 1-Click-Handel fort.",
+    "retryInWalletOrContinueNoFunds": "Nicht genügend Guthaben, um die Sitzung zu starten. Bitte zahlen Sie mehr ein und versuchen Sie es erneut in {walletName} oder fahren Sie ohne 1-Click Trading fort.",
     "continueWithoutOneClickTrading": "Ohne 1-Click-Handel fortfahren",
     "retry": "Wiederholen",
     "openExtension": "Öffnen Sie die Browsererweiterung {walletName} um Ihre Wallet zu verbinden.",

--- a/packages/web/localizations/en.json
+++ b/packages/web/localizations/en.json
@@ -863,6 +863,7 @@
     "approveOneClickTradingSession": "Approve 1-Click Trading in {walletName}.",
     "errorInitializingOneClickTradingSession": "1-Click Trading could not be enabled.",
     "retryInWalletOrContinue": "Retry in {walletName}, or continue without 1-Click Trading.",
+    "retryInWalletOrContinueNoFunds": "Not enough funds to start the session. Please deposit more and retry in {walletName}, or proceed without 1-Click Trading.",
     "continueWithoutOneClickTrading": "Continue without 1-Click Trading",
     "retry": "Retry",
     "openExtension": "Open the {walletName} browser extension to connect your wallet.",

--- a/packages/web/localizations/en.json
+++ b/packages/web/localizations/en.json
@@ -497,6 +497,8 @@
       "oneClickTradingExpired": "1-Click Trading expired",
       "oneClickTradingDisabled": "1-Click Trading disabled",
       "currentlyUnavailable": "1-Click Trading currently unavailable",
+      "couldNotStartSession": "Unable to initiate session",
+      "notEnoughFunds": "Insufficient funds to start session. Please deposit and try again.",
       "networkFeeTooHigh": "Network fee too high",
       "startANewSession": "Start a new session",
       "increaseFeeLimit": "Increase network fee limit",

--- a/packages/web/localizations/en.json
+++ b/packages/web/localizations/en.json
@@ -497,8 +497,6 @@
       "oneClickTradingExpired": "1-Click Trading expired",
       "oneClickTradingDisabled": "1-Click Trading disabled",
       "currentlyUnavailable": "1-Click Trading currently unavailable",
-      "couldNotStartSession": "Unable to initiate session",
-      "notEnoughFunds": "Insufficient funds to start session. Please deposit and try again.",
       "networkFeeTooHigh": "Network fee too high",
       "startANewSession": "Start a new session",
       "increaseFeeLimit": "Increase network fee limit",

--- a/packages/web/localizations/es.json
+++ b/packages/web/localizations/es.json
@@ -863,6 +863,7 @@
     "approveOneClickTradingSession": "Aprobar operaciones con 1 clic en {walletName}",
     "errorInitializingOneClickTradingSession": "No se pudo habilitar el comercio con 1 clic.",
     "retryInWalletOrContinue": "Vuelva a intentarlo en {walletName} o continúe sin 1-Click Trading.",
+    "retryInWalletOrContinueNoFunds": "No hay fondos suficientes para iniciar la sesión. Deposite más y vuelva a intentarlo en {walletName} o continúe sin operar con 1 clic.",
     "continueWithoutOneClickTrading": "Continuar sin operar con 1 clic",
     "retry": "Rever",
     "openExtension": "Abra la extensión del navegador {walletName} para conectar su billetera.",

--- a/packages/web/localizations/fa.json
+++ b/packages/web/localizations/fa.json
@@ -863,6 +863,7 @@
     "approveOneClickTradingSession": "تأیید معامله 1-کلیک در {walletName} .",
     "errorInitializingOneClickTradingSession": "1-Click Trading را نمی توان فعال کرد.",
     "retryInWalletOrContinue": "در {walletName} دوباره امتحان کنید، یا بدون 1-Click Trading ادامه دهید.",
+    "retryInWalletOrContinueNoFunds": "بودجه کافی برای شروع جلسه وجود ندارد. لطفاً مقدار بیشتری را واریز کنید و دوباره در {walletName} امتحان کنید، یا بدون 1-Click Trading ادامه دهید.",
     "continueWithoutOneClickTrading": "بدون 1-Click Trading ادامه دهید",
     "retry": "دوباره امتحان کنید",
     "openExtension": "باز کن",

--- a/packages/web/localizations/fr.json
+++ b/packages/web/localizations/fr.json
@@ -863,6 +863,7 @@
     "approveOneClickTradingSession": "Approuvez le trading en 1 clic dans {walletName} .",
     "errorInitializingOneClickTradingSession": "Le trading en 1 clic n'a pas pu être activé.",
     "retryInWalletOrContinue": "Réessayez dans {walletName} ou continuez sans trading en 1 clic.",
+    "retryInWalletOrContinueNoFunds": "Pas assez de fonds pour démarrer la session. Veuillez déposer davantage et réessayer dans {walletName} , ou procéder sans trading en 1 clic.",
     "continueWithoutOneClickTrading": "Continuer sans trading en 1 clic",
     "retry": "Recommencez",
     "openExtension": "Ouvrez l'extension de navigateur {walletName} pour connecter votre portefeuille.",

--- a/packages/web/localizations/gu.json
+++ b/packages/web/localizations/gu.json
@@ -863,6 +863,7 @@
     "approveOneClickTradingSession": "{walletName} માં 1-ક્લિક ટ્રેડિંગને મંજૂરી આપો.",
     "errorInitializingOneClickTradingSession": "1-ક્લિક ટ્રેડિંગ સક્ષમ કરી શકાયું નથી.",
     "retryInWalletOrContinue": "{walletName} માં ફરી પ્રયાસ કરો, અથવા 1-ક્લિક ટ્રેડિંગ વિના ચાલુ રાખો.",
+    "retryInWalletOrContinueNoFunds": "સત્ર શરૂ કરવા માટે પૂરતું ભંડોળ નથી. કૃપા કરીને વધુ જમા કરો અને {walletName} માં ફરી પ્રયાસ કરો અથવા 1-ક્લિક ટ્રેડિંગ વિના આગળ વધો.",
     "continueWithoutOneClickTrading": "1-ક્લિક ટ્રેડિંગ વિના ચાલુ રાખો",
     "retry": "ફરી પ્રયાસ કરો",
     "openExtension": "તમારા વૉલેટને કનેક્ટ કરવા માટે {walletName} બ્રાઉઝર એક્સ્ટેંશન ખોલો.",

--- a/packages/web/localizations/hi.json
+++ b/packages/web/localizations/hi.json
@@ -863,6 +863,7 @@
     "approveOneClickTradingSession": "{walletName} में 1-क्लिक ट्रेडिंग को मंजूरी दें।",
     "errorInitializingOneClickTradingSession": "1-क्लिक ट्रेडिंग सक्षम नहीं की जा सकी।",
     "retryInWalletOrContinue": "{walletName} में पुनः प्रयास करें, या 1-क्लिक ट्रेडिंग के बिना जारी रखें।",
+    "retryInWalletOrContinueNoFunds": "सत्र शुरू करने के लिए पर्याप्त धनराशि नहीं है। कृपया अधिक जमा करें और {walletName} में पुनः प्रयास करें, या 1-क्लिक ट्रेडिंग के बिना आगे बढ़ें।",
     "continueWithoutOneClickTrading": "1-क्लिक ट्रेडिंग के बिना जारी रखें",
     "retry": "पुन: प्रयास करें",
     "openExtension": "अपने वॉलेट को कनेक्ट करने के लिए {walletName} ब्राउज़र एक्सटेंशन खोलें।",

--- a/packages/web/localizations/ja.json
+++ b/packages/web/localizations/ja.json
@@ -863,6 +863,7 @@
     "approveOneClickTradingSession": "{walletName}での 1-Click 取引を承認します。",
     "errorInitializingOneClickTradingSession": "1-Click 取引を有効にできませんでした。",
     "retryInWalletOrContinue": "{walletName}で再試行するか、1-Click 取引を行わずに続行してください。",
+    "retryInWalletOrContinueNoFunds": "セッションを開始するには資金が足りません。さらに入金して{walletName}で再試行するか、1 クリック取引をせずに続行してください。",
     "continueWithoutOneClickTrading": "1-Click 取引を行わずに続行する",
     "retry": "リトライ",
     "openExtension": "{walletName}ブラウザ拡張機能を開いてウォレットに接続します。",

--- a/packages/web/localizations/ko.json
+++ b/packages/web/localizations/ko.json
@@ -863,6 +863,7 @@
     "approveOneClickTradingSession": "{walletName} 에서 1-클릭 거래를 승인합니다.",
     "errorInitializingOneClickTradingSession": "1-클릭 거래를 활성화할 수 없습니다.",
     "retryInWalletOrContinue": "{walletName} 에서 다시 시도하거나 1-클릭 거래 없이 계속하세요.",
+    "retryInWalletOrContinueNoFunds": "세션을 시작하는 데 필요한 자금이 부족합니다. 더 입금하고 {walletName} 에 다시 시도하거나 1-클릭 거래 없이 진행하세요.",
     "continueWithoutOneClickTrading": "원클릭 거래 없이 계속하기",
     "retry": "다시 해 보다",
     "openExtension": "{walletName} 브라우저 확장 프로그램을 열어서 지갑을 연결하세요.",

--- a/packages/web/localizations/pl.json
+++ b/packages/web/localizations/pl.json
@@ -863,6 +863,7 @@
     "approveOneClickTradingSession": "Zatwierdź handel jednym kliknięciem w {walletName} .",
     "errorInitializingOneClickTradingSession": "Nie można włączyć handlu jednym kliknięciem.",
     "retryInWalletOrContinue": "Spróbuj ponownie w {walletName} lub kontynuuj bez handlu 1-Click.",
+    "retryInWalletOrContinueNoFunds": "Za mało środków na rozpoczęcie sesji. Wpłać więcej i spróbuj ponownie w {walletName} lub kontynuuj bez handlu jednym kliknięciem.",
     "continueWithoutOneClickTrading": "Kontynuuj bez handlu jednym kliknięciem",
     "retry": "Spróbować ponownie",
     "openExtension": "Otwórz rozszerzenie przeglądarkowe {walletName}, aby połączyć swój portfel.",

--- a/packages/web/localizations/pt-br.json
+++ b/packages/web/localizations/pt-br.json
@@ -863,6 +863,7 @@
     "approveOneClickTradingSession": "Aprove a negociação com 1 clique em {walletName} .",
     "errorInitializingOneClickTradingSession": "A negociação em 1 clique não pôde ser ativada.",
     "retryInWalletOrContinue": "Tente novamente em {walletName} ou continue sem negociação em 1 clique.",
+    "retryInWalletOrContinueNoFunds": "Não há fundos suficientes para iniciar a sessão. Deposite mais e tente novamente em {walletName} , ou prossiga sem a negociação em 1 clique.",
     "continueWithoutOneClickTrading": "Continue sem negociação em 1 clique",
     "retry": "Tentar novamente",
     "openExtension": "Abra a extensão do navegador {walletName} para conectar sua carteira.",

--- a/packages/web/localizations/ro.json
+++ b/packages/web/localizations/ro.json
@@ -863,6 +863,7 @@
     "approveOneClickTradingSession": "Aprobați tranzacționarea cu 1 clic în {walletName} .",
     "errorInitializingOneClickTradingSession": "Tranzacționarea cu 1 clic nu a putut fi activată.",
     "retryInWalletOrContinue": "Încercați din nou în {walletName} sau continuați fără tranzacționarea cu un singur clic.",
+    "retryInWalletOrContinueNoFunds": "Nu sunt suficiente fonduri pentru a începe sesiunea. Depuneți mai mult și încercați din nou în {walletName} sau continuați fără tranzacționarea cu un singur clic.",
     "continueWithoutOneClickTrading": "Continuați fără tranzacționare cu 1 clic",
     "retry": "Reîncercați",
     "openExtension": "Deschideți extensia browserului {walletName} pentru a vă conecta la portofelul dvs.",

--- a/packages/web/localizations/ru.json
+++ b/packages/web/localizations/ru.json
@@ -863,6 +863,7 @@
     "approveOneClickTradingSession": "Одобрить торговлю в один клик в {walletName} .",
     "errorInitializingOneClickTradingSession": "Невозможно включить торговлю в 1 клик.",
     "retryInWalletOrContinue": "Повторите попытку через {walletName} или продолжите без торговли в один клик.",
+    "retryInWalletOrContinueNoFunds": "Недостаточно средств для начала сессии. Пожалуйста, внесите больше средств и повторите попытку в {walletName} или продолжайте без торговли в один клик.",
     "continueWithoutOneClickTrading": "Продолжить без торговли в 1 клик",
     "retry": "Повторить попытку",
     "openExtension": "Откройте расширение браузера {walletName} , чтобы подключить свой кошелек.",

--- a/packages/web/localizations/tr.json
+++ b/packages/web/localizations/tr.json
@@ -863,6 +863,7 @@
     "approveOneClickTradingSession": "{walletName} öğesinde Tek Tıklamayla Ticareti onaylayın.",
     "errorInitializingOneClickTradingSession": "Tek Tıklamayla Ticaret etkinleştirilemedi.",
     "retryInWalletOrContinue": "{walletName} yeniden deneyin veya Tek Tıklamayla Ticaret yapmadan devam edin.",
+    "retryInWalletOrContinueNoFunds": "Oturumu başlatmak için yeterli para yok. Lütfen daha fazla para yatırın ve {walletName} ile yeniden deneyin veya Tek Tıklamayla Ticaret yapmadan devam edin.",
     "continueWithoutOneClickTrading": "Tek Tıklamayla İşlem Yapmadan Devam Edin",
     "retry": "Yeniden dene",
     "openExtension": "{walletName} tarayıcı eklentisini açarak cüzdanınızı bağlayın.",

--- a/packages/web/localizations/zh-cn.json
+++ b/packages/web/localizations/zh-cn.json
@@ -863,6 +863,7 @@
     "approveOneClickTradingSession": "批准{walletName}中的一键交易。",
     "errorInitializingOneClickTradingSession": "无法启用一键交易。",
     "retryInWalletOrContinue": "在{walletName}中重试，或继续而不进行一键交易。",
+    "retryInWalletOrContinueNoFunds": "资金不足，无法启动会话。请存入更多资金并在{walletName}中重试，或不进行一键交易继续操作。",
     "continueWithoutOneClickTrading": "无需一键交易即可继续",
     "retry": "重试",
     "openExtension": "打开 {walletName} 浏览器扩展程序以连接您的钱包。",

--- a/packages/web/localizations/zh-hk.json
+++ b/packages/web/localizations/zh-hk.json
@@ -863,6 +863,7 @@
     "approveOneClickTradingSession": "批准{walletName}中的一鍵交易。",
     "errorInitializingOneClickTradingSession": "無法啟用一鍵交易。",
     "retryInWalletOrContinue": "在{walletName}中重試，或繼續而不進行一鍵交易。",
+    "retryInWalletOrContinueNoFunds": "資金不足，無法啟動會議。請存入更多資金並在{walletName}中重試，或繼續而不進行一鍵交易。",
     "continueWithoutOneClickTrading": "無需一鍵交易即可繼續",
     "retry": "重試",
     "openExtension": "打開 {walletName} 瀏覽器擴展程序來連接您的錢包。",

--- a/packages/web/localizations/zh-tw.json
+++ b/packages/web/localizations/zh-tw.json
@@ -863,6 +863,7 @@
     "approveOneClickTradingSession": "批准{walletName}中的一鍵交易。",
     "errorInitializingOneClickTradingSession": "無法啟用一鍵交易。",
     "retryInWalletOrContinue": "在{walletName}中重試，或繼續而不進行一鍵交易。",
+    "retryInWalletOrContinueNoFunds": "資金不足，無法啟動會議。請存入更多資金並在{walletName}中重試，或繼續而不進行一鍵交易。",
     "continueWithoutOneClickTrading": "無需一鍵交易即可繼續",
     "retry": "重試",
     "openExtension": "打開 {walletName} 瀏覽器擴展程序來連接您的錢包。",

--- a/packages/web/modals/profile.tsx
+++ b/packages/web/modals/profile.tsx
@@ -49,7 +49,7 @@ import {
 import { useAmplitudeAnalytics, useDisclosure, useWindowSize } from "~/hooks";
 import { useBridge } from "~/hooks/bridge";
 import { useCreateOneClickTradingSession } from "~/hooks/mutations/one-click-trading";
-import { useIsCosmosNewAccount } from "~/hooks/use-is-new-account";
+import { useIsCosmosNewAccount } from "~/hooks/use-is-cosmos-new-account";
 import { ModalBase, ModalBaseProps } from "~/modals/base";
 import { useStore } from "~/stores";
 import { formatPretty } from "~/utils/formatter";

--- a/packages/web/modals/wallet-select/__tests__/wallet-select.spec.ts
+++ b/packages/web/modals/wallet-select/__tests__/wallet-select.spec.ts
@@ -7,7 +7,7 @@ describe("getModalView", () => {
     const result = getModalView({
       qrState: State.Init,
       isInitializingOneClickTrading: false,
-      hasOneClickTradingError: false,
+      oneClickTradingError: null,
       hasBroadcastedTx: false,
       walletStatus: WalletStatus.Connecting,
     });
@@ -19,18 +19,18 @@ describe("getModalView", () => {
       // @ts-expect-error
       qrState: "other", // Assuming other is a valid state
       isInitializingOneClickTrading: false,
-      hasOneClickTradingError: false,
+      oneClickTradingError: null,
       hasBroadcastedTx: false,
       walletStatus: WalletStatus.Connecting,
     });
     expect(result).toBe("qrCode");
   });
 
-  it('should return "initializeOneClickTradingError" when walletStatus is Connected and hasOneClickTradingError is true', () => {
+  it('should return "initializeOneClickTradingError" when walletStatus is Connected and oneClickTradingError is not null', () => {
     const result = getModalView({
       qrState: State.Init,
       isInitializingOneClickTrading: false,
-      hasOneClickTradingError: true,
+      oneClickTradingError: new Error("Some error"),
       hasBroadcastedTx: false,
       walletStatus: WalletStatus.Connected,
     });
@@ -41,7 +41,7 @@ describe("getModalView", () => {
     const result = getModalView({
       qrState: State.Init,
       isInitializingOneClickTrading: true,
-      hasOneClickTradingError: false,
+      oneClickTradingError: null,
       hasBroadcastedTx: false,
       walletStatus: WalletStatus.Connected,
     });
@@ -52,7 +52,7 @@ describe("getModalView", () => {
     const result = getModalView({
       qrState: State.Init,
       isInitializingOneClickTrading: true,
-      hasOneClickTradingError: false,
+      oneClickTradingError: null,
       hasBroadcastedTx: true,
       walletStatus: WalletStatus.Connected,
     });
@@ -63,7 +63,7 @@ describe("getModalView", () => {
     const result = getModalView({
       qrState: State.Init,
       isInitializingOneClickTrading: false,
-      hasOneClickTradingError: false,
+      oneClickTradingError: null,
       hasBroadcastedTx: false,
       walletStatus: WalletStatus.Connected,
     });
@@ -74,7 +74,7 @@ describe("getModalView", () => {
     const result = getModalView({
       qrState: State.Init,
       isInitializingOneClickTrading: false,
-      hasOneClickTradingError: false,
+      oneClickTradingError: null,
       hasBroadcastedTx: false,
       walletStatus: WalletStatus.Error,
     });
@@ -86,7 +86,7 @@ describe("getModalView", () => {
       // @ts-expect-error
       qrState: "other", // Assuming "other" is a valid state
       isInitializingOneClickTrading: false,
-      hasOneClickTradingError: false,
+      oneClickTradingError: null,
       hasBroadcastedTx: false,
       walletStatus: WalletStatus.Error,
     });
@@ -97,7 +97,7 @@ describe("getModalView", () => {
     const result = getModalView({
       qrState: State.Init,
       isInitializingOneClickTrading: false,
-      hasOneClickTradingError: false,
+      oneClickTradingError: null,
       hasBroadcastedTx: false,
       walletStatus: WalletStatus.Rejected,
     });
@@ -108,7 +108,7 @@ describe("getModalView", () => {
     const result = getModalView({
       qrState: State.Init,
       isInitializingOneClickTrading: false,
-      hasOneClickTradingError: false,
+      oneClickTradingError: null,
       hasBroadcastedTx: false,
       walletStatus: WalletStatus.NotExist,
     });
@@ -119,7 +119,7 @@ describe("getModalView", () => {
     const result = getModalView({
       qrState: State.Init,
       isInitializingOneClickTrading: false,
-      hasOneClickTradingError: false,
+      oneClickTradingError: null,
       hasBroadcastedTx: false,
       walletStatus: WalletStatus.Disconnected,
     });
@@ -130,10 +130,23 @@ describe("getModalView", () => {
     const result = getModalView({
       qrState: State.Init,
       isInitializingOneClickTrading: false,
-      hasOneClickTradingError: false,
+      oneClickTradingError: null,
       hasBroadcastedTx: false,
       walletStatus: undefined,
     });
     expect(result).toBe("list");
+  });
+
+  it('should return "initializeOneClickTradingErrorInsufficientFee" when walletStatus is Connected and oneClickTradingError is an insufficient fee error', () => {
+    const result = getModalView({
+      qrState: State.Init,
+      isInitializingOneClickTrading: false,
+      oneClickTradingError: new Error(
+        "account abcdefghijklmnopqrstuvwxyz1234567890abcdef not found"
+      ),
+      hasBroadcastedTx: false,
+      walletStatus: WalletStatus.Connected,
+    });
+    expect(result).toBe("initializeOneClickTradingErrorInsufficientFee");
   });
 });

--- a/packages/web/modals/wallet-select/cosmos-wallet-state.tsx
+++ b/packages/web/modals/wallet-select/cosmos-wallet-state.tsx
@@ -173,11 +173,19 @@ export const CosmosWalletState: FunctionComponent<
       );
     }
 
-    if (modalView === "initializeOneClickTradingError") {
+    if (
+      modalView === "initializeOneClickTradingError" ||
+      modalView === "initializeOneClickTradingErrorInsufficientFee"
+    ) {
       const title = t("walletSelect.errorInitializingOneClickTradingSession");
-      const desc = t("walletSelect.retryInWalletOrContinue", {
-        walletName: walletInfo?.prettyName ?? "",
-      });
+      const desc =
+        modalView === "initializeOneClickTradingErrorInsufficientFee"
+          ? t("walletSelect.retryInWalletOrContinueNoFunds", {
+              walletName: walletInfo?.prettyName ?? "",
+            })
+          : t("walletSelect.retryInWalletOrContinue", {
+              walletName: walletInfo?.prettyName ?? "",
+            });
 
       return (
         <ErrorWalletState

--- a/packages/web/modals/wallet-select/cosmos-wallet-state.tsx
+++ b/packages/web/modals/wallet-select/cosmos-wallet-state.tsx
@@ -15,6 +15,7 @@ import { ErrorWalletState } from "~/components/wallet-states";
 import { CosmosWalletRegistry } from "~/config";
 import { useFeatureFlags, useTranslation, WalletSelectOption } from "~/hooks";
 import { useHasInstalledCosmosWallets } from "~/hooks/use-has-installed-wallets";
+import { usePreviousConnectedCosmosAccount } from "~/hooks/use-previous-connected-cosmos-account";
 import { WalletSelectModalProps } from "~/modals/wallet-select";
 import { OnConnectWallet } from "~/modals/wallet-select/use-connect-wallet";
 import { ModalView } from "~/modals/wallet-select/utils";
@@ -28,6 +29,7 @@ enum WalletSelect1CTScreens {
   Settings = "Settings",
   WelcomeBack = "WelcomeBack",
   ConnectAWallet = "ConnectAWallet",
+  Tutorial = "Tutorial",
 }
 
 export const CosmosWalletState: FunctionComponent<
@@ -68,6 +70,8 @@ export const CosmosWalletState: FunctionComponent<
     const { accountStore, chainStore } = useStore();
     const featureFlags = useFeatureFlags();
     const hasInstalledWallets = useHasInstalledCosmosWallets();
+    const { previousConnectedCosmosAccount, hasFunds } =
+      usePreviousConnectedCosmosAccount();
 
     const show1CT =
       hasInstalledWallets &&
@@ -261,8 +265,10 @@ export const CosmosWalletState: FunctionComponent<
       oneClickTradingScreen = WalletSelect1CTScreens.Settings;
     } else if (!show1CTEditParams && accountStore.hasUsedOneClickTrading) {
       oneClickTradingScreen = WalletSelect1CTScreens.WelcomeBack;
-    } else {
+    } else if (previousConnectedCosmosAccount && hasFunds) {
       oneClickTradingScreen = WalletSelect1CTScreens.Introduction;
+    } else {
+      oneClickTradingScreen = WalletSelect1CTScreens.Tutorial;
     }
 
     return (
@@ -321,6 +327,9 @@ export const CosmosWalletState: FunctionComponent<
                   isDisabled={!transaction1CTParams}
                 />
               </div>
+            </Screen>
+            <Screen screenName={WalletSelect1CTScreens.Tutorial}>
+              <WalletTutorial />
             </Screen>
           </ScreenManager>
         ) : (

--- a/packages/web/modals/wallet-select/cosmos-wallet-state.tsx
+++ b/packages/web/modals/wallet-select/cosmos-wallet-state.tsx
@@ -258,14 +258,20 @@ export const CosmosWalletState: FunctionComponent<
       return <QRCodeView wallet={currentWallet!} />;
     }
 
+    const isReturningUser = previousConnectedCosmosAccount && hasFunds;
+
     let oneClickTradingScreen: WalletSelect1CTScreens;
     if (show1CTConnectAWallet) {
       oneClickTradingScreen = WalletSelect1CTScreens.ConnectAWallet;
     } else if (show1CTEditParams) {
       oneClickTradingScreen = WalletSelect1CTScreens.Settings;
-    } else if (!show1CTEditParams && accountStore.hasUsedOneClickTrading) {
+    } else if (
+      !show1CTEditParams &&
+      isReturningUser &&
+      accountStore.hasUsedOneClickTrading
+    ) {
       oneClickTradingScreen = WalletSelect1CTScreens.WelcomeBack;
-    } else if (previousConnectedCosmosAccount && hasFunds) {
+    } else if (isReturningUser) {
       oneClickTradingScreen = WalletSelect1CTScreens.Introduction;
     } else {
       oneClickTradingScreen = WalletSelect1CTScreens.Tutorial;

--- a/packages/web/modals/wallet-select/index.tsx
+++ b/packages/web/modals/wallet-select/index.tsx
@@ -22,6 +22,7 @@ import { FullWalletList } from "~/modals/wallet-select/full-wallet-list";
 import { SimpleWalletList } from "~/modals/wallet-select/simple-wallet-list";
 import { useConnectWallet } from "~/modals/wallet-select/use-connect-wallet";
 import { getModalView, ModalView } from "~/modals/wallet-select/utils";
+import { useStore } from "~/stores";
 
 export interface WalletSelectModalProps extends ModalBaseProps {
   /**
@@ -41,6 +42,7 @@ export const WalletSelectModal: FunctionComponent<WalletSelectModalProps> =
       onConnect: onConnectProp,
       layout = "full",
     } = props;
+    const { accountStore } = useStore();
     const { isMobile } = useWindowSize();
     const featureFlags = useFeatureFlags();
     const hasInstalledWallets = useHasInstalledCosmosWallets();
@@ -78,7 +80,9 @@ export const WalletSelectModal: FunctionComponent<WalletSelectModalProps> =
       isLoading: isLoading1CTParams,
       spendLimitTokenDecimals,
       reset: reset1CTParams,
-    } = useOneClickTradingParams();
+    } = useOneClickTradingParams({
+      defaultIsOneClickEnabled: accountStore.hasUsedOneClickTrading,
+    });
 
     const {
       onConnect: onConnectWallet,

--- a/packages/web/modals/wallet-select/index.tsx
+++ b/packages/web/modals/wallet-select/index.tsx
@@ -72,8 +72,6 @@ export const WalletSelectModal: FunctionComponent<WalletSelectModalProps> =
 
     const [show1CTConnectAWallet, setShow1CTConnectAWallet] = useState(false);
 
-    const hasOneClickTradingError = !!create1CTSession.error;
-
     const {
       transaction1CTParams,
       setTransaction1CTParams,
@@ -109,7 +107,7 @@ export const WalletSelectModal: FunctionComponent<WalletSelectModalProps> =
             qrState,
             walletStatus: cosmosWalletStatus,
             isInitializingOneClickTrading,
-            hasOneClickTradingError,
+            oneClickTradingError: create1CTSession.error as Error | null,
             hasBroadcastedTx,
           })
         );
@@ -120,8 +118,8 @@ export const WalletSelectModal: FunctionComponent<WalletSelectModalProps> =
       isOpen,
       qrMessage,
       isInitializingOneClickTrading,
-      hasOneClickTradingError,
       hasBroadcastedTx,
+      create1CTSession.error,
     ]);
 
     useUpdateEffect(() => {

--- a/packages/web/modals/wallet-select/use-connect-wallet.ts
+++ b/packages/web/modals/wallet-select/use-connect-wallet.ts
@@ -12,7 +12,6 @@ import { EthereumChainIds } from "~/config/wagmi";
 import { CosmosWalletRegistry } from "~/config/wallet-registry";
 import { useConnectEvmWallet } from "~/hooks/evm-wallet";
 import { CreateOneClickSessionError } from "~/hooks/mutations/one-click-trading";
-import { usePreviousConnectedCosmosAccount } from "~/hooks/use-previous-connected-cosmos-account";
 import { WalletSelectOption } from "~/hooks/use-wallet-select";
 import { WagmiWalletConnectType } from "~/modals/wallet-select/use-selectable-wallets";
 import { useStore } from "~/stores";
@@ -50,8 +49,6 @@ export const useConnectWallet = ({
 
   const { connectAsync: connectEvmWallet, ...connectEvmWalletUtils } =
     useConnectEvmWallet();
-  const { setPreviousConnectedCosmosAccount: setPreviousConnectedAccount } =
-    usePreviousConnectedCosmosAccount();
 
   const [lazyWalletInfo, setLazyWalletInfo] =
     useState<(typeof CosmosWalletRegistry)[number]>();
@@ -182,7 +179,7 @@ export const useConnectWallet = ({
     await connectEvmWallet(
       { connector: wallet, chainId: chainId },
       {
-        onSuccess: ({ accounts }) => {
+        onSuccess: () => {
           onConnectProp?.({ walletType: "evm" });
         },
         onError: (e) => {

--- a/packages/web/modals/wallet-select/use-connect-wallet.ts
+++ b/packages/web/modals/wallet-select/use-connect-wallet.ts
@@ -12,6 +12,7 @@ import { EthereumChainIds } from "~/config/wagmi";
 import { CosmosWalletRegistry } from "~/config/wallet-registry";
 import { useConnectEvmWallet } from "~/hooks/evm-wallet";
 import { CreateOneClickSessionError } from "~/hooks/mutations/one-click-trading";
+import { usePreviousConnectedCosmosAccount } from "~/hooks/use-previous-connected-cosmos-account";
 import { WalletSelectOption } from "~/hooks/use-wallet-select";
 import { WagmiWalletConnectType } from "~/modals/wallet-select/use-selectable-wallets";
 import { useStore } from "~/stores";
@@ -49,6 +50,8 @@ export const useConnectWallet = ({
 
   const { connectAsync: connectEvmWallet, ...connectEvmWalletUtils } =
     useConnectEvmWallet();
+  const { setPreviousConnectedCosmosAccount: setPreviousConnectedAccount } =
+    usePreviousConnectedCosmosAccount();
 
   const [lazyWalletInfo, setLazyWalletInfo] =
     useState<(typeof CosmosWalletRegistry)[number]>();
@@ -86,7 +89,9 @@ export const useConnectWallet = ({
       wallet
         .connect(false)
         .then(() => {
-          onConnectProp?.({ walletType: "cosmos" });
+          onConnectProp?.({
+            walletType: "cosmos",
+          });
         })
         .catch(handleConnectError);
       return;
@@ -136,7 +141,9 @@ export const useConnectWallet = ({
     return walletRepo
       .connect(wallet.name, false)
       .then(async () => {
-        onConnectProp?.({ walletType: "cosmos" });
+        onConnectProp?.({
+          walletType: "cosmos",
+        });
 
         if (isOneClickEnabled && onCreate1CTSession) {
           try {
@@ -175,7 +182,7 @@ export const useConnectWallet = ({
     await connectEvmWallet(
       { connector: wallet, chainId: chainId },
       {
-        onSuccess: () => {
+        onSuccess: ({ accounts }) => {
           onConnectProp?.({ walletType: "evm" });
         },
         onError: (e) => {

--- a/packages/web/modals/wallet-select/wallet-tutorial.tsx
+++ b/packages/web/modals/wallet-select/wallet-tutorial.tsx
@@ -32,17 +32,17 @@ const OnboardingSteps = (t: MultiLanguageT) => [
 export const WalletTutorial = () => {
   const { t } = useTranslation();
   return (
-    <div className="flex flex-col px-8 pt-1.5">
+    <div className="flex h-full flex-col px-8 pt-1.5">
       <h1 className="mb-10 w-full text-center text-h6 font-h6 tracking-wider">
         {t("walletSelect.gettingStarted")}
       </h1>
       <Stepper
-        className="relative flex flex-col gap-2"
+        className="relative flex h-full flex-col justify-between gap-2"
         autoplay={{ stopOnHover: true, delayInMs: 4000 }}
       >
         <StepperLeftChevronNavigation className="absolute left-0 top-1/2 z-50 -translate-y-1/2 transform" />
         {OnboardingSteps(t).map(({ title, content }) => (
-          <Step key={title}>
+          <Step key={title} className="my-auto">
             <div className="flex flex-col items-center justify-center gap-10 text-center">
               <div className="h-[186px] w-[186px]">
                 <Image

--- a/packages/web/pages/_app.tsx
+++ b/packages/web/pages/_app.tsx
@@ -28,7 +28,7 @@ import { ErrorFallback } from "~/components/error/error-fallback";
 import { Pill } from "~/components/indicators/pill";
 import { MainLayout } from "~/components/layouts";
 import { MainLayoutMenu } from "~/components/main-menu";
-import { OneClickToast } from "~/components/one-click-trading/one-click-toast";
+import { OneClickToast } from "~/components/one-click-trading/one-click-trading-toast";
 import { AmplitudeEvent, EventName } from "~/config";
 import { wagmiConfig } from "~/config/wagmi";
 import {


### PR DESCRIPTION
### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-748/1-ct-toggle-on-wallet-connection-modal-should-default-to-being-toggled)

## Testing and Verifying

- [ ] Should only see 1CT onboarding in wallet select when the previous connected wallet has funds
- [ ] Should see 'Welcome back' if the user has started at least one 1CT session 