### PR TITLE
(1CT) Change network fee limit to use gas limit

### DIFF
--- a/packages/stores/src/account/base.ts
+++ b/packages/stores/src/account/base.ts
@@ -60,6 +60,7 @@ import {
   apiClient,
   ApiClientError,
   isNil,
+  OneClickTradingMaxGasLimit,
   unixNanoSecondsToSeconds,
 } from "@osmosis-labs/utils";
 import axios from "axios";
@@ -773,11 +774,13 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
     const oneClickTradingInfo = await this.getOneClickTradingInfo();
 
     const isWithinNetworkFeeLimit =
-      oneClickTradingInfo &&
-      fee?.amount.length === 1 &&
-      fee?.amount[0].denom === "uosmo" &&
-      new Dec(fee.amount[0].amount).lte(
-        new Dec(oneClickTradingInfo.networkFeeLimit.amount)
+      !!oneClickTradingInfo &&
+      new Dec(fee.gas).lte(
+        new Dec(
+          typeof oneClickTradingInfo.networkFeeLimit !== "string"
+            ? OneClickTradingMaxGasLimit
+            : oneClickTradingInfo.networkFeeLimit
+        )
       );
 
     if (
@@ -1276,7 +1279,6 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
           nonCriticalExtensionOptions:
             nonCriticalExtensionOptions?.map(encodeAnyBase64),
           bech32Address: wallet.address,
-          onlyDefaultFeeDenom: signOptions.useOneClickTrading,
           gasMultiplier: GasMultiplier,
         },
       });

--- a/packages/stores/src/account/types.ts
+++ b/packages/stores/src/account/types.ts
@@ -5,7 +5,6 @@ import {
   Wallet,
 } from "@cosmos-kit/core";
 import {
-  Currency,
   OneClickTradingHumanizedSessionPeriod,
   OneClickTradingTimeLimit,
 } from "@osmosis-labs/types";
