### PR TITLE
(Deposit/Withdraw) Flow not visible when page scrolled down

### DIFF
--- a/packages/web/components/bridge/immersive-bridge.tsx
+++ b/packages/web/components/bridge/immersive-bridge.tsx
@@ -158,7 +158,7 @@ export const ImmersiveBridgeFlow = ({
             <Transition
               show={isVisible}
               as="div"
-              className="absolute top-0 z-[999] flex h-screen w-screen bg-osmoverse-900"
+              className="fixed inset-0 z-[999] flex h-screen w-screen bg-osmoverse-900"
               enter="transition-opacity duration-300"
               enterFrom="opacity-0"
               enterTo="opacity-100"


### PR DESCRIPTION
## What is the purpose of the change:

If the page is scrolled down at all (in portfolio page or asset info page), the d/w flow is popped to the top of the page out of sight and scrolling is locked. We should ensure the flow appears fixed in the window viewport.

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-863/scroll-issues-flow-not-visible-when-page-scrolled-down)