### PR TITLE
Split parallel swap tests and use 2 wallets

### DIFF
--- a/.github/await_deployment.py
+++ b/.github/await_deployment.py
@@ -30,8 +30,8 @@ def wait_for_deployment(timeout):
     os.system(f'echo "{gh_out}" >> $GITHUB_ENV')
     os.system(f'echo Vercel deployment: "{gh_out}" >> $GITHUB_STEP_SUMMARY')
     for i in range(1, timeout):
-        print(f"Sleep for 30 seconds and get deployment uid {vercel_uid} and url: {vercel_url}")
-        time.sleep(30)
+        print(f"Sleep for 15 seconds and get deployment uid {vercel_uid} and url: {vercel_url}")
+        time.sleep(15)
         current_url = f"https://api.vercel.com/v13/deployments/{vercel_uid}"
         current_response = requests.get(current_url, headers=headers)
         status = current_response.json()['status']
@@ -44,4 +44,4 @@ def wait_for_deployment(timeout):
     return f"environment_url={vercel_url}"
 
 
-wait_for_deployment(40)
+wait_for_deployment(80)

--- a/.github/workflows/monitoring-geo-e2e-tests.yml
+++ b/.github/workflows/monitoring-geo-e2e-tests.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 10
     name: ${{ matrix.env }}-fe-quote-tests
     needs: setup-matrix
-    runs-on: macos-latest
+    runs-on: buildjet-4vcpu-ubuntu-2204
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.setup-matrix.outputs.matrix)}}
@@ -48,11 +48,10 @@ jobs:
           TEST_PROXY: ${{ matrix.server-url }}
           TEST_PROXY_USERNAME: ${{secrets.TEST_PROXY_USERNAME}}
           TEST_PROXY_PASSWORD: ${{secrets.TEST_PROXY_PASSWORD}}
-          PRIVATE_KEY: ${{secrets.TEST_PRIVATE_KEY}}
           USE_TEST_PROXY: ${{ matrix.test-proxy }}
         run: |
           cd packages/web
-          npx playwright test select pools transactions
+          npx playwright test select pools
       - name: upload test results
         if: failure()
         id: e2e-test-results
@@ -61,16 +60,10 @@ jobs:
           name: ${{ matrix.env }}-quote-test-results
           path: packages/web/playwright-report
 
-  fe-swap-tests:
+  fe-swap-us-tests:
     timeout-minutes: 10
-    name: ${{ matrix.env }}-fe-swap-tests
-    needs: setup-matrix
+    name: fe-swap-us-tests
     runs-on: macos-latest
-    environment:
-      name: prod_swap_test
-    strategy:
-      fail-fast: false
-      matrix: ${{fromJson(needs.setup-matrix.outputs.matrix)}}
     steps:
       - name: Echo IP
         run: curl -L "https://ipinfo.io" -s
@@ -90,14 +83,10 @@ jobs:
       - name: Install Playwright
         run: |
           yarn --cwd packages/web install --frozen-lockfile && npx playwright install --with-deps chromium
-      - name: Run Swap tests on ${{ matrix.env }}
+      - name: Run Swap tests in US
         env:
           BASE_URL: "https://app.osmosis.zone"
-          TEST_PROXY: ${{ matrix.server-url }}
-          TEST_PROXY_USERNAME: ${{ secrets.TEST_PROXY_USERNAME }}
-          TEST_PROXY_PASSWORD: ${{ secrets.TEST_PROXY_PASSWORD }}
-          PRIVATE_KEY_S: ${{ secrets.PRIVATE_KEY_S }}
-          USE_TEST_PROXY: ${{ matrix.test-proxy }}
+          PRIVATE_KEY_S: ${{ secrets.TEST_PRIVATE_KEY_1 }}
         run: |
           cd packages/web
           npx playwright test -g "Test Swap Stables feature"
@@ -106,7 +95,7 @@ jobs:
         id: e2e-test-results
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.env }}-swap-test-results
+          name: us-swap-test-results
           path: packages/web/playwright-report
       - name: Send Slack alert if test fails
         id: slack
@@ -144,10 +133,97 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SERVER_E2E_TESTS_SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
+  fe-swap-eu-tests:
+    timeout-minutes: 10
+    name: fe-swap-eu-tests
+    needs: fe-swap-us-tests
+    runs-on: macos-latest
+    steps:
+      - name: Echo IP
+        run: curl -L "https://ipinfo.io" -s
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.OS }}-20.x-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.OS }}-20.x-
+      - name: Install Playwright
+        run: |
+          yarn --cwd packages/web install --frozen-lockfile && npx playwright install --with-deps chromium
+      - name: Run Swap tests in US
+        env:
+          BASE_URL: "https://app.osmosis.zone"
+          TEST_PROXY: "http://138.68.112.16:8888"
+          TEST_PROXY_USERNAME: ${{ secrets.TEST_PROXY_USERNAME }}
+          TEST_PROXY_PASSWORD: ${{ secrets.TEST_PROXY_PASSWORD }}
+          PRIVATE_KEY_S: ${{ secrets.TEST_PRIVATE_KEY_1 }}
+          USE_TEST_PROXY: "true"
+        run: |
+          cd packages/web
+          npx playwright test -g "Test Swap Stables feature"
+      - name: upload test results
+        if: failure()
+        id: e2e-test-results
+        uses: actions/upload-artifact@v4
+        with:
+          name: eu-swap-test-results
+          path: packages/web/playwright-report
+
+  fe-swap-sg-tests:
+    timeout-minutes: 10
+    name: fe-swap-sg-tests
+    needs: fe-swap-us-tests
+    runs-on: macos-latest
+    steps:
+      - name: Echo IP
+        run: curl -L "https://ipinfo.io" -s
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.OS }}-20.x-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.OS }}-20.x-
+      - name: Install Playwright
+        run: |
+          yarn --cwd packages/web install --frozen-lockfile && npx playwright install --with-deps chromium
+      - name: Run Swap tests in US
+        env:
+          BASE_URL: "https://app.osmosis.zone"
+          TEST_PROXY: "http://139.59.218.19:8888"
+          TEST_PROXY_USERNAME: ${{ secrets.TEST_PROXY_USERNAME }}
+          TEST_PROXY_PASSWORD: ${{ secrets.TEST_PROXY_PASSWORD }}
+          PRIVATE_KEY_S: ${{ secrets.TEST_PRIVATE_KEY_2 }}
+          USE_TEST_PROXY: "true"
+        run: |
+          cd packages/web
+          npx playwright test -g "Test Swap Stables feature"
+      - name: upload test results
+        if: failure()
+        id: e2e-test-results
+        uses: actions/upload-artifact@v4
+        with:
+          name: sg-swap-test-results
+          path: packages/web/playwright-report
+
   delete-deployments:
     runs-on: ubuntu-latest
     if: always()
