### PR TITLE
fix assetlist used for create concentrated liquidity modal

### DIFF
--- a/packages/web/components/complex/pool/create/cl/set-base-info.tsx
+++ b/packages/web/components/complex/pool/create/cl/set-base-info.tsx
@@ -21,7 +21,7 @@ import React, { Fragment, useMemo, useState } from "react";
 import { Icon } from "~/components/assets/icon";
 import { SelectionToken } from "~/components/complex/pool/create/cl-pool";
 import { Spinner } from "~/components/loaders";
-import { AssetLists } from "~/config/mock-asset-lists";
+import { AssetLists } from "~/config/generated/asset-lists";
 import { useDisclosure, useFilteredData } from "~/hooks";
 import { TokenSelectModal } from "~/modals";
 import { useStore } from "~/stores";


### PR DESCRIPTION
## What is the purpose of the change:

Uses the generated assetlist, instead of the mock testing assetlist

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->
