### PR TITLE
Flip USDC by default

### DIFF
--- a/packages/web/components/transactions/transaction-details/transaction-details-content.tsx
+++ b/packages/web/components/transactions/transaction-details/transaction-details-content.tsx
@@ -70,8 +70,8 @@ export const TransactionDetailsContent = ({
   // if USDC, toggle conversion - temporary until stablecoin logic is implemented
   useEffect(() => {
     if (
-      conversion.numerator.denom !== "USDC" &&
-      conversion.denominator.denom === "USDC"
+      conversion.numerator.denom.includes("USDC") ||
+      conversion.denominator.denom.includes("USDC")
     ) {
       toggleConversion();
     }


### PR DESCRIPTION
## What is the purpose of the change:

- from: Can we make the execution price for trade history always default to the USDC one if one asset is USDC?

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-881/transaction-usdc-default)

## Brief Changelog

- if denominator is USDC (but not numerator) - flip the execution price by default

## Testing and Verifying

https://github.com/user-attachments/assets/601afcc5-8f69-4792-a641-92b52dfe3f84



