### PR TITLE
fix: :bug: fix y axis rendering for small prices

### DIFF
--- a/packages/web/components/chart/light-weight-charts/utils.ts
+++ b/packages/web/components/chart/light-weight-charts/utils.ts
@@ -8,7 +8,10 @@ export const priceFormatter = (price: number) => {
   const minimumDecimals = 2;
   const maxDecimals = Math.max(getDecimalCount(price), minimumDecimals);
 
-  if (price < 0) {
+  /**
+   * Exclude negative and small values
+   */
+  if (price < 0 || price < 10e-17) {
     return "";
   }
 


### PR DESCRIPTION
## What is the purpose of the change:

Fix odd behavior on Y axis with extremely long scientific notation

![image](https://github.com/user-attachments/assets/b708c0ff-5763-4cb4-b73e-3f83e22cebb8)

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-657/odd-behavior-on-y-axis-with-extremely-long-scientific-notation)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->
