### PR TITLE
Add WETH Variant Deposit Overrides to Satellite

### DIFF
--- a/packages/web/config/ibc-overrides.ts
+++ b/packages/web/config/ibc-overrides.ts
@@ -749,6 +749,24 @@ const MainnetIBCAdditionalData: Partial<
     depositUrlOverride: "https://app.picasso.network/?from=SOLANA&to=OSMOSIS",
     withdrawUrlOverride: "https://app.picasso.network/?from=OSMOSIS&to=SOLANA",
   },
+  "ETH.arb.axl": {
+    depositUrlOverride:
+      "https://satellite.money/?source=arbitrum&destination=osmosis&asset_denom=arbitrum-weth-wei",
+    withdrawUrlOverride:
+      "https://satellite.money/?source=osmosis&destination=arbitrum&asset_denom=arbitrum-weth-wei",
+  },
+  "ETH.base.axl": {
+    depositUrlOverride:
+      "https://satellite.money/?source=base&destination=osmosis&asset_denom=base-weth-wei",
+    withdrawUrlOverride:
+      "https://satellite.money/?source=osmosis&destination=base&asset_denom=base-weth-wei",
+  },
+  "ETH.matic.axl": {
+    depositUrlOverride:
+      "https://satellite.money/?source=polygon&destination=osmosis&asset_denom=polygon-weth-wei",
+    withdrawUrlOverride:
+      "https://satellite.money/?source=osmosis&destination=polygon&asset_denom=polygon-weth-wei",
+  },
 };
 
 export const IBCAdditionalData: AdditionalData = IS_TESTNET


### PR DESCRIPTION
## What is the purpose of the change:

Add WETH Variant Deposit Overrides to Satellite so that we can properly list these assets.
They should be added to the Axelar integrated bridge, but I do not have the ability to add to it.

## Brief Changelog

Add deposit and withdraw override to Satellite in ibc-overrides.ts for ETH.arb.axl, ETH.base.axl, and ETH.matic.axl

## Testing and Verifying

This change has been tested locally by rebuilding the website and verified content and links are expected
