### PR TITLE
Add fallback gas limit to txs

### DIFF
--- a/packages/bridge/src/axelar/index.ts
+++ b/packages/bridge/src/axelar/index.ts
@@ -424,6 +424,7 @@ export class AxelarBridgeProvider implements BridgeProvider {
         ],
       },
       bech32Address: params.fromAddress,
+      fallbackGasLimit: cosmosMsgOpts.ibcTransfer.gas,
     }).catch((e) => {
       if (
         e instanceof Error &&

--- a/packages/bridge/src/ibc/index.ts
+++ b/packages/bridge/src/ibc/index.ts
@@ -59,37 +59,8 @@ export class IbcBridgeProvider implements BridgeProvider {
       this.estimateTransferTime(fromChainId, toChainId),
     ]);
 
-    const txSimulation = await estimateGasFee({
-      chainId: fromChainId,
-      chainList: this.ctx.chainList,
-      body: {
-        messages: [
-          this.protoRegistry.encodeAsAny({
-            typeUrl: signDoc.msgTypeUrl,
-            value: signDoc.msg,
-          }),
-        ],
-      },
-      bech32Address: params.fromAddress,
-    }).catch((e) => {
-      if (
-        e instanceof Error &&
-        e.message.includes(
-          "No fee tokens found with sufficient balance on account"
-        )
-      ) {
-        throw new BridgeQuoteError({
-          bridgeId: IbcBridgeProvider.ID,
-          errorType: "InsufficientAmountError",
-          message: e.message,
-        });
-      }
-
-      throw e;
-    });
-
-    const gasFee = txSimulation.amount[0];
-    const gasAsset = await this.getGasAsset(fromChainId, gasFee.denom);
+    const gasAsset = signDoc.gasAsset;
+    const gasFee = signDoc.gasFee;
 
     return {
       input: {
@@ -110,21 +81,16 @@ export class IbcBridgeProvider implements BridgeProvider {
         amount: "0",
       },
       estimatedTime,
-      estimatedGasFee: {
-        address: gasAsset?.address ?? gasFee.denom,
-        denom: gasAsset?.denom ?? gasFee.denom,
-        decimals: gasAsset?.decimals ?? 0,
-        coinGeckoId: gasAsset?.coinGeckoId,
-        amount: gasFee.amount,
-      },
-      transactionRequest: {
-        ...signDoc,
-        gasFee: {
-          gas: txSimulation.gas,
-          amount: gasFee.amount,
-          denom: gasFee.denom,
-        },
-      },
+      estimatedGasFee: gasFee
+        ? {
+            address: gasAsset?.address ?? gasFee.denom,
+            denom: gasAsset?.denom ?? gasFee.denom,
+            decimals: gasAsset?.decimals ?? 0,
+            coinGeckoId: gasAsset?.coinGeckoId,
+            amount: gasFee.amount,
+          }
+        : undefined,
+      transactionRequest: signDoc,
     };
   }
 
@@ -174,7 +140,7 @@ export class IbcBridgeProvider implements BridgeProvider {
    */
   async getTransactionData(
     params: GetBridgeQuoteParams
-  ): Promise<CosmosBridgeTransactionRequest> {
+  ): Promise<CosmosBridgeTransactionRequest & { gasAsset?: BridgeAsset }> {
     this.validate(params);
 
     const { sourceChannel, sourcePort, address } = this.getIbcSource(params);
@@ -209,6 +175,7 @@ export class IbcBridgeProvider implements BridgeProvider {
         ],
       },
       bech32Address: params.fromAddress,
+      fallbackGasLimit: cosmosMsgOpts.ibcTransfer.gas,
     }).catch((e) => {
       if (
         e instanceof Error &&
@@ -226,15 +193,22 @@ export class IbcBridgeProvider implements BridgeProvider {
       throw e;
     });
 
+    const gasFee = txSimulation.amount[0];
+    const gasAsset = await this.getGasAsset(
+      params.fromChain.chainId as string,
+      gasFee.denom
+    );
+
     return {
       type: "cosmos",
       msgTypeUrl: typeUrl,
       msg,
       gasFee: {
         gas: txSimulation.gas,
-        amount: txSimulation.amount[0].amount,
-        denom: txSimulation.amount[0].denom,
+        amount: gasFee.amount,
+        denom: gasFee.denom,
       },
+      gasAsset,
     };
   }
 

--- a/packages/bridge/src/skip/__tests__/skip-bridge-provider.spec.ts
+++ b/packages/bridge/src/skip/__tests__/skip-bridge-provider.spec.ts
@@ -128,7 +128,7 @@ describe("SkipBridgeProvider", () => {
     });
 
     expect(quote).toBeDefined();
-    expect(quote).toEqual({
+    expect(quote).toMatchObject({
       input: {
         amount: "10000000000000000000",
         denom: "ETH",

--- a/packages/bridge/src/skip/index.ts
+++ b/packages/bridge/src/skip/index.ts
@@ -459,7 +459,7 @@ export class SkipBridgeProvider implements BridgeProvider {
 
   async createCosmosTransaction(
     message: SkipMultiChainMsg
-  ): Promise<Omit<CosmosBridgeTransactionRequest, "gas">> {
+  ): Promise<CosmosBridgeTransactionRequest & { fallbackGasLimit?: number }> {
     const messageData = JSON.parse(message.msg);
 
     if ("contract" in messageData) {
@@ -487,6 +487,7 @@ export class SkipBridgeProvider implements BridgeProvider {
         type: "cosmos",
         msgTypeUrl: typeUrl,
         msg,
+        fallbackGasLimit: cosmwasmMsgOpts.executeWasm.gas,
       };
     } else {
       // is an ibc transfer
@@ -514,6 +515,7 @@ export class SkipBridgeProvider implements BridgeProvider {
         type: "cosmos",
         msgTypeUrl: typeUrl,
         msg: value,
+        fallbackGasLimit: cosmosMsgOpts.ibcTransfer.gas,
       };
     }
   }
@@ -737,7 +739,7 @@ export class SkipBridgeProvider implements BridgeProvider {
 
   async estimateGasFee(
     params: GetBridgeQuoteParams,
-    txData: BridgeTransactionRequest
+    txData: BridgeTransactionRequest & { fallbackGasLimit?: number }
   ) {
     if (txData.type === "evm") {
       const evmChain = Object.values(EthereumChainInfo).find(
@@ -792,6 +794,7 @@ export class SkipBridgeProvider implements BridgeProvider {
           ],
         },
         bech32Address: params.fromAddress,
+        fallbackGasLimit: txData.fallbackGasLimit,
       }).catch((e) => {
         if (
           e instanceof Error &&

--- a/packages/tx/src/gas.ts
+++ b/packages/tx/src/gas.ts
@@ -77,6 +77,7 @@ export async function estimateGasFee({
   bech32Address,
   gasMultiplier = 1.5,
   onlyDefaultFeeDenom,
+  fallbackGasLimit,
 }: {
   chainId: string;
   chainList: ChainWithFeatures[];
@@ -88,6 +89,11 @@ export async function estimateGasFee({
    *  Default: `1.5` */
   gasMultiplier?: number;
 
+  /**
+   * If tx simulation fails for some reason, this can be provided as a fallback gas limit.
+   */
+  fallbackGasLimit?: number;
+
   sendCoin?: { denom: string; amount: string };
 
   /** Force the use of fee token returned by default from `getGasPrice`. Overrides `excludedFeeDenoms` option. */
@@ -98,6 +104,15 @@ export async function estimateGasFee({
     chainList,
     body,
     bech32Address,
+  }).catch((e) => {
+    if (fallbackGasLimit) {
+      console.warn(
+        "Using fallback gas limit: Error",
+        e instanceof Error ? e.message : e
+      );
+      return { gasUsed: fallbackGasLimit, coinsSpent: [] };
+    }
+    throw e;
   });
 
   const gasLimit = String(Math.round(gasUsed * gasMultiplier));

--- a/packages/tx/src/msg.ts
+++ b/packages/tx/src/msg.ts
@@ -21,7 +21,7 @@ export const createMsgOpts = <
 /** Core message options for cosmos-based chains. */
 export const cosmosMsgOpts = createMsgOpts({
   ibcTransfer: {
-    gas: 450000,
+    gas: 250000,
     messageComposer:
       ibc.applications.transfer.v1.MessageComposer.withTypeUrl.transfer,
   },

--- a/packages/web/hooks/use-connect-wallet-modal-redirect.tsx
+++ b/packages/web/hooks/use-connect-wallet-modal-redirect.tsx
@@ -29,7 +29,11 @@ export function useConnectWalletModalRedirect(
   const { accountStore } = useStore();
   const osmosisAccount = accountStore.getWallet(accountStore.osmosisChainId);
 
-  const { onOpenWalletSelect, isLoading: isWalletLoading } = useWalletSelect();
+  const { onOpenWalletSelect, isLoading: isWalletLoading_ } = useWalletSelect();
+  const isWalletLoading =
+    isWalletLoading_ ||
+    !osmosisAccount?.walletStatus ||
+    osmosisAccount.walletStatus === WalletStatus.Connecting;
 
   const [walletInitiallyConnected, setWalletInitiallyConnected] = useState(
     () => osmosisAccount?.walletStatus === WalletStatus.Connected
@@ -55,8 +59,8 @@ export function useConnectWalletModalRedirect(
   return {
     showModalBase: showSelf,
     accountActionButton:
-      osmosisAccount?.walletStatus === WalletStatus.Connected ||
-      isWalletLoading ? (
+      isWalletLoading ||
+      osmosisAccount?.walletStatus === WalletStatus.Connected ? (
         <Button {...actionButtonProps}>{actionButtonProps.children}</Button>
       ) : (
         <Button


### PR DESCRIPTION
## What is the purpose of the change:

<!-- > Add a description of the overall background and high level changes that this PR introduces

_(E.g.: This pull request improves area A by adding ...._ -->

On EVM hybrid chains the simulate query will throw an error if the user hasn't transacted on the account yet. This PR adds a param to the `estimateGasFee` function to give the providers an option to fallback to a hardcoded gas value in the scenario that the estimation query fails. This will help improve reliability of users depositing from such chains.
