### PR TITLE
[Limit Orders - V3]: Limit Price Display for Low Values

### DIFF
--- a/packages/web/components/place-limit-tool/index.tsx
+++ b/packages/web/components/place-limit-tool/index.tsx
@@ -378,6 +378,10 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
     }, [orderDirection, swapState.error, t]);
 
     const isButtonDisabled = useMemo(() => {
+      if (swapState.insufficientFunds) {
+        return true;
+      }
+
       if (swapState.isMarket) {
         return (
           swapState.marketState.inAmountInput.isEmpty ||
@@ -393,6 +397,7 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
       swapState.isMarket,
       swapState.marketState.inAmountInput.amount,
       swapState.marketState.inAmountInput.isEmpty,
+      swapState.insufficientFunds,
       isMarketLoading,
     ]);
 

--- a/packages/web/components/place-limit-tool/limit-price-selector.tsx
+++ b/packages/web/components/place-limit-tool/limit-price-selector.tsx
@@ -186,9 +186,10 @@ export const LimitPriceSelector: FC<LimitPriceSelectorProps> = ({
                 min={0}
                 className="bg-transparent text-white-full transition-colors placeholder:text-osmoverse-600"
                 value={swapState.priceState.orderPrice}
-                placeholder={parseFloat(
-                  swapState.priceState.price.toString()
-                ).toFixed(4)}
+                placeholder={formatPretty(
+                  priceState.priceFiat,
+                  getPriceExtendedFormatOptions(priceState.priceFiat.toDec())
+                ).replace("$", "")}
                 onChange={(e) => {
                   const value = e.target.value.trim();
                   if (!isValidNumericalRawInput(value) || value.length === 0)

--- a/packages/web/hooks/limit-orders/use-place-limit.ts
+++ b/packages/web/hooks/limit-orders/use-place-limit.ts
@@ -601,7 +601,7 @@ const useLimitPrice = ({
   // Sets a user based order price, if nothing is input it resets the form (including percentage adjustments)
   const setManualOrderPrice = useCallback(
     (price: string) => {
-      if (countDecimals(price) > 4) {
+      if (countDecimals(price) > 12) {
         return;
       }
 


### PR DESCRIPTION
## What is the purpose of the change:
Adjusted the price display for limit holders to account for low value prices.

### Linear Task

[LIM-244: Custom Price Decimal Cap...](https://linear.app/osmosis/issue/LIM-244/custom-price-decimal-cap-should-be-made-to-12)

## Brief Changelog
- Homogenized price display for limit price selection
- Increased price input decimal places to 12
- Fixed an issue with button not being disabled on insufficient funds for buy/sell tab
