### PR TITLE
(Deposit/Withdraw) Reduce thrashing in loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,5 +81,6 @@
     "@keplr-wallet/router": "0.10.24-ibc.go.v7.hot.fix",
     "@keplr-wallet/types": "0.10.24-ibc.go.v7.hot.fix",
     "@keplr-wallet/unit": "0.10.24-ibc.go.v7.hot.fix"
-  }
+  },
+  "dependencies": {}
 }

--- a/packages/web/components/bridge/amount-screen.tsx
+++ b/packages/web/components/bridge/amount-screen.tsx
@@ -145,7 +145,7 @@ export const AmountScreen = observer(
       selectedQuote,
       buttonErrorMessage,
       buttonText,
-      isLoadingBridgeQuote,
+      isLoadingAnyBridgeQuote,
       isLoadingBridgeTransaction,
       isInsufficientBal,
       isInsufficientFee,
@@ -1096,7 +1096,7 @@ export const AmountScreen = observer(
               </Menu>
             )}
 
-            {isLoadingBridgeQuote && (
+            {isLoadingAnyBridgeQuote && (
               <div className="flex animate-[fadeIn_0.25s] items-center justify-between">
                 <div className="flex items-center gap-2">
                   <Spinner className="text-wosmongton-500" />
@@ -1110,7 +1110,7 @@ export const AmountScreen = observer(
               </div>
             )}
 
-            {!isLoadingBridgeQuote && !isNil(selectedQuote) && (
+            {!isLoadingAnyBridgeQuote && !isNil(selectedQuote) && (
               <TransferDetails
                 quote={
                   quote as BridgeQuote & {
@@ -1143,7 +1143,7 @@ export const AmountScreen = observer(
                   <Button
                     disabled={
                       !isNil(buttonErrorMessage) ||
-                      isLoadingBridgeQuote ||
+                      isLoadingAnyBridgeQuote ||
                       isLoadingBridgeTransaction ||
                       cryptoAmount === "" ||
                       cryptoAmount === "0" ||

--- a/packages/web/components/bridge/use-bridge-quotes.ts
+++ b/packages/web/components/bridge/use-bridge-quotes.ts
@@ -678,7 +678,7 @@ export const useBridgeQuotes = ({
     !isLoadingAnyBridgeQuote;
 
   let buttonText: string;
-  if (buttonErrorMessage) {
+  if (buttonErrorMessage && !isLoadingAnyBridgeQuote) {
     buttonText = buttonErrorMessage;
   } else if (warnUserOfSlippage || warnUserOfPriceImpact) {
     buttonText = t("assets.transfer.transferAnyway");

--- a/yarn.lock
+++ b/yarn.lock
@@ -10039,25 +10039,10 @@ camelcase@^6.2.0:
   resolved "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
-caniuse-lite@^1.0.30001286:
-  version "1.0.30001562"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001562.tgz#9d16c5fd7e9c592c4cd5e304bc0f75b0008b2759"
-  integrity sha512-kfte3Hym//51EdX4239i+Rmp20EsLIYGdPkERegTgU19hQWCRhsRFGKHTliUlsry53tv17K7n077Kqa0WJU4ng==
-
-caniuse-lite@^1.0.30001297, caniuse-lite@^1.0.30001449:
-  version "1.0.30001478"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001478.tgz"
-  integrity sha512-gMhDyXGItTHipJj2ApIvR+iVB5hd0KP3svMWWXDvZOmjzJJassGLMfxRkQCSYgGd2gtdL/ReeiyvMSFD1Ss6Mw==
-
-caniuse-lite@^1.0.30001579:
-  version "1.0.30001596"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001596.tgz#da06b79c3d9c3d9958eb307aa832ac68ead79bee"
-  integrity sha512-zpkZ+kEr6We7w63ORkoJ2pOfBwBkY/bJrG/UZ90qNb45Isblu8wzDgevEOrRL1r9dWayHjYiiyCMEXPn4DweGQ==
-
-caniuse-lite@^1.0.30001587:
-  version "1.0.30001617"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001617.tgz#809bc25f3f5027ceb33142a7d6c40759d7a901eb"
-  integrity sha512-mLyjzNI9I+Pix8zwcrpxEbGlfqOkF9kM3ptzmKNw5tizSyYwMe+nGLTqMK9cO+0E+Bh6TsBxNAaHWEM8xwSsmA==
+caniuse-lite@^1.0.30001286, caniuse-lite@^1.0.30001297, caniuse-lite@^1.0.30001449, caniuse-lite@^1.0.30001579, caniuse-lite@^1.0.30001587:
+  version "1.0.30001643"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001643.tgz"
+  integrity sha512-ERgWGNleEilSrHM6iUz/zJNSQTP8Mr21wDWpdgvRwcTXGAq6jMtOUPP4dqFPTdKqZ2wKTdtB+uucZ3MRpAUSmg==
 
 case@1.6.3:
   version "1.6.3"


### PR DESCRIPTION
## What is the purpose of the change:

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

Update UI only when all quotes are loaded, instead of the best quote being loaded while others are still loading. This causes less thrash in the UI since, as the best quote is being selected, the loading state does not constantly toggle on and off. This improves the UX by reducing the amount of changes in the UI.

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-864/amount-screen-improve-loading-ux)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->
