### PR TITLE
(Deposit/Withdraw) Prevent selected quote from changing if tx pending

### DIFF
--- a/packages/web/components/bridge/use-bridge-quotes.ts
+++ b/packages/web/components/bridge/use-bridge-quotes.ts
@@ -344,6 +344,7 @@ export const useBridgeQuotes = ({
 
     if (
       !!bestQuote &&
+      !isTxPending &&
       ((bestQuote?.provider.id !== selectedBridgeProvider &&
         !isBridgeProviderControlledMode) ||
         isBridgeProviderNotFound)
@@ -355,6 +356,7 @@ export const useBridgeQuotes = ({
     quoteResults,
     selectedBridgeProvider,
     isBridgeProviderControlledMode,
+    isTxPending,
   ]);
 
   const isInsufficientFee = useMemo(() => {


### PR DESCRIPTION
## What is the purpose of the change:

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

If the best quote logic never goes in to controlled (by the user) mode, there's a risk the selected quote could change while the user is confirming a tx. If the user goes forward with the tx, there's a risk the wrong status source provider could be used to track the status of the tx. This should not be possible. This PR fixes that by not setting the preferred provider while a tx is pending.

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-780/prevent-selected-quote-from-changing-while-tx-is-pending)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->
* Check `isTxPending` before changing selected provider