### PR TITLE
(Deposit/Withdraw) Typing . on empty input should automatically add the 0

### DIFF
--- a/packages/web/components/control/crypto-fiat-input.tsx
+++ b/packages/web/components/control/crypto-fiat-input.tsx
@@ -121,10 +121,6 @@ export const CryptoFiatInput: FunctionComponent<{
       let nextValue = value;
       if (!isValidNumericalRawInput(nextValue) && nextValue !== "") return;
 
-      if (nextValue === ".") {
-        nextValue = "0.";
-      }
-
       if (type === "fiat") {
         // Update the crypto amount based on the fiat amount
         const priceInFiat = assetPrice.toDec();

--- a/packages/web/components/input/scaled-currency-input.tsx
+++ b/packages/web/components/input/scaled-currency-input.tsx
@@ -102,7 +102,8 @@ export function ScaledCurrencyInput({
                 fontSize: "inherit",
               }}
               onChange={(e) => {
-                const nextValue = e.target.value;
+                let nextValue = e.target.value;
+                if (nextValue === ".") nextValue = "0.";
                 if (nextValue !== "" && !isNumeric(nextValue)) return;
                 setInputValue(nextValue);
               }}


### PR DESCRIPTION
## What is the purpose of the change:

Currently, users have to type 0 followed by a . to enter a decimal. To improve the user experience, we can automatically add the 0 if a user starts with a dot

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-854/typing-on-empty-input-should-automatically-add-the-0)

## Brief Changelog

 - [ ] Typing . on empty input should automatically add the 0
