### PR TITLE
feat: add new earn strategy endpoint schema

### DIFF
--- a/packages/server/src/queries/complex/earn/strategies.ts
+++ b/packages/server/src/queries/complex/earn/strategies.ts
@@ -71,7 +71,12 @@ export async function getStrategyBalance(
   });
 }
 
-export async function getStrategyAnnualPercentages(aprUrl: string) {
+export async function getStrategyAnnualPercentages(
+  strategyId: string,
+  rawAprUrl: string
+) {
+  const aprUrl = rawAprUrl.replace("${id}", strategyId);
+
   return await cachified({
     cache: earnStrategyAnnualPercentagesCache,
     ttl: 1000 * 20,
@@ -86,7 +91,9 @@ export async function getStrategyAnnualPercentages(aprUrl: string) {
   });
 }
 
-export async function getStrategyTVL(tvlUrl: string) {
+export async function getStrategyTVL(strategyId: string, rawTvlUrl: string) {
+  const tvlUrl = rawTvlUrl.replace("${id}", strategyId);
+
   return await cachified({
     cache: earnStrategyTVLCache,
     ttl: 1000 * 20,
@@ -123,7 +130,10 @@ export async function getStrategies({
           categories: StategyCMSCategory[];
           platforms: StategyCMSCategory[];
           riskReportUrl: string;
-        }>({ filePath: `cms/earn/strategies.json` });
+        }>({
+          filePath: `cms/earn/strategies.json`,
+          commitHash: "fd745214f7471931e80b36363863e27f0ea681bf",
+        });
 
         const aggregatedStrategies: StrategyCMSData[] = [];
 
@@ -157,6 +167,7 @@ export async function getStrategies({
 
           aggregatedStrategies.push({
             ...rawStrategy,
+            balanceUrl: rawStrategy.balance,
             depositAssets: depositAssets.filter(
               (deposit) => !!deposit
             ) as MinimalAsset[],

--- a/packages/server/src/queries/complex/earn/strategies.ts
+++ b/packages/server/src/queries/complex/earn/strategies.ts
@@ -40,8 +40,13 @@ const earnRawStrategyCMSDataCache = new LRUCache<string, CacheEntry>(
 );
 export async function getStrategyBalance(
   strategyId: string,
-  userOsmoAddress: string
+  userOsmoAddress: string,
+  rawBalanceUrl?: string
 ) {
+  const balanceUrl = rawBalanceUrl
+    ?.replace("${id}", strategyId)
+    ?.replace("${address}", userOsmoAddress);
+
   return await cachified({
     cache: earnStrategyBalanceCache,
     ttl: 1000 * 20,
@@ -49,7 +54,7 @@ export async function getStrategyBalance(
     getFreshValue: async (): Promise<EarnStrategyBalance | undefined> => {
       try {
         const { balance, strategy, unclaimed_rewards } =
-          await queryEarnUserBalance(strategyId, userOsmoAddress);
+          await queryEarnUserBalance(strategyId, userOsmoAddress, balanceUrl);
 
         return {
           balance: {

--- a/packages/server/src/queries/complex/earn/strategies.ts
+++ b/packages/server/src/queries/complex/earn/strategies.ts
@@ -41,11 +41,11 @@ const earnRawStrategyCMSDataCache = new LRUCache<string, CacheEntry>(
 export async function getStrategyBalance(
   strategyId: string,
   userOsmoAddress: string,
-  rawBalanceUrl?: string
+  rawBalanceUrl: string
 ) {
   const balanceUrl = rawBalanceUrl
-    ?.replace("${id}", strategyId)
-    ?.replace("${address}", userOsmoAddress);
+    .replace("${id}", strategyId)
+    .replace("${address}", userOsmoAddress);
 
   return await cachified({
     cache: earnStrategyBalanceCache,
@@ -54,7 +54,7 @@ export async function getStrategyBalance(
     getFreshValue: async (): Promise<EarnStrategyBalance | undefined> => {
       try {
         const { balance, strategy, unclaimed_rewards } =
-          await queryEarnUserBalance(strategyId, userOsmoAddress, balanceUrl);
+          await queryEarnUserBalance(balanceUrl);
 
         return {
           balance: {
@@ -137,7 +137,6 @@ export async function getStrategies({
           riskReportUrl: string;
         }>({
           filePath: `cms/earn/strategies.json`,
-          commitHash: "fd745214f7471931e80b36363863e27f0ea681bf",
         });
 
         const aggregatedStrategies: StrategyCMSData[] = [];
@@ -172,7 +171,6 @@ export async function getStrategies({
 
           aggregatedStrategies.push({
             ...rawStrategy,
-            balanceUrl: rawStrategy.balance,
             depositAssets: depositAssets.filter(
               (deposit) => !!deposit
             ) as MinimalAsset[],

--- a/packages/server/src/queries/data-services/earn.ts
+++ b/packages/server/src/queries/data-services/earn.ts
@@ -257,12 +257,16 @@ export interface EarnStrategy extends Omit<StrategyCMSData, "tvl"> {
 
 export function queryEarnUserBalance(
   strategyId: string,
-  userOsmoAddress: string
+  userOsmoAddress: string,
+  balanceUrl?: string
 ): Promise<RawEarnStrategyBalance> {
-  const url = new URL(
-    `/earn/strategies/${strategyId}/balance/${userOsmoAddress}`,
-    NUMIA_BASE_URL
-  );
+  const url = balanceUrl
+    ? balanceUrl
+    : new URL(
+        `/earn/strategies/${strategyId}/balance/${userOsmoAddress}`,
+        NUMIA_BASE_URL
+      );
+
   return apiClient(url.toString());
 }
 

--- a/packages/server/src/queries/data-services/earn.ts
+++ b/packages/server/src/queries/data-services/earn.ts
@@ -2,8 +2,6 @@ import { PricePretty, RatePretty } from "@keplr-wallet/unit";
 import { MinimalAsset } from "@osmosis-labs/types";
 import { apiClient } from "@osmosis-labs/utils";
 
-import { NUMIA_BASE_URL } from "../../env";
-
 export const EarnStrategyCategories = [
   "Staking",
   "Perp LP",
@@ -190,7 +188,7 @@ export interface StrategyCMSData {
   /**
    * URL for querying Balance
    */
-  balanceUrl?: string;
+  balance?: string;
   /**
    * Link for geoblocking check
    */
@@ -239,7 +237,7 @@ export interface EarnStrategyBalance {
 export type TokensType = "stablecoins" | "correlated" | "bluechip";
 
 export interface EarnStrategy extends Omit<StrategyCMSData, "tvl"> {
-  balance: PricePretty;
+  totalBalance: PricePretty;
   holdsTokens: boolean;
   daily?: RatePretty;
   tvl?: StrategyTVL;
@@ -256,17 +254,8 @@ export interface EarnStrategy extends Omit<StrategyCMSData, "tvl"> {
 }
 
 export function queryEarnUserBalance(
-  strategyId: string,
-  userOsmoAddress: string,
-  balanceUrl?: string
+  url: string
 ): Promise<RawEarnStrategyBalance> {
-  const url = balanceUrl
-    ? balanceUrl
-    : new URL(
-        `/earn/strategies/${strategyId}/balance/${userOsmoAddress}`,
-        NUMIA_BASE_URL
-      );
-
   return apiClient(url.toString());
 }
 

--- a/packages/server/src/queries/data-services/earn.ts
+++ b/packages/server/src/queries/data-services/earn.ts
@@ -94,6 +94,7 @@ export interface RawStrategyCMSData {
   contract: string;
   tvl: string;
   apr: string;
+  balance?: string;
   geoblock: string;
   lockDuration: string;
   riskLevel: number;
@@ -186,6 +187,10 @@ export interface StrategyCMSData {
    * URL for querying TVL
    */
   tvl: string;
+  /**
+   * URL for querying Balance
+   */
+  balanceUrl?: string;
   /**
    * Link for geoblocking check
    */

--- a/packages/trpc/src/earn.ts
+++ b/packages/trpc/src/earn.ts
@@ -17,8 +17,12 @@ export const earnRouter = createTRPCRouter({
         userOsmoAddress: z.string(),
       })
     )
-    .query(async ({ input: { strategyId, userOsmoAddress } }) => {
-      const res = await getStrategyBalance(strategyId, userOsmoAddress);
+    .query(async ({ input: { strategyId, userOsmoAddress, balanceUrl } }) => {
+      const res = await getStrategyBalance(
+        strategyId,
+        userOsmoAddress,
+        balanceUrl
+      );
       return res;
     }),
   getStrategyAnnualPercentages: publicProcedure

--- a/packages/trpc/src/earn.ts
+++ b/packages/trpc/src/earn.ts
@@ -10,21 +10,27 @@ import { createTRPCRouter, publicProcedure } from "./api";
 
 export const earnRouter = createTRPCRouter({
   getStrategyBalance: publicProcedure
-    .input(z.object({ strategyId: z.string(), userOsmoAddress: z.string() }))
+    .input(
+      z.object({
+        strategyId: z.string(),
+        balanceUrl: z.string().optional(),
+        userOsmoAddress: z.string(),
+      })
+    )
     .query(async ({ input: { strategyId, userOsmoAddress } }) => {
       const res = await getStrategyBalance(strategyId, userOsmoAddress);
       return res;
     }),
   getStrategyAnnualPercentages: publicProcedure
-    .input(z.object({ aprUrl: z.string() }))
-    .query(async ({ input: { aprUrl } }) => {
-      const res = await getStrategyAnnualPercentages(aprUrl);
+    .input(z.object({ strategyId: z.string(), aprUrl: z.string() }))
+    .query(async ({ input: { strategyId, aprUrl } }) => {
+      const res = await getStrategyAnnualPercentages(strategyId, aprUrl);
       return res;
     }),
   getStrategyTVL: publicProcedure
-    .input(z.object({ tvlUrl: z.string() }))
-    .query(async ({ input: { tvlUrl } }) => {
-      const res = await getStrategyTVL(tvlUrl);
+    .input(z.object({ strategyId: z.string(), tvlUrl: z.string() }))
+    .query(async ({ input: { strategyId, tvlUrl } }) => {
+      const res = await getStrategyTVL(strategyId, tvlUrl);
       return res;
     }),
   getStrategies: publicProcedure.query(({ ctx }) => getStrategies(ctx)),

--- a/packages/trpc/src/earn.ts
+++ b/packages/trpc/src/earn.ts
@@ -13,7 +13,7 @@ export const earnRouter = createTRPCRouter({
     .input(
       z.object({
         strategyId: z.string(),
-        balanceUrl: z.string().optional(),
+        balanceUrl: z.string(),
         userOsmoAddress: z.string(),
       })
     )

--- a/packages/web/components/earn/table/columns.tsx
+++ b/packages/web/components/earn/table/columns.tsx
@@ -187,7 +187,7 @@ export const tableColumns = [
     ),
     cell: RiskCell,
   }),
-  columnHelper.accessor("balance", {
+  columnHelper.accessor("totalBalance", {
     header: () => <ColumnCellHeader tKey={"assets.table.columns.balance"} />,
     cell: (item) => (
       <div className="flex flex-col">

--- a/packages/web/hooks/use-get-earn-strategies.ts
+++ b/packages/web/hooks/use-get-earn-strategies.ts
@@ -67,6 +67,7 @@ export const useGetEarnStrategies = (
     (isWalletConnected ? _strategies ?? [] : []).map((strat) =>
       q.edge.earn.getStrategyBalance(
         {
+          balanceUrl: strat.balanceUrl,
           strategyId: strat.id,
           userOsmoAddress,
         },
@@ -84,6 +85,7 @@ export const useGetEarnStrategies = (
     (_strategies ?? []).map((strat) =>
       q.edge.earn.getStrategyAnnualPercentages(
         {
+          strategyId: strat.id,
           aprUrl: strat.aprUrl ?? "",
         },
         {
@@ -93,6 +95,7 @@ export const useGetEarnStrategies = (
           select: (data) => ({ ...data, strategyId: strat.id }),
           trpc: { context: { skipBatch: true } },
           retry: false,
+          enabled: Boolean(strat.aprUrl),
         }
       )
     )
@@ -102,6 +105,7 @@ export const useGetEarnStrategies = (
     (_strategies ?? []).map((strat) =>
       q.edge.earn.getStrategyTVL(
         {
+          strategyId: strat.id,
           tvlUrl: strat.tvlUrl ?? "",
         },
         {
@@ -123,7 +127,9 @@ export const useGetEarnStrategies = (
         queryKey: ["geoblocked", strat.geoblock],
         queryFn: async () => {
           return {
-            response: await apiClient<LevanaGeoBlockedResponse>(strat.geoblock),
+            response: await apiClient<LevanaGeoBlockedResponse>(
+              strat.geoblock.replace("${id}", strat.id)
+            ),
             geoblock: strat.geoblock,
           };
         },

--- a/packages/web/hooks/use-strategy-table-config.ts
+++ b/packages/web/hooks/use-strategy-table-config.ts
@@ -38,7 +38,7 @@ export const useStrategyTableConfig = (
     getSortedRowModel: getSortedRowModel(),
     state: {
       columnVisibility: {
-        balance: showBalance,
+        totalBalance: showBalance,
         depositAssets: !isMobile,
         provider: false,
         holdsTokens: false,


### PR DESCRIPTION
## What is the purpose of the change:

We wanna be able to support custom tvl, apr and balance api for each strategy, to be able to do that we need to change the current schema inside our cms:

https://github.com/osmosis-labs/fe-content/pull/86

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-781/add-new-earn-strategy-endpoint-schema)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->
