### PR TITLE
feat: limit order amplitude events

### DIFF
--- a/packages/web/components/complex/orders-history/index.tsx
+++ b/packages/web/components/complex/orders-history/index.tsx
@@ -52,6 +52,10 @@ export const OrderHistory = observer(() => {
       await claimAllOrders();
       logEvent([EventName.LimitOrder.claimOrdersCompleted]);
     } catch (error) {
+      if (error instanceof Error && error.message === "Request rejected") {
+        // don't log when the user rejects in wallet
+        return;
+      }
       const { message } = error as Error;
       logEvent([
         EventName.LimitOrder.claimOrdersFailed,

--- a/packages/web/components/complex/orders-history/index.tsx
+++ b/packages/web/components/complex/orders-history/index.tsx
@@ -24,7 +24,9 @@ import { useStore } from "~/stores";
 export type Order = ReturnType<typeof useOrderbookAllActiveOrders>["orders"][0];
 
 export const OrderHistory = observer(() => {
-  const { logEvent } = useAmplitudeAnalytics();
+  const { logEvent } = useAmplitudeAnalytics({
+    onLoadEvent: [EventName.LimitOrder.pageViewed],
+  });
   const { accountStore } = useStore();
   const wallet = accountStore.getWallet(accountStore.osmosisChainId);
 

--- a/packages/web/components/complex/orders-history/index.tsx
+++ b/packages/web/components/complex/orders-history/index.tsx
@@ -7,11 +7,13 @@ import { useWindowVirtualizer } from "@tanstack/react-virtual";
 import { observer } from "mobx-react-lite";
 import Image from "next/image";
 import Link from "next/link";
-import React, { useEffect, useMemo } from "react";
+import React, { useCallback, useEffect, useMemo } from "react";
 
 import { Icon } from "~/components/assets";
 import { tableColumns } from "~/components/complex/orders-history/columns";
 import { Spinner } from "~/components/loaders";
+import { EventName } from "~/config";
+import { useAmplitudeAnalytics } from "~/hooks";
 import {
   DisplayableLimitOrder,
   useOrderbookAllActiveOrders,
@@ -22,6 +24,7 @@ import { useStore } from "~/stores";
 export type Order = ReturnType<typeof useOrderbookAllActiveOrders>["orders"][0];
 
 export const OrderHistory = observer(() => {
+  const { logEvent } = useAmplitudeAnalytics();
   const { accountStore } = useStore();
   const wallet = accountStore.getWallet(accountStore.osmosisChainId);
 
@@ -40,6 +43,20 @@ export const OrderHistory = observer(() => {
   const { count, claimAllOrders } = useOrderbookClaimableOrders({
     userAddress: wallet?.address ?? "",
   });
+
+  const claimOrders = useCallback(async () => {
+    try {
+      logEvent([EventName.LimitOrder.claimOrdersStarted]);
+      await claimAllOrders();
+      logEvent([EventName.LimitOrder.claimOrdersCompleted]);
+    } catch (error) {
+      const { message } = error as Error;
+      logEvent([
+        EventName.LimitOrder.claimOrdersFailed,
+        { errorMessage: message },
+      ]);
+    }
+  }, [claimAllOrders, logEvent]);
 
   const filledOrders = useMemo(
     () =>
@@ -274,7 +291,7 @@ export const OrderHistory = observer(() => {
                     </div>
                     <button
                       className="flex items-center justify-center rounded-[48px] bg-wosmongton-700 py-3 px-4"
-                      onClick={claimAllOrders}
+                      onClick={claimOrders}
                     >
                       <span className="subtitle1">Claim all</span>
                     </button>

--- a/packages/web/components/place-limit-tool/index.tsx
+++ b/packages/web/components/place-limit-tool/index.tsx
@@ -20,20 +20,21 @@ import { LimitTradeDetails } from "~/components/place-limit-tool/limit-trade-det
 import { TRADE_TYPES } from "~/components/swap-tool/order-type-selector";
 import { TradeDetails } from "~/components/swap-tool/trade-details";
 import { Button } from "~/components/ui/button";
+import { EventPage } from "~/config";
 import { useTranslation, useWalletSelect } from "~/hooks";
-import { OrderDirection, usePlaceLimit } from "~/hooks/limit-orders";
+import { usePlaceLimit } from "~/hooks/limit-orders";
 import { useOrderbookAllActiveOrders } from "~/hooks/limit-orders/use-orderbook";
 import { ReviewLimitOrderModal } from "~/modals/review-limit-order";
 import { useStore } from "~/stores";
 
 export interface PlaceLimitToolProps {
-  orderDirection: OrderDirection;
+  page: EventPage;
 }
 
 const WHALE_MESSAGE_THRESHOLD = 100;
 
 export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
-  () => {
+  ({ page }: PlaceLimitToolProps) => {
     const { accountStore } = useStore();
     const { t } = useTranslation();
     const [reviewOpen, setReviewOpen] = useState<boolean>(false);
@@ -60,6 +61,7 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
       baseDenom: base,
       quoteDenom: quote,
       type,
+      page,
     });
 
     // Adjust price to base price if the type changes to "market"

--- a/packages/web/components/place-limit-tool/limit-trade-details.tsx
+++ b/packages/web/components/place-limit-tool/limit-trade-details.tsx
@@ -1,7 +1,6 @@
 import { Disclosure } from "@headlessui/react";
-import { Dec, PricePretty } from "@keplr-wallet/unit";
+import { Dec } from "@keplr-wallet/unit";
 import { EmptyAmountError } from "@osmosis-labs/keplr-hooks";
-import { DEFAULT_VS_CURRENCY } from "@osmosis-labs/server";
 import classNames from "classnames";
 import React, { FC, memo, useMemo } from "react";
 
@@ -20,18 +19,9 @@ interface LimitTradeDetailsProps {
 export const LimitTradeDetails: FC<LimitTradeDetailsProps> = memo(
   ({ swapState }) => {
     const { t } = useTranslation();
-    const { makerFeeFiat /*totalFeeFiat*/ } = useMemo(() => {
-      const makerFeeFiat = (
-        swapState.paymentFiatValue ??
-        new PricePretty(DEFAULT_VS_CURRENCY, new Dec(0))
-      ).mul(swapState.makerFee);
-
-      const totalFeeFiat = makerFeeFiat;
-      return {
-        makerFeeFiat,
-        totalFeeFiat,
-      };
-    }, [swapState.makerFee, swapState.paymentFiatValue]);
+    const makerFeeFiat = useMemo(() => {
+      return swapState.feeUsdValue;
+    }, [swapState.feeUsdValue]);
 
     const isLoading = useMemo(() => {
       return swapState.isMakerFeeLoading;

--- a/packages/web/components/place-limit-tool/limit-trade-details.tsx
+++ b/packages/web/components/place-limit-tool/limit-trade-details.tsx
@@ -19,9 +19,6 @@ interface LimitTradeDetailsProps {
 export const LimitTradeDetails: FC<LimitTradeDetailsProps> = memo(
   ({ swapState }) => {
     const { t } = useTranslation();
-    const makerFeeFiat = useMemo(() => {
-      return swapState.feeUsdValue;
-    }, [swapState.feeUsdValue]);
 
     const isLoading = useMemo(() => {
       return swapState.isMakerFeeLoading;
@@ -130,7 +127,7 @@ export const LimitTradeDetails: FC<LimitTradeDetailsProps> = memo(
                     <span>
                       <span className="text-osmoverse-100">
                         ~
-                        {formatPretty(makerFeeFiat, {
+                        {formatPretty(swapState.feeUsdValue, {
                           maxDecimals: 2,
                           minimumFractionDigits: 2,
                         })}

--- a/packages/web/components/swap-tool/order-type-selector.tsx
+++ b/packages/web/components/swap-tool/order-type-selector.tsx
@@ -4,8 +4,8 @@ import { parseAsString, parseAsStringLiteral, useQueryState } from "nuqs";
 import React, { Fragment, useEffect, useMemo } from "react";
 
 import { Icon } from "~/components/assets";
-import { SpriteIconId } from "~/config";
-import { useTranslation } from "~/hooks";
+import { EventName, SpriteIconId } from "~/config";
+import { useAmplitudeAnalytics, useTranslation } from "~/hooks";
 import { useOrderbook } from "~/hooks/limit-orders/use-orderbook";
 
 interface UITradeType {
@@ -22,6 +22,7 @@ export const TRADE_TYPES = ["market", "limit"] as const;
 
 export const OrderTypeSelector = () => {
   const { t } = useTranslation();
+  const { logEvent } = useAmplitudeAnalytics();
 
   const [type, setType] = useQueryState(
     "type",
@@ -38,6 +39,18 @@ export const OrderTypeSelector = () => {
       setType("market");
     }
   }, [orderbook, setType, type]);
+
+  useEffect(() => {
+    switch (type) {
+      case "market":
+        logEvent([EventName.LimitOrder.marketOrderSelected]);
+        break;
+      case "limit":
+        logEvent([EventName.LimitOrder.limitOrderSelected]);
+        break;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [type]);
 
   const uiTradeTypes: UITradeType[] = useMemo(
     () => [

--- a/packages/web/components/trade-tool/index.tsx
+++ b/packages/web/components/trade-tool/index.tsx
@@ -1,7 +1,7 @@
 import { observer } from "mobx-react-lite";
 import Link from "next/link";
 import { parseAsStringEnum, useQueryState } from "nuqs";
-import { FunctionComponent, useMemo } from "react";
+import { FunctionComponent, useEffect, useMemo } from "react";
 
 import { Icon } from "~/components/assets";
 import { ClientOnly } from "~/components/client-only";
@@ -12,7 +12,8 @@ import {
   SwapToolTab,
   SwapToolTabs,
 } from "~/components/swap-tool/swap-tool-tabs";
-import { EventPage } from "~/config";
+import { EventName, EventPage } from "~/config";
+import { useAmplitudeAnalytics } from "~/hooks";
 import { useOrderbookClaimableOrders } from "~/hooks/limit-orders/use-orderbook";
 import { useStore } from "~/stores";
 
@@ -22,6 +23,7 @@ export interface TradeToolProps {
 
 export const TradeTool: FunctionComponent<TradeToolProps> = observer(
   ({ page }: TradeToolProps) => {
+    const { logEvent } = useAmplitudeAnalytics();
     const [tab, setTab] = useQueryState(
       "tab",
       parseAsStringEnum<SwapToolTab>(Object.values(SwapToolTab)).withDefault(
@@ -38,6 +40,21 @@ export const TradeTool: FunctionComponent<TradeToolProps> = observer(
       userAddress:
         accountStore.getWallet(accountStore.osmosisChainId)?.address ?? "",
     });
+
+    useEffect(() => {
+      switch (tab) {
+        case SwapToolTab.BUY:
+          logEvent([EventName.LimitOrder.buySelected]);
+          break;
+        case SwapToolTab.SELL:
+          logEvent([EventName.LimitOrder.sellSelected]);
+          break;
+        case SwapToolTab.SWAP:
+          logEvent([EventName.LimitOrder.swapSelected]);
+          break;
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [tab]);
 
     return (
       <ClientOnly>

--- a/packages/web/components/trade-tool/index.tsx
+++ b/packages/web/components/trade-tool/index.tsx
@@ -12,74 +12,75 @@ import {
   SwapToolTab,
   SwapToolTabs,
 } from "~/components/swap-tool/swap-tool-tabs";
+import { EventPage } from "~/config";
 import { useOrderbookClaimableOrders } from "~/hooks/limit-orders/use-orderbook";
 import { useStore } from "~/stores";
 
-export interface TradeToolProps {}
+export interface TradeToolProps {
+  page: EventPage;
+}
 
-export const TradeTool: FunctionComponent<TradeToolProps> = observer(() => {
-  const [tab, setTab] = useQueryState(
-    "tab",
-    parseAsStringEnum<SwapToolTab>(Object.values(SwapToolTab)).withDefault(
-      SwapToolTab.SWAP
-    )
-  );
+export const TradeTool: FunctionComponent<TradeToolProps> = observer(
+  ({ page }: TradeToolProps) => {
+    const [tab, setTab] = useQueryState(
+      "tab",
+      parseAsStringEnum<SwapToolTab>(Object.values(SwapToolTab)).withDefault(
+        SwapToolTab.SWAP
+      )
+    );
 
-  const { accountStore } = useStore();
-  const isWalletConnected = accountStore.getWallet(
-    accountStore.osmosisChainId
-  )?.isWalletConnected;
+    const { accountStore } = useStore();
+    const isWalletConnected = accountStore.getWallet(
+      accountStore.osmosisChainId
+    )?.isWalletConnected;
 
-  const { count } = useOrderbookClaimableOrders({
-    userAddress:
-      accountStore.getWallet(accountStore.osmosisChainId)?.address ?? "",
-  });
+    const { count } = useOrderbookClaimableOrders({
+      userAddress:
+        accountStore.getWallet(accountStore.osmosisChainId)?.address ?? "",
+    });
 
-  return (
-    <ClientOnly>
-      <div className="relative flex flex-col gap-3 md:gap-3 md:px-3 md:pb-4 md:pt-4">
-        <div className="flex w-full items-center justify-between">
-          <SwapToolTabs activeTab={tab} setTab={setTab} />
-          <div className="flex items-center gap-3">
-            {tab !== SwapToolTab.SWAP && <OrderTypeSelector />}
-            {isWalletConnected && (
-              <Link
-                href={"/transactions?tab=orders&fromPage=swap"}
-                className="relative flex h-12 w-12 items-center justify-center overflow-visible rounded-full bg-osmoverse-825 transition-colors hover:bg-osmoverse-700"
-              >
-                <Icon
-                  id="history-uncolored"
-                  width={24}
-                  height={24}
-                  className="h-6 w-6 text-wosmongton-200"
-                />
-                {count > 0 && (
-                  <div className="absolute -top-1 -right-1 flex h-6 w-6 items-center justify-center rounded-full bg-[#A51399]">
-                    <span className="text-xs leading-[14px]">{count}</span>
-                  </div>
-                )}
-              </Link>
-            )}
+    return (
+      <ClientOnly>
+        <div className="relative flex flex-col gap-3 md:gap-3 md:px-3 md:pb-4 md:pt-4">
+          <div className="flex w-full items-center justify-between">
+            <SwapToolTabs activeTab={tab} setTab={setTab} />
+            <div className="flex items-center gap-3">
+              {tab !== SwapToolTab.SWAP && <OrderTypeSelector />}
+              {isWalletConnected && (
+                <Link
+                  href={"/transactions?tab=orders&fromPage=swap"}
+                  className="relative flex h-12 w-12 items-center justify-center overflow-visible rounded-full bg-osmoverse-825 transition-colors hover:bg-osmoverse-700"
+                >
+                  <Icon
+                    id="history-uncolored"
+                    width={24}
+                    height={24}
+                    className="h-6 w-6 text-wosmongton-200"
+                  />
+                  {count > 0 && (
+                    <div className="absolute -top-1 -right-1 flex h-6 w-6 items-center justify-center rounded-full bg-[#A51399]">
+                      <span className="text-xs leading-[14px]">{count}</span>
+                    </div>
+                  )}
+                </Link>
+              )}
+            </div>
           </div>
+          {useMemo(() => {
+            switch (tab) {
+              case SwapToolTab.BUY:
+                return <PlaceLimitTool page={page} />;
+              case SwapToolTab.SELL:
+                return <PlaceLimitTool page={page} />;
+              case SwapToolTab.SWAP:
+              default:
+                return (
+                  <AltSwapTool useOtherCurrencies useQueryParams page={page} />
+                );
+            }
+          }, [tab, page])}
         </div>
-        {useMemo(() => {
-          switch (tab) {
-            case SwapToolTab.BUY:
-              return <PlaceLimitTool orderDirection={"bid"} />;
-            case SwapToolTab.SELL:
-              return <PlaceLimitTool orderDirection={"ask"} />;
-            case SwapToolTab.SWAP:
-            default:
-              return (
-                <AltSwapTool
-                  useOtherCurrencies
-                  useQueryParams
-                  page="Swap Page"
-                />
-              );
-          }
-        }, [tab])}
-      </div>
-    </ClientOnly>
-  );
-});
+      </ClientOnly>
+    );
+  }
+);

--- a/packages/web/config/analytics-events.ts
+++ b/packages/web/config/analytics-events.ts
@@ -250,6 +250,11 @@ export const EventName = {
     accessed: "1CT: Accessed",
   },
   LimitOrder: {
+    buySelected: "Buy tab selected",
+    sellSelected: "Sell tab selected",
+    swapSelected: "Swap tab selected",
+    marketOrderSelected: "Market Order selected",
+    limitOrderSelected: "Limit Order selected",
     placeOrderStarted: "Limit Order: Place order started",
     placeOrderCompleted: "Limit Order: Place order completed",
     placeOrderFailed: "Limit Order: Place order failed",

--- a/packages/web/config/analytics-events.ts
+++ b/packages/web/config/analytics-events.ts
@@ -249,4 +249,9 @@ export const EventName = {
     enableOneClickTrading: "1CT: Enable 1-Click Trading",
     accessed: "1CT: Accessed",
   },
+  LimitOrder: {
+    placeOrderStarted: "Limit Order: Place order started",
+    placeOrderCompleted: "Limit Order: Place order completed",
+    placeOrderFailed: "Limit Order: Place order failed",
+  },
 };

--- a/packages/web/config/analytics-events.ts
+++ b/packages/web/config/analytics-events.ts
@@ -253,9 +253,9 @@ export const EventName = {
     placeOrderStarted: "Limit Order: Place order started",
     placeOrderCompleted: "Limit Order: Place order completed",
     placeOrderFailed: "Limit Order: Place order failed",
-    claimOrdersStarted: "Limit Order: Claim order started",
-    claimOrdersCompleted: "Limit Order: Claim order completed",
-    claimOrdersFailed: "Limit Order: Claim order failed",
+    claimOrdersStarted: "Limit Order: Claim all orders started",
+    claimOrdersCompleted: "Limit Order: Claim all orders completed",
+    claimOrdersFailed: "Limit Order: Claim all orders failed",
     pageViewed: "Limit Order: Order page viewed",
   },
 };

--- a/packages/web/config/analytics-events.ts
+++ b/packages/web/config/analytics-events.ts
@@ -253,5 +253,8 @@ export const EventName = {
     placeOrderStarted: "Limit Order: Place order started",
     placeOrderCompleted: "Limit Order: Place order completed",
     placeOrderFailed: "Limit Order: Place order failed",
+    claimOrdersStarted: "Limit Order: Claim order started",
+    claimOrdersCompleted: "Limit Order: Claim order completed",
+    claimOrdersFailed: "Limit Order: Claim order failed",
   },
 };

--- a/packages/web/config/analytics-events.ts
+++ b/packages/web/config/analytics-events.ts
@@ -256,5 +256,6 @@ export const EventName = {
     claimOrdersStarted: "Limit Order: Claim order started",
     claimOrdersCompleted: "Limit Order: Claim order completed",
     claimOrdersFailed: "Limit Order: Claim order failed",
+    pageViewed: "Limit Order: Order page viewed",
   },
 };

--- a/packages/web/pages/index.tsx
+++ b/packages/web/pages/index.tsx
@@ -74,7 +74,7 @@ const HomeNew = () => {
       <div className="flex h-auto w-full justify-center">
         <div className="flex w-[35rem] flex-col gap-4 lg:mx-auto md:mt-mobile-header">
           {featureFlags.swapsAdBanner && <SwapAdsBanner />}
-          <TradeTool />
+          <TradeTool page={"Swap Page"} />
         </div>
       </div>
     </main>


### PR DESCRIPTION
## What is the purpose of the change:
This change adds amplitude analytics events for limit orders. The following events are included:
- Place Limit Started
- Place Limit Completed
- Place Limit Failed
- Claim All Orders Started
- Claim All Orders Failed
- Order History Page Viewed
- Buy/Sell/Swap tab selected
- Limit/Market selected

The current events for swaps were also added for market orders.

### Linear Task

[LIM-178: Add Amplitude Analytics Events](https://linear.app/osmosis/issue/LIM-178/add-amplitude-analytic-events)

## Brief Changelog
- Added limit order amplitude analytics event names
- Added event logs for limit order related events
