### PR TITLE
(Deposit/Withdraw) Fix: use address and not source denom for all EVM assets

### DIFF
--- a/packages/bridge/src/skip/index.ts
+++ b/packages/bridge/src/skip/index.ts
@@ -292,10 +292,13 @@ export class SkipBridgeProvider implements BridgeProvider {
       for (const counterparty of counterparties) {
         // check if supported by skip
         if (!("chainId" in counterparty)) continue;
+        const address =
+          "address" in counterparty
+            ? counterparty.address
+            : counterparty.sourceDenom;
         if (
           !assets[counterparty.chainId]?.assets.some(
-            (a) =>
-              a.denom.toLowerCase() === counterparty.sourceDenom.toLowerCase()
+            (a) => a.denom.toLowerCase() === address.toLowerCase()
           )
         )
           continue;
@@ -306,13 +309,13 @@ export class SkipBridgeProvider implements BridgeProvider {
           // check if supported by skip
           if (
             assets[c.chainId].assets.some(
-              (a) => a.denom.toLowerCase() === c.sourceDenom.toLowerCase()
+              (a) => a.denom.toLowerCase() === address.toLowerCase()
             )
           ) {
-            foundVariants.setAsset(c.chainId, c.sourceDenom, {
+            foundVariants.setAsset(c.chainId, address, {
               chainId: c.chainId,
               chainType: "cosmos",
-              address: c.sourceDenom,
+              address: address,
               denom: c.symbol,
               decimals: c.decimals,
             });
@@ -324,13 +327,13 @@ export class SkipBridgeProvider implements BridgeProvider {
           // check if supported by skip
           if (
             assets[c.chainId].assets.some(
-              (a) => a.denom.toLowerCase() === c.sourceDenom.toLowerCase()
+              (a) => a.denom.toLowerCase() === address.toLowerCase()
             )
           ) {
-            foundVariants.setAsset(c.chainId.toString(), c.sourceDenom, {
+            foundVariants.setAsset(c.chainId.toString(), address, {
               chainId: c.chainId,
               chainType: "evm",
-              address: c.sourceDenom,
+              address: address,
               denom: c.symbol,
               decimals: c.decimals,
             });

--- a/packages/bridge/src/squid/__tests__/squid-bridge-provider.spec.ts
+++ b/packages/bridge/src/squid/__tests__/squid-bridge-provider.spec.ts
@@ -3266,6 +3266,14 @@ describe("SquidBridgeProvider", () => {
           decimals: 18,
         },
         {
+          chainId: 1,
+          chainType: "evm",
+          chainName: "Ethereum",
+          denom: "ETH",
+          address: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+          decimals: 18,
+        },
+        {
           chainId: "agoric-3",
           chainType: "cosmos",
           chainName: "agoric",
@@ -3341,14 +3349,6 @@ describe("SquidBridgeProvider", () => {
           denom: "axlETH",
           address:
             "ibc/E3AB0DFDE9E782262B770C32DF94AC2A92B93DC4825376D6F6C874D3C877864E",
-          decimals: 18,
-        },
-        {
-          chainId: 1,
-          chainType: "evm",
-          chainName: "Ethereum",
-          denom: "ETH",
-          address: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
           decimals: 18,
         },
         {

--- a/packages/bridge/src/squid/index.ts
+++ b/packages/bridge/src/squid/index.ts
@@ -294,11 +294,14 @@ export class SquidBridgeProvider implements BridgeProvider {
       for (const counterparty of assetListAsset?.counterparty ?? []) {
         // check if supported by squid
         if (!("chainId" in counterparty)) continue;
+        const address =
+          "address" in counterparty
+            ? counterparty.address
+            : counterparty.sourceDenom;
         if (
           !tokens.some(
             (t) =>
-              t.address.toLowerCase() ===
-                counterparty.sourceDenom.toLowerCase() &&
+              t.address.toLowerCase() === address.toLowerCase() &&
               t.chainId === counterparty.chainId
           )
         )
@@ -307,10 +310,10 @@ export class SquidBridgeProvider implements BridgeProvider {
         if (counterparty.chainType === "cosmos") {
           const c = counterparty as CosmosCounterparty;
 
-          foundVariants.setAsset(c.chainId, c.sourceDenom, {
+          foundVariants.setAsset(c.chainId, address, {
             chainId: c.chainId,
             chainType: "cosmos",
-            address: c.sourceDenom,
+            address: address,
             denom: c.symbol,
             decimals: c.decimals,
           });
@@ -318,10 +321,10 @@ export class SquidBridgeProvider implements BridgeProvider {
         if (counterparty.chainType === "evm") {
           const c = counterparty as EVMCounterparty;
 
-          foundVariants.setAsset(c.chainId.toString(), c.sourceDenom, {
+          foundVariants.setAsset(c.chainId.toString(), address, {
             chainId: c.chainId,
             chainType: "evm",
-            address: c.sourceDenom,
+            address: address,
             denom: c.symbol,
             decimals: c.decimals,
           });


### PR DESCRIPTION
## What is the purpose of the change:

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

Some EVM counterparties would have the proper ERC20 address in the source denom. However, many EVM counterparties would contain the proper address in the address member instead. Now, if it's an EVM counterparty, we only check the address to confirm it's available in the provider's asset list. This should make even more EVM assets available from providers.