-    needs: [fe-quote-tests, fe-swap-tests]
+    needs:
+      [fe-quote-tests, fe-swap-us-tests, fe-swap-sg-tests, fe-swap-eu-tests]
     steps:
       - name: Delete Previous deployments
         uses: actions/github-script@v7

--- a/packages/web/e2e/tests/swap.stables.spec.ts
+++ b/packages/web/e2e/tests/swap.stables.spec.ts
@@ -10,8 +10,7 @@ import { WalletPage } from "../pages/wallet-page";
 
 test.describe("Test Swap Stables feature", () => {
   let context: BrowserContext;
-  const walletId =
-    process.env.WALLET_ID_S ?? "osmo1dkmsds5j6q9l9lv4dkhas68767tlqfx8ls5j0c";
+  //const walletId = process.env.WALLET_ID_S ?? "osmo1dkmsds5j6q9l9lv4dkhas68767tlqfx8ls5j0c";
   const privateKey = process.env.PRIVATE_KEY_S ?? "private_key_s";
   const password = process.env.PASSWORD ?? "TestPassword2024.";
   let swapPage: SwapPage;
@@ -40,10 +39,7 @@ test.describe("Test Swap Stables feature", () => {
     await walletPage.setWalletNameAndPassword("Test Stables", password);
     await walletPage.selectChainsAndSave();
     await walletPage.finish();
-    // Wait for random timeout between 1 and 120 seconds, only monitoring tests
-    const randomWait = Math.floor(Math.random() * 120);
     page = context.pages()[0];
-    await page.waitForTimeout(randomWait * 1000);
     // Switch to Application
     swapPage = new SwapPage(page);
     await swapPage.goto();
@@ -63,7 +59,7 @@ test.describe("Test Swap Stables feature", () => {
     const { msgContentAmount } = await swapPage.swapAndGetWalletMsg(context);
     expect(msgContentAmount).toBeTruthy();
     expect(msgContentAmount).toContain("denom: " + USDC);
-    expect(msgContentAmount).toContain("sender: " + walletId);
+    //expect(msgContentAmount).toContain("sender: " + walletId);
     expect(msgContentAmount).toContain("token_out_denom: " + USDCa);
     expect(swapPage.isTransactionBroadcasted(10));
     expect(swapPage.isTransactionSuccesful(10));
@@ -78,7 +74,7 @@ test.describe("Test Swap Stables feature", () => {
     const { msgContentAmount } = await swapPage.swapAndGetWalletMsg(context);
     expect(msgContentAmount).toBeTruthy();
     expect(msgContentAmount).toContain("denom: " + USDCa);
-    expect(msgContentAmount).toContain("sender: " + walletId);
+    //expect(msgContentAmount).toContain("sender: " + walletId);
     expect(msgContentAmount).toContain("token_out_denom: " + USDC);
     expect(swapPage.isTransactionBroadcasted(10));
     expect(swapPage.isTransactionSuccesful(10));
@@ -93,7 +89,7 @@ test.describe("Test Swap Stables feature", () => {
     const { msgContentAmount } = await swapPage.swapAndGetWalletMsg(context);
     expect(msgContentAmount).toBeTruthy();
     expect(msgContentAmount).toContain(USDC);
-    expect(msgContentAmount).toContain("sender: " + walletId);
+    //expect(msgContentAmount).toContain("sender: " + walletId);
     expect(msgContentAmount).toContain(allUSDT);
     expect(swapPage.isTransactionBroadcasted(10));
     expect(swapPage.isTransactionSuccesful(10));
@@ -108,7 +104,7 @@ test.describe("Test Swap Stables feature", () => {
     const { msgContentAmount } = await swapPage.swapAndGetWalletMsg(context);
     expect(msgContentAmount).toBeTruthy();
     expect(msgContentAmount).toContain("denom: " + USDC);
-    expect(msgContentAmount).toContain("sender: " + walletId);
+    //expect(msgContentAmount).toContain("sender: " + walletId);
     expect(msgContentAmount).toContain(allUSDT);
     expect(swapPage.isTransactionBroadcasted(10));
     expect(swapPage.isTransactionSuccesful(10));


### PR DESCRIPTION
## What is the purpose of the change:

- Split and order monitoring tests
- Use 2 wallets for swap tests

### Linear Task

[Align test workflows and use more wallets](https://linear.app/osmosis/issue/FE-846)
