### PR TITLE
(Deposit/Withdraw) Cleanup: move bridge specific errors into providers

### DIFF
--- a/packages/bridge/src/axelar/index.ts
+++ b/packages/bridge/src/axelar/index.ts
@@ -170,7 +170,7 @@ export class AxelarBridgeProvider implements BridgeProvider {
           ) {
             throw new BridgeQuoteError({
               bridgeId: AxelarBridgeProvider.ID,
-              errorType: "UnsupportedQuoteError",
+              errorType: "InsufficientAmountError",
               message: `Negative output amount ${new IntPretty(
                 expectedOutputAmount
               ).trim(true)} for asset in: ${new IntPretty(fromAmount).trim(
@@ -413,6 +413,21 @@ export class AxelarBridgeProvider implements BridgeProvider {
           ],
         },
         bech32Address: params.fromAddress,
+      }).catch((e) => {
+        if (
+          e instanceof Error &&
+          e.message.includes(
+            "No fee tokens found with sufficient balance on account"
+          )
+        ) {
+          throw new BridgeQuoteError({
+            bridgeId: AxelarBridgeProvider.ID,
+            errorType: "InsufficientAmountError",
+            message: e.message,
+          });
+        }
+
+        throw e;
       });
 
       const gasFee = txSimulation.amount[0];

--- a/packages/bridge/src/ibc/index.ts
+++ b/packages/bridge/src/ibc/index.ts
@@ -63,6 +63,21 @@ export class IbcBridgeProvider implements BridgeProvider {
         ],
       },
       bech32Address: params.fromAddress,
+    }).catch((e) => {
+      if (
+        e instanceof Error &&
+        e.message.includes(
+          "No fee tokens found with sufficient balance on account"
+        )
+      ) {
+        throw new BridgeQuoteError({
+          bridgeId: IbcBridgeProvider.ID,
+          errorType: "InsufficientAmountError",
+          message: e.message,
+        });
+      }
+
+      throw e;
     });
     const gasFee = txSimulation.amount[0];
     const gasAsset = this.getGasAsset(fromChainId, gasFee.denom);

--- a/packages/bridge/src/skip/index.ts
+++ b/packages/bridge/src/skip/index.ts
@@ -126,6 +126,7 @@ export class SkipBridgeProvider implements BridgeProvider {
               if (
                 msg.includes(
                   "Input amount is too low to cover"
+                  // Could be Axelar or CCTP
                 )
               ) {
                 throw new BridgeQuoteError({

--- a/packages/bridge/src/skip/index.ts
+++ b/packages/bridge/src/skip/index.ts
@@ -125,7 +125,7 @@ export class SkipBridgeProvider implements BridgeProvider {
               const msg = e.message;
               if (
                 msg.includes(
-                  "Input amount is too low to cover CCTP bridge relay fee"
+                  "Input amount is too low to cover"
                 )
               ) {
                 throw new BridgeQuoteError({

--- a/packages/bridge/src/skip/index.ts
+++ b/packages/bridge/src/skip/index.ts
@@ -112,13 +112,42 @@ export class SkipBridgeProvider implements BridgeProvider {
           });
         }
 
-        const route = await this.skipClient.route({
-          source_asset_denom: sourceAsset.denom,
-          source_asset_chain_id: fromChain.chainId.toString(),
-          dest_asset_denom: destinationAsset.denom,
-          dest_asset_chain_id: toChain.chainId.toString(),
-          amount_in: fromAmount,
-        });
+        const route = await this.skipClient
+          .route({
+            source_asset_denom: sourceAsset.denom,
+            source_asset_chain_id: fromChain.chainId.toString(),
+            dest_asset_denom: destinationAsset.denom,
+            dest_asset_chain_id: toChain.chainId.toString(),
+            amount_in: fromAmount,
+          })
+          .catch((e) => {
+            if (e instanceof Error) {
+              const msg = e.message;
+              if (
+                msg.includes(
+                  "Input amount is too low to cover CCTP bridge relay fee"
+                )
+              ) {
+                throw new BridgeQuoteError({
+                  bridgeId: SkipBridgeProvider.ID,
+                  errorType: "InsufficientAmountError",
+                  message: msg,
+                });
+              }
+              if (
+                msg.includes(
+                  "cannot transfer across cctp after route demands swap"
+                )
+              ) {
+                throw new BridgeQuoteError({
+                  bridgeId: SkipBridgeProvider.ID,
+                  errorType: "NoQuotesError",
+                  message: msg,
+                });
+              }
+            }
+            throw e;
+          });
 
         const addressList = await this.getAddressList(
           route.chain_ids,
@@ -818,6 +847,21 @@ export class SkipBridgeProvider implements BridgeProvider {
           ],
         },
         bech32Address: params.fromAddress,
+      }).catch((e) => {
+        if (
+          e instanceof Error &&
+          e.message.includes(
+            "No fee tokens found with sufficient balance on account"
+          )
+        ) {
+          throw new BridgeQuoteError({
+            bridgeId: SkipBridgeProvider.ID,
+            errorType: "InsufficientAmountError",
+            message: e.message,
+          });
+        }
+
+        throw e;
       });
 
       const gasFee = txSimulation.amount[0];

--- a/packages/web/components/bridge/use-bridge-quotes.ts
+++ b/packages/web/components/bridge/use-bridge-quotes.ts
@@ -391,21 +391,6 @@ export const useBridgeQuotes = ({
     return false;
   }, [someError, inputCoin, selectedQuote]);
 
-  // const isInsufficientFee =
-  //   // Cosmos not fee tokens error
-  //   someError?.message.includes(
-  //     "No fee tokens found with sufficient balance on account"
-  //   ) ||
-  //   (inputAmountRaw !== "" &&
-  //     availableBalance &&
-  //     selectedQuote?.gasCost !== undefined &&
-  //     selectedQuote.gasCost.denom === availableBalance.denom && // make sure the fee is in the same denom as the asset
-  //     inputCoin
-  //       ?.toDec()
-  //       .sub(availableBalance.toDec()) // subtract by available balance to get the maximum transfer amount
-  //       .abs()
-  //       .lt(selectedQuote.gasCost.toDec()));
-
   const bridgeTransaction =
     api.bridgeTransfer.getTransactionRequestByBridge.useQuery(
       {

--- a/packages/web/components/bridge/use-bridge-quotes.ts
+++ b/packages/web/components/bridge/use-bridge-quotes.ts
@@ -360,17 +360,7 @@ export const useBridgeQuotes = ({
   ]);
 
   const isInsufficientFee = useMemo(() => {
-    if (
-      someError?.message.includes(
-        "No fee tokens found with sufficient balance on account"
-      ) ||
-      someError?.message.includes(
-        "Input amount is too low to cover CCTP bridge relay fee"
-      ) ||
-      someError?.message.includes(
-        "cannot transfer across cctp after route demands swap"
-      )
-    )
+    if (someError?.message.includes("InsufficientAmountError" as BridgeError))
       return true;
 
     if (!inputCoin || !selectedQuote || !selectedQuote.gasCost) return false;


### PR DESCRIPTION
## What is the purpose of the change:

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

It's better for bridge provider specific errors to be caught within the provider and re-propogated as a predictable error that can be handled on the client, vs handing provider-specific errors directly on the client. This helps improve end user messaging to what exactly has gone wrong given their specific input, as we can simplify the categorization of errors on the client. More types of errors we encounter from providers in the future can follow this same paradigm; we can catch the error message strings in the provider then repropogate them as some predictable category of errors. Or, we can fall back to the generic category of error: `UnsupportedQuoteError`.

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-779/cleanup-move-bridge-specific-errors-into-providers)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

* Handle CCTP errors within Skip as insufficient fee errors (not enough to pay CCTP fee)
* Handle Swap-after-CCTP errors in Skip as "UnsupportedQuoteError"
* Handle Cosmos gas estimation errors of there not being a fee token as an insufficient amount error (which will be shown as insufficient fee)
