### PR TITLE
(Deposit/Withdraw) Timeout height

### DIFF
--- a/packages/bridge/src/interface.ts
+++ b/packages/bridge/src/interface.ts
@@ -12,8 +12,12 @@ export interface BridgeProviderContext {
   assetLists: AssetList[];
   chainList: Chain[];
 
-  /** Provides current timeout height for a chain of given chainId. */
-  getTimeoutHeight(params: { chainId: string }): Promise<{
+  /** Provides current timeout height for a chain of given chainId.
+   *  If a destination address is provided, the bech32Prefix will be used to get the chain. */
+  getTimeoutHeight(params: {
+    chainId?: string;
+    destinationAddress?: string;
+  }): Promise<{
     revisionNumber: string | undefined;
     revisionHeight: string;
   }>;

--- a/packages/bridge/src/skip/__tests__/skip-bridge-provider.spec.ts
+++ b/packages/bridge/src/skip/__tests__/skip-bridge-provider.spec.ts
@@ -339,7 +339,11 @@ describe("SkipBridgeProvider", () => {
 
     const txRequest = (await provider.createTransaction(
       "1",
-      "osmosis-1",
+      {
+        chainId: "osmosis-1",
+        chainName: "osmosis",
+        chainType: "cosmos",
+      },
       "0xabc",
       messages
     )) as EvmBridgeTransactionRequest;

--- a/packages/bridge/src/skip/index.ts
+++ b/packages/bridge/src/skip/index.ts
@@ -129,6 +129,9 @@ export class SkipBridgeProvider implements BridgeProvider {
                 msg.includes(
                   "Input amount is too low to cover"
                   // Could be Axelar or CCTP
+                ) ||
+                msg.includes(
+                  "Difference in USD value of route input and output is too large"
                 )
               ) {
                 throw new BridgeQuoteError({

--- a/packages/bridge/src/skip/index.ts
+++ b/packages/bridge/src/skip/index.ts
@@ -215,7 +215,7 @@ export class SkipBridgeProvider implements BridgeProvider {
 
         const transactionRequest = await this.createTransaction(
           fromChain.chainId.toString(),
-          toChain.chainId.toString(),
+          toChain,
           fromAddress as Address,
           msgs
         );
@@ -444,7 +444,7 @@ export class SkipBridgeProvider implements BridgeProvider {
 
   async createTransaction(
     fromChainId: string,
-    toChainId: string,
+    toChain: BridgeChain,
     address: Address,
     messages: SkipMsg[]
   ) {
@@ -459,7 +459,7 @@ export class SkipBridgeProvider implements BridgeProvider {
 
       if ("multi_chain_msg" in message) {
         return await this.createCosmosTransaction(
-          toChainId,
+          toChain,
           message.multi_chain_msg
         );
       }
@@ -467,7 +467,7 @@ export class SkipBridgeProvider implements BridgeProvider {
   }
 
   async createCosmosTransaction(
-    toChainId: string,
+    toChain: BridgeChain,
     message: SkipMultiChainMsg
   ): Promise<CosmosBridgeTransactionRequest & { fallbackGasLimit?: number }> {
     const messageData = JSON.parse(message.msg);
@@ -502,9 +502,14 @@ export class SkipBridgeProvider implements BridgeProvider {
     } else {
       // is an ibc transfer
 
-      const timeoutHeight = await this.ctx.getTimeoutHeight({
-        chainId: toChainId,
-      });
+      // If toChain is not cosmos, this IBC transfer is an
+      // intermediary IBC transfer where we need to get the
+      // timeout from the bech32 prefix of the receiving address
+      const timeoutHeight = await this.ctx.getTimeoutHeight(
+        toChain.chainType === "cosmos"
+          ? toChain
+          : { destinationAddress: messageData.receiver }
+      );
 
       const { typeUrl, value } = cosmosMsgOpts.ibcTransfer.messageComposer({
         sourcePort: messageData.source_port,

--- a/packages/server/src/queries/complex/get-timeout-height.ts
+++ b/packages/server/src/queries/complex/get-timeout-height.ts
@@ -7,13 +7,20 @@ import { queryRPCStatus } from "../../queries/cosmos";
 export async function getTimeoutHeight({
   chainList,
   chainId,
+  destinationAddress,
 }: {
   chainList: Chain[];
-  chainId: string;
+  chainId?: string;
+  /**
+   * WARNING: bech32 prefix may be the same across different chains,
+   * retulting in the use of an unintended chain.
+   */
+  destinationAddress?: string;
 }) {
   const destinationCosmosChain = getChain({
     chainList,
     chainId,
+    destinationAddress,
   });
 
   if (!destinationCosmosChain) {

--- a/packages/tx/src/gas.ts
+++ b/packages/tx/src/gas.ts
@@ -107,7 +107,7 @@ export async function estimateGasFee({
   }).catch((e) => {
     if (fallbackGasLimit) {
       console.warn(
-        "Using fallback gas limit",
+        "WARNING Using fallback gas limit:",
         e instanceof Error ? e.message : e
       );
       return { gasUsed: fallbackGasLimit, coinsSpent: [] };


### PR DESCRIPTION
## What is the purpose of the change:

<!-- > Add a description of the overall background and high level changes that this PR introduces -->

There was a regression when migrating getTimeoutHeight to explicitly accept ChainIDs. If the transfer's destination chain is an EVM chain, this would clearly not work. So, this re-adds the ability to get the timeout height of a chain by bech32prefix, which will be useful for getting the Axelar timeout height for an IBC transfer from Osmosis to Axelar as the initial transfer to an EVM chain.

This also classifies an error message from Skip as an insufficient amount error.