### PR TITLE
(Deposit/Withdraw) Skip: add a fallback gas cost for failed state override ERC20 gas estimations

### DIFF
--- a/packages/bridge/src/skip/index.ts
+++ b/packages/bridge/src/skip/index.ts
@@ -780,7 +780,11 @@ export class SkipBridgeProvider implements BridgeProvider {
             },
           ],
         })
-        .then((gas) => BigInt(gas));
+        .catch((e) => {
+          console.error(e);
+          // if there's an error, return a common ER20 transfer gas amount
+          return BigInt(80_000);
+        });
     } catch (err) {
       console.error("failed to estimate gas:", err);
       return BigInt(0);


### PR DESCRIPTION
## What is the purpose of the change:

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

If an RPC doesn't support a 3rd param for the state override (to consider an ERC20 transfer as pre approved), it will fall back to a common ERC20 transfer gas cost.

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-578/fix-skip-bridge-provider-evm-estimate-gas-statediff)
