### PR TITLE
[Limit Orders - V3]: Denom Selection Updates

### DIFF
--- a/packages/web/components/swap-tool/price-selector.tsx
+++ b/packages/web/components/swap-tool/price-selector.tsx
@@ -22,6 +22,25 @@ type AssetWithBalance = Asset & MaybeUserAssetCoin;
 
 const UI_DEFAULT_QUOTES = ["USDC", "USDT"];
 
+const VALID_QUOTES = [
+  ...UI_DEFAULT_QUOTES,
+  "USDC.sol.axl",
+  "USDC.sol.wh",
+  "USDC.eth.grv",
+  "USDC.eth.wh",
+  "USDC.matic.axl",
+  "USDC.avax.axl",
+  "USDC.eth.axl",
+  "USDT.sol.axl",
+  "USDT.eth.grv",
+  "USDT.eth.wh",
+  "USDT.matic.axl",
+  "USDT.avax.axl",
+  "USDT.kava",
+  "USDT.eth.pica",
+  "USDT.sol.pica",
+];
+
 function sortByAmount(
   assetA?: MaybeUserAssetCoin,
   assetB?: MaybeUserAssetCoin
@@ -89,6 +108,14 @@ export const PriceSelector = memo(() => {
       select: (data) =>
         data.items
           .map((walletAsset) => {
+            if (
+              !(tab === "sell" ? UI_DEFAULT_QUOTES : VALID_QUOTES).includes(
+                walletAsset.coinDenom
+              )
+            ) {
+              return undefined;
+            }
+
             const asset = getAssetFromAssetList({
               assetLists: AssetLists,
               symbol: walletAsset.coinDenom,

--- a/packages/web/components/swap-tool/price-selector.tsx
+++ b/packages/web/components/swap-tool/price-selector.tsx
@@ -15,7 +15,7 @@ import { useDisclosure, useTranslation } from "~/hooks";
 import { useOrderbookSelectableDenoms } from "~/hooks/limit-orders/use-orderbook";
 import { AddFundsModal } from "~/modals/add-funds";
 import { useStore } from "~/stores";
-import { formatPretty, getPriceExtendedFormatOptions } from "~/utils/formatter";
+import { formatFiatPrice } from "~/utils/formatter";
 import { api } from "~/utils/trpc";
 
 type AssetWithBalance = Asset & MaybeUserAssetCoin;
@@ -459,12 +459,8 @@ const SelectableQuotes = observer(
                           "text-white-full": availableBalance.gt(new Dec(0)),
                         })}
                       >
-                        {formatPretty(
-                          new PricePretty(
-                            DEFAULT_VS_CURRENCY,
-                            availableBalance
-                          ),
-                          getPriceExtendedFormatOptions(availableBalance)
+                        {formatFiatPrice(
+                          new PricePretty(DEFAULT_VS_CURRENCY, availableBalance)
                         )}
                       </span>
                       <span className="body2 font-light">

--- a/packages/web/hooks/limit-orders/use-place-limit.ts
+++ b/packages/web/hooks/limit-orders/use-place-limit.ts
@@ -563,7 +563,7 @@ export const usePlaceLimit = ({
     placeLimit,
     baseTokenBalance,
     quoteTokenBalance,
-    isBalancesFetched: isBalancesLoading,
+    isBalancesFetched: !isBalancesLoading,
     insufficientFunds,
     paymentFiatValue,
     paymentTokenValue,

--- a/packages/web/hooks/limit-orders/use-place-limit.ts
+++ b/packages/web/hooks/limit-orders/use-place-limit.ts
@@ -626,7 +626,7 @@ const useLimitPrice = ({
   // Sets a user based order price, if nothing is input it resets the form (including percentage adjustments)
   const setManualOrderPrice = useCallback(
     (price: string) => {
-      if (countDecimals(price) > 4) {
+      if (countDecimals(price) > 12) {
         return;
       }
 

--- a/packages/web/modals/token-select-modal-limit.tsx
+++ b/packages/web/modals/token-select-modal-limit.tsx
@@ -120,12 +120,6 @@ export const TokenSelectModalLimit: FunctionComponent<TokenSelectModalLimitProps
       const { onMouseDown: onMouseDownQuickSelect } =
         useDraggableScroll(quickSelectRef);
 
-      const onClose = () => {
-        setIsRequestingClose(true);
-        setKeyboardSelectedIndex(0);
-        onCloseProp?.();
-      };
-
       const onSelect = (coinDenom: string) => {
         onSelectProp?.(coinDenom);
         onClose();
@@ -156,10 +150,6 @@ export const TokenSelectModalLimit: FunctionComponent<TokenSelectModalLimitProps
 
         onSelect(coinDenom);
       };
-
-      useWindowKeyActions({
-        Escape: onClose,
-      });
 
       const { handleKeyDown: containerKeyDown } = useKeyActions({
         ArrowDown: () => {
@@ -218,6 +208,18 @@ export const TokenSelectModalLimit: FunctionComponent<TokenSelectModalLimitProps
         selectableAssets,
         ["coinDenom", "coinName"]
       );
+
+      const onClose = () => {
+        setIsRequestingClose(true);
+        setKeyboardSelectedIndex(0);
+        onCloseProp?.();
+        setQuery("");
+        if (setAssetQueryInput) setAssetQueryInput("");
+      };
+
+      useWindowKeyActions({
+        Escape: onClose,
+      });
 
       const searchValue = useMemo(
         () => (!!assetQueryInput ? assetQueryInput : filterValue),

--- a/packages/web/modals/token-select-modal-limit.tsx
+++ b/packages/web/modals/token-select-modal-limit.tsx
@@ -267,7 +267,7 @@ export const TokenSelectModalLimit: FunctionComponent<TokenSelectModalLimitProps
             isOpen={isOpen}
             onRequestClose={onClose}
             hideCloseButton
-            className="w-[512px] rounded-5xl !p-0"
+            className="!max-h-[90vh] w-[512px] self-start rounded-5xl !p-0"
           >
             <div className="flex h-full w-full flex-col overflow-hidden rounded-3xl bg-osmoverse-850">
               <div className="relative flex min-h-[80px] items-center justify-center p-4">
@@ -296,7 +296,7 @@ export const TokenSelectModalLimit: FunctionComponent<TokenSelectModalLimitProps
                   >
                     {t("limitOrders.connectYourWallet")}
                   </button>
-                  <p className="font-semibold">
+                  <p className="font-semibold text-osmoverse-300">
                     {t("limitOrders.toSeeYourBalances")}
                   </p>
                 </div>
@@ -361,71 +361,72 @@ export const TokenSelectModalLimit: FunctionComponent<TokenSelectModalLimitProps
               ) : (
                 <div className="no-scrollbar flex flex-col overflow-auto py-3 px-4">
                   {/* TODO: fix typing */}
-                  {(results as any[]).map(
-                    (
-                      {
-                        coinDenom,
-                        coinMinimalDenom,
-                        coinImageUrl,
-                        coinName,
-                        amount,
-                        usdValue,
-                        isVerified,
-                      },
-                      index
-                    ) => {
-                      return (
-                        <button
-                          key={coinMinimalDenom}
-                          className={classNames(
-                            "flex cursor-pointer items-center justify-between rounded-2xl p-4 transition-colors duration-150 ease-out",
-                            {
-                              "bg-osmoverse-900":
-                                keyboardSelectedIndex === index,
-                            }
-                          )}
-                          data-testid="token-select-asset"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            onClickAsset?.(coinDenom);
-                          }}
-                          onMouseOver={() => setKeyboardSelectedIndex(index)}
-                          onFocus={() => setKeyboardSelectedIndex(index)}
-                          {...{
-                            [dataAttributeName]: getTokenItemId(
-                              uniqueId,
-                              index
-                            ),
-                          }}
-                        >
-                          <div
+                  {results.length > 0 ? (
+                    (results as any[]).map(
+                      (
+                        {
+                          coinDenom,
+                          coinMinimalDenom,
+                          coinImageUrl,
+                          coinName,
+                          amount,
+                          usdValue,
+                          isVerified,
+                        },
+                        index
+                      ) => {
+                        return (
+                          <button
+                            key={coinMinimalDenom}
                             className={classNames(
-                              "flex w-full items-center justify-between text-left",
+                              "flex cursor-pointer items-center justify-between rounded-2xl p-4 transition-colors duration-150 ease-out",
                               {
-                                "opacity-40":
-                                  !shouldShowUnverifiedAssets && !isVerified,
+                                "bg-osmoverse-900":
+                                  keyboardSelectedIndex === index,
                               }
                             )}
+                            data-testid="token-select-asset"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              onClickAsset?.(coinDenom);
+                            }}
+                            onMouseOver={() => setKeyboardSelectedIndex(index)}
+                            onFocus={() => setKeyboardSelectedIndex(index)}
+                            {...{
+                              [dataAttributeName]: getTokenItemId(
+                                uniqueId,
+                                index
+                              ),
+                            }}
                           >
-                            <div className="flex items-center gap-4">
-                              {coinImageUrl && (
-                                <div className="h-12 w-12 rounded-full">
-                                  <Image
-                                    src={coinImageUrl}
-                                    alt={`${coinDenom} icon`}
-                                    width={48}
-                                    height={48}
-                                    className="rounded-full"
-                                  />
-                                </div>
+                            <div
+                              className={classNames(
+                                "flex w-full items-center justify-between text-left",
+                                {
+                                  "opacity-40":
+                                    !shouldShowUnverifiedAssets && !isVerified,
+                                }
                               )}
-                              <div className="flex flex-col">
-                                <span className="subtitle1">{coinName}</span>
-                                <span className="subtitle2 text-osmoverse-400">
-                                  {coinDenom}
-                                </span>
-                              </div>
-                              {/* {!isVerified && shouldShowUnverifiedAssets && (
+                            >
+                              <div className="flex items-center gap-4">
+                                {coinImageUrl && (
+                                  <div className="h-12 w-12 rounded-full">
+                                    <Image
+                                      src={coinImageUrl}
+                                      alt={`${coinDenom} icon`}
+                                      width={48}
+                                      height={48}
+                                      className="rounded-full"
+                                    />
+                                  </div>
+                                )}
+                                <div className="flex flex-col">
+                                  <span className="subtitle1">{coinName}</span>
+                                  <span className="subtitle2 text-osmoverse-400">
+                                    {coinDenom}
+                                  </span>
+                                </div>
+                                {/* {!isVerified && shouldShowUnverifiedAssets && (
                               <Tooltip
                                 content={t(
                                   "components.selectToken.unverifiedAsset"
@@ -437,26 +438,29 @@ export const TokenSelectModalLimit: FunctionComponent<TokenSelectModalLimitProps
                                 />
                               </Tooltip>
                             )} */}
-                            </div>
+                              </div>
 
-                            {isWalletConnected && !hideBalances && (
-                              <div className="flex flex-col items-end gap-1">
-                                <p
-                                  className={classNames("text-osmoverse-400", {
-                                    "text-white-full": usdValue,
-                                  })}
-                                >
-                                  {formatPretty(
-                                    usdValue ??
-                                      new PricePretty(DEFAULT_VS_CURRENCY, 0)
+                              {isWalletConnected && !hideBalances && (
+                                <div className="flex flex-col items-end gap-1">
+                                  <p
+                                    className={classNames(
+                                      "text-osmoverse-400",
+                                      {
+                                        "text-white-full": usdValue,
+                                      }
+                                    )}
+                                  >
+                                    {formatPretty(
+                                      usdValue ??
+                                        new PricePretty(DEFAULT_VS_CURRENCY, 0)
+                                    )}
+                                  </p>
+                                  {amount && (
+                                    <span className="body2 text-osmoverse-300">
+                                      {formatPretty(amount).split(" ")[0]}
+                                    </span>
                                   )}
-                                </p>
-                                {amount && (
-                                  <span className="body2 text-osmoverse-300">
-                                    {formatPretty(amount).split(" ")[0]}
-                                  </span>
-                                )}
-                                {/* <Link
+                                  {/* <Link
                                 href={"#"}
                                 className="subtitle2 inline-flex items-center text-wosmongton-300"
                               >
@@ -468,9 +472,9 @@ export const TokenSelectModalLimit: FunctionComponent<TokenSelectModalLimitProps
                                   />
                                 </div>
                               </Link> */}
-                              </div>
-                            )}
-                            {/* {amount &&
+                                </div>
+                              )}
+                              {/* {amount &&
                             isVerified &&
                             usdValue &&
                             amount.toDec().isPositive() && (
@@ -485,15 +489,31 @@ export const TokenSelectModalLimit: FunctionComponent<TokenSelectModalLimitProps
                                 </span>
                               </div>
                             )} */}
-                          </div>
-                          {/* {!shouldShowUnverifiedAssets && !isVerified && (
+                            </div>
+                            {/* {!shouldShowUnverifiedAssets && !isVerified && (
                           <p className="caption whitespace-nowrap text-wosmongton-200">
                             {t("components.selectToken.clickToActivate")}
                           </p>
                         )} */}
-                        </button>
-                      );
-                    }
+                          </button>
+                        );
+                      }
+                    )
+                  ) : (
+                    <div className="flex flex-col items-center justify-center py-8 text-center text-osmoverse-300">
+                      <Icon
+                        id="search"
+                        width={32}
+                        height={32}
+                        className="text-osmoverse-700"
+                      />
+                      <span className="mt-6 text-h6 font-h6 text-white-high">
+                        No results for "{searchValue}"
+                      </span>
+                      <span className="body1 pt-1">
+                        Try adjusting your search query
+                      </span>
+                    </div>
                   )}
                   <Intersection
                     onVisible={() => {

--- a/packages/web/utils/formatter.ts
+++ b/packages/web/utils/formatter.ts
@@ -12,6 +12,7 @@ import {
   getDecimalCount,
   getNumberMagnitude,
   toScientificNotation,
+  trimPlaceholderZeros,
 } from "~/utils/number";
 
 type CustomFormatOpts = {
@@ -354,3 +355,24 @@ export const compressZeros = (
     decimalDigits: otherDigits,
   };
 };
+
+/**
+ * Formats a fiat price using `getPriceExtendedFormatOptions` and displays `<0.01` if the price is less than $0.01.
+ * Rounds to the provided `maxDecimals` parameter.
+ */
+export function formatFiatPrice(price: PricePretty, maxDecimals = 2) {
+  if (!price.toDec().isZero() && price.toDec().lt(new Dec(0.01))) {
+    return "<$0.01";
+  }
+
+  const truncatedAmount = new Dec(
+    parseFloat(price.toDec().toString()).toFixed(maxDecimals).toString()
+  );
+  const truncatedPrice = new PricePretty(price.fiatCurrency, truncatedAmount);
+
+  return trimPlaceholderZeros(
+    formatPretty(truncatedPrice, {
+      ...getPriceExtendedFormatOptions(truncatedPrice.toDec()),
+    })
+  );
+}


### PR DESCRIPTION
## What is the purpose of the change:
These changes alter denom selections:
- Quote denoms are restricted to select assets (defined in `VALID_QUOTES` in `price-selector.tsx`)
- Quote denom balances have improved formatting ("<$0.01" for sub 1c displays)
- Base denom selection modal is a fixed position and reduced height
- Denom selection modal resets search when closing
- Refactored balance fetching for `usePlaceLimit`
