### PR TITLE
feat: added limitations to price input to prevent erroring

### DIFF
--- a/packages/web/components/input/limit-input.tsx
+++ b/packages/web/components/input/limit-input.tsx
@@ -9,7 +9,7 @@ import { Icon } from "~/components/assets";
 import { Spinner } from "~/components/loaders";
 import { useWindowSize } from "~/hooks";
 import { isValidNumericalRawInput } from "~/hooks/input/use-amount-input";
-import { trimPlaceholderZeros } from "~/utils/number";
+import { countDecimals, trimPlaceholderZeros } from "~/utils/number";
 
 export interface LimitInputProps {
   baseAsset: MinimalAsset;
@@ -60,14 +60,6 @@ export enum FocusedInput {
 const nonFocusedClasses =
   "top-[45%] text-wosmongton-200 hover:cursor-pointer select-none";
 const focusedClasses = "top-[0%] font-h3 font-normal";
-
-const countDecimals = function (value: string) {
-  const split = value.split(".");
-  if (split.length > 1) {
-    return split[1].length;
-  }
-  return 0;
-};
 
 const transformAmount = (value: string, decimalCount = 18) => {
   let updatedValue = value;

--- a/packages/web/components/place-limit-tool/index.tsx
+++ b/packages/web/components/place-limit-tool/index.tsx
@@ -202,6 +202,7 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
                     swapState.priceState.spotPrice
                   )
                 }
+                inPriceFetching={swapState.priceState.priceRefetching}
               />
             )}
           </>

--- a/packages/web/components/swap-tool/trade-details.tsx
+++ b/packages/web/components/swap-tool/trade-details.tsx
@@ -13,7 +13,7 @@ import AutosizeInput from "react-input-autosize";
 import { useMeasure } from "react-use";
 
 import { Icon } from "~/components/assets";
