### PR TITLE
fix: removed query calls when parameters don't exist for orderbooks

### DIFF
--- a/packages/web/components/swap-tool/price-selector.tsx
+++ b/packages/web/components/swap-tool/price-selector.tsx
@@ -91,7 +91,7 @@ export const PriceSelector = memo(
     const { data: userQuotes } = api.edge.assets.getUserAssets.useQuery(
       { userOsmoAddress: wallet?.address },
       {
-        enabled: Boolean(wallet?.address),
+        enabled: !!wallet?.address,
         select: (data) =>
           data.items
             .filter((walletAsset) =>

--- a/packages/web/hooks/limit-orders/use-orderbook.ts
+++ b/packages/web/hooks/limit-orders/use-orderbook.ts
@@ -224,7 +224,7 @@ const useMakerFee = ({ orderbookAddress }: { orderbookAddress: string }) => {
       osmoAddress: orderbookAddress,
     },
     {
-      enabled: Boolean(orderbookAddress),
+      enabled: !!orderbookAddress,
     }
   );
 
@@ -268,7 +268,7 @@ export const useOrderbookAllActiveOrders = ({
       getNextPageParam: (lastPage) => lastPage.nextCursor,
       initialCursor: 0,
       keepPreviousData: true,
-      enabled: Boolean(userAddress) && addresses.length > 0,
+      enabled: !!userAddress && addresses.length > 0,
     }
   );
 
@@ -304,7 +304,7 @@ export const useOrderbookClaimableOrders = ({
       userOsmoAddress: userAddress,
     },
     {
-      enabled: Boolean(userAddress) && addresses.length > 0,
+      enabled: !!userAddress && addresses.length > 0,
     }
   );
 

--- a/packages/web/hooks/limit-orders/use-orderbook.ts
+++ b/packages/web/hooks/limit-orders/use-orderbook.ts
@@ -219,9 +219,14 @@ const useMakerFee = ({ orderbookAddress }: { orderbookAddress: string }) => {
     data: makerFeeData,
     isLoading,
     error,
-  } = api.edge.orderbooks.getMakerFee.useQuery({
-    osmoAddress: orderbookAddress,
-  });
+  } = api.edge.orderbooks.getMakerFee.useQuery(
+    {
+      osmoAddress: orderbookAddress,
+    },
+    {
+      enabled: Boolean(orderbookAddress),
+    }
+  );
 
   const makerFee = useMemo(() => {
     if (isLoading) return new Dec(0);
@@ -263,6 +268,7 @@ export const useOrderbookAllActiveOrders = ({
       getNextPageParam: (lastPage) => lastPage.nextCursor,
       initialCursor: 0,
       keepPreviousData: true,
+      enabled: Boolean(userAddress) && addresses.length > 0,
     }
   );
 
@@ -292,10 +298,15 @@ export const useOrderbookClaimableOrders = ({
     data: orders,
     isLoading,
     isFetching,
-  } = api.edge.orderbooks.getClaimableOrders.useQuery({
-    contractAddresses: addresses,
-    userOsmoAddress: userAddress,
-  });
+  } = api.edge.orderbooks.getClaimableOrders.useQuery(
+    {
+      contractAddresses: addresses,
+      userOsmoAddress: userAddress,
+    },
+    {
+      enabled: Boolean(userAddress) && addresses.length > 0,
+    }
+  );
 
   const claimAllOrders = useCallback(async () => {
     if (!account || !orders) return;

--- a/packages/web/hooks/limit-orders/use-place-limit.ts
+++ b/packages/web/hooks/limit-orders/use-place-limit.ts
@@ -261,7 +261,7 @@ export const usePlaceLimit = ({
     api.local.balances.getUserBalances.useQuery(
       { bech32Address: account?.address ?? "" },
       {
-        enabled: !!account?.address,
+        enabled: Boolean(account?.address),
         select: (balances) =>
           balances.find(({ denom }) => denom === baseAsset?.coinMinimalDenom)
             ?.coin,
@@ -271,7 +271,7 @@ export const usePlaceLimit = ({
     api.local.balances.getUserBalances.useQuery(
       { bech32Address: account?.address ?? "" },
       {
-        enabled: !!account?.address,
+        enabled: Boolean(account?.address),
         select: (balances) =>
           balances.find(({ denom }) => denom === quoteAsset?.coinMinimalDenom)
             ?.coin,
@@ -408,13 +408,23 @@ const useLimitPrice = ({
   orderDirection: OrderDirection;
   baseDenom?: string;
 }) => {
-  const { data, isLoading } = api.edge.orderbooks.getOrderbookState.useQuery({
-    osmoAddress: orderbookContractAddress,
-  });
+  const { data, isLoading } = api.edge.orderbooks.getOrderbookState.useQuery(
+    {
+      osmoAddress: orderbookContractAddress,
+    },
+    {
+      enabled: Boolean(orderbookContractAddress),
+    }
+  );
   const { data: assetPrice, isLoading: loadingAssetPrice } =
-    api.edge.assets.getAssetPrice.useQuery({
-      coinMinimalDenom: baseDenom ?? "",
-    });
+    api.edge.assets.getAssetPrice.useQuery(
+      {
+        coinMinimalDenom: baseDenom ?? "",
+      },
+      {
+        enabled: Boolean(baseDenom) && baseDenom!.length > 0,
+      }
+    );
 
   const [orderPrice, setOrderPrice] = useState("");
   const [manualPercentAdjusted, setManualPercentAdjusted] = useState("");

--- a/packages/web/hooks/limit-orders/use-place-limit.ts
+++ b/packages/web/hooks/limit-orders/use-place-limit.ts
@@ -261,7 +261,7 @@ export const usePlaceLimit = ({
     api.local.balances.getUserBalances.useQuery(
       { bech32Address: account?.address ?? "" },
       {
-        enabled: Boolean(account?.address),
+        enabled: !!account?.address,
         select: (balances) =>
           balances.find(({ denom }) => denom === baseAsset?.coinMinimalDenom)
             ?.coin,
@@ -271,7 +271,7 @@ export const usePlaceLimit = ({
     api.local.balances.getUserBalances.useQuery(
       { bech32Address: account?.address ?? "" },
       {
-        enabled: Boolean(account?.address),
+        enabled: !!account?.address,
         select: (balances) =>
           balances.find(({ denom }) => denom === quoteAsset?.coinMinimalDenom)
             ?.coin,
@@ -413,7 +413,7 @@ const useLimitPrice = ({
       osmoAddress: orderbookContractAddress,
     },
     {
-      enabled: Boolean(orderbookContractAddress),
+      enabled: !!orderbookContractAddress,
     }
   );
   const { data: assetPrice, isLoading: loadingAssetPrice } =
@@ -422,7 +422,7 @@ const useLimitPrice = ({
         coinMinimalDenom: baseDenom ?? "",
       },
       {
-        enabled: Boolean(baseDenom) && baseDenom!.length > 0,
+        enabled: !!baseDenom,
       }
     );
 

--- a/packages/web/hooks/limit-orders/use-place-limit.ts
+++ b/packages/web/hooks/limit-orders/use-place-limit.ts
@@ -497,7 +497,7 @@ const useLimitPrice = ({
       osmoAddress: orderbookContractAddress,
     },
     {
-      enabled: orderbookContractAddress.length > 0,
+      enabled: !!orderbookContractAddress,
     }
   );
   const {

--- a/packages/web/hooks/limit-orders/use-place-limit.ts
+++ b/packages/web/hooks/limit-orders/use-place-limit.ts
@@ -492,9 +492,14 @@ const useLimitPrice = ({
   orderDirection: OrderDirection;
   baseDenom?: string;
 }) => {
-  const { data, isLoading } = api.edge.orderbooks.getOrderbookState.useQuery({
-    osmoAddress: orderbookContractAddress,
-  });
+  const { data, isLoading } = api.edge.orderbooks.getOrderbookState.useQuery(
+    {
+      osmoAddress: orderbookContractAddress,
+    },
+    {
+      enabled: orderbookContractAddress.length > 0,
+    }
+  );
   const {
     data: assetPrice,
     isLoading: loadingAssetPrice,
@@ -503,7 +508,7 @@ const useLimitPrice = ({
     {
       coinMinimalDenom: baseDenom ?? "",
     },
-    { refetchInterval: 10000 }
+    { refetchInterval: 10000, enabled: !!baseDenom }
   );
 
   const [orderPrice, setOrderPrice] = useState("");


### PR DESCRIPTION
## What is the purpose of the change:
These changes add the `enabled` flag to several limit orders related queries.

### Linear Task

[LIM-190: Disable Orderbook Queries when Necessary](https://linear.app/osmosis/issue/LIM-190/disable-orderbook-queries-when-necessary)

## Brief Changelog
- Added `enabled` flag to all limit order related queries