### PR TITLE
Tolerate missing staking token in chain type

### DIFF
--- a/packages/server/src/queries/complex/concentrated-liquidity/index.ts
+++ b/packages/server/src/queries/complex/concentrated-liquidity/index.ts
@@ -274,7 +274,7 @@ export async function mapGetUserPositionDetails({
 
   const stakeCurrency = getAsset({
     ...params,
-    anyDenom: params.chainList[0].staking.staking_tokens[0].denom,
+    anyDenom: params.chainList[0].staking!.staking_tokens[0].denom,
   });
 
   const lockableDurations = getLockableDurations();

--- a/packages/server/src/queries/complex/staking/superfluid.ts
+++ b/packages/server/src/queries/complex/staking/superfluid.ts
@@ -33,7 +33,7 @@ export async function calcOsmoSuperfluidEquivalent({
       // primary chain
       const chain = chainList[0];
 
-      const stakeDenom = chain.staking.staking_tokens[0].denom;
+      const stakeDenom = chain.staking!.staking_tokens[0].denom;
       const stakeAsset = getAsset({ assetLists, anyDenom: stakeDenom });
       const equivalentAsset = denom.startsWith("gamm")
         ? makeGammShareCurrency(getShareDenomPoolId(denom))

--- a/packages/types/src/chain-types.ts
+++ b/packages/types/src/chain-types.ts
@@ -36,7 +36,7 @@ export interface Chain {
   fees: {
     fee_tokens: FeeToken[];
   };
-  staking: {
+  staking?: {
     staking_tokens: StakingToken[];
     lock_duration?: LockDuration;
   };

--- a/packages/utils/src/chain-utils.ts
+++ b/packages/utils/src/chain-utils.ts
@@ -35,10 +35,15 @@ export function getChainStakeTokenSourceDenom({
 
   if (!chain) {
     console.info(`Chain ${chainId} not found`);
-    return undefined;
+    return;
   }
 
-  return chain.staking.staking_tokens[0].denom;
+  if (!chain.staking) {
+    console.error("This chain does not have staking info:", chainId);
+    return;
+  }
+
+  return chain.staking!.staking_tokens[0].denom;
 }
 
 export class ChainIdHelper {

--- a/packages/web/config/utils.ts
+++ b/packages/web/config/utils.ts
@@ -116,8 +116,7 @@ export function getKeplrCompatibleChain({
     return undefined;
   }
 
-  const stakingTokenSourceDenom =
-    "staking" in chain ? chain.staking.staking_tokens[0].denom : undefined;
+  const stakingTokenSourceDenom = chain.staking?.staking_tokens[0].denom;
   const stakeAsset = assetList!.assets.find(
     (asset) => asset.sourceDenom === stakingTokenSourceDenom
   );

--- a/packages/web/config/utils.ts
+++ b/packages/web/config/utils.ts
@@ -116,16 +116,11 @@ export function getKeplrCompatibleChain({
     return undefined;
   }
 
-  const stakingTokenSourceDenom = chain.staking.staking_tokens[0].denom;
+  const stakingTokenSourceDenom =
+    "staking" in chain ? chain.staking.staking_tokens[0].denom : undefined;
   const stakeAsset = assetList!.assets.find(
     (asset) => asset.sourceDenom === stakingTokenSourceDenom
   );
-
-  if (!stakeAsset) {
-    console.warn(
-      `Failed to find stake asset for ${stakingTokenSourceDenom} on ${chain.chain_name}. Proceeding to use minimalDenom as currency.`
-    );
-  }
 
   const stakeDisplayDecimals = stakeAsset?.decimals;
   const stakeSourceDenom = stakeAsset?.sourceDenom;
@@ -212,20 +207,36 @@ export function getKeplrCompatibleChain({
       },
       []
     ),
-    stakeCurrency: {
-      coinDecimals: stakeDisplayDecimals ?? 0,
-      coinDenom: stakeAsset?.symbol ?? stakingTokenSourceDenom,
-      coinMinimalDenom: stakeSourceDenom ?? stakingTokenSourceDenom,
-      coinGeckoId: stakeAsset?.coingeckoId,
-      coinImageUrl:
-        stakeAsset?.logoURIs.svg || stakeAsset?.logoURIs.png
-          ? getImageRelativeFilePath(
-              stakeAsset.logoURIs.svg ?? stakeAsset.logoURIs.png!,
-              stakeAsset.symbol
-            )
-          : undefined,
-      base: stakeAsset?.coinMinimalDenom,
-    },
+    stakeCurrency:
+      // Note: this is a hacky fix since it's possible for chains to have no staking token (i.e. Noble)
+      // Newever versions of Keplr made this nullable, but our Keplr stores are from an old version of Keplr.
+      // I don't anticipate this being an issue since we don't really use staking tokens on other chain in our FE features.
+      // Further, most chains have staking tokens.
+      // So, I add a placeholder token to stay compatible with the ChainInfo types that we imported into the keplr-* packages in the monorepo.
+      // Long term, once we remove the keplr stores for good and delete that code, we can upgrade our Keplr chain type to use the newer
+      // type that tolerates missing staking tokens. Then, we can suggest chains to Keplr wallet with Staking tokens missing.
+      stakeAsset &&
+      stakeDisplayDecimals &&
+      (stakeSourceDenom || stakingTokenSourceDenom)
+        ? {
+            coinDecimals: stakeDisplayDecimals ?? 0,
+            coinDenom: stakeAsset.symbol ?? stakingTokenSourceDenom,
+            coinMinimalDenom: stakeSourceDenom ?? stakingTokenSourceDenom!,
+            coinGeckoId: stakeAsset.coingeckoId,
+            coinImageUrl:
+              stakeAsset.logoURIs.svg || stakeAsset.logoURIs.png
+                ? getImageRelativeFilePath(
+                    stakeAsset.logoURIs.svg ?? stakeAsset.logoURIs.png!,
+                    stakeAsset.symbol
+                  )
+                : undefined,
+            base: stakeAsset.coinMinimalDenom,
+          }
+        : {
+            coinDecimals: 0,
+            coinDenom: "STAKE",
+            coinMinimalDenom: "tempStakePlaceholder",
+          },
     feeCurrencies: chain.fees.fee_tokens.reduce<
       ChainInfoWithExplorer["feeCurrencies"]
     >((acc, token) => {


### PR DESCRIPTION
## What is the purpose of the change:

<!-- > Add a description of the overall background and high level changes that this PR introduces -->

Newever versions of Keplr made this nullable, but our Keplr stores are from an old version of Keplr.
I don't anticipate this being an issue since we don't really use staking tokens on other chain in our FE features.
Further, most chains have staking tokens.
So, I add a placeholder token to stay compatible with the ChainInfo types that we imported into the keplr-* packages in the monorepo.
Long term, once we remove the keplr stores for good and delete that code, we can upgrade our Keplr chain type to use the newer type that tolerates missing staking tokens. Then, we can suggest chains to Keplr wallet with Staking tokens missing.

### Linear Task

<!-- > Add a link to the linear task that this PR is addressing. TIP: go to the linear task and use Ctrl/⌘ + C to copy a link. -->

## Brief Changelog

-

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->