-import { Spinner } from "~/components/loaders";
+import { SkeletonLoader, Spinner } from "~/components/loaders";
 import { RouteLane } from "~/components/swap-tool/split-route";
 import { EventName } from "~/config";
 import {
@@ -36,6 +36,7 @@ interface TradeDetailsProps {
   outFiatAmountLessSlippage?: PricePretty;
   inDenom?: string;
   inPrice?: CoinPretty | PricePretty;
+  inPriceFetching?: boolean;
 }
 
 export const TradeDetails = ({
@@ -45,6 +46,7 @@ export const TradeDetails = ({
   outFiatAmountLessSlippage,
   inDenom,
   inPrice,
+  inPriceFetching,
 }: Partial<TradeDetailsProps>) => {
   const { logEvent } = useAmplitudeAnalytics();
   const { t } = useTranslation();
@@ -106,22 +108,25 @@ export const TradeDetails = ({
                 )}
                 disabled={isInAmountEmpty}
               >
-                <span
-                  className={classNames(
-                    "body2 text-osmoverse-300 transition-opacity",
-                    {
-                      "opacity-0": open,
-                    }
-                  )}
-                >
-                  {inDenom} {t("assets.table.price").toLowerCase()} ≈{" "}
-                  {inPrice &&
-                    formatPretty(inPrice ?? inPrice ?? new Dec(0), {
-                      maxDecimals: inPrice
-                        ? 2
-                        : Math.min(swapState?.toAsset?.coinDecimals ?? 8, 8),
-                    })}
-                </span>
+                <SkeletonLoader isLoaded={Boolean(inPrice)}>
+                  <span
+                    className={classNames(
+                      "body2 text-osmoverse-300 transition-opacity",
+                      {
+                        "opacity-0": open,
+                        "animate-pulse": inPriceFetching,
+                      }
+                    )}
+                  >
+                    {inDenom} {t("assets.table.price").toLowerCase()} ≈{" "}
+                    {inPrice &&
+                      formatPretty(inPrice ?? inPrice ?? new Dec(0), {
+                        maxDecimals: inPrice
+                          ? 2
+                          : Math.min(swapState?.toAsset?.coinDecimals ?? 8, 8),
+                      })}
+                  </span>
+                </SkeletonLoader>
                 <span
                   className={classNames("absolute transition-opacity", {
                     "opacity-100": open,

--- a/packages/web/modals/review-limit-order.tsx
+++ b/packages/web/modals/review-limit-order.tsx
@@ -2,7 +2,6 @@ import { Dec, PricePretty } from "@keplr-wallet/unit";
 import { DEFAULT_VS_CURRENCY } from "@osmosis-labs/server";
 import classNames from "classnames";
 import Image from "next/image";
-import { useQueryState } from "nuqs";
 import { ReactNode, useCallback, useMemo, useState } from "react";
 
 import { Icon } from "~/components/assets";
@@ -10,7 +9,7 @@ import { Button } from "~/components/buttons";
 import { useTranslation } from "~/hooks";
 import { OrderDirection, PlaceLimitState } from "~/hooks/limit-orders";
 import { ModalBase } from "~/modals/base";
-import { formatPretty } from "~/utils/formatter";
+import { formatPretty, getPriceExtendedFormatOptions } from "~/utils/formatter";
 
 export interface ReviewLimitOrderModalProps {
   isOpen: boolean;
@@ -60,16 +59,16 @@ export const ReviewLimitOrderModal: React.FC<ReviewLimitOrderModalProps> = ({
   const price = useMemo(() => {
     if (placeLimitState.isMarket) {
       const priceState = placeLimitState.priceState;
-      const price =
-        orderDirection === "bid"
-          ? priceState.askSpotPrice
-          : priceState.bidSpotPrice;
+      const price = priceState.spotPrice;
       return price ?? new Dec(0);
     }
     return placeLimitState.priceState.price;
-  }, [placeLimitState.isMarket, placeLimitState.priceState, orderDirection]);
+  }, [placeLimitState.isMarket, placeLimitState.priceState]);
 
-  const [orderType] = useQueryState("type");
+  const orderType = useMemo(
+    () => (placeLimitState.isMarket ? "market" : "limit"),
+    [placeLimitState.isMarket]
+  );
 
   const onConfirm = useCallback(async () => {
     setIsSigningMessage(true);
@@ -119,7 +118,11 @@ export const ReviewLimitOrderModal: React.FC<ReviewLimitOrderModalProps> = ({
                   : "0"}
               </h5>
               <span className="text-body1 text-osmoverse-300">
-                {t("limitOrders.at")} ${formatPretty(price ?? new Dec(0))}
+                {t("limitOrders.at")} $
+                {formatPretty(
+                  price ?? new Dec(0),
+                  getPriceExtendedFormatOptions(price)
+                )}
               </span>
             </div>
           </div>
@@ -205,7 +208,12 @@ export const ReviewLimitOrderModal: React.FC<ReviewLimitOrderModalProps> = ({
               left={t("assets.table.price")}
               right={
                 <span className="text-osmoverse-100">
-                  {price ? `$${formatPretty(price)}` : "$0"}
+                  {price
+                    ? `$${formatPretty(
+                        price,
+                        getPriceExtendedFormatOptions(price)
+                      )}`
+                    : "$0"}
                 </span>
               }
             />

--- a/packages/web/utils/number.ts
+++ b/packages/web/utils/number.ts
@@ -77,10 +77,10 @@ export function removeCommasFromNumber(number: string): string {
   return number.replace(/,/g, "");
 }
 
-export const countDecimals = function (value: string) {
+export function countDecimals(value: string) {
   const split = value.split(".");
   if (split.length > 1) {
     return split[1].length;
   }
   return 0;
-};
+}

--- a/packages/web/utils/number.ts
+++ b/packages/web/utils/number.ts
@@ -76,3 +76,11 @@ export function addCommasToNumber(number: string | number): string {
 export function removeCommasFromNumber(number: string): string {
   return number.replace(/,/g, "");
 }
+
+export const countDecimals = function (value: string) {
+  const split = value.split(".");
+  if (split.length > 1) {
+    return split[1].length;
+  }
+  return 0;
+};


### PR DESCRIPTION
## What is the purpose of the change:
These changes add restrictions to the price input by limiting it to min/max price. The fiat price input is also restricted to 2 decimal places similar to the fiat amount input.

These changes also include refectching of the spot price but this needs testing in another branch for how it affects limit input.

### Linear Task

[LIM-179: Price Input Causes Crash on Large Value](https://linear.app/osmosis/issue/LIM-179/[bug]-price-input-causes-crash-on-large-value)

