### PR TITLE
fix: :bug: fix hidden alloyed composition

### DIFF
--- a/packages/web/pages/assets/[denom].tsx
+++ b/packages/web/pages/assets/[denom].tsx
@@ -179,7 +179,7 @@ const AssetInfoView: FunctionComponent<AssetInfoPageStaticProps> = observer(
                   {SwapTool_}
                 </div>
               </div>
-              {asset.areTransfersDisabled && asset.contract ? (
+              {!asset.areTransfersDisabled && asset.contract ? (
                 <AlloyedAssetsSection
                   className="hidden xl:block"
                   title={title ?? asset.coinDenom}
@@ -194,7 +194,7 @@ const AssetInfoView: FunctionComponent<AssetInfoPageStaticProps> = observer(
               <div className="xl:hidden">{SwapTool_}</div>
               <AssetBalance className="xl:hidden" />
               <AssetStats className="xl:hidden" />
-              {asset.areTransfersDisabled && asset.contract ? (
+              {!asset.areTransfersDisabled && asset.contract ? (
                 <AlloyedAssetsSection
                   className="xl:hidden"
                   title={title ?? asset.coinDenom}


### PR DESCRIPTION
## What is the purpose of the change:

<!-- > Add a description of the overall background and high level changes that this PR introduces -->

### Linear Task

<!-- > Add a link to the linear task that this PR is addressing. TIP: go to the linear task and use Ctrl/⌘ + C to copy a link. -->

https://linear.app/osmosis/issue/FE-941/alloyed-asset-composition-is-hidden

## Brief Changelog

- Fix alloyed composition section rendering, now it should be available for all alloyed assets.

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->
