### PR TITLE
fix: frontend bug breaking weighted LP

### DIFF
--- a/packages/pools/src/weighted.ts
+++ b/packages/pools/src/weighted.ts
@@ -133,7 +133,7 @@ export class WeightedPool implements SharePool, RoutablePool {
 
   /** LBP pool */
   get smoothWeightChange(): SmoothWeightChangeParams | undefined {
-    if (this.raw.pool_params.smooth_weight_change_params !== null) {
+    if (this.raw.pool_params.smooth_weight_change_params != null) {
       const {
         start_time,
         duration,


### PR DESCRIPTION
FE used to depend on amino encoding of pools.

But SQS returns app encoding.

The difference wasn't accounted for in the transition.

This PR fixes the bug around inconsistency => we need to do a proper move away from amino