### PR TITLE
Use to SQS pools provider

### DIFF
--- a/packages/server/src/queries/complex/pools/index.ts
+++ b/packages/server/src/queries/complex/pools/index.ts
@@ -33,6 +33,7 @@ export type PoolProvider = (params: {
   assetLists: AssetList[];
   chainList: Chain[];
   poolIds?: string[];
+  minLiquidityUsd?: number;
 }) => Promise<Pool[]>;
 
 export const PoolFilterSchema = z.object({
@@ -77,7 +78,11 @@ export async function getPools(
   params: Partial<PoolFilter> & { assetLists: AssetList[]; chainList: Chain[] },
   poolProvider: PoolProvider = getPoolsFromSidecar
 ): Promise<Pool[]> {
-  let pools = await poolProvider({ ...params, poolIds: params?.poolIds });
+  let pools = await poolProvider({
+    ...params,
+    poolIds: params?.poolIds,
+    minLiquidityUsd: params?.minLiquidityUsd,
+  });
 
   if (params?.types) {
     pools = pools.filter(({ type }) =>

--- a/packages/server/src/queries/complex/pools/index.ts
+++ b/packages/server/src/queries/complex/pools/index.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { IS_TESTNET } from "../../../env";
 import { search, SearchSchema } from "../../../utils/search";
 import { PoolRawResponse } from "../../osmosis";
-import { getPoolsFromIndexer, getPoolsFromSidecar } from "./providers";
+import { getPoolsFromSidecar } from "./providers";
 
 const allPooltypes = [
   "concentrated",
@@ -75,9 +75,7 @@ export async function getPool({
  *  Params can be used to filter the results by a fuzzy search on the id, type, or coin denoms, as well as a specific id or type. */
 export async function getPools(
   params: Partial<PoolFilter> & { assetLists: AssetList[]; chainList: Chain[] },
-  poolProvider: PoolProvider = IS_TESTNET
-    ? getPoolsFromSidecar
-    : getPoolsFromIndexer
+  poolProvider: PoolProvider = getPoolsFromSidecar
 ): Promise<Pool[]> {
   let pools = await poolProvider({ ...params, poolIds: params?.poolIds });
 

--- a/packages/server/src/queries/complex/pools/providers/sidecar.ts
+++ b/packages/server/src/queries/complex/pools/providers/sidecar.ts
@@ -21,18 +21,23 @@ const poolsCache = new LRUCache<string, CacheEntry>(DEFAULT_LRU_OPTIONS);
 export function getPoolsFromSidecar({
   assetLists,
   poolIds,
+  minLiquidityUsd,
 }: {
   assetLists: AssetList[];
   chainList: Chain[];
   poolIds?: string[];
+  minLiquidityUsd?: number;
 }): Promise<Pool[]> {
   return cachified({
     cache: poolsCache,
-    key: poolIds ? `sidecar-pools-${poolIds.join(",")}` : "sidecar-pools",
+    key:
+      (poolIds ? `sidecar-pools-${poolIds.join(",")}` : "sidecar-pools") +
+      minLiquidityUsd,
     ttl: 5_000, // 5 seconds
     getFreshValue: async () => {
       const sidecarPools = await timeout(
-        () => queryPools({ poolIds }),
+        () =>
+          queryPools({ poolIds, minLiquidityCap: minLiquidityUsd?.toString() }),
         9_000, // 9 seconds
         "sidecarQueryPools"
       )();

--- a/packages/server/src/queries/complex/pools/providers/sidecar.ts
+++ b/packages/server/src/queries/complex/pools/providers/sidecar.ts
@@ -8,7 +8,7 @@ import { IS_TESTNET } from "../../../../env";
 import { PoolRawResponse } from "../../../../queries/osmosis";
 import { queryPools } from "../../../../queries/sidecar";
 import { DEFAULT_LRU_OPTIONS } from "../../../../utils/cache";
-import { calcSumCoinsValue, getAsset } from "../../assets";
+import { getAsset } from "../../assets";
 import { DEFAULT_VS_CURRENCY } from "../../assets/config";
 import { getCosmwasmPoolTypeFromCodeId } from "../env";
 import { Pool, PoolType } from "../index";
@@ -20,7 +20,6 @@ const poolsCache = new LRUCache<string, CacheEntry>(DEFAULT_LRU_OPTIONS);
 /** Lightly cached pools from sidecar service. */
 export function getPoolsFromSidecar({
   assetLists,
-  chainList,
   poolIds,
 }: {
   assetLists: AssetList[];
@@ -44,37 +43,14 @@ export function getPoolsFromSidecar({
           // Do nothing since low liq pools often contain unlisted tokens
         }
       });
-      const totalFiatLockedValues: (PricePretty | undefined)[] =
-        await Promise.all(
-          reserveCoins.map((reserve) =>
-            reserve
-              ? timeout(
-                  () =>
-                    calcSumCoinsValue({
-                      assetLists,
-                      chainList,
-                      coins: reserve,
-                    }).then(
-                      (value) => new PricePretty(DEFAULT_VS_CURRENCY, value)
-                    ),
-                  15_000, // 15 seconds
-                  "getPoolsFromSidecar:calcSumCoinsValue"
-                )()
-              : Promise.resolve(undefined)
-          )
-        );
 
       return sidecarPools
-        .map((sidecarPool, index) => {
-          if (reserveCoins[index] === undefined) return;
-          if (totalFiatLockedValues[index] === undefined) return;
-
-          return makePoolFromSidecarPool({
+        .map((sidecarPool, index) =>
+          makePoolFromSidecarPool({
             sidecarPool,
-            totalFiatValueLocked: totalFiatLockedValues[index] as PricePretty,
-            reserveCoins: reserveCoins[index] as CoinPretty[],
-          });
-        })
+            reserveCoins: reserveCoins[index] ?? null,
+          })
+        )
         .filter(Boolean) as Pool[];
     },
   });
@@ -84,16 +60,14 @@ export function getPoolsFromSidecar({
 function makePoolFromSidecarPool({
   sidecarPool,
   reserveCoins,
-  totalFiatValueLocked,
 }: {
   sidecarPool: SidecarPool;
   reserveCoins: CoinPretty[] | null;
-  totalFiatValueLocked: PricePretty | null;
 }): Pool | undefined {
   // contains unlisted or invalid assets
   // We avoid this check in testnet because we would like to show the pools even if we don't have accurate listing
   // to ease integrations.
-  if ((!reserveCoins || !totalFiatValueLocked) && !IS_TESTNET) return;
+  if (!reserveCoins && !IS_TESTNET) return;
 
   return {
     id: getPoolIdFromChainPool(sidecarPool.chain_model),
@@ -103,9 +77,10 @@ function makePoolFromSidecarPool({
 
     // We expect the else case to occur only in testnet
     reserveCoins: reserveCoins ? reserveCoins : [],
-    totalFiatValueLocked: totalFiatValueLocked
-      ? totalFiatValueLocked
-      : new PricePretty(DEFAULT_VS_CURRENCY, 0),
+    totalFiatValueLocked: new PricePretty(
+      DEFAULT_VS_CURRENCY,
+      sidecarPool.liquidity_cap
+    ),
   };
 }
 

--- a/packages/server/src/queries/sidecar/pools.ts
+++ b/packages/server/src/queries/sidecar/pools.ts
@@ -48,7 +48,7 @@ export type ChainPool =
   | ChainConcentratedPool
   | ChainCosmwasmPool;
 
-export type PoolsResponse = {
+export type SqsPool = {
   /** Sidecar returns the same pool models as the node. */
   chain_model: ChainPool;
   balances: {
@@ -56,12 +56,15 @@ export type PoolsResponse = {
     amount: string;
   }[];
   spread_factor: string;
-}[];
+  /** Int: capitalization in USD. Will be `"0"` if liquidity_cap_error is present. */
+  liquidity_cap: string;
+  liquidity_cap_error: string;
+};
 
-export async function queryPools({ poolIds }: { poolIds?: string[] } = {}) {
+export function queryPools({ poolIds }: { poolIds?: string[] } = {}) {
   const url = new URL(
     poolIds ? `/pools?IDs=${poolIds.join(",")}` : "/pools",
     SIDECAR_BASE_URL
   );
-  return await apiClient<PoolsResponse>(url.toString());
+  return apiClient<SqsPool[]>(url.toString());
 }

--- a/packages/server/src/queries/sidecar/pools.ts
+++ b/packages/server/src/queries/sidecar/pools.ts
@@ -61,10 +61,20 @@ export type SqsPool = {
   liquidity_cap_error: string;
 };
 
-export function queryPools({ poolIds }: { poolIds?: string[] } = {}) {
-  const url = new URL(
-    poolIds ? `/pools?IDs=${poolIds.join(",")}` : "/pools",
-    SIDECAR_BASE_URL
-  );
+export function queryPools({
+  poolIds,
+  minLiquidityCap,
+}: { poolIds?: string[]; minLiquidityCap?: string } = {}) {
+  const url = new URL("/pools", SIDECAR_BASE_URL);
+  const params = new URLSearchParams();
+
+  if (poolIds) {
+    params.append("IDs", poolIds.join(","));
+  }
+  if (minLiquidityCap) {
+    params.append("min_liquidity_cap", minLiquidityCap);
+  }
+
+  url.search = params.toString();
   return apiClient<SqsPool[]>(url.toString());
 }

--- a/packages/trpc/src/pools.ts
+++ b/packages/trpc/src/pools.ts
@@ -110,21 +110,16 @@ export const poolsRouter = createTRPCRouter({
       }) =>
         maybeCachePaginatedItems({
           getFreshItems: async () => {
-            const poolsPromise = getPools({
-              ...ctx,
-              search,
-              minLiquidityUsd,
-              types,
-              denoms,
-            });
-            const incentivesPromise = getCachedPoolIncentivesMap();
-            const marketMetricsPromise = getCachedPoolMarketMetricsMap();
-
-            /** Get remote data via concurrent requests, if needed. */
             const [pools, incentives, marketMetrics] = await Promise.all([
-              poolsPromise,
-              incentivesPromise,
-              marketMetricsPromise,
+              getPools({
+                ...ctx,
+                search,
+                minLiquidityUsd,
+                types,
+                denoms,
+              }),
+              getCachedPoolIncentivesMap(),
+              getCachedPoolMarketMetricsMap(),
             ]);
 
             const marketIncentivePools = pools


### PR DESCRIPTION
## What is the purpose of the change:

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

Now that SQS pools query returns capitalization (TVL), we can avoid the performance issue of sending additional SQS price queries to calculate it within the edge function. This should greatly increase performance and allow us to remove the Numia indexer as a major dependency here. As a secondary consequence, pool detail pages should be more performant since SQS supports querying by individual pool ID(s), which greatly reduces the load of getting individual pools (since all pools don't need to be queried)

### Linear Task

[FE-909 : Use SQS pools](https://linear.app/osmosis/issue/FE-909/use-sqs-pools)

## Brief Changelog

<!-- _(for example:)_

- _This adds frontend_asset_name to page_name_
- _Adds a new button for ..._
- _Removes the ..._ -->
* Add liquidity capitalization to SQS pools response, and remove price queries to get those values

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->
Tested manually locally