### PR TITLE
(Deposit/Withdraw) check for CCTP bridge fee

### DIFF
--- a/packages/web/components/bridge/use-bridge-quotes.ts
+++ b/packages/web/components/bridge/use-bridge-quotes.ts
@@ -360,6 +360,9 @@ export const useBridgeQuotes = ({
     someError?.message.includes(
       "No fee tokens found with sufficient balance on account"
     ) ||
+    someError?.message.includes(
+      "Input amount is too low to cover CCTP bridge relay fee"
+    ) ||
     (inputAmountRaw !== "" &&
       availableBalance &&
       selectedQuote?.transferFee !== undefined &&


### PR DESCRIPTION
## What is the purpose of the change:

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

Classify an error containing `Input amount is too low to cover CCTP bridge relay fee` as insufficient fee error.

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-761/skip-show-insufficient-cctp-relay-fee-as-insufficient-fee-error)
