### PR TITLE
[Limit Orders - V3]: Review Modal 

### DIFF
--- a/packages/web/components/place-limit-tool/index.tsx
+++ b/packages/web/components/place-limit-tool/index.tsx
@@ -560,7 +560,8 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
           isConfirmationDisabled={isSendingTx}
           isOpen={reviewOpen}
           onClose={() => setReviewOpen(false)}
-          swapState={swapState.marketState}
+          expectedOutput={swapState.expectedTokenAmountOut}
+          expectedOutputFiat={swapState.expectedFiatAmountOut}
           orderType={type}
           percentAdjusted={swapState.priceState.percentAdjusted}
           limitPriceFiat={swapState.priceState.priceFiat}
@@ -568,6 +569,11 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
           slippageConfig={slippageConfig}
           gasAmount={swapState.gas.gasAmountFiat}
           isGasLoading={swapState.gas.isLoading}
+          limitSetPriceLock={swapState.priceState.setPriceLock}
+          inAmountToken={swapState.paymentTokenValue}
+          inAmountFiat={swapState.paymentFiatValue}
+          fromAsset={swapState.marketState.fromAsset}
+          toAsset={swapState.marketState.toAsset}
         />
         <AddFundsModal
           isOpen={isAddFundsModalOpen}

--- a/packages/web/components/swap-tool/alt.tsx
+++ b/packages/web/components/swap-tool/alt.tsx
@@ -649,7 +649,6 @@ export const AltSwapTool: FunctionComponent<SwapToolProps> = observer(
           title="Swap"
           isOpen={showSwapReviewModal}
           onClose={() => setShowSwapReviewModal(false)}
-          swapState={swapState}
           confirmAction={sendSwapTx}
           isConfirmationDisabled={isConfirmationDisabled}
           slippageConfig={slippageConfig}
@@ -657,6 +656,12 @@ export const AltSwapTool: FunctionComponent<SwapToolProps> = observer(
           outFiatAmountLessSlippage={outFiatAmountLessSlippage}
           outputDifference={outputDifference}
           showOutputDifferenceWarning={showOutputDifferenceWarning}
+          fromAsset={swapState.fromAsset}
+          toAsset={swapState.toAsset}
+          inAmountToken={swapState.inAmountInput.amount}
+          inAmountFiat={swapState.inAmountInput.fiatValue}
+          expectedOutput={swapState.quote?.amount}
+          expectedOutputFiat={swapState.tokenOutFiatValue}
         />
         <AddFundsModal
           isOpen={isAddFundsModalOpen}

--- a/packages/web/hooks/limit-orders/use-place-limit.ts
+++ b/packages/web/hooks/limit-orders/use-place-limit.ts
@@ -542,6 +542,7 @@ export const usePlaceLimit = ({
       !isBaseTokenBalanceLoading && !isQuoteTokenBalanceLoading,
     insufficientFunds,
     paymentFiatValue,
+    paymentTokenValue,
     makerFee,
     isMakerFeeLoading,
     expectedTokenAmountOut,
@@ -576,6 +577,8 @@ const useLimitPrice = ({
   orderDirection: OrderDirection;
   baseDenom?: string;
 }) => {
+  const [priceLocked, setPriceLock] = useState(false);
+
   const {
     data: assetPrice,
     isLoading: loadingSpotPrice,
@@ -584,7 +587,7 @@ const useLimitPrice = ({
     {
       coinMinimalDenom: baseDenom ?? "",
     },
-    { refetchInterval: 5000, enabled: !!baseDenom }
+    { refetchInterval: 5000, enabled: !!baseDenom && !priceLocked }
   );
 
   const [orderPrice, setOrderPrice] = useState("");
@@ -743,5 +746,6 @@ const useLimitPrice = ({
     isValidPrice,
     isBeyondOppositePrice,
     isSpotPriceRefetching,
+    setPriceLock,
   };
 };


### PR DESCRIPTION
## What is the purpose of the change:
These changes freeze limit price when the review modal is opened. It also adds adjustments to the review modal to display the correct values on a limit order.

### Linear Task

[LIM-248: Limit Order Review Page...](https://linear.app/osmosis/issue/LIM-248/limit-order-review-page-should-not-be-updating-the-price)
[LIM-252: Limit Sell Price...](https://linear.app/osmosis/issue/LIM-252/limit-sell-price-seems-to-be-set-to-market-price-instead-of-the-actual)

## Brief Changelog
- Made `ReviewOrder` props more explicit
- Added a `priceLocked` state value to price state for limit orders, this is toggled when review order is opened