@@ -105,9 +104,10 @@ export interface OneClickTradingInfo {
   readonly sessionKey: string;
   readonly userOsmoAddress: string;
 
-  networkFeeLimit: Currency & {
-    amount: string;
-  };
+  /**
+   * Max gas limit allowed for the transaction.
+   */
+  networkFeeLimit: string;
 
   spendLimit: {
     decimals: number;

--- a/packages/trpc/src/one-click-trading.ts
+++ b/packages/trpc/src/one-click-trading.ts
@@ -1,4 +1,4 @@
-import { CoinPretty, Dec, DecUtils, PricePretty } from "@keplr-wallet/unit";
+import { Dec, DecUtils, PricePretty } from "@keplr-wallet/unit";
 import {
   DEFAULT_VS_CURRENCY,
   getAsset,
@@ -7,6 +7,7 @@ import {
   queryAuthenticatorSpendLimit,
 } from "@osmosis-labs/server";
 import { OneClickTradingTransactionParams } from "@osmosis-labs/types";
+import { OneClickTradingMaxGasLimit } from "@osmosis-labs/utils";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 
@@ -25,22 +26,12 @@ export const oneClickTradingRouter = createTRPCRouter({
         spendLimitTokenDecimals: number;
       }
     > => {
-      const osmosisChain = ctx.chainList[0];
-      const [osmoAsset, usdcAsset] = await Promise.all([
-        await getAsset({
-          ...ctx,
-          anyDenom: osmosisChain.fees.fee_tokens[0].denom,
-        }),
-        getAsset({ ...ctx, anyDenom: "usdc" }),
-      ]);
+      const usdcAsset = await getAsset({ ...ctx, anyDenom: "usdc" });
 
       return {
         spendLimit: new PricePretty(DEFAULT_VS_CURRENCY, new Dec(5_000)),
         spendLimitTokenDecimals: usdcAsset.coinDecimals,
-        networkFeeLimit: new CoinPretty(
-          osmoAsset,
-          DecUtils.getTenExponentN(osmoAsset.coinDecimals)
-        ),
+        networkFeeLimit: OneClickTradingMaxGasLimit,
         sessionPeriod: {
           end: "1hour" as const,
         },

--- a/packages/types/src/one-click-trading-types.ts
+++ b/packages/types/src/one-click-trading-types.ts
@@ -1,4 +1,4 @@
-import type { CoinPretty, PricePretty } from "@keplr-wallet/unit";
+import type { PricePretty } from "@keplr-wallet/unit";
 
 export type AvailableOneClickTradingMessages =
   | "/osmosis.poolmanager.v1beta1.MsgSwapExactAmountIn"
@@ -24,7 +24,11 @@ export type OneClickTradingHumanizedSessionPeriod =
 export interface OneClickTradingTransactionParams {
   isOneClickEnabled: boolean;
   spendLimit: PricePretty;
-  networkFeeLimit: CoinPretty;
+
+  /**
+   * Max gas limit allowed for the transaction.
+   */
+  networkFeeLimit: string;
 
   // Time limit for the session to be considered valid.
   sessionPeriod: {

--- a/packages/utils/src/gas-utils.ts
+++ b/packages/utils/src/gas-utils.ts
@@ -7,3 +7,5 @@ export const DefaultGasPriceStep: {
   average: 0.025,
   high: 0.04,
 };
+
+export const OneClickTradingMaxGasLimit = "400000000";

--- a/packages/web/components/navbar/index.tsx
+++ b/packages/web/components/navbar/index.tsx
@@ -421,8 +421,8 @@ const WalletInfo: FunctionComponent<
         <SkeletonLoader isLoaded={!isLoadingUserOsmoAsset}>
           <Tooltip
             visible={isOneClickProfileTooltipOpen && !isOneClickIntroModalOpen}
-            trigger="manual"
             interactive
+            skipTrigger
             content={
               <div className="relative flex max-w-[240px] items-center gap-2">
                 <IconButton

--- a/packages/web/components/one-click-trading/__tests__/one-click-trading-settings.spec.ts
+++ b/packages/web/components/one-click-trading/__tests__/one-click-trading-settings.spec.ts
@@ -1,18 +1,8 @@
-import { CoinPretty, Dec, PricePretty } from "@keplr-wallet/unit";
+import { Dec, PricePretty } from "@keplr-wallet/unit";
 import { DEFAULT_VS_CURRENCY } from "@osmosis-labs/server";
 import { OneClickTradingTransactionParams } from "@osmosis-labs/types";
 
 import { compare1CTTransactionParams } from "../one-click-trading-settings";
-
-const mockCoinPretty = (amount: number) =>
-  new CoinPretty(
-    {
-      coinDenom: "OSMO",
-      coinDecimals: 6,
-      coinMinimalDenom: "uosmo",
-    },
-    new Dec(amount)
-  );
 
 const mockPricePretty = (amount: number) =>
   new PricePretty(DEFAULT_VS_CURRENCY, new Dec(amount));
@@ -22,7 +12,7 @@ describe("compare1CTTransactionParams", () => {
     const prevParams: OneClickTradingTransactionParams = {
       isOneClickEnabled: true,
       spendLimit: mockPricePretty(5000),
-      networkFeeLimit: mockCoinPretty(13485),
+      networkFeeLimit: "13485",
       sessionPeriod: { end: "1hour" },
     };
 
@@ -36,7 +26,7 @@ describe("compare1CTTransactionParams", () => {
     const prevParams: OneClickTradingTransactionParams = {
       isOneClickEnabled: true,
       spendLimit: mockPricePretty(5000),
-      networkFeeLimit: mockCoinPretty(13485),
+      networkFeeLimit: "13485",
       sessionPeriod: { end: "1hour" },
     };
 
@@ -53,7 +43,7 @@ describe("compare1CTTransactionParams", () => {
     const prevParams: OneClickTradingTransactionParams = {
       isOneClickEnabled: true,
       spendLimit: mockPricePretty(5000),
-      networkFeeLimit: mockCoinPretty(13485),
+      networkFeeLimit: "13485",
       sessionPeriod: { end: "1hour" },
     };
 

--- a/packages/web/components/tooltip/tooltip.tsx
+++ b/packages/web/components/tooltip/tooltip.tsx
@@ -12,6 +12,7 @@ export const Tooltip = ({
   className,
   rootClassNames,
   enablePropagation,
+  skipTrigger,
   ...props
 }: PropsWithChildren<
   TooltipProps &
@@ -19,6 +20,7 @@ export const Tooltip = ({
     Omit<TippyProps, "content"> & {
       rootClassNames?: string;
       enablePropagation?: boolean;
+      skipTrigger?: boolean;
     }
 >) => {
   return (
@@ -29,7 +31,7 @@ export const Tooltip = ({
           rootClassNames
         )}
         content={content}
-        trigger={trigger ?? "mouseenter focus"}
+        trigger={skipTrigger ? undefined : trigger ?? "mouseenter focus"}
         {...props}
       >
         <div

--- a/packages/web/hooks/mutations/one-click-trading/use-create-one-click-trading-session.tsx
+++ b/packages/web/hooks/mutations/one-click-trading/use-create-one-click-trading-session.tsx
@@ -361,10 +361,7 @@ export const useCreateOneClickTradingSession = ({
         allowedMessages,
         sessionPeriod,
         sessionStartedAtUnix: dayjs().unix(),
-        networkFeeLimit: {
-          ...transaction1CTParams.networkFeeLimit.currency,
-          amount: transaction1CTParams.networkFeeLimit.toCoin().amount,
-        },
+        networkFeeLimit: transaction1CTParams.networkFeeLimit,
         spendLimit: {
           amount: allowedAmount,
           decimals: spendLimitTokenDecimals,

--- a/packages/web/hooks/one-click-trading/use-one-click-trading-params.ts
+++ b/packages/web/hooks/one-click-trading/use-one-click-trading-params.ts
@@ -1,7 +1,8 @@
-import { CoinPretty, Dec, DecUtils, PricePretty } from "@keplr-wallet/unit";
+import { Dec, DecUtils, PricePretty } from "@keplr-wallet/unit";
 import { DEFAULT_VS_CURRENCY } from "@osmosis-labs/server";
 import { OneClickTradingInfo } from "@osmosis-labs/stores";
 import { OneClickTradingTransactionParams } from "@osmosis-labs/types";
+import { OneClickTradingMaxGasLimit } from "@osmosis-labs/utils";
 import { useCallback, useEffect, useState } from "react";
 
 import { api } from "~/utils/trpc";
@@ -15,10 +16,10 @@ export function getParametersFromOneClickTradingInfo({
 }): OneClickTradingTransactionParams {
   return {
     isOneClickEnabled: defaultIsOneClickEnabled,
-    networkFeeLimit: new CoinPretty(
-      oneClickTradingInfo.networkFeeLimit,
-      new Dec(oneClickTradingInfo.networkFeeLimit.amount)
-    ),
+    networkFeeLimit:
+      typeof oneClickTradingInfo.networkFeeLimit !== "string"
+        ? OneClickTradingMaxGasLimit
+        : oneClickTradingInfo.networkFeeLimit,
     sessionPeriod: {
       end: oneClickTradingInfo.humanizedSessionPeriod,
     },

--- a/packages/web/localizations/de.json
+++ b/packages/web/localizations/de.json
@@ -499,7 +499,6 @@
       "currentlyUnavailable": "1-Click Trading derzeit nicht verfügbar",
       "networkFeeTooHigh": "Netzwerkgebühr zu hoch",
       "startANewSession": "Neue Sitzung starten",
-      "increaseFeeLimit": "Erhöhen Sie das Netzwerkgebührenlimit",
       "approveManually": "Manuell genehmigen in {walletName}",
       "continueWithWallet": "Fahren Sie mit der Brieftasche fort",
       "sessionEnded": "Die Sitzung wurde auf diesem Gerät beendet",

--- a/packages/web/localizations/en.json
+++ b/packages/web/localizations/en.json
@@ -499,7 +499,6 @@
       "currentlyUnavailable": "1-Click Trading currently unavailable",
       "networkFeeTooHigh": "Network fee too high",
       "startANewSession": "Start a new session",
-      "increaseFeeLimit": "Increase network fee limit",
       "approveManually": "Approve manually in {walletName}",
       "continueWithWallet": "Continue with wallet",
       "sessionEnded": "Session ended on this device",

--- a/packages/web/localizations/es.json
+++ b/packages/web/localizations/es.json
@@ -499,7 +499,6 @@
       "currentlyUnavailable": "Trading con 1 clic no disponible actualmente",
       "networkFeeTooHigh": "Tarifa de red demasiado alta",
       "startANewSession": "Iniciar una nueva sesión",
-      "increaseFeeLimit": "Aumentar el límite de la tarifa de red",
       "approveManually": "Aprobar manualmente en {walletName}",
       "continueWithWallet": "Continuar con la billetera",
       "sessionEnded": "La sesión finalizó en este dispositivo",

--- a/packages/web/localizations/fa.json
+++ b/packages/web/localizations/fa.json
@@ -499,7 +499,6 @@
       "currentlyUnavailable": "1-کلیک کنید تجارت در حال حاضر در دسترس نیست",
       "networkFeeTooHigh": "هزینه شبکه خیلی بالاست",
       "startANewSession": "یک جلسه جدید را شروع کنید",
-      "increaseFeeLimit": "افزایش سقف هزینه شبکه",
       "approveManually": "تأیید دستی در {walletName}",
       "continueWithWallet": "با کیف پول ادامه دهید",
       "sessionEnded": "جلسه در این دستگاه به پایان رسید",

--- a/packages/web/localizations/fr.json
+++ b/packages/web/localizations/fr.json
@@ -499,7 +499,6 @@
       "currentlyUnavailable": "Trading en 1 clic actuellement indisponible",
       "networkFeeTooHigh": "Frais de réseau trop élevés",
       "startANewSession": "Démarrer une nouvelle session",
-      "increaseFeeLimit": "Augmenter la limite des frais de réseau",
       "approveManually": "Approuver manuellement dans {walletName}",
       "continueWithWallet": "Continuer avec le portefeuille",
       "sessionEnded": "Session terminée sur cet appareil",

--- a/packages/web/localizations/gu.json
+++ b/packages/web/localizations/gu.json
@@ -499,7 +499,6 @@
       "currentlyUnavailable": "1-ક્લિક ટ્રેડિંગ હાલમાં અનુપલબ્ધ છે",
       "networkFeeTooHigh": "નેટવર્ક ફી ખૂબ વધારે છે",
       "startANewSession": "નવું સત્ર શરૂ કરો",
-      "increaseFeeLimit": "નેટવર્ક ફી મર્યાદા વધારો",
       "approveManually": "{walletName} માં મેન્યુઅલી મંજૂર કરો",
       "continueWithWallet": "વૉલેટ સાથે ચાલુ રાખો",
       "sessionEnded": "આ ઉપકરણ પર સત્ર સમાપ્ત થયું",

--- a/packages/web/localizations/hi.json
+++ b/packages/web/localizations/hi.json
@@ -499,7 +499,6 @@
       "currentlyUnavailable": "1-क्लिक ट्रेडिंग फिलहाल उपलब्ध नहीं है",
       "networkFeeTooHigh": "नेटवर्क शुल्क बहुत अधिक है",
       "startANewSession": "नया सत्र शुरू करें",
-      "increaseFeeLimit": "नेटवर्क शुल्क सीमा बढ़ाएँ",
       "approveManually": "{walletName} में मैन्युअल रूप से स्वीकृत करें",
       "continueWithWallet": "बटुए के साथ जारी रखें",
       "sessionEnded": "इस डिवाइस पर सत्र समाप्त हो गया",

--- a/packages/web/localizations/ja.json
+++ b/packages/web/localizations/ja.json
@@ -499,7 +499,6 @@
       "currentlyUnavailable": "1クリック取引は現在利用できません",
       "networkFeeTooHigh": "ネットワーク料金が高すぎる",
       "startANewSession": "新しいセッションを開始する",
-      "increaseFeeLimit": "ネットワーク料金の上限を引き上げる",
       "approveManually": "{walletName}で手動で承認する",
       "continueWithWallet": "ウォレットを続ける",
       "sessionEnded": "このデバイスでセッションが終了しました",

--- a/packages/web/localizations/ko.json
+++ b/packages/web/localizations/ko.json
@@ -499,7 +499,6 @@
       "currentlyUnavailable": "현재 1-클릭 거래를 이용할 수 없습니다",
       "networkFeeTooHigh": "네트워크 수수료가 너무 높음",
       "startANewSession": "새 세션 시작",
-      "increaseFeeLimit": "네트워크 수수료 한도 인상",
       "approveManually": "{walletName} 에서 수동으로 승인하세요.",
       "continueWithWallet": "지갑으로 계속하기",
       "sessionEnded": "이 기기에서 세션이 종료되었습니다.",

--- a/packages/web/localizations/pl.json
+++ b/packages/web/localizations/pl.json
@@ -499,7 +499,6 @@
       "currentlyUnavailable": "Handel jednym kliknięciem jest obecnie niedostępny",
       "networkFeeTooHigh": "Opłata sieciowa jest zbyt wysoka",
       "startANewSession": "Rozpocznij nową sesję",
-      "increaseFeeLimit": "Zwiększ limit opłat sieciowych",
       "approveManually": "Zatwierdź ręcznie w {walletName}",
       "continueWithWallet": "Kontynuuj z portfelem",
       "sessionEnded": "Sesja zakończyła się na tym urządzeniu",

--- a/packages/web/localizations/pt-br.json
+++ b/packages/web/localizations/pt-br.json
@@ -499,7 +499,6 @@
       "currentlyUnavailable": "Negociação em 1 Clique atualmente indisponível",
       "networkFeeTooHigh": "Taxa de rede muito alta",
       "startANewSession": "Iniciar uma nova sessão",
-      "increaseFeeLimit": "Aumentar o limite de taxa de rede",
       "approveManually": "Aprovar manualmente em {walletName}",
       "continueWithWallet": "Continuar com carteira",
       "sessionEnded": "A sessão terminou neste dispositivo",

--- a/packages/web/localizations/ro.json
+++ b/packages/web/localizations/ro.json
@@ -499,7 +499,6 @@
       "currentlyUnavailable": "1-Click Trading nu este disponibil momentan",
       "networkFeeTooHigh": "Taxa de rețea prea mare",
       "startANewSession": "Începeți o nouă sesiune",
-      "increaseFeeLimit": "Creșteți limita taxei de rețea",
       "approveManually": "Aprobați manual în {walletName}",
       "continueWithWallet": "Continuați cu portofelul",
       "sessionEnded": "Sesiunea s-a încheiat pe acest dispozitiv",

--- a/packages/web/localizations/ru.json
+++ b/packages/web/localizations/ru.json
@@ -499,7 +499,6 @@
       "currentlyUnavailable": "Торговля в 1 клик в настоящее время недоступна",
       "networkFeeTooHigh": "Плата за сеть слишком высока",
       "startANewSession": "Начать новый сеанс",
-      "increaseFeeLimit": "Увеличить лимит комиссии сети",
       "approveManually": "Утвердить вручную в {walletName}",
       "continueWithWallet": "Продолжить с кошельком",
       "sessionEnded": "Сеанс завершен на этом устройстве",

--- a/packages/web/localizations/tr.json
+++ b/packages/web/localizations/tr.json
@@ -499,7 +499,6 @@
       "currentlyUnavailable": "Tek Tıkla Ticaret şu anda kullanılamıyor",
       "networkFeeTooHigh": "Ağ ücreti çok yüksek",
       "startANewSession": "Yeni bir oturum başlat",
-      "increaseFeeLimit": "Ağ ücreti sınırını artırın",
       "approveManually": "{walletName} içinde manuel olarak onaylayın",
       "continueWithWallet": "Cüzdanla devam et",
       "sessionEnded": "Bu cihazda oturum sona erdi",

--- a/packages/web/localizations/zh-cn.json
+++ b/packages/web/localizations/zh-cn.json
@@ -499,7 +499,6 @@
       "currentlyUnavailable": "一键交易目前不可用",
       "networkFeeTooHigh": "网络费太高",
       "startANewSession": "开始新会话",
-      "increaseFeeLimit": "提高网络费用限额",
       "approveManually": "在{walletName}中手动批准",
       "continueWithWallet": "继续使用钱包",
       "sessionEnded": "会话在此设备上结束",

--- a/packages/web/localizations/zh-hk.json
+++ b/packages/web/localizations/zh-hk.json
@@ -499,7 +499,6 @@
       "currentlyUnavailable": "一鍵交易目前無法使用",
       "networkFeeTooHigh": "網路費太高",
       "startANewSession": "開始新會話",
-      "increaseFeeLimit": "提高網路費用限額",
       "approveManually": "在{walletName}中手動核准",
       "continueWithWallet": "繼續使用錢包",
       "sessionEnded": "會話在此裝置上結束",

--- a/packages/web/localizations/zh-tw.json
+++ b/packages/web/localizations/zh-tw.json
@@ -499,7 +499,6 @@
       "currentlyUnavailable": "一鍵交易目前無法使用",
       "networkFeeTooHigh": "網路費太高",
       "startANewSession": "開始新會話",
-      "increaseFeeLimit": "提高網路費用限額",
       "approveManually": "在{walletName}中手動核准",
       "continueWithWallet": "繼續使用錢包",
       "sessionEnded": "會話在此裝置上結束",

--- a/packages/web/stores/index.tsx
+++ b/packages/web/stores/index.tsx
@@ -4,7 +4,6 @@ import { toast } from "react-toastify";
 import { displayToast, ToastType } from "~/components/alert";
 import { Button } from "~/components/ui/button";
 import { useTranslation } from "~/hooks";
-import { useGlobalIs1CTIntroModalScreen } from "~/modals";
 import { RootStore } from "~/stores/root";
 import { api } from "~/utils/trpc";
 
@@ -34,8 +33,6 @@ const EXCEEDS_1CT_NETWORK_FEE_LIMIT_TOAST_ID = "exceeds-1ct-network-fee-limit";
 
 export const StoreProvider = ({ children }: PropsWithChildren) => {
   const apiUtils = api.useUtils();
-  const [_, setOneClickTradingIntroModalScreen] =
-    useGlobalIs1CTIntroModalScreen();
   const { t } = useTranslation();
   const [rootStore] = useState(
     () =>
@@ -53,20 +50,7 @@ export const StoreProvider = ({ children }: PropsWithChildren) => {
               {
                 titleTranslationKey: "oneClickTrading.toast.networkFeeTooHigh",
                 captionElement: (
-                  <div className="flex flex-col items-start gap-2">
-                    <Button
-                      variant="link"
-                      className="!h-auto self-start !px-0 !py-0  text-wosmongton-300"
-                      onClick={() => {
-                        toast.dismiss(EXCEEDS_1CT_NETWORK_FEE_LIMIT_TOAST_ID);
-                        setOneClickTradingIntroModalScreen(
-                          "settings-no-back-button"
-                        );
-                        finish();
-                      }}
-                    >
-                      {t("oneClickTrading.toast.increaseFeeLimit")}
-                    </Button>
+                  <div className="flex flex-col items-start">
                     <Button
                       variant="link"
                       className="!h-auto self-start !px-0 !py-0  text-wosmongton-300"


### PR DESCRIPTION
## What is the purpose of the change:

Use the gas limit instead of OSMO as the network fee limit. This will allow us to set limits for other tokens, not just OSMO. Currently, the limit is set to 400,000,000, equivalent to 1 OSMO at today's gas price. In the future, we can lower it if needed for better protection

### Linear Task

[Linear Task URL](jose/fe-713-remove-network-fee-adjustment-from-settings-and-set-it-to-1)

## Testing and Verifying

- [ ] Can perform 1CT transactions