### PR TITLE
(Deposit/Withdraw) Include gas fee from quote in cosmos transactions

### DIFF
--- a/packages/bridge/src/axelar/__tests__/axelar-bridge-provider.spec.ts
+++ b/packages/bridge/src/axelar/__tests__/axelar-bridge-provider.spec.ts
@@ -62,6 +62,7 @@ beforeEach(() => {
 
 afterEach(() => {
   jest.clearAllMocks();
+  server.resetHandlers(); // Reset server handlers after each test
 });
 
 describe("AxelarBridgeProvider", () => {
@@ -360,9 +361,7 @@ describe("AxelarBridgeProvider", () => {
 
   it("should get a quote", async () => {
     const mockDepositClient: Partial<AxelarAssetTransfer> = {
-      getDepositAddress: jest
-        .fn()
-        .mockResolvedValue("0x66F0c98E45341d5C0Da7E943D803e5eF0C11B373"),
+      getDepositAddress: jest.fn().mockResolvedValue("0x123"),
     };
     const mockQueryClient: Partial<AxelarQueryAPI> = {
       getTransferFee: jest.fn().mockResolvedValue({
@@ -430,11 +429,6 @@ describe("AxelarBridgeProvider", () => {
         denom: "ETH",
         address: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
         decimals: 18,
-      },
-      transactionRequest: {
-        data: "0xa9059cbb00000000000000000000000066f0c98e45341d5c0da7e943d803e5ef0c11b3730000000000000000000000000000000000000000000000000000000000000001",
-        to: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
-        type: "evm",
       },
     });
   });

--- a/packages/bridge/src/axelar/__tests__/axelar-bridge-provider.spec.ts
+++ b/packages/bridge/src/axelar/__tests__/axelar-bridge-provider.spec.ts
@@ -42,27 +42,24 @@ jest.mock("@cosmjs/proto-signing", () => ({
 
 beforeEach(() => {
   server.use(
-    rest.post("https://api.axelarscan.io/deposit-address", (_req, res, ctx) => {
-      return res(ctx.json({ depositAddress: "0x123" }));
-    }),
+    rest.post("https://api.axelarscan.io/deposit-address", (_req, res, ctx) =>
+      res(ctx.json({ depositAddress: "0x123" }))
+    ),
     rest.get(
       "https://axelar-mainnet.s3.us-east-2.amazonaws.com/mainnet-asset-config.json",
-      (_req, res, ctx) => {
-        return res(ctx.json({}));
-      }
+      (_req, res, ctx) => res(ctx.json({}))
     ),
-    rest.get("https://api.axelarscan.io/api/getChains", (_req, res, ctx) => {
-      return res(ctx.json(MockAxelarChains));
-    }),
-    rest.get("https://api.axelarscan.io/api/getAssets", (_req, res, ctx) => {
-      return res(ctx.json(MockAxelarAssets));
-    })
+    rest.get("https://api.axelarscan.io/api/getChains", (_req, res, ctx) =>
+      res(ctx.json(MockAxelarChains))
+    ),
+    rest.get("https://api.axelarscan.io/api/getAssets", (_req, res, ctx) =>
+      res(ctx.json(MockAxelarAssets))
+    )
   );
 });
 
 afterEach(() => {
   jest.clearAllMocks();
-  server.resetHandlers(); // Reset server handlers after each test
 });
 
 describe("AxelarBridgeProvider", () => {

--- a/packages/bridge/src/axelar/__tests__/axelar-bridge-provider.spec.ts
+++ b/packages/bridge/src/axelar/__tests__/axelar-bridge-provider.spec.ts
@@ -360,7 +360,9 @@ describe("AxelarBridgeProvider", () => {
 
   it("should get a quote", async () => {
     const mockDepositClient: Partial<AxelarAssetTransfer> = {
-      getDepositAddress: jest.fn().mockResolvedValue("0x123"),
+      getDepositAddress: jest
+        .fn()
+        .mockResolvedValue("0x66F0c98E45341d5C0Da7E943D803e5eF0C11B373"),
     };
     const mockQueryClient: Partial<AxelarQueryAPI> = {
       getTransferFee: jest.fn().mockResolvedValue({
@@ -428,6 +430,11 @@ describe("AxelarBridgeProvider", () => {
         denom: "ETH",
         address: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
         decimals: 18,
+      },
+      transactionRequest: {
+        data: "0xa9059cbb00000000000000000000000066f0c98e45341d5c0da7e943d803e5ef0c11b3730000000000000000000000000000000000000000000000000000000000000001",
+        to: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+        type: "evm",
       },
     });
   });

--- a/packages/bridge/src/ibc/__tests__/ibc-bridge-provider.spec.ts
+++ b/packages/bridge/src/ibc/__tests__/ibc-bridge-provider.spec.ts
@@ -155,7 +155,7 @@ describe("IbcBridgeProvider", () => {
 
   it("should return a valid BridgeQuote", async () => {
     (estimateGasFee as jest.Mock).mockResolvedValue({
-      amount: [{ amount: "5000", denom: "uatom", isNeededForTx: true }],
+      amount: [{ amount: "5000", denom: "uatom", isSubtractiveFee: true }],
     });
 
     const quote: BridgeQuote = await provider.getQuote(mockAtomToOsmosis);
@@ -177,7 +177,7 @@ describe("IbcBridgeProvider", () => {
 
   it("should calculate the correct toAmount when gas fee is not needed for tx", async () => {
     (estimateGasFee as jest.Mock).mockResolvedValue({
-      amount: [{ amount: "5000", denom: "uatom", isNeededForTx: false }],
+      amount: [{ amount: "5000", denom: "uatom", isSubtractiveFee: false }],
     });
 
     const quote: BridgeQuote = await provider.getQuote(mockAtomToOsmosis);

--- a/packages/bridge/src/ibc/index.ts
+++ b/packages/bridge/src/ibc/index.ts
@@ -117,7 +117,14 @@ export class IbcBridgeProvider implements BridgeProvider {
         coinGeckoId: gasAsset?.coinGeckoId,
         amount: gasFee.amount,
       },
-      transactionRequest: signDoc,
+      transactionRequest: {
+        ...signDoc,
+        gasFee: {
+          gas: txSimulation.gas,
+          amount: gasFee.amount,
+          denom: gasFee.denom,
+        },
+      },
     };
   }
 

--- a/packages/bridge/src/interface.ts
+++ b/packages/bridge/src/interface.ts
@@ -382,7 +382,7 @@ export interface BridgeQuote {
   estimatedGasFee?: BridgeCoin;
 
   /** Sign doc. */
-  transactionRequest: BridgeTransactionRequest;
+  transactionRequest?: BridgeTransactionRequest;
 }
 
 export interface BridgeExternalUrl {

--- a/packages/bridge/src/interface.ts
+++ b/packages/bridge/src/interface.ts
@@ -332,6 +332,11 @@ export interface CosmosBridgeTransactionRequest {
   type: "cosmos";
   msgTypeUrl: string;
   msg: Record<string, any>;
+  gasFee?: {
+    gas: string;
+    denom: string;
+    amount: string;
+  };
 }
 
 interface QRCodeBridgeTransactionRequest {

--- a/packages/bridge/src/interface.ts
+++ b/packages/bridge/src/interface.ts
@@ -382,7 +382,7 @@ export interface BridgeQuote {
   estimatedGasFee?: BridgeCoin;
 
   /** Sign doc. */
-  transactionRequest?: BridgeTransactionRequest;
+  transactionRequest: BridgeTransactionRequest;
 }
 
 export interface BridgeExternalUrl {

--- a/packages/bridge/src/skip/__tests__/skip-bridge-provider.spec.ts
+++ b/packages/bridge/src/skip/__tests__/skip-bridge-provider.spec.ts
@@ -181,6 +181,11 @@ describe("SkipBridgeProvider", () => {
           timeoutTimestamp: "0",
           memo: '{"destination_chain":"Ethereum","destination_address":"0xD397883c12b71ea39e0d9f6755030205f31A1c96","payload":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,120,99,236,5,177,35,136,92,118,9,176,92,53,223,119,127,63,24,2,88],"type":2,"fee":{"amount":"7725420487422623","recipient":"axelar1aythygn6z5thymj6tmzfwekzh05ewg3l7d6y89"}}',
         },
+        gasFee: {
+          amount: "1232",
+          denom: "uosmo",
+          gas: "420000",
+        },
       },
       estimatedGasFee: {
         amount: "1232",
@@ -188,6 +193,7 @@ describe("SkipBridgeProvider", () => {
         coinGeckoId: "osmosis",
         decimals: 6,
         address: "uosmo",
+        gas: "420000",
       },
     });
   });

--- a/packages/bridge/src/skip/index.ts
+++ b/packages/bridge/src/skip/index.ts
@@ -420,7 +420,21 @@ export class SkipBridgeProvider implements BridgeProvider {
     params: GetBridgeQuoteParams
   ): Promise<BridgeTransactionRequest> {
     const quote = await this.getQuote(params);
-    return quote.transactionRequest!;
+    const transactionRequest = quote.transactionRequest!;
+    const estimatedGasFee = await this.estimateGasFee(
+      params,
+      transactionRequest
+    );
+    return transactionRequest.type === "cosmos" && estimatedGasFee?.gas
+      ? {
+          ...transactionRequest,
+          gasFee: {
+            gas: estimatedGasFee.gas,
+            denom: estimatedGasFee.address,
+            amount: estimatedGasFee.amount,
+          },
+        }
+      : transactionRequest;
   }
 
   async createTransaction(

--- a/packages/bridge/src/squid/index.ts
+++ b/packages/bridge/src/squid/index.ts
@@ -272,6 +272,13 @@ export class SquidBridgeProvider implements BridgeProvider {
                 transactionRequest.data,
                 fromAddress,
                 { denom: fromAsset.address, amount: fromAmount }
+                // gasCosts.length === 1
+                //   ? {
+                //       gas: gasCosts[0].estimate,
+                //       denom: gasCosts[0].token.address,
+                //       amount: gasCosts[0].amount,
+                //     }
+                //   : undefined
               ),
         };
       },
@@ -488,6 +495,12 @@ export class SquidBridgeProvider implements BridgeProvider {
     fromCoin: {
       denom: string;
       amount: string;
+    },
+    /** Gas fee from quote */
+    gasFee?: {
+      gas: string;
+      denom: string;
+      amount: string;
     }
   ): Promise<CosmosBridgeTransactionRequest> {
     try {
@@ -541,6 +554,7 @@ export class SquidBridgeProvider implements BridgeProvider {
           type: "cosmos",
           msgTypeUrl: typeUrl,
           msg,
+          gasFee,
         };
       } else if (parsedData.msgTypeUrl === WasmTransferType) {
         const cosmwasmData = parsedData as {
@@ -565,6 +579,7 @@ export class SquidBridgeProvider implements BridgeProvider {
           type: "cosmos",
           msgTypeUrl: typeUrl,
           msg,
+          gasFee,
         };
       }
 

--- a/packages/bridge/src/squid/index.ts
+++ b/packages/bridge/src/squid/index.ts
@@ -272,6 +272,8 @@ export class SquidBridgeProvider implements BridgeProvider {
                 transactionRequest.data,
                 fromAddress,
                 { denom: fromAsset.address, amount: fromAmount }
+                // TODO: uncomment when we're able to find a way to get gas limit from Squid
+                // or get it ourselves
                 // gasCosts.length === 1
                 //   ? {
                 //       gas: gasCosts[0].estimate,

--- a/packages/stores/src/account/base.ts
+++ b/packages/stores/src/account/base.ts
@@ -566,7 +566,7 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
       };
 
       // Estimate gas fee & token if not provided
-      if (!fee) {
+      if (typeof fee === "undefined") {
         try {
           fee = await this.estimateFee({
             wallet,

--- a/packages/stores/src/account/base.ts
+++ b/packages/stores/src/account/base.ts
@@ -831,8 +831,6 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
 
     const forceSignDirect = isAuthenticatorMsg;
 
-    console.log({ fee });
-
     return ("signAmino" in offlineSigner || "signAmino" in wallet.client) &&
       !forceSignDirect
       ? this.signAmino({

--- a/packages/tx/src/gas.ts
+++ b/packages/tx/src/gas.ts
@@ -48,7 +48,7 @@ export type QuoteStdFee = {
      * Indicates that the simulated transaction spends the account's balance required for the fee.
      * Likely, the input spent amount needs to be adjusted by subtracting this amount.
      */
-    isNeededForTx?: boolean;
+    isSubtractiveFee?: boolean;
   }[];
 };
 

--- a/packages/tx/src/gas.ts
+++ b/packages/tx/src/gas.ts
@@ -419,8 +419,8 @@ export async function getGasFeeAmount({
      * then we are missing balance to pay for the transaction. In this case,
      * we need to find an alternative token or subtract this amount from the input.
      */
-    const isBalanceNeededForTx = new Dec(spentAmount).gt(
-      new Dec(amount).sub(new Dec(feeAmount))
+    const isBalanceNeededForTx = new Int(spentAmount).gt(
+      new Int(amount).sub(new Int(feeAmount))
     );
 
     /**

--- a/packages/web/components/bridge/amount-screen.tsx
+++ b/packages/web/components/bridge/amount-screen.tsx
@@ -146,7 +146,6 @@ export const AmountScreen = observer(
       buttonErrorMessage,
       buttonText,
       isLoadingBridgeQuote,
-      isLoadingBridgeTransaction,
       isInsufficientBal,
       isInsufficientFee,
       warnUserOfPriceImpact,
@@ -1188,7 +1187,6 @@ export const AmountScreen = observer(
                     disabled={
                       !isNil(buttonErrorMessage) ||
                       isLoadingBridgeQuote ||
-                      isLoadingBridgeTransaction ||
                       cryptoAmount === "" ||
                       cryptoAmount === "0" ||
                       isNil(selectedQuote) ||

--- a/packages/web/components/bridge/use-bridge-quotes.ts
+++ b/packages/web/components/bridge/use-bridge-quotes.ts
@@ -450,7 +450,7 @@ export const useBridgeQuotes = ({
   }, [isTxPending, onRequestClose, transferInitiated]);
 
   const [isApprovingToken, setIsApprovingToken] = useState(false);
-  const handleEvmTx = async (
+  const signAndBroadcastEvmTx = async (
     quote: NonNullable<typeof selectedQuote>["quote"]
   ) => {
     if (!isEvmWalletConnected || !evmAddress || !evmConnector)
@@ -541,7 +541,7 @@ export const useBridgeQuotes = ({
     }
   };
 
-  const handleCosmosTx = async (
+  const signAndBroadcastCosmosTx = async (
     quote: NonNullable<typeof selectedQuote>["quote"]
   ) => {
     if (!fromChain || fromChain?.chainType !== "cosmos") {
@@ -622,8 +622,8 @@ export const useBridgeQuotes = ({
 
     const tx =
       transactionRequest.type === "evm"
-        ? handleEvmTx({ ...quote, transactionRequest })
-        : handleCosmosTx({ ...quote, transactionRequest });
+        ? signAndBroadcastEvmTx({ ...quote, transactionRequest })
+        : signAndBroadcastCosmosTx({ ...quote, transactionRequest });
 
     await tx.catch((e) => {
       console.error(transactionRequest.type, "transaction failed", e);

--- a/packages/web/components/bridge/use-bridge-quotes.ts
+++ b/packages/web/components/bridge/use-bridge-quotes.ts
@@ -587,13 +587,10 @@ export const useBridgeQuotes = ({
     const transactionRequest = selectedQuote?.transactionRequest;
     const quote = selectedQuote?.quote;
 
-    console.log(selectedQuote);
-
     if (!transactionRequest || !quote) {
       console.error("No quote or transaction to use for transfer");
       return;
     }
-    // console.log(transactionRequest?.gasFee);
 
     const tx =
       transactionRequest.type === "evm"
@@ -655,11 +652,12 @@ export const useBridgeQuotes = ({
       ? accountStore.getWallet(fromChain.chainId)?.isWalletConnected ?? false
       : false;
   const isDepositReady = isDeposit && isFromWalletConnected;
+  const isWithdrawReady = direction === "withdraw";
   const userCanAdvance =
-    isDepositReady &&
+    (isDepositReady || isWithdrawReady) &&
     !isInsufficientFee &&
     !isInsufficientBal &&
-    !isLoadingAnyBridgeQuote &&
+    !isLoadingBridgeQuote &&
     !isTxPending &&
     Boolean(selectedQuote);
 

--- a/packages/web/components/bridge/use-bridge-quotes.ts
+++ b/packages/web/components/bridge/use-bridge-quotes.ts
@@ -526,6 +526,7 @@ export const useBridgeQuotes = ({
     }
     const transactionRequest =
       quote.transactionRequest as CosmosBridgeTransactionRequest;
+    const gasFee = transactionRequest.gasFee;
     return accountStore.signAndBroadcast(
       fromChain.chainId,
       transactionRequest.msgTypeUrl,
@@ -539,18 +540,20 @@ export const useBridgeQuotes = ({
       // Setting the fee from the transaction request
       // ensures the user is using the same fee token & amount as seen in the quote.
       // If not present, it will be estimated & the token will be chosen by our logic.
-      transactionRequest.gasFee
+      gasFee
         ? {
-            gas: transactionRequest.gasFee.gas,
+            gas: gasFee.gas,
             amount: [
               {
-                denom: transactionRequest.gasFee.denom,
-                amount: transactionRequest.gasFee.amount,
+                denom: gasFee.denom,
+                amount: gasFee.amount,
               },
             ],
           }
         : undefined,
-      undefined,
+      {
+        preferNoSetFee: Boolean(gasFee),
+      },
       (tx: DeliverTxResponse) => {
         if (tx.code == null || tx.code === 0) {
           const queries = queriesStore.get(fromChain.chainId);

--- a/packages/web/config/ibc-overrides.ts
+++ b/packages/web/config/ibc-overrides.ts
@@ -110,17 +110,6 @@ const MainnetIBCAdditionalData: Partial<
       ],
     },
   },
-  "wstETH.eth.axl": {
-    sourceChainNameOverride: "Ethereum",
-    originBridgeInfo: {
-      bridge: "axelar" as const,
-      wallets: ["metamask" as const, "walletconnect" as const],
-      method: "deposit-address" as const,
-      sourceChainTokens: [
-        AxelarSourceChainTokenConfigs(environment).wsteth.ethereum,
-      ],
-    },
-  },
   SOL: {
     depositUrlOverride: "/wormhole?from=solana&to=osmosis&token=SOL",
     withdrawUrlOverride: "/wormhole?from=osmosis&to=solana&token=SOL",


### PR DESCRIPTION
## What is the purpose of the change:

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

Before, we were re-estimating gas fee and alt gas tokens for cosmos transaction objects coming from bridge providers. The issue with that approach is a provider could quote an alternative fee token that doesn't get chosen in our custom gas logic. This PR forwards the quoted gas token along with the cosmos transaction request which can then be passed to the wallet to ensure a consistent and accurate UX.

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-866/cosmos-tx-include-stdfee-in-cosmostransactionrequest)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->
* Include gas in quote response transaction data for cosmos transactions
* Prefer transactionRequest from getQuote instead of separate getTransactionData query (for accuracy and consistency)
* Update tests
