### PR TITLE
feat: added canonical orderbooks query to edge router for orderbooks

### DIFF
--- a/packages/server/src/queries/complex/orderbooks/pools.ts
+++ b/packages/server/src/queries/complex/orderbooks/pools.ts
@@ -3,17 +3,11 @@ import { LRUCache } from "lru-cache";
 
 import { DEFAULT_LRU_OPTIONS } from "../../../utils/cache";
 import { ChainCosmwasmPool, queryPools } from "../../sidecar";
+import { queryCanonicalOrderbooks } from "../../sidecar/orderbooks";
 
 const orderbookPoolsCache = new LRUCache<string, CacheEntry>(
   DEFAULT_LRU_OPTIONS
 );
-
-const orderBookCodeIds = [865, 885];
-
-interface OrderbookInstantiateMsg {
-  quote_denom: string;
-  base_denom: string;
-}
 
 export interface Orderbook {
   baseDenom: string;
@@ -28,25 +22,25 @@ export function getOrderbookPools() {
     key: `orderbookPools`,
     ttl: 1000 * 60 * 60, // 1 hour
     getFreshValue: () =>
-      queryPools().then((data) => {
-        return data
-          .filter((pool) => {
-            const chainModel = pool.chain_model as ChainCosmwasmPool;
-            return orderBookCodeIds.includes(chainModel.code_id);
-          })
-          .map((pool) => {
-            const chainModel = pool.chain_model as ChainCosmwasmPool;
-            const instMsg: OrderbookInstantiateMsg = JSON.parse(
-              atob(chainModel.instantiate_msg)
-            );
+      queryCanonicalOrderbooks().then(async (data) => {
+        const pools = await queryPools({
+          poolIds: data.map((pool) => pool.pool_id.toString()),
+        });
+        return data.map((orderbook) => {
+          const pool = pools.find(
+            (pool) =>
+              (pool.chain_model as ChainCosmwasmPool).pool_id ===
+              orderbook.pool_id
+          );
 
-            return {
-              baseDenom: instMsg.base_denom,
-              quoteDenom: instMsg.quote_denom,
-              contractAddress: chainModel.contract_address,
-              poolId: chainModel.pool_id.toString(),
-            };
-          }) as Orderbook[];
+          return {
+            baseDenom: orderbook.base,
+            quoteDenom: orderbook.quote,
+            contractAddress: (pool!.chain_model as ChainCosmwasmPool)
+              .contract_address,
+            poolId: orderbook.pool_id.toString(),
+          };
+        }) as Orderbook[];
       }),
   });
 }

--- a/packages/server/src/queries/complex/orderbooks/pools.ts
+++ b/packages/server/src/queries/complex/orderbooks/pools.ts
@@ -2,7 +2,6 @@ import cachified, { CacheEntry } from "cachified";
 import { LRUCache } from "lru-cache";
 
 import { DEFAULT_LRU_OPTIONS } from "../../../utils/cache";
-import { ChainCosmwasmPool, queryPools } from "../../sidecar";
 import { queryCanonicalOrderbooks } from "../../sidecar/orderbooks";
 
 const orderbookPoolsCache = new LRUCache<string, CacheEntry>(
@@ -23,21 +22,11 @@ export function getOrderbookPools() {
     ttl: 1000 * 60 * 60, // 1 hour
     getFreshValue: () =>
       queryCanonicalOrderbooks().then(async (data) => {
-        const pools = await queryPools({
-          poolIds: data.map((pool) => pool.pool_id.toString()),
-        });
         return data.map((orderbook) => {
-          const pool = pools.find(
-            (pool) =>
-              (pool.chain_model as ChainCosmwasmPool).pool_id ===
-              orderbook.pool_id
-          );
-
           return {
             baseDenom: orderbook.base,
             quoteDenom: orderbook.quote,
-            contractAddress: (pool!.chain_model as ChainCosmwasmPool)
-              .contract_address,
+            contractAddress: orderbook.contract_address,
             poolId: orderbook.pool_id.toString(),
           };
         }) as Orderbook[];

--- a/packages/server/src/queries/sidecar/orderbooks.ts
+++ b/packages/server/src/queries/sidecar/orderbooks.ts
@@ -6,6 +6,7 @@ export type CanonicalOrderbooksResponse = {
   base: string;
   quote: string;
   pool_id: number;
+  contract_address: string;
 }[];
 
 export async function queryCanonicalOrderbooks() {

--- a/packages/server/src/queries/sidecar/orderbooks.ts
+++ b/packages/server/src/queries/sidecar/orderbooks.ts
@@ -1,0 +1,14 @@
+import { apiClient } from "@osmosis-labs/utils";
+
+import { SIDECAR_BASE_URL } from "../../env";
+
+export type CanonicalOrderbooksResponse = {
+  base: string;
+  quote: string;
+  pool_id: number;
+}[];
+
+export async function queryCanonicalOrderbooks() {
+  const url = new URL("/pools/canonical-orderbooks", SIDECAR_BASE_URL);
+  return await apiClient<CanonicalOrderbooksResponse>(url.toString());
+}

--- a/packages/web/hooks/limit-orders/use-orderbook.ts
+++ b/packages/web/hooks/limit-orders/use-orderbook.ts
@@ -11,11 +11,11 @@ import { useSwapAsset } from "~/hooks/use-swap";
 import { useStore } from "~/stores";
 import { api } from "~/utils/trpc";
 
-const USDC_DENOM = process.env.NEXT_PUBLIC_IS_TESTNET
-  ? "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
-  : "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4";
-const USDT_DENOM = process.env.NEXT_PUBLIC_IS_TESTNET ? "" : "";
-const validDenoms = [USDC_DENOM, USDT_DENOM];
+// const USDC_DENOM = process.env.NEXT_PUBLIC_IS_TESTNET
+//   ? "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
+//   : "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4";
+// const USDT_DENOM = process.env.NEXT_PUBLIC_IS_TESTNET ? "" : "";
+// const validDenoms = [USDC_DENOM, USDT_DENOM];
 
 /**
  * Retrieves all available orderbooks for the current chain.
@@ -29,14 +29,7 @@ export const useOrderbooks = (): {
   const { data: orderbooks, isLoading } =
     api.edge.orderbooks.getPools.useQuery();
 
-  const onlyStableOrderbooks = useMemo(
-    () =>
-      (orderbooks ?? []).filter(({ quoteDenom }) =>
-        validDenoms.includes(quoteDenom)
-      ),
-    [orderbooks]
-  );
-  return { orderbooks: onlyStableOrderbooks, isLoading };
+  return { orderbooks: orderbooks ?? [], isLoading };
 };
 
 /**


### PR DESCRIPTION
## What is the purpose of the change:
This change adds a new SQS query to identify which orderbooks to use from the frontend.

### Linear Task

[LIM-188: Add Canonical Orderbook SQS Query](https://linear.app/osmosis/issue/LIM-188/add-canonical-orderbook-sqs-query)

## Brief Changelog
- Updated `getOrderbookPools` to use a new `queryCanonicalOrderbooks` query for SQS
