### PR TITLE
(Deposit/Withdraw) Fix initial chain race condition

### DIFF
--- a/packages/web/components/bridge/use-bridges-supported-assets.ts
+++ b/packages/web/components/bridge/use-bridges-supported-assets.ts
@@ -116,6 +116,12 @@ export const useBridgesSupportedAssets = ({
       Record<string, Set<Bridge>>
     > = {};
 
+    // Since the chains are sorted, wait for all providers to return before
+    // generating a result
+    if (isLoading) {
+      return {};
+    }
+
     type AssetsByChainId =
       RouterOutputs["bridgeTransfer"]["getSupportedAssetsByBridge"]["supportedAssets"]["assetsByChainId"];
 
@@ -195,7 +201,7 @@ export const useBridgesSupportedAssets = ({
         "providerName"
       >[]
     >;
-  }, [successfulQueries]);
+  }, [successfulQueries, isLoading]);
 
   const supportedChains = useMemo(() => {
     return Array.from(


### PR DESCRIPTION
## What is the purpose of the change:

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

Wait for all providers to return supported chains + assets before allowing the client to pick the first chain in the sorted list of chains. Now, the sorted list will contain all eventually supported chains.

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-861/increase-reliability-of-picking-first-chain)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

* Use isLoading flag to return no supported assets + chains results if any provider is loading

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->
