### PR TITLE
Swap WBTC for BTC favourite + reorder

### DIFF
--- a/packages/web/config/feature-flag.ts
+++ b/packages/web/config/feature-flag.ts
@@ -29,10 +29,10 @@ export const RecommendedSwapDenoms = [
   "OSMO",
   "USDC",
   "USDT",
-  "ATOM",
-  "TIA",
-  "WBTC",
+  "BTC",
   "ETH",
+  "ATOM",
+  "TIA"
 ];
 
 export const UnPoolWhitelistedPoolIds: { [poolId: string]: boolean } = {


### PR DESCRIPTION
## What is the purpose of the change:

With allBTC being made canonical, this swaps out the "Favourite" WBTC entry for BTC
It also reorders the assets to place more emphasis on BTC and ETH trading

### Linear Task

N/A

## Brief Changelog

Edits list of swap favourites

## Testing and Verifying

This change has not been tested locally
