### PR TITLE
(Deposit/Withdraw) Axelar: throw if out amount negative

### DIFF
--- a/packages/bridge/src/axelar/index.ts
+++ b/packages/bridge/src/axelar/index.ts
@@ -3,7 +3,7 @@ import type {
   AxelarQueryAPI,
 } from "@axelar-network/axelarjs-sdk";
 import { Registry } from "@cosmjs/proto-signing";
-import { CoinPretty, Dec } from "@keplr-wallet/unit";
+import { CoinPretty, Dec, IntPretty } from "@keplr-wallet/unit";
 import { ibcProtoRegistry } from "@osmosis-labs/proto-codecs";
 import { estimateGasFee } from "@osmosis-labs/tx";
 import type { IbcTransferMethod } from "@osmosis-labs/types";
@@ -163,6 +163,21 @@ export class AxelarBridgeProvider implements BridgeProvider {
           const expectedOutputAmount = new Dec(fromAmount).sub(
             new Dec(transferFeeRes.fee.amount)
           );
+
+          if (
+            expectedOutputAmount.isZero() ||
+            expectedOutputAmount.isNegative()
+          ) {
+            throw new BridgeQuoteError({
+              bridgeId: AxelarBridgeProvider.ID,
+              errorType: "UnsupportedQuoteError",
+              message: `Negative output amount ${new IntPretty(
+                expectedOutputAmount
+              ).trim(true)} for asset in: ${new IntPretty(fromAmount).trim(
+                true
+              )} ${fromAsset.denom}`,
+            });
+          }
 
           return {
             estimatedTime: this.getWaitTime(fromChainAxelarId),


### PR DESCRIPTION
## What is the purpose of the change:

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

Axelar provider was able to return negative output amounts in selectable quotes. This should not be possible. Axelar now throws and is not selectable if the fee exceeds the final out amount.

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-763/prevent-negative-expected-output)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->
