### PR TITLE
(Deposit/Withdraw) Inequality symbols

### DIFF
--- a/packages/web/components/bridge/bridge-provider-dropdown.tsx
+++ b/packages/web/components/bridge/bridge-provider-dropdown.tsx
@@ -168,7 +168,7 @@ export const BridgeProviderDropdown = ({
                           {expectedOutputFiat.toString()}
                         </p>
                         <p className="body2 md:caption whitespace-nowrap text-osmoverse-200">
-                          ~{totalFee} {t("transfer.fee")}
+                          ~ {totalFee} {t("transfer.fee")}
                         </p>
                       </div>
                     </button>

--- a/packages/web/components/bridge/quote-detail.tsx
+++ b/packages/web/components/bridge/quote-detail.tsx
@@ -187,7 +187,8 @@ export const ExpandDetailsControlContent: FunctionComponent<{
       <div className="flex items-center gap-2 md:gap-1">
         {!open && totalFees && (
           <span className="subtitle1 md:body2">
-            ~{totalFees.inequalitySymbol(false).toString()} {t("transfer.fees")}
+            ~ {totalFees.inequalitySymbol(false).toString()}{" "}
+            {t("transfer.fees")}
           </span>
         )}
         {(warnUserOfPriceImpact || warnUserOfSlippage) && (

--- a/packages/web/components/bridge/quote-detail.tsx
+++ b/packages/web/components/bridge/quote-detail.tsx
@@ -187,7 +187,7 @@ export const ExpandDetailsControlContent: FunctionComponent<{
       <div className="flex items-center gap-2 md:gap-1">
         {!open && totalFees && (
           <span className="subtitle1 md:body2">
-            ~{totalFees.toString()} {t("transfer.fees")}
+            ~{totalFees.inequalitySymbol(false).toString()} {t("transfer.fees")}
           </span>
         )}
         {(warnUserOfPriceImpact || warnUserOfSlippage) && (

--- a/packages/web/components/bridge/review-screen.tsx
+++ b/packages/web/components/bridge/review-screen.tsx
@@ -271,11 +271,11 @@ const AssetBox: FunctionComponent<{
         </div>
         <div className="text-right md:flex md:flex-col md:gap-1">
           <div className="subtitle1 md:body2">
-            {type === "to" && "~"} {value.toString()}
+            {type === "to" && "~"} {value.inequalitySymbol(false).toString()}
           </div>
           <div className="body1 md:caption text-osmoverse-300">
             {type === "to" && "~"}{" "}
-            {formatPretty(coin, {
+            {formatPretty(coin.inequalitySymbol(false), {
               maxDecimals: 10,
             })}
           </div>


### PR DESCRIPTION
## What is the purpose of the change:

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

Since tildes are always used to indicate an approximation, I disabled the inequality symbol as it communicates the same idea, but just for smaller values

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-746/remove-tilde-from-anything-with-less-than-operator)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->
