### PR TITLE
[Limit Orders]: Price Input Redesign

### DIFF
--- a/packages/web/components/place-limit-tool/index.tsx
+++ b/packages/web/components/place-limit-tool/index.tsx
@@ -152,6 +152,12 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
             disabled={false}
             orderDirection={orderDirection}
           />
+          {type === "limit" && (
+            <LimitPriceSelector
+              swapState={swapState}
+              orderDirection={orderDirection}
+            />
+          )}
           <div className="relative flex flex-col rounded-2xl bg-osmoverse-1000">
             <p
               className={classNames(
@@ -184,27 +190,19 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
               insufficientFunds={swapState.insufficientFunds}
             />
           </div>
-          <>
-            {type === "limit" && (
-              <LimitPriceSelector
-                swapState={swapState}
-                orderDirection={orderDirection}
-              />
-            )}
-            {!swapState.isMarket && <LimitTradeDetails swapState={swapState} />}
-            {swapState.isMarket && (
-              <TradeDetails
-                swapState={swapState.marketState}
-                inDenom={swapState.baseAsset?.coinDenom}
-                inPrice={
-                  new PricePretty(
-                    DEFAULT_VS_CURRENCY,
-                    swapState.priceState.spotPrice
-                  )
-                }
-              />
-            )}
-          </>
+          {!swapState.isMarket && <LimitTradeDetails swapState={swapState} />}
+          {swapState.isMarket && (
+            <TradeDetails
+              swapState={swapState.marketState}
+              inDenom={swapState.baseAsset?.coinDenom}
+              inPrice={
+                new PricePretty(
+                  DEFAULT_VS_CURRENCY,
+                  swapState.priceState.spotPrice
+                )
+              }
+            />
+          )}
           {!account?.isWalletConnected ? (
             <Button
               onClick={() =>

--- a/packages/web/components/place-limit-tool/index.tsx
+++ b/packages/web/components/place-limit-tool/index.tsx
@@ -68,7 +68,7 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
         type === "market" &&
         swapState.priceState.percentAdjusted.abs().gt(new Dec(0))
       ) {
-        swapState.priceState.adjustByPercentage(new Dec(0));
+        swapState.priceState.reset();
       }
     }, [swapState.priceState, type]);
 

--- a/packages/web/components/place-limit-tool/limit-price-selector.tsx
+++ b/packages/web/components/place-limit-tool/limit-price-selector.tsx
@@ -121,7 +121,7 @@ export const LimitPriceSelector: FC<LimitPriceSelectorProps> = ({
   return (
     <div className="flex w-full flex-col items-start justify-start rounded-2xl bg-osmoverse-1000 py-3 px-5">
       <label
-        className="inline-flex w-full items-center justify-between gap-1 py-3"
+        className="inline-flex min-h-[32px] w-full items-center justify-between gap-1"
         htmlFor="price-input"
       >
         <span className="body2 text-osmoverse-300">
@@ -129,7 +129,6 @@ export const LimitPriceSelector: FC<LimitPriceSelectorProps> = ({
             denom: swapState.baseAsset?.coinDenom ?? "",
           })}{" "}
         </span>
-
         <div className="flex items-center justify-center">
           <SkeletonLoader
             isLoaded={priceState.spotPrice && !priceState.isLoading}
@@ -154,18 +153,15 @@ export const LimitPriceSelector: FC<LimitPriceSelectorProps> = ({
                     })}
                   />
                 )}
-              <div
-                className={classNames(
-                  "body2 inline-flex items-center gap-1 font-body2",
-                  {
-                    "text-rust-400": swapState.priceState.isBeyondOppositePrice,
-                    "text-osmoverse-300":
-                      !swapState.priceState.isBeyondOppositePrice,
-                  }
-                )}
+              <span
+                className={classNames("body2", {
+                  "text-rust-400": swapState.priceState.isBeyondOppositePrice,
+                  "text-osmoverse-300":
+                    !swapState.priceState.isBeyondOppositePrice,
+                })}
               >
-                <span>{priceLabel}</span>
-              </div>
+                {priceLabel}
+              </span>
             </div>
           </SkeletonLoader>
           {swapState.priceState.isBeyondOppositePrice && (
@@ -241,10 +237,11 @@ export const LimitPriceSelector: FC<LimitPriceSelectorProps> = ({
           </button>
         </div>
       </div>
-      <div className="grid w-full grid-cols-4 items-center justify-around gap-2 py-2">
+      <div className="flex w-full items-center justify-between gap-2 pt-3 pb-2">
         {percentAdjustmentOptions.map(({ label, value }) => (
           <button
-            className="mr-1 flex h-8 w-full items-center justify-center rounded-5xl border border-osmoverse-700 px-3 disabled:opacity-50"
+            type="button"
+            className="flex h-8 w-full items-center justify-center rounded-5xl border border-osmoverse-700 px-3 py-1 disabled:opacity-50"
             key={`limit-price-adjust-${label}`}
             onClick={() => {
               priceState.setPrice("");
@@ -254,8 +251,8 @@ export const LimitPriceSelector: FC<LimitPriceSelectorProps> = ({
             }}
             disabled={!priceState.spotPrice || priceState.isLoading}
           >
-            <span className="text-wosmongton-200">
-              {label !== "0%" && (orderDirection === "bid" ? "-" : "+")}
+            <span className="body2 text-wosmongton-200">
+              {orderDirection === "bid" ? "-" : "+"}
               {label}
             </span>
           </button>

--- a/packages/web/components/place-limit-tool/limit-price-selector.tsx
+++ b/packages/web/components/place-limit-tool/limit-price-selector.tsx
@@ -48,11 +48,6 @@ export const LimitPriceSelector: FC<LimitPriceSelectorProps> = ({
   }, [inputMode, input]);
 
   useEffect(() => {
-    swapState.priceState.reset();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [orderDirection]);
-
-  useEffect(() => {
     if (
       priceState.spotPrice &&
       priceState.orderPrice.length > 0 &&
@@ -141,7 +136,7 @@ export const LimitPriceSelector: FC<LimitPriceSelectorProps> = ({
           >
             <div
               className={classNames("flex items-center justify-center", {
-                "animate-pulse": swapState.priceState.isAssetPriceRefetching,
+                "animate-pulse": swapState.priceState.isSpotPriceRefetching,
               })}
             >
               {inputMode === InputMode.Price &&

--- a/packages/web/components/place-limit-tool/limit-price-selector.tsx
+++ b/packages/web/components/place-limit-tool/limit-price-selector.tsx
@@ -1,6 +1,6 @@
 import { Dec } from "@keplr-wallet/unit";
 import classNames from "classnames";
-import React, { FC, useCallback, useMemo, useState } from "react";
+import React, { FC, useCallback, useEffect, useMemo, useState } from "react";
 import AutosizeInput from "react-input-autosize";
 
 import { Icon } from "~/components/assets";
@@ -8,10 +8,11 @@ import { SkeletonLoader } from "~/components/loaders";
 import { Tooltip } from "~/components/tooltip";
 import { useTranslation } from "~/hooks";
 import { OrderDirection, PlaceLimitState } from "~/hooks/limit-orders";
-import { formatPretty } from "~/utils/formatter";
+import { formatPretty, getPriceExtendedFormatOptions } from "~/utils/formatter";
+import { trimPlaceholderZeros } from "~/utils/number";
 
 const percentAdjustmentOptions = [
-  { value: new Dec(0), label: "0%" },
+  { value: new Dec(0.005), label: "0.5%" },
   { value: new Dec(0.02), label: "2%" },
   { value: new Dec(0.05), label: "5%" },
   { value: new Dec(0.1), label: "10%" },
@@ -43,40 +44,64 @@ export const LimitPriceSelector: FC<LimitPriceSelectorProps> = ({
     );
   }, [inputMode]);
 
+  useEffect(() => {
+    swapState.priceState.reset();
+  }, [orderDirection]);
+
+  useEffect(() => {
+    if (
+      priceState.spotPrice &&
+      priceState.orderPrice.length > 0 &&
+      inputMode === InputMode.Price
+    ) {
+      const percentAdjusted = new Dec(priceState.orderPrice)
+        .quo(priceState.spotPrice)
+        .sub(new Dec(1))
+        .mul(new Dec(100));
+
+      priceState._setPercentAdjustedUnsafe(
+        percentAdjusted.isZero()
+          ? ""
+          : formatPretty(percentAdjusted.abs(), {
+              maxDecimals: 2,
+            }).toString()
+      );
+    }
+  }, [priceState.spotPrice, priceState.orderPrice, inputMode]);
+
   const priceLabel = useMemo(() => {
     if (inputMode === InputMode.Percentage) {
-      return formatPretty(priceState.priceFiat);
+      return formatPretty(
+        priceState.priceFiat,
+        getPriceExtendedFormatOptions(priceState.priceFiat.toDec())
+      );
     }
     return priceState.percentAdjusted.isZero()
       ? t("limitOrders.marketPrice")
-      : `${
-          priceState.percentAdjusted.isNegative()
-            ? priceState.percentAdjusted
-                .mul(new Dec(100))
-                .truncate()
-                .abs()
-                .toString()
-            : priceState.percentAdjusted
-                .mul(new Dec(100))
-                .abs()
-                .round()
-                .toString()
-        }% ${
-          priceState.percentAdjusted.isNegative()
-            ? t("limitOrders.below")
-            : t("limitOrders.above")
-        } ${t("limitOrders.currentPrice")}`;
+      : `${formatPretty(priceState.percentAdjusted.mul(new Dec(100)).abs())}%`;
   }, [inputMode, priceState.percentAdjusted, priceState.priceFiat, t]);
 
   const inputSuffix = useMemo(() => {
     return inputMode === InputMode.Price
       ? `= 1 ${swapState.baseAsset?.coinDenom}`
-      : `% ${
+      : priceState.percentAdjusted.isZero()
+      ? `${
           orderDirection === "bid"
             ? t("limitOrders.below")
             : t("limitOrders.above")
+        } ${t("limitOrders.currentPrice")}`
+      : `${
+          priceState.percentAdjusted.isNegative()
+            ? t("limitOrders.below")
+            : t("limitOrders.above")
         } ${t("limitOrders.currentPrice")}`;
-  }, [inputMode, swapState.baseAsset?.coinDenom, orderDirection, t]);
+  }, [
+    inputMode,
+    swapState.baseAsset?.coinDenom,
+    t,
+    priceState.percentAdjusted,
+    orderDirection,
+  ]);
 
   const TooltipContent = useMemo(() => {
     const translationId =
@@ -92,39 +117,59 @@ export const LimitPriceSelector: FC<LimitPriceSelectorProps> = ({
       </div>
     );
   }, [orderDirection, t]);
+
   return (
-    <>
-      <div className="inline-flex w-full items-center justify-between gap-1 pt-6">
-        <SkeletonLoader
-          isLoaded={priceState.spotPrice && !priceState.isLoading}
-        >
-          <div>
-            <span className="body2 text-osmoverse-300">
-              {t("limitOrders.whenDenomPriceIs", {
-                denom: swapState.baseAsset?.coinDenom ?? "",
-              })}{" "}
-            </span>
-            <button
-              className={classNames("body2 inline-flex items-center gap-1", {
-                "text-rust-400": swapState.priceState.isBeyondOppositePrice,
-                "text-wosmongton-300":
-                  !swapState.priceState.isBeyondOppositePrice,
+    <div className="flex w-full flex-col items-start justify-start rounded-2xl bg-osmoverse-1000 py-3 px-5">
+      <label
+        className="inline-flex w-full items-center justify-between gap-1 py-3"
+        htmlFor="price-input"
+      >
+        <span className="body2 text-osmoverse-300">
+          {t("limitOrders.whenDenomPriceIs", {
+            denom: swapState.baseAsset?.coinDenom ?? "",
+          })}{" "}
+        </span>
+
+        <div className="flex items-center justify-center">
+          <SkeletonLoader
+            isLoaded={priceState.spotPrice && !priceState.isLoading}
+          >
+            <div
+              className={classNames("flex items-center justify-center", {
+                "animate-pulse": swapState.priceState.isAssetPriceRefetching,
               })}
-              onClick={swapInputMode}
             >
-              <span>{priceLabel}</span>
-              <Icon
-                id="arrows-swap-16"
-                className="h-4 w-4"
-                width={16}
-                height={16}
-              />
-            </button>
-          </div>
-        </SkeletonLoader>
-        <div>
+              {inputMode === InputMode.Price &&
+                !swapState.priceState.percentAdjusted.isZero() && (
+                  <Icon
+                    id="triangle-down"
+                    width={12}
+                    height={6}
+                    className={classNames("mr-1 scale-75", {
+                      "text-rust-400":
+                        swapState.priceState.isBeyondOppositePrice ||
+                        swapState.priceState.percentAdjusted.isNegative(),
+                      "rotate-180 text-bullish-400":
+                        swapState.priceState.percentAdjusted.isPositive(),
+                    })}
+                  />
+                )}
+              <div
+                className={classNames(
+                  "body2 inline-flex items-center gap-1 font-body2",
+                  {
+                    "text-rust-400": swapState.priceState.isBeyondOppositePrice,
+                    "text-osmoverse-300":
+                      !swapState.priceState.isBeyondOppositePrice,
+                  }
+                )}
+              >
+                <span>{priceLabel}</span>
+              </div>
+            </div>
+          </SkeletonLoader>
           {swapState.priceState.isBeyondOppositePrice && (
-            <span className="body2 text-rust-400">
+            <span className="body2 ml-2 text-rust-400">
               <Tooltip
                 content={TooltipContent}
                 rootClassNames="!bg-osmoverse-1000 border border-[#E4E1FB33] rounded-2xl"
@@ -134,64 +179,86 @@ export const LimitPriceSelector: FC<LimitPriceSelectorProps> = ({
             </span>
           )}
         </div>
-      </div>
-      <div className="flex w-full flex-col items-start justify-start rounded-2xl bg-osmoverse-1000 py-3 px-5">
-        <SkeletonLoader
-          isLoaded={priceState.spotPrice && !priceState.isLoading}
-        >
-          <div className="inline-flex items-center gap-1 py-1 text-h6 font-h6">
-            {/** TODO: Dynamic width */}
+      </label>
+      <div className="flex w-full items-center justify-between">
+        <div className="inline-flex items-end gap-1 py-3 text-h6 font-h6">
+          <SkeletonLoader
+            isLoaded={priceState.spotPrice && !priceState.isLoading}
+          >
             {inputMode === InputMode.Price && <span>$</span>}
             {inputMode === InputMode.Price ? (
               <AutosizeInput
+                id="price-input"
                 type="number"
                 min={0}
                 extraWidth={0}
                 inputClassName="bg-transparent text-white-full"
                 value={swapState.priceState.orderPrice}
                 placeholder={formatPretty(
-                  swapState.priceState.spotPrice ?? new Dec(0)
+                  swapState.priceState.price,
+                  getPriceExtendedFormatOptions(swapState.priceState.price)
                 )}
                 onChange={(e) => swapState.priceState.setPrice(e.target.value)}
               />
             ) : (
               <AutosizeInput
-                type="number"
-                min={0}
+                id="price-input"
+                type="string"
                 extraWidth={0}
                 inputClassName="bg-transparent text-white-full"
                 value={swapState.priceState.manualPercentAdjusted}
-                placeholder={formatPretty(
-                  swapState.priceState.percentAdjusted.mul(new Dec(100)).abs()
+                placeholder={trimPlaceholderZeros(
+                  swapState.priceState.percentAdjusted
+                    .mul(new Dec(100))
+                    .abs()
+                    .toString()
                 )}
                 onChange={(e) =>
-                  swapState.priceState.setPercentAdjusted(e.target.value)
+                  swapState.priceState.setPercentAdjusted(
+                    e.target.value.replace("%", "")
+                  )
                 }
               />
             )}
-            <span className="text-osmoverse-400">{inputSuffix}</span>
-          </div>
-        </SkeletonLoader>
-        <div className="mt-1 flex items-center">
-          {percentAdjustmentOptions.map(({ label, value }) => (
-            <button
-              className="mr-1 flex h-8 items-center rounded-5xl border border-osmoverse-700 px-3"
-              key={`limit-price-adjust-${label}`}
-              onClick={() =>
-                swapState.priceState.setPercentAdjusted(
-                  formatPretty(value.mul(new Dec(100)))
-                )
-              }
-              disabled={!priceState.spotPrice || priceState.isLoading}
-            >
-              <span className="text-wosmongton-200">
-                {label !== "0%" && (orderDirection === "bid" ? "-" : "+")}
-                {label}
-              </span>
-            </button>
-          ))}
+            {inputMode === InputMode.Percentage && (
+              <span className="text-white-full">%</span>
+            )}
+          </SkeletonLoader>
+          {priceState.spotPrice && !priceState.isLoading && (
+            <span className="body2 text-osmoverse-400">{inputSuffix}</span>
+          )}
+        </div>
+
+        <div className="rounded-full border-[1px] border-osmoverse-700 text-wosmongton-300">
+          <button
+            onClick={swapInputMode}
+            disabled={priceState.isLoading || priceState.isBeyondOppositePrice}
+            className="flex h-8 w-8 items-center justify-center disabled:opacity-50"
+          >
+            <Icon id="switch" width={16} height={16} />
+          </button>
         </div>
       </div>
-    </>
+      <div className="grid w-full grid-cols-4 items-center justify-around gap-2 py-2">
+        {percentAdjustmentOptions.map(({ label, value }) => (
+          <button
+            className="mr-1 flex h-8 w-full items-center justify-center rounded-5xl border border-osmoverse-700 px-3 disabled:opacity-50"
+            key={`limit-price-adjust-${label}`}
+            onClick={() => {
+              priceState.setPrice("");
+              priceState.setPercentAdjusted(
+                formatPretty(value.mul(new Dec(100)))
+              );
+            }}
+            disabled={!priceState.spotPrice || priceState.isLoading}
+          >
+            <span className="text-wosmongton-200">
+              {label !== "0%" && (orderDirection === "bid" ? "-" : "+")}
+              {label}
+            </span>
+          </button>
+        ))}
+      </div>
+    </div>
   );
 };

--- a/packages/web/components/place-limit-tool/limit-price-selector.tsx
+++ b/packages/web/components/place-limit-tool/limit-price-selector.tsx
@@ -32,6 +32,7 @@ export const LimitPriceSelector: FC<LimitPriceSelectorProps> = ({
   swapState,
   orderDirection,
 }) => {
+  const [input, setInput] = useState<HTMLInputElement | null>(null);
   const { t } = useTranslation();
   const { priceState } = swapState;
   const [inputMode, setInputMode] = useState(InputMode.Percentage);
@@ -42,10 +43,13 @@ export const LimitPriceSelector: FC<LimitPriceSelectorProps> = ({
         ? InputMode.Price
         : InputMode.Percentage
     );
-  }, [inputMode]);
+
+    if (input) input.focus();
+  }, [inputMode, input]);
 
   useEffect(() => {
     swapState.priceState.reset();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [orderDirection]);
 
   useEffect(() => {
@@ -67,6 +71,7 @@ export const LimitPriceSelector: FC<LimitPriceSelectorProps> = ({
             }).toString()
       );
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [priceState.spotPrice, priceState.orderPrice, inputMode]);
 
   const priceLabel = useMemo(() => {
@@ -199,6 +204,7 @@ export const LimitPriceSelector: FC<LimitPriceSelectorProps> = ({
                   getPriceExtendedFormatOptions(swapState.priceState.price)
                 )}
                 onChange={(e) => swapState.priceState.setPrice(e.target.value)}
+                inputRef={setInput}
               />
             ) : (
               <AutosizeInput
@@ -213,6 +219,7 @@ export const LimitPriceSelector: FC<LimitPriceSelectorProps> = ({
                     .abs()
                     .toString()
                 )}
+                inputRef={setInput}
                 onChange={(e) =>
                   swapState.priceState.setPercentAdjusted(
                     e.target.value.replace("%", "")


### PR DESCRIPTION
## What is the purpose of the change:
These changes redesign the price input and fix/improve the functionality. It also includes an adjustment to default state to include a percentage adjustment around the current spot price.

The state of the price is also adjusted based on refetched asset prices to keep it in sync.

### Linear Task

[LIM-198: Price Input](https://linear.app/osmosis/issue/LIM-198/[redesign]-price-input)
[LIM-195: Validate refetching price does not cause issues with limit price](https://linear.app/osmosis/issue/LIM-195/validate-refetching-price-does-not-cause-issues-with-limit-price)
[LIM-197: Adjust default limit price to be a percentage around spot price](https://linear.app/osmosis/issue/LIM-197/adjust-default-limit-price-to-be-a-percentage-around-spot-price)

## Brief Changelog
- Reworked `useLimitPrice`
- If a user inputs a percentage their manual price is removed to allow adjustment around spot price
- If a user inputs a set price the percentage input is adjusted
- If a user crosses the spot price swapping inputs is disabled
- Pricing updates with refetched spot price 
- Redesigned the price input component
