### PR TITLE
Api client: add object check

### DIFF
--- a/packages/utils/src/api-client.ts
+++ b/packages/utils/src/api-client.ts
@@ -89,7 +89,8 @@ export async function apiClient<T>(
         });
       }
 
-      if (response.ok) {
+      // Look for specific errors returned from OK response
+      if (response.ok && typeof data === "object") {
         // Cosmos chains return a code if there's an error
         if ("code" in data && Boolean(data.code)) {
           throw new ApiClientError({


### PR DESCRIPTION
## What is the purpose of the change:

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

I've noticed in vercel logs text data responses are assumed to be objects. This checks for the data being an object using `in` operator.

Example Vercel error:
```
Fetch Error. Info: {
  endpoint: 'https://stage-proxy-data-api.osmosis-labs.workers.dev/tokens/v2/mcap',
  config: { method: 'GET', body: undefined },
  status: 200,
  exception: TypeError: Cannot use 'in' operator to search for 'code' in n/a
    at (../utils/build/api-client.js:80:24)
    at (../utils/build/api-client.js:5:57)
}
```