### PR TITLE
(Deposit/Withdraw) handle cosmwasm transactions

### DIFF
--- a/packages/bridge/src/msg.ts
+++ b/packages/bridge/src/msg.ts
@@ -1,4 +1,4 @@
-import { ibc } from "@osmosis-labs/proto-codecs";
+import { cosmwasm, ibc } from "@osmosis-labs/proto-codecs";
 
 interface AccountMsgOpt {
   shareCoinDecimals?: number;
@@ -25,5 +25,13 @@ export const cosmosMsgOpts = createMsgOpts({
     gas: 450000,
     messageComposer:
       ibc.applications.transfer.v1.MessageComposer.withTypeUrl.transfer,
+  },
+});
+
+export const cosmwasmMsgOpts = createMsgOpts({
+  executeWasm: {
+    gas: 0,
+    messageComposer:
+      cosmwasm.wasm.v1.MessageComposer.withTypeUrl.executeContract,
   },
 });

--- a/packages/bridge/src/skip/__tests__/skip-bridge-provider.spec.ts
+++ b/packages/bridge/src/skip/__tests__/skip-bridge-provider.spec.ts
@@ -361,7 +361,7 @@ describe("SkipBridgeProvider", () => {
       value: "0x3e8",
     };
 
-    const gasCost = await provider.estimateGasCost(params, txData);
+    const gasCost = await provider.estimateGasFee(params, txData);
 
     expect(gasCost).toBeDefined();
     expect(gasCost?.amount).toBeDefined();
@@ -416,7 +416,7 @@ describe("SkipBridgeProvider", () => {
       ],
     });
 
-    const gasCost = await provider.estimateGasCost(params, txData);
+    const gasCost = await provider.estimateGasFee(params, txData);
 
     expect(gasCost).toBeDefined();
     expect(gasCost?.amount).toBe("1000");

--- a/packages/bridge/src/squid/index.ts
+++ b/packages/bridge/src/squid/index.ts
@@ -236,7 +236,8 @@ export class SquidBridgeProvider implements BridgeProvider {
               })
             : await this.createCosmosTransaction(
                 transactionRequest.data,
-                fromAddress
+                fromAddress,
+                { denom: fromAsset.address, amount: fromAmount }
               ),
         };
       },
