### PR TITLE
(Deposit/Withdraw) Connect chain pending approval button state

### DIFF
--- a/packages/web/localizations/de.json
+++ b/packages/web/localizations/de.json
@@ -910,6 +910,7 @@
     "from": "Von {network}",
     "to": "Zu {network}",
     "max": "Max",
+    "pendingApproval": "Ausstehende Genehmigung",
     "available": "verfügbar",
     "connectTo": "Verbinden mit {network}",
     "transferWith": "Übertragen mit",

--- a/packages/web/localizations/en.json
+++ b/packages/web/localizations/en.json
@@ -910,6 +910,7 @@
     "from": "From",
     "to": "To",
     "max": "Max",
+    "pendingApproval": "Pending approval",
     "available": "available",
     "connectTo": "Connect to {network}",
     "transferWith": "Transfer with",

--- a/packages/web/localizations/es.json
+++ b/packages/web/localizations/es.json
@@ -910,6 +910,7 @@
     "from": "De",
     "to": "A",
     "max": "máx.",
+    "pendingApproval": "Aprobación pendiente",
     "available": "disponible",
     "connectTo": "Conéctese a {network}",
     "transferWith": "Transferir con",

--- a/packages/web/localizations/fa.json
+++ b/packages/web/localizations/fa.json
@@ -910,6 +910,7 @@
     "from": "از",
     "to": "برای",
     "max": "حداکثر",
+    "pendingApproval": "در انتظار تایید",
     "available": "در دسترس",
     "connectTo": "اتصال به {network}",
     "transferWith": "انتقال با",

--- a/packages/web/localizations/fr.json
+++ b/packages/web/localizations/fr.json
@@ -910,6 +910,7 @@
     "from": "De",
     "to": "Vers",
     "max": "Max.",
+    "pendingApproval": "En attente de validation",
     "available": "disponible",
     "connectTo": "Connectez-vous à {network}",
     "transferWith": "Transfert avec",

--- a/packages/web/localizations/gu.json
+++ b/packages/web/localizations/gu.json
@@ -910,6 +910,7 @@
     "from": "માંથી",
     "to": "માટે",
     "max": "મહત્તમ",
+    "pendingApproval": "મંજૂરી બાકી હોવી",
     "available": "ઉપલબ્ધ",
     "connectTo": "{network} થી કનેક્ટ કરો",
     "transferWith": "સાથે ટ્રાન્સફર કરો",

--- a/packages/web/localizations/hi.json
+++ b/packages/web/localizations/hi.json
@@ -910,6 +910,7 @@
     "from": "से",
     "to": "को",
     "max": "अधिकतम",
+    "pendingApproval": "लंबित अनुमोदन",
     "available": "उपलब्ध",
     "connectTo": "{network} से कनेक्ट करें",
     "transferWith": "साथ स्थानांतरित करें",

--- a/packages/web/localizations/ja.json
+++ b/packages/web/localizations/ja.json
@@ -910,6 +910,7 @@
     "from": "{network}から",
     "to": "{network}へ",
     "max": "マックス",
+    "pendingApproval": "承認待ちの",
     "available": "利用可能",
     "connectTo": "{network}に接続します",
     "transferWith": "転送",

--- a/packages/web/localizations/ko.json
+++ b/packages/web/localizations/ko.json
@@ -910,6 +910,7 @@
     "from": "에서",
     "to": "에게",
     "max": "맥스",
+    "pendingApproval": "승인 대기 중",
     "available": "사용 가능",
     "connectTo": "{network} 에 연결",
     "transferWith": "다음으로 환승",

--- a/packages/web/localizations/pl.json
+++ b/packages/web/localizations/pl.json
@@ -910,6 +910,7 @@
     "from": "Z",
     "to": "Do",
     "max": "Maks",
+    "pendingApproval": "Oczekuje na zatwierdzenie",
     "available": "dostępny",
     "connectTo": "Połącz się z {network}",
     "transferWith": "Przenieś z",

--- a/packages/web/localizations/pt-br.json
+++ b/packages/web/localizations/pt-br.json
@@ -910,6 +910,7 @@
     "from": "De",
     "to": "Para",
     "max": "Máx.",
+    "pendingApproval": "Aprovação pendente",
     "available": "disponível",
     "connectTo": "Conecte-se a {network}",
     "transferWith": "Transferir com",

--- a/packages/web/localizations/ro.json
+++ b/packages/web/localizations/ro.json
@@ -910,6 +910,7 @@
     "from": "De la",
     "to": "Către",
     "max": "Max",
+    "pendingApproval": "Aprobare in asteptare",
     "available": "disponibil",
     "connectTo": "Conectați-vă la {network}",
     "transferWith": "Transfer cu",

--- a/packages/web/localizations/ru.json
+++ b/packages/web/localizations/ru.json
@@ -910,6 +910,7 @@
     "from": "Из",
     "to": "Чтобы",
     "max": "Макс",
+    "pendingApproval": "В ожидании утверждения",
     "available": "доступный",
     "connectTo": "Подключитесь к {network}",
     "transferWith": "Трансфер с",

--- a/packages/web/localizations/tr.json
+++ b/packages/web/localizations/tr.json
@@ -910,6 +910,7 @@
     "from": "kaynağından",
     "to": "için",
     "max": "Maksimum",
+    "pendingApproval": "Onay bekleyen",
     "available": "mevcut",
     "connectTo": "{network} ağına bağlanın",
     "transferWith": "Şununla aktar:",

--- a/packages/web/localizations/zh-cn.json
+++ b/packages/web/localizations/zh-cn.json
@@ -910,6 +910,7 @@
     "from": "从",
     "to": "到",
     "max": "最大限度",
+    "pendingApproval": "等待批准",
     "available": "可用的",
     "connectTo": "连接到{network}",
     "transferWith": "转让",

--- a/packages/web/localizations/zh-hk.json
+++ b/packages/web/localizations/zh-hk.json
@@ -910,6 +910,7 @@
     "from": "從",
     "to": "到",
     "max": "最大限度",
+    "pendingApproval": "待批准",
     "available": "可用的",
     "connectTo": "連接到{network}",
     "transferWith": "轉移與",

--- a/packages/web/localizations/zh-tw.json
+++ b/packages/web/localizations/zh-tw.json
@@ -910,6 +910,7 @@
     "from": "從",
     "to": "到",
     "max": "最大限度",
+    "pendingApproval": "待批准",
     "available": "可用的",
     "connectTo": "連接到{network}",
     "transferWith": "轉移與",

--- a/packages/web/modals/wallet-select/use-selectable-wallets.ts
+++ b/packages/web/modals/wallet-select/use-selectable-wallets.ts
@@ -30,7 +30,7 @@ export const useSelectableWallets = ({
           }
 
           if (wallet.type === WagmiMetamaskSdkType) {
-            walletToAdd.name = walletToAdd.name + " (Mobile)";
+            walletToAdd.name = walletToAdd.name + " Mobile";
           }
 
           if (wallet.name === "WalletConnect") {
@@ -43,6 +43,10 @@ export const useSelectableWallets = ({
             if (wallet.type === "injected") {
               walletToAdd.name = "Coinbase Extension";
             }
+          }
+
+          if (wallet.name === "Keplr") {
+            walletToAdd.name = "Keplr EVM";
           }
 
           return [...acc, walletToAdd];


### PR DESCRIPTION
## What is the purpose of the change:

When a chain is pending approval, the button should be disabled and say "pending approval"

### Linear Task

[Linear Task URL](https://linear.app/osmosis/issue/FE-877/connect-chain-pending-approval-button-state)
