### PR TITLE
Upload test results on failure only

### DIFF
--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -65,7 +65,7 @@ jobs:
           cd packages/web
           npx playwright test -g "Test Swap feature"
       - name: upload Swap test results
-        if: always()
+        if: failure()
         id: swap-test-results
         uses: actions/upload-artifact@v4
         with:
@@ -102,7 +102,7 @@ jobs:
           cd packages/web
           npx playwright test -g "Test Portfolio feature"
       - name: upload Portfolio test results
-        if: always()
+        if: failure()
         id: portfolio-test-results
         uses: actions/upload-artifact@v4
         with:
@@ -137,7 +137,7 @@ jobs:
           cd packages/web
           npx playwright test pools select
       - name: upload pools test results
-        if: always()
+        if: failure()
         id: pools-test-results
         uses: actions/upload-artifact@v4
         with:
@@ -174,7 +174,7 @@ jobs:
           cd packages/web
           npx playwright test -g "Test Transactions feature"
       - name: upload transactions test results
-        if: always()
+        if: failure()
         id: transactions-test-results
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/monitoring-e2e-tests.yml
+++ b/.github/workflows/monitoring-e2e-tests.yml
@@ -122,7 +122,7 @@ jobs:
           cd packages/web
           npx playwright test -g "Test Select Swap Pair feature"
       - name: upload test results
-        if: always()
+        if: failure()
         id: e2e-test-results
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/monitoring-geo-e2e-tests.yml
+++ b/.github/workflows/monitoring-geo-e2e-tests.yml
@@ -54,7 +54,7 @@ jobs:
           cd packages/web
           npx playwright test select pools transactions
       - name: upload test results
-        if: always()
+        if: failure()
         id: e2e-test-results
         uses: actions/upload-artifact@v4
         with:
@@ -102,7 +102,7 @@ jobs:
           cd packages/web
           npx playwright test -g "Test Swap Stables feature"
       - name: upload test results
-        if: always()
+        if: failure()
         id: e2e-test-results
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## What is the purpose of the change:

In order to speedup test execution only upload test results on failure.