@@ -444,7 +445,11 @@ export class SquidBridgeProvider implements BridgeProvider {
 
   async createCosmosTransaction(
     data: string,
-    fromAddress: string
+    fromAddress: string,
+    fromAmount: {
+      denom: string;
+      amount: string;
+    }
   ): Promise<CosmosBridgeTransactionRequest> {
     try {
       const parsedData = JSON.parse(data) as {
@@ -514,7 +519,7 @@ export class SquidBridgeProvider implements BridgeProvider {
             sender: fromAddress,
             contract: cosmwasmData.msg.wasm.contract,
             msg: Buffer.from(JSON.stringify(cosmwasmData.msg.wasm.msg)),
-            funds: [],
+            funds: [fromAmount],
           });
 
         return {

--- a/packages/bridge/src/squid/index.ts
+++ b/packages/bridge/src/squid/index.ts
@@ -446,7 +446,7 @@ export class SquidBridgeProvider implements BridgeProvider {
   async createCosmosTransaction(
     data: string,
     fromAddress: string,
-    fromAmount: {
+    fromCoin: {
       denom: string;
       amount: string;
     }
@@ -519,7 +519,7 @@ export class SquidBridgeProvider implements BridgeProvider {
             sender: fromAddress,
             contract: cosmwasmData.msg.wasm.contract,
             msg: Buffer.from(JSON.stringify(cosmwasmData.msg.wasm.msg)),
-            funds: [fromAmount],
+            funds: [fromCoin],
           });
 
         return {

--- a/packages/bridge/src/squid/index.ts
+++ b/packages/bridge/src/squid/index.ts
@@ -30,6 +30,7 @@ import { BridgeQuoteError } from "../errors";
 import {
   BridgeAsset,
   BridgeChain,
+  BridgeDepositAddress,
   BridgeExternalUrl,
   BridgeProvider,
   BridgeProviderContext,
@@ -40,8 +41,9 @@ import {
   GetBridgeExternalUrlParams,
   GetBridgeQuoteParams,
   GetBridgeSupportedAssetsParams,
+  GetDepositAddressParams,
 } from "../interface";
-import { cosmosMsgOpts } from "../msg";
+import { cosmosMsgOpts, cosmwasmMsgOpts } from "../msg";
 import { BridgeAssetMap } from "../utils";
 
 const IbcTransferType = "/ibc.applications.transfer.v1.MsgTransfer";
@@ -66,6 +68,9 @@ export class SquidBridgeProvider implements BridgeProvider {
         ? "https://axelarscan.io"
         : "https://testnet.axelarscan.io";
   }
+  getDepositAddress?:
+    | ((params: GetDepositAddressParams) => Promise<BridgeDepositAddress>)
+    | undefined;
 
   async getQuote({
     fromAmount,
@@ -441,62 +446,87 @@ export class SquidBridgeProvider implements BridgeProvider {
     try {
       const parsedData = JSON.parse(data) as {
         msgTypeUrl: typeof IbcTransferType | typeof WasmTransferType;
-        msg: {
-          sourcePort: string;
-          sourceChannel: string;
-          token: {
-            denom: string;
-            amount: string;
-          };
-          sender: string;
-          receiver: string;
-          timeoutTimestamp: {
-            low: number;
-            high: number;
-            unsigned: boolean;
-          };
-          memo: string;
-        };
       };
 
-      if (
-        parsedData.msgTypeUrl !== "/ibc.applications.transfer.v1.MsgTransfer"
-      ) {
-        throw new BridgeQuoteError({
-          bridgeId: SquidBridgeProvider.ID,
-          errorType: "CreateCosmosTxError",
-          message:
-            "Unknown message type. Osmosis FrontEnd only supports the transfer message type",
+      if (parsedData.msgTypeUrl === IbcTransferType) {
+        const ibcData = parsedData as {
+          msgTypeUrl: typeof IbcTransferType;
+          msg: {
+            sourcePort: string;
+            sourceChannel: string;
+            token: {
+              denom: string;
+              amount: string;
+            };
+            sender: string;
+            receiver: string;
+            timeoutTimestamp: {
+              low: number;
+              high: number;
+              unsigned: boolean;
+            };
+            memo: string;
+          };
+        };
+
+        const timeoutHeight = await this.ctx.getTimeoutHeight({
+          destinationAddress: ibcData.msg.receiver,
         });
+
+        const { typeUrl, value: msg } =
+          cosmosMsgOpts.ibcTransfer.messageComposer({
+            memo: ibcData.msg.memo,
+            receiver: ibcData.msg.receiver,
+            sender: ibcData.msg.sender,
+            sourceChannel: ibcData.msg.sourceChannel,
+            sourcePort: ibcData.msg.sourcePort,
+            timeoutTimestamp: new Long(
+              ibcData.msg.timeoutTimestamp.low,
+              ibcData.msg.timeoutTimestamp.high,
+              ibcData.msg.timeoutTimestamp.unsigned
+            ).toString() as any,
+            // @ts-ignore
+            timeoutHeight,
+            token: ibcData.msg.token,
+          });
+
+        return {
+          type: "cosmos",
+          msgTypeUrl: typeUrl,
+          msg,
+        };
+      } else if (parsedData.msgTypeUrl === WasmTransferType) {
+        const cosmwasmData = parsedData as {
+          msgTypeUrl: typeof WasmTransferType;
+          msg: {
+            wasm: {
+              contract: string;
+              msg: object;
+            };
+          };
+        };
+
+        const { typeUrl, value: msg } =
+          cosmwasmMsgOpts.executeWasm.messageComposer({
+            sender: "test",
+            contract: cosmwasmData.msg.wasm.contract,
+            msg: Buffer.from(JSON.stringify(cosmwasmData.msg.wasm.msg)),
+            funds: [],
+          });
+
+        return {
+          type: "cosmos",
+          msgTypeUrl: typeUrl,
+          msg,
+        };
       }
 
-      const timeoutHeight = await this.ctx.getTimeoutHeight({
-        destinationAddress: parsedData.msg.receiver,
+      throw new BridgeQuoteError({
+        bridgeId: SquidBridgeProvider.ID,
+        errorType: "CreateCosmosTxError",
+        message:
+          "Unknown message type. Osmosis FrontEnd only supports the IBC transfer and cosmwasm executeMsg message type",
       });
-
-      const { typeUrl, value: msg } = cosmosMsgOpts.ibcTransfer.messageComposer(
-        {
-          memo: parsedData.msg.memo,
-          receiver: parsedData.msg.receiver,
-          sender: parsedData.msg.sender,
-          sourceChannel: parsedData.msg.sourceChannel,
-          sourcePort: parsedData.msg.sourcePort,
-          timeoutTimestamp: new Long(
-            parsedData.msg.timeoutTimestamp.low,
-            parsedData.msg.timeoutTimestamp.high,
-            parsedData.msg.timeoutTimestamp.unsigned
-          ).toString() as any,
-          // @ts-ignore
-          timeoutHeight,
-          token: parsedData.msg.token,
-        }
-      );
-
-      return {
-        type: "cosmos",
-        msgTypeUrl: typeUrl,
-        msg,
-      };
     } catch (e) {
       const error = e as Error | BridgeQuoteError;
 

--- a/packages/bridge/src/squid/index.ts
+++ b/packages/bridge/src/squid/index.ts
@@ -234,7 +234,10 @@ export class SquidBridgeProvider implements BridgeProvider {
                 estimateFromAmount,
                 transactionRequest,
               })
-            : await this.createCosmosTransaction(transactionRequest.data),
+            : await this.createCosmosTransaction(
+                transactionRequest.data,
+                fromAddress
+              ),
         };
       },
     });
@@ -439,9 +442,9 @@ export class SquidBridgeProvider implements BridgeProvider {
     };
   }
 
-  /** TODO: Handle WASM transactions */
   async createCosmosTransaction(
-    data: string
+    data: string,
+    fromAddress: string
   ): Promise<CosmosBridgeTransactionRequest> {
     try {
       const parsedData = JSON.parse(data) as {
@@ -508,7 +511,7 @@ export class SquidBridgeProvider implements BridgeProvider {
 
         const { typeUrl, value: msg } =
           cosmwasmMsgOpts.executeWasm.messageComposer({
-            sender: "test",
+            sender: fromAddress,
             contract: cosmwasmData.msg.wasm.contract,
             msg: Buffer.from(JSON.stringify(cosmwasmData.msg.wasm.msg)),
             funds: [],

--- a/packages/server/src/utils/superjson.ts
+++ b/packages/server/src/utils/superjson.ts
@@ -119,4 +119,13 @@ superjson.registerCustom<Duration, string>(
   "dayjs.Duration"
 );
 
+superjson.registerCustom<Buffer, string>(
+  {
+    isApplicable: (v): v is Buffer => Buffer.isBuffer(v),
+    serialize: (v) => v.toString("base64"),
+    deserialize: (v) => Buffer.from(v, "base64"),
+  },
+  "Buffer"
+);
+
 export { superjson };

--- a/packages/utils/src/asset-utils.ts
+++ b/packages/utils/src/asset-utils.ts
@@ -1,4 +1,9 @@
-import type { Asset, AssetList, MinimalAsset } from "@osmosis-labs/types";
+import type {
+  Asset,
+  AssetList,
+  Counterparty,
+  MinimalAsset,
+} from "@osmosis-labs/types";
 
 /** Find asset in asset list config given any of the available identifiers. */
 export function getAssetFromAssetList({
@@ -78,4 +83,69 @@ export function makeMinimalAsset(assetListAsset: Asset): MinimalAsset {
     isAlloyed,
     contract,
   };
+}
+
+export function isSameVariant(
+  assetLists: AssetList[],
+  rootAssetDenom: string,
+  compareAssetDenom: string
+): boolean {
+  const findAssetByDenom = (assetList: AssetList, denom: string) => {
+    return assetList.assets.find((asset) => asset.coinMinimalDenom === denom);
+  };
+
+  const rootAsset = assetLists
+    .map((assetList) => findAssetByDenom(assetList, rootAssetDenom))
+    .find((asset) => asset);
+
+  const compareAsset = assetLists
+    .map((assetList) => findAssetByDenom(assetList, compareAssetDenom))
+    .find((asset) => asset);
+
+  if (!rootAsset && !compareAsset) {
+    return false;
+  }
+
+  if (!rootAsset) {
+    // Try recursively with compare asset as root
+    return isSameVariant(assetLists, compareAssetDenom, rootAssetDenom);
+  }
+
+  // directly compare variantGroupKey
+  if (
+    compareAsset &&
+    rootAsset.variantGroupKey === compareAsset.variantGroupKey
+  ) {
+    return true;
+  }
+
+  // compare all counterparty entries for same variant
+  if (rootAsset.variantGroupKey) {
+    const counterparties = assetLists
+      .flatMap(({ assets }) => assets)
+      .reduce((acc, asset) => {
+        if (asset.variantGroupKey === rootAsset.variantGroupKey) {
+          acc.push(...asset.counterparty);
+        }
+        return acc;
+      }, [] as Counterparty[]);
+
+    for (const counterparty of counterparties) {
+      if (
+        "address" in counterparty &&
+        counterparty.address.toLowerCase() === compareAssetDenom.toLowerCase()
+      ) {
+        return true;
+      }
+      if (
+        "sourceDenom" in counterparty &&
+        counterparty.sourceDenom.toLowerCase() ===
+          compareAssetDenom.toLowerCase()
+      ) {
+        return true;
+      }
+    }
+  }
+
+  return false;
 }

--- a/packages/web/components/bridge/amount-screen.tsx
+++ b/packages/web/components/bridge/amount-screen.tsx
@@ -1113,7 +1113,8 @@ export const AmountScreen = observer(
                       isLoadingBridgeTransaction ||
                       cryptoAmount === "" ||
                       cryptoAmount === "0" ||
-                      isNil(selectedQuote)
+                      isNil(selectedQuote) ||
+                      !quote.userCanAdvance
                     }
                     className="w-full md:h-12"
                     variant={

--- a/packages/web/components/bridge/amount-screen.tsx
+++ b/packages/web/components/bridge/amount-screen.tsx
@@ -1149,7 +1149,12 @@ export const AmountScreen = observer(
                     toChain={toChain}
                     toAddress={toAddress}
                     bridges={Array.from(
-                      new Set(Object.values(fromAsset.supportedVariants).flat())
+                      new Set(
+                        Object.values(
+                          (direction === "withdraw" ? toAsset : fromAsset)
+                            .supportedVariants
+                        ).flat()
+                      )
                     )}
                     onRequestClose={() => setAreMoreOptionsVisible(false)}
                   />
@@ -1166,7 +1171,12 @@ export const AmountScreen = observer(
             fromAsset={fromAsset}
             toAddress={toAddress}
             bridges={Array.from(
-              new Set(Object.values(fromAsset.supportedVariants).flat())
+              new Set(
+                Object.values(
+                  (direction === "withdraw" ? toAsset : fromAsset)
+                    .supportedVariants
+                ).flat()
+              )
             )}
             onDone={onClose}
           />

--- a/packages/web/components/bridge/amount-screen.tsx
+++ b/packages/web/components/bridge/amount-screen.tsx
@@ -701,6 +701,7 @@ export const AmountScreen = observer(
               isInsufficientBal={Boolean(isInsufficientBal)}
               isInsufficientFee={Boolean(isInsufficientFee)}
               transferGasCost={selectedQuote?.gasCost}
+              transferFeeCost={selectedQuote?.transferFee}
               setFiatAmount={setFiatAmount}
               setCryptoAmount={setCryptoAmount}
               setInputUnit={setInputUnit}

--- a/packages/web/components/bridge/amount-screen.tsx
+++ b/packages/web/components/bridge/amount-screen.tsx
@@ -55,6 +55,7 @@ import {
   BridgeProviderDropdownRow,
   EstimatedTimeRow,
   ExpandDetailsControlContent,
+  ExpectedOutputRow,
   NetworkFeeRow,
   ProviderFeesRow,
   TotalFeesRow,
@@ -701,7 +702,6 @@ export const AmountScreen = observer(
               isInsufficientBal={Boolean(isInsufficientBal)}
               isInsufficientFee={Boolean(isInsufficientFee)}
               transferGasCost={selectedQuote?.gasCost}
-              transferFeeCost={selectedQuote?.transferFee}
               setFiatAmount={setFiatAmount}
               setCryptoAmount={setCryptoAmount}
               setInputUnit={setInputUnit}
@@ -1372,6 +1372,11 @@ const TransferDetails: FunctionComponent<{
             <TotalFeesRow
               isRefetchingQuote={isRefetchingQuote}
               selectedQuote={selectedQuote}
+            />
+            <ExpectedOutputRow
+              isRefetchingQuote={isRefetchingQuote}
+              selectedQuote={selectedQuote}
+              warnUserOfSlippage={Boolean(warnUserOfSlippage)}
             />
           </DisclosurePanel>
         </div>

--- a/packages/web/components/bridge/crypto-fiat-input.tsx
+++ b/packages/web/components/bridge/crypto-fiat-input.tsx
@@ -50,8 +50,8 @@ export const CryptoFiatInput: FunctionComponent<{
   isInsufficientBal,
   isInsufficientFee,
   transferGasCost,
-  setFiatAmount,
-  setCryptoAmount,
+  setFiatAmount: setFiatAmountProp,
+  setCryptoAmount: setCryptoAmountProp,
   setInputUnit,
 }) => {
   const { t } = useTranslation();
@@ -84,6 +84,30 @@ export const CryptoFiatInput: FunctionComponent<{
   const inputValue = new PricePretty(
     assetPrice.fiatCurrency,
     new Dec(fiatInputRaw === "" ? 0 : fiatInputRaw)
+  );
+
+  const setCryptoAmount = useCallback(
+    (amount: string) =>
+      setCryptoAmountProp(
+        new IntPretty(amount)
+          .locale(false)
+          .trim(true)
+          .maxDecimals(asset.decimals)
+          .toString()
+      ),
+    [setCryptoAmountProp, asset]
+  );
+
+  const setFiatAmount = useCallback(
+    (amount: string) =>
+      setFiatAmountProp(
+        new IntPretty(amount)
+          .locale(false)
+          .trim(true)
+          .maxDecimals(assetPrice.fiatCurrency.maxDecimals)
+          .toString()
+      ),
+    [setFiatAmountProp, assetPrice]
   );
 
   const onInput = useCallback(
@@ -140,11 +164,6 @@ export const CryptoFiatInput: FunctionComponent<{
         maxTransferAmount = asset.amount.toDec();
       }
 
-      // add slippage if there's any fee subtraction
-      if (gasFeeMatchesInputDenom || transferFeeMatchesInputDenom) {
-        maxTransferAmount = maxTransferAmount.mul(subtractGasSlippage);
-      }
-
       if (
         maxTransferAmount.isPositive() &&
         !inputCoin.toDec().equals(maxTransferAmount)
@@ -161,14 +180,7 @@ export const CryptoFiatInput: FunctionComponent<{
     }
   }, [asset, isMax, onInput]);
 
-  const fiatCurrentValue = `${assetPrice.symbol}${
-    fiatInputRaw.endsWith(".") || Number(fiatInputRaw) === 0
-      ? fiatInputRaw
-      : new IntPretty(fiatInputRaw)
-          .locale(false)
-          .trim(true)
-          .maxDecimals(assetPrice.fiatCurrency.maxDecimals)
-  }`;
+  const fiatCurrentValue = `${assetPrice.symbol}${fiatInputRaw}`;
   const fiatInputFontSize = calcTextSizeClass(
     fiatCurrentValue.length,
     isMobile

--- a/packages/web/components/bridge/more-bridge-options.tsx
+++ b/packages/web/components/bridge/more-bridge-options.tsx
@@ -48,7 +48,12 @@ export const MoreBridgeOptionsModal: FunctionComponent<
       },
       {
         enabled:
-          !!fromAsset && !!toAsset && !!fromChain && !!toChain && !!toAddress,
+          !!fromAsset &&
+          !!toAsset &&
+          !!fromChain &&
+          !!toChain &&
+          !!toAddress &&
+          !!bridges.length,
 
         // skip batching so this query does not get
         // batched with getSupportedAssetsByBridge query
@@ -156,7 +161,12 @@ export const OnlyExternalBridgeSuggest: FunctionComponent<
       },
       {
         enabled:
-          !!fromAsset && !!toAsset && !!fromChain && !!toChain && !!toAddress,
+          !!fromAsset &&
+          !!toAsset &&
+          !!fromChain &&
+          !!toChain &&
+          !!toAddress &&
+          !!bridges.length,
 
         // skip batching so this query does not get
         // batched with getSupportedAssetsByBridge query

--- a/packages/web/components/bridge/quote-detail.tsx
+++ b/packages/web/components/bridge/quote-detail.tsx
@@ -119,7 +119,7 @@ export const TotalFeesRow: FunctionComponent<{
   selectedQuote: NonNullable<BridgeQuote["selectedQuote"]>;
   isRefetchingQuote: boolean;
 }> = ({ selectedQuote, isRefetchingQuote }) => {
-  const totalCost = calcSelectedQuoteTotalFee(selectedQuote);
+  const totalCost = selectedQuote.quote.totalFeeFiatValue;
   if (!totalCost) return null;
 
   return (
@@ -142,7 +142,7 @@ export const ExpectedOutputRow: FunctionComponent<{
     isLoading={isRefetchingQuote}
   >
     <p className={warnUserOfSlippage ? "text-rust-300" : "text-osmoverse-100"}>
-      {selectedQuote.expectedOutputFiat.toString()}
+      {selectedQuote.expectedOutputFiat.toString()}{" "}
       <span
         className={classNames({
           "text-osmoverse-300": !warnUserOfSlippage,
@@ -153,18 +153,6 @@ export const ExpectedOutputRow: FunctionComponent<{
     </p>
   </QuoteDetailRow>
 );
-
-export function calcSelectedQuoteTotalFee(
-  quote: NonNullable<BridgeQuote["selectedQuote"]>
-) {
-  let totalCost = quote.gasCostFiat;
-  if (quote.transferFeeFiat) {
-    totalCost = totalCost
-      ? totalCost.add(quote.transferFeeFiat)
-      : quote.transferFeeFiat;
-  }
-  return totalCost;
-}
 
 export const ExpandDetailsControlContent: FunctionComponent<{
   selectedQuote: NonNullable<BridgeQuote["selectedQuote"]>;
@@ -185,7 +173,7 @@ export const ExpandDetailsControlContent: FunctionComponent<{
   isRemainingTimePaused,
   showRemainingTime = false,
 }) => {
-  const totalFees = calcSelectedQuoteTotalFee(selectedQuote);
+  const totalFees = selectedQuote.quote.totalFeeFiatValue;
 
   return (
     <div className="flex items-center gap-2 md:gap-1">

--- a/packages/web/components/bridge/review-screen.tsx
+++ b/packages/web/components/bridge/review-screen.tsx
@@ -167,7 +167,7 @@ export const ReviewScreen: FunctionComponent<ConfirmationScreenProps> = ({
           isLoading={quote.isTxPending || quote.isApprovingToken}
           className="w-full md:h-12"
           onClick={onConfirm}
-          disabled={!quote.userCanInteract}
+          disabled={!quote.userCanAdvance}
         >
           <div className="md:subtitle1 text-h6 font-h6">
             {quote?.txButtonText ?? t("transfer.confirm")}

--- a/packages/web/components/bridge/use-bridge-quotes.ts
+++ b/packages/web/components/bridge/use-bridge-quotes.ts
@@ -364,6 +364,9 @@ export const useBridgeQuotes = ({
       ) ||
       someError?.message.includes(
         "Input amount is too low to cover CCTP bridge relay fee"
+      ) ||
+      someError?.message.includes(
+        "cannot transfer across cctp after route demands swap"
       )
     )
       return true;

--- a/packages/web/components/bridge/use-bridge-quotes.ts
+++ b/packages/web/components/bridge/use-bridge-quotes.ts
@@ -682,7 +682,10 @@ export const useBridgeQuotes = ({
       : false;
   const isDepositReady =
     isDeposit && isWalletConnected && !isLoadingBridgeQuote && !isTxPending;
-  const userCanInteract = isDepositReady || isWithdrawReady;
+  const userCanAdvance =
+    (isDepositReady || isWithdrawReady) &&
+    !isInsufficientFee &&
+    !isInsufficientBal;
 
   let buttonText: string;
   if (buttonErrorMessage) {
@@ -714,7 +717,7 @@ export const useBridgeQuotes = ({
     buttonText,
     buttonErrorMessage,
 
-    userCanInteract,
+    userCanAdvance,
     isTxPending,
     isApprovingToken,
     onTransfer,

--- a/packages/web/components/bridge/use-bridge-quotes.ts
+++ b/packages/web/components/bridge/use-bridge-quotes.ts
@@ -181,7 +181,9 @@ export const useBridgeQuotes = ({
             !isTxPending &&
             inputAmount.isPositive() &&
             Object.values(quoteParams).every((param) => !isNil(param)) &&
-            !isInsufficientBal,
+            !isInsufficientBal &&
+            // must have balance amount loaded, even if 0
+            Boolean(availableBalance),
           staleTime: 5_000,
           cacheTime: 5_000,
           // Disable retries, as useQueries


### PR DESCRIPTION
## What is the purpose of the change:

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

Squid and Skip would use cosmwasm to initiate a multi hop swap and transfer from Osmosis side to the counterparty. Before, only basic IBC transfers were encoded and provided. Now, cosmwasm contract calls are encoded and returned as sign docs to the FE.

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-765/handle-cosmwasm-transactions-for-usdc-withdraws)
[Convert transfer fee to from asset of like variants](https://linear.app/osmosis/issue/FE-767/convert-transfer-fee-to-from-asset-of-like-variants)
[Skip: show insufficient CCTP relay fee as insufficient fee error](https://linear.app/osmosis/issue/FE-761/skip-show-insufficient-cctp-relay-fee-as-insufficient-fee-error)
[Fee subracted when not necessary](https://linear.app/osmosis/issue/FE-753/fee-subracted-when-not-necessary)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->
* Encode cosmwasm contract calls coming from skip and squid
* Subtract transfer fee from input amount if denoms are the same (TODO: subtract transfer fee from like variants as well. Perhaps we should return variant denoms that are equivalent to the transfer fee in the tRPC router, and change the denom to the from denom if there's a match. This would allow the fee to be properly subtracted, and the denom would be reflected in the UI)
