### PR TITLE
Added monocart coverage

### DIFF
--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -109,7 +109,7 @@ jobs:
           name: preview-portfolio-test-results
           path: packages/web/playwright-report
 
-  preview-pools-tests:
+  preview-pools-and-select-pair-tests:
     needs: wait-for-deployment
     runs-on: ubuntu-latest
     steps:
@@ -135,7 +135,7 @@ jobs:
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
         run: |
           cd packages/web
-          npx playwright test -g "Test Select Pool feature"
+          npx playwright test pools select
       - name: upload pools test results
         if: always()
         id: pools-test-results

--- a/packages/web/e2e/tests/pools.spec.ts
+++ b/packages/web/e2e/tests/pools.spec.ts
@@ -1,21 +1,33 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import { BrowserContext, chromium, expect, test } from "@playwright/test";
+import { BrowserContext, chromium, expect, Page, test } from "@playwright/test";
+import { addCoverageReport, attachCoverageReport } from "monocart-reporter";
 
 import { PoolsPage } from "../pages/pools-page";
 
 test.describe("Test Select Pool feature", () => {
   let context: BrowserContext;
   let poolsPage: PoolsPage;
+  let page: Page;
 
   test.beforeAll(async () => {
     context = await chromium.launchPersistentContext("", {
       headless: true,
       viewport: { width: 1280, height: 1024 },
     });
-    poolsPage = new PoolsPage(context.pages()[0]);
+    page = context.pages()[0];
+    await page.coverage.startJSCoverage({
+      resetOnNavigation: false,
+    });
+    poolsPage = new PoolsPage(page);
   });
 
   test.afterAll(async () => {
+    const coverage = await page.coverage.stopJSCoverage();
+    // coverage report
+    const report = await attachCoverageReport(coverage, test.info());
+    console.log(report.summary);
+
+    await addCoverageReport(coverage, test.info());
     await context.close();
   });
 

--- a/packages/web/e2e/tests/portfolio.wallet.spec.ts
+++ b/packages/web/e2e/tests/portfolio.wallet.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import { BrowserContext, chromium, expect, test } from "@playwright/test";
+import { BrowserContext, chromium, expect, Page, test } from "@playwright/test";
+import { addCoverageReport, attachCoverageReport } from "monocart-reporter";
 import process from "process";
 
 import { UnzipExtension } from "~/e2e/unzip-extension";
@@ -14,6 +15,7 @@ test.describe("Test Portfolio feature", () => {
   let portfolioPage: PortfolioPage;
   let dollarBalanceRegEx = /\$\d+/;
   let digitBalanceRegEx = /\d+\.\d+/;
+  let page: Page;
 
   test.beforeAll(async () => {
     const pathToExtension = new UnzipExtension().getPathToExtension();
@@ -32,7 +34,7 @@ test.describe("Test Portfolio feature", () => {
     // Get all new pages (including Extension) in the context and wait
     const emptyPage = context.pages()[0];
     await emptyPage.waitForTimeout(2000);
-    const page = context.pages()[1];
+    page = context.pages()[1];
     const walletPage = new WalletPage(page);
     // Import existing Wallet (could be aggregated in one function).
     await walletPage.importWalletWithPrivateKey(privateKey);
@@ -40,7 +42,11 @@ test.describe("Test Portfolio feature", () => {
     await walletPage.selectChainsAndSave();
     await walletPage.finish();
     // Switch to Application
-    portfolioPage = new PortfolioPage(context.pages()[0]);
+    page = context.pages()[0];
+    await page.coverage.startJSCoverage({
+      resetOnNavigation: false,
+    });
+    portfolioPage = new PortfolioPage(page);
     await portfolioPage.goto();
     await portfolioPage.connectWallet();
     await portfolioPage.hideZeroBalances();
@@ -48,6 +54,12 @@ test.describe("Test Portfolio feature", () => {
   });
 
   test.afterAll(async () => {
+    const coverage = await page.coverage.stopJSCoverage();
+    // coverage report
+    const report = await attachCoverageReport(coverage, test.info());
+    console.log(report.summary);
+
+    await addCoverageReport(coverage, test.info());
     await context.close();
   });
 

--- a/packages/web/e2e/tests/select.spec.ts
+++ b/packages/web/e2e/tests/select.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import { BrowserContext, chromium, test } from "@playwright/test";
+import { BrowserContext, chromium, Page, test } from "@playwright/test";
+import { addCoverageReport, attachCoverageReport } from "monocart-reporter";
 
 import { SwapPage } from "../pages/swap-page";
 
@@ -7,17 +8,28 @@ import { SwapPage } from "../pages/swap-page";
 test.describe("Test Select Swap Pair feature", () => {
   let context: BrowserContext;
   let swapPage: SwapPage;
+  let page: Page;
 
   test.beforeAll(async () => {
     context = await chromium.launchPersistentContext("", {
       headless: true,
       viewport: { width: 1280, height: 1024 },
     });
-    swapPage = new SwapPage(context.pages()[0]);
+    page = context.pages()[0];
+    await page.coverage.startJSCoverage({
+      resetOnNavigation: false,
+    });
+    swapPage = new SwapPage(page);
     await swapPage.goto();
   });
 
   test.afterAll(async () => {
+    const coverage = await page.coverage.stopJSCoverage();
+    // coverage report
+    const report = await attachCoverageReport(coverage, test.info());
+    console.log(report.summary);
+
+    await addCoverageReport(coverage, test.info());
     await context.close();
   });
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -180,6 +180,7 @@
     "jest-in-case": "^1.0.2",
     "jest-launchdarkly-mock": "^2.1.0",
     "knip": "^5.17.4",
+    "monocart-reporter": "^2.6.0",
     "msw-trpc": "1.3.3",
     "next-router-mock": "0.9.13",
     "postcss": "^8.4.5",

--- a/packages/web/playwright.config.ts
+++ b/packages/web/playwright.config.ts
@@ -14,7 +14,14 @@ export default defineConfig({
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [
     ["html", { open: "never" }],
-    ["junit", { outputFile: "test-results/test-results.xml" }],
+    ["junit", { outputFile: "./playwright-report/test-results.xml" }],
+    [
+      "monocart-reporter",
+      {
+        name: "Test Coverage Report",
+        outputFile: "./playwright-report/cov-report.html",
+      },
+    ],
   ],
   timeout: 90000,
   testDir: "./e2e/tests",


### PR DESCRIPTION
## What is the purpose of the change:

Added monocart coverage for E2E tests. Coverage report will look like this.

![Screenshot 2024-07-12 at 17 15 37](https://github.com/user-attachments/assets/b6010911-2f7c-4924-b756-b005c1fb5fac)

### Linear Task

[UI test automation code coverage](https://linear.app/osmosis/issue/FE-185)
