### PR TITLE
Migrate pools page epoch countdown to tRPC

### DIFF
--- a/packages/server/src/queries/complex/index.ts
+++ b/packages/server/src/queries/complex/index.ts
@@ -4,6 +4,7 @@ export * from "./chains";
 export * from "./concentrated-liquidity";
 export * from "./earn";
 export * from "./get-timeout-height";
+export * from "./osmosis";
 export * from "./pools";
 export * from "./staking";
 export * from "./swap-routers";

--- a/packages/server/src/queries/complex/osmosis/epochs.ts
+++ b/packages/server/src/queries/complex/osmosis/epochs.ts
@@ -1,18 +1,44 @@
 import { Chain } from "@osmosis-labs/types";
 import cachified, { CacheEntry } from "cachified";
+import dayjs from "dayjs";
+import { Duration } from "dayjs/plugin/duration";
 import { LRUCache } from "lru-cache";
 
-import { queryEpochs } from "../../../queries/osmosis/epochs";
+import { Epochs, queryEpochs } from "../../../queries/osmosis/epochs";
 import { DEFAULT_LRU_OPTIONS } from "../../../utils/cache";
 
 const epochsCache = new LRUCache<string, CacheEntry>(DEFAULT_LRU_OPTIONS);
 
-export function getEpochs({ chainList }: { chainList: Chain[] }) {
+export type Epoch = {
+  duration: Duration;
+  startTime: Date;
+  endTime: Date;
+} & Omit<Epochs["epochs"][0], "duration">;
+
+export function getEpochs({
+  chainList,
+}: {
+  chainList: Chain[];
+}): Promise<Epoch[]> {
   return cachified({
     cache: epochsCache,
     key: "epochs",
     ttl: 1000 * 30, // 30 seconds
     getFreshValue: () =>
-      queryEpochs({ chainList }).then(({ epochs }) => epochs),
+      queryEpochs({ chainList }).then(({ epochs }) =>
+        epochs.map((e) => {
+          const duration = dayjs.duration(
+            parseInt(e.duration.replace("s", "")) * 1000
+          );
+          const startTime = new Date(e.current_epoch_start_time);
+
+          return {
+            ...e,
+            duration,
+            startTime,
+            endTime: dayjs(startTime).add(duration).toDate(),
+          };
+        })
+      ),
   });
 }

--- a/packages/server/src/queries/complex/osmosis/epochs.ts
+++ b/packages/server/src/queries/complex/osmosis/epochs.ts
@@ -23,7 +23,7 @@ export function getEpochs({
   return cachified({
     cache: epochsCache,
     key: "epochs",
-    ttl: 1000 * 30, // 30 seconds
+    ttl: 1000 * 60, // 60 seconds
     getFreshValue: () =>
       queryEpochs({ chainList }).then(({ epochs }) =>
         epochs.map((e) => {

--- a/packages/server/src/queries/complex/pools/incentives.ts
+++ b/packages/server/src/queries/complex/pools/incentives.ts
@@ -15,9 +15,9 @@ import {
   queryPoolAprsRange,
 } from "../../data-services/pool-aprs";
 import { Gauge, queryGauges } from "../../osmosis";
-import { Epochs } from "../../osmosis/epochs";
 import { queryIncentivizedPools } from "../../osmosis/incentives/incentivized-pools";
 import { getEpochs } from "../osmosis";
+import { Epoch } from "../osmosis/epochs";
 
 /**
  * Pools that are excluded from showing external boost incentives APRs.
@@ -302,17 +302,11 @@ export function getActiveGauges({ chainList }: { chainList: Chain[] }) {
 const DURATION_1_DAY = 86400000;
 const MAX_NEW_GAUGES_PER_DAY = 100;
 
-function checkForStaleness(
-  gauge: Gauge,
-  lastGaugeId: number,
-  epochs: Epochs["epochs"]
-) {
+function checkForStaleness(gauge: Gauge, lastGaugeId: number, epochs: Epoch[]) {
   const parsedGaugeStartTime = Date.parse(gauge.start_time);
 
   const NOW = Date.now();
-  const CURRENT_EPOCH_START_TIME = Date.parse(
-    epochs[0].current_epoch_start_time
-  );
+  const CURRENT_EPOCH_START_TIME = epochs[0].startTime.getTime();
 
   return (
     gauge.distributed_coins.length > 0 ||

--- a/packages/trpc/src/chains.ts
+++ b/packages/trpc/src/chains.ts
@@ -12,7 +12,7 @@ export const chainsRouter = createTRPCRouter({
         findChainNameOrId: z.string(),
       })
     )
-    .query(async ({ input: { findChainNameOrId }, ctx }) =>
+    .query(({ input: { findChainNameOrId }, ctx }) =>
       getChain({
         ...ctx,
         chainNameOrId: findChainNameOrId,
@@ -24,7 +24,7 @@ export const chainsRouter = createTRPCRouter({
         chainId: z.number(),
       })
     )
-    .query(async ({ input: { chainId } }) =>
+    .query(({ input: { chainId } }) =>
       Object.values(EthereumChainInfo).find((chain) => chain.id === chainId)
     ),
 });

--- a/packages/trpc/src/index.ts
+++ b/packages/trpc/src/index.ts
@@ -8,6 +8,7 @@ export * from "./earn";
 export * from "./middleware";
 export * from "./one-click-trading";
 export * from "./parameter-types";
+export * from "./params";
 export * from "./pools";
 export * from "./staking";
 export * from "./swap";

--- a/packages/trpc/src/params.ts
+++ b/packages/trpc/src/params.ts
@@ -1,0 +1,13 @@
+import { getEpochs } from "@osmosis-labs/server";
+
+import { createTRPCRouter, publicProcedure } from "./api";
+
+/** Contains Osmosis param data, or miscellaneous Osmosis queries that don't fit into
+ *  other router categories.
+ */
+export const paramsRouter = createTRPCRouter({
+  /** Get Cosmos chain. */
+  getEpochs: publicProcedure.query(({ ctx }) =>
+    getEpochs({ chainList: ctx.chainList })
+  ),
+});

--- a/packages/web/components/overview/pools.tsx
+++ b/packages/web/components/overview/pools.tsx
@@ -24,7 +24,7 @@ export const PoolsOverview: FunctionComponent<
       coinMinimalDenom: "uosmo",
     }
   );
-  const { data: epochs } = api.local.params.getEpochs.useQuery();
+  const { data: epochs } = api.edge.params.getEpochs.useQuery();
 
   // update time every second
   const [timeRemaining, setTimeRemaining] = useState<string | null>(null);

--- a/packages/web/server/api/edge-router.ts
+++ b/packages/web/server/api/edge-router.ts
@@ -3,6 +3,7 @@ import {
   chainsRouter,
   createTRPCRouter,
   earnRouter,
+  paramsRouter,
   poolsRouter,
   stakingRouter,
   transactionsRouter,
@@ -16,4 +17,5 @@ export const edgeRouter = createTRPCRouter({
   earn: earnRouter,
   transactions: transactionsRouter,
   chains: chainsRouter,
+  params: paramsRouter,
 });

--- a/packages/web/server/api/local-router.ts
+++ b/packages/web/server/api/local-router.ts
@@ -4,7 +4,6 @@ import {
   concentratedLiquidityRouter,
   createTRPCRouter,
   oneClickTradingRouter,
-  paramsRouter,
   swapRouter,
 } from "@osmosis-labs/trpc";
 
@@ -19,6 +18,5 @@ export const localRouter = createTRPCRouter({
   concentratedLiquidity: concentratedLiquidityRouter,
   oneClickTrading: oneClickTradingRouter,
   cms: cmsRouter,
-  params: paramsRouter,
   bridgeTransfer: localBridgeTransferRouter,
 });

--- a/packages/web/server/api/local-router.ts
+++ b/packages/web/server/api/local-router.ts
@@ -4,6 +4,7 @@ import {
   concentratedLiquidityRouter,
   createTRPCRouter,
   oneClickTradingRouter,
+  paramsRouter,
   swapRouter,
 } from "@osmosis-labs/trpc";
 
@@ -18,5 +19,6 @@ export const localRouter = createTRPCRouter({
   concentratedLiquidity: concentratedLiquidityRouter,
   oneClickTrading: oneClickTradingRouter,
   cms: cmsRouter,
+  params: paramsRouter,
   bridgeTransfer: localBridgeTransferRouter,
 });


### PR DESCRIPTION
## What is the purpose of the change:

<!-- > Add a description of the overall background and high level changes that this PR introduces -->

User tRPC instead of MobX queries for getting the epoch countdown. The changes were pretty minimal, so, we can easily remove the tRPC routers + UI component later, as I've heard we'll eventually the countdown from the pools page.

### Linear Task

<!-- > Add a link to the linear task that this PR is addressing. TIP: go to the linear task and use Ctrl/⌘ + C to copy a link. -->
[FE-12 : Pools page: epoch countdown](https://linear.app/osmosis/issue/FE-12/pools-page-epoch-countdown)
## Brief Changelog

- Add params router, which exposes cached and processed getEpochs query from complex folder
  - My intention with this router is it will hold all miscellaneous Osmosis params or other queries that can't really be categorized neatly into other pools, staking, earn, assets etc. routers
- Use tRPC query instead of MobX query store in pools overview component
  - Remove observer wrapper from component, since there's no more references to any MobX stores in that component

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->
Tested locally