### PR TITLE
fix: fixed quote/asset denom fetching for active orders

### DIFF
--- a/packages/trpc/src/orderbook-router.ts
+++ b/packages/trpc/src/orderbook-router.ts
@@ -240,6 +240,7 @@ export const orderbookRouter = createTRPCRouter({
             orderbookAddress: contractOsmoAddress,
             chainList: ctx.chainList,
           });
+
           const quoteAsset = getAssetFromAssetList({
             assetLists: ctx.assetLists,
             sourceDenom: quote_denom,
@@ -248,6 +249,7 @@ export const orderbookRouter = createTRPCRouter({
             assetLists: ctx.assetLists,
             sourceDenom: base_denom,
           });
+
           return getTickInfoAndTransformOrders(
             contractOsmoAddress,
             resp.orders,
@@ -302,13 +304,14 @@ export const orderbookRouter = createTRPCRouter({
               });
               const quoteAsset = getAssetFromAssetList({
                 assetLists: ctx.assetLists,
-                sourceDenom: quote_denom,
+                coinMinimalDenom: quote_denom,
               });
 
               const baseAsset = getAssetFromAssetList({
                 assetLists: ctx.assetLists,
-                sourceDenom: base_denom,
+                coinMinimalDenom: base_denom,
               });
+
               const mappedOrders = await getTickInfoAndTransformOrders(
                 contractOsmoAddress,
                 resp.orders,

--- a/packages/trpc/src/orderbook-router.ts
+++ b/packages/trpc/src/orderbook-router.ts
@@ -217,54 +217,6 @@ export const orderbookRouter = createTRPCRouter({
         makerFee,
       };
     }),
-  getActiveOrders: publicProcedure
-    .input(
-      GetInfiniteLimitOrdersInputSchema.merge(
-        z.object({ contractOsmoAddress: z.string().startsWith("osmo") })
-      )
-    )
-    .query(async ({ input, ctx }) => {
-      return maybeCachePaginatedItems({
-        getFreshItems: async () => {
-          const { contractOsmoAddress, userOsmoAddress } = input;
-          if (contractOsmoAddress.length === 0 || userOsmoAddress.length === 0)
-            return [];
-          const resp = await getOrderbookActiveOrders({
-            orderbookAddress: contractOsmoAddress,
-            userOsmoAddress: userOsmoAddress,
-            chainList: ctx.chainList,
-          });
-
-          if (resp.orders.length === 0) return [];
-          const { quote_denom, base_denom } = await getOrderbookDenoms({
-            orderbookAddress: contractOsmoAddress,
-            chainList: ctx.chainList,
-          });
-
-          const quoteAsset = getAssetFromAssetList({
-            assetLists: ctx.assetLists,
-            sourceDenom: quote_denom,
-          });
-          const baseAsset = getAssetFromAssetList({
-            assetLists: ctx.assetLists,
-            sourceDenom: base_denom,
-          });
-
-          return getTickInfoAndTransformOrders(
-            contractOsmoAddress,
-            resp.orders,
-            ctx.chainList,
-            quoteAsset,
-            baseAsset
-          );
-        },
-        cacheKey: JSON.stringify([
-          "active-orders",
-          input.contractOsmoAddress,
-          input.userOsmoAddress,
-        ]),
-      });
-    }),
   getAllActiveOrders: publicProcedure
     .input(
       GetInfiniteLimitOrdersInputSchema.merge(

--- a/packages/web/hooks/limit-orders/use-orderbook.ts
+++ b/packages/web/hooks/limit-orders/use-orderbook.ts
@@ -218,29 +218,6 @@ const useMakerFee = ({ orderbookAddress }: { orderbookAddress: string }) => {
   };
 };
 
-export const useActiveLimitOrdersByOrderbook = ({
-  orderbookAddress,
-  userAddress,
-}: {
-  orderbookAddress: string;
-  userAddress: string;
-}) => {
-  const { data: orders, isLoading } =
-    api.edge.orderbooks.getActiveOrders.useInfiniteQuery({
-      contractOsmoAddress: orderbookAddress,
-      userOsmoAddress: userAddress,
-    });
-
-  const allOrders = useMemo(() => {
-    return orders?.pages.flatMap((page) => page.items) ?? [];
-  }, [orders]);
-
-  return {
-    orders: allOrders,
-    isLoading,
-  };
-};
-
 export type DisplayableLimitOrder = MappedLimitOrder;
 
 export const useOrderbookAllActiveOrders = ({


### PR DESCRIPTION
## What is the purpose of the change:
These changes fix fetching of quote asset for limit orders and remove an unused query.


### Linear Task

[FE-664: Asset Values are Incorrect on Open Orders Page](https://linear.app/osmosis/issue/FE-664/asset-asset-values-are-incorrect-on-open-orders-page)

## Brief Changelog
- Altered `getAssetFromAssetList` call in `orderbookRouter.getAllActiveOrders`
