### PR TITLE
(Deposit/Withdraw) IBC provider: use asset list for Osmosis alt fee token metadata

### DIFF
--- a/packages/bridge/src/ibc/index.ts
+++ b/packages/bridge/src/ibc/index.ts
@@ -213,14 +213,27 @@ export class IbcBridgeProvider implements BridgeProvider {
   }
 
   /**
-   * Gets gas asset from asset list, attempting to match the coinMinimalDenom or counterparty denom.
+   * Gets gas asset from asset list or chain list, attempting to match the coinMinimalDenom or chainSuggestionDenom.
    * @returns gas bridge asset, or undefined if not found.
    */
   async getGasAsset(
     fromChainId: string,
     denom: string
   ): Promise<BridgeAsset | undefined> {
-    // check the asset list
+    // try to get asset list fee asset first, or otherwise the chain fee currency
+    const assetListAsset = this.ctx.assetLists
+      .flatMap(({ assets }) => assets)
+      .find((asset) => asset.coinMinimalDenom);
+
+    if (assetListAsset) {
+      return {
+        address: assetListAsset.coinMinimalDenom,
+        denom: assetListAsset.symbol,
+        decimals: assetListAsset.decimals,
+        coinGeckoId: assetListAsset.coingeckoId,
+      };
+    }
+
     const chains = await this.getChains();
     const chain = chains.find((c) => c.chain_id === fromChainId);
     const feeCurrency = chain?.feeCurrencies.find(


### PR DESCRIPTION
## What is the purpose of the change:

<!-- > Add a description of the overall background and high level changes that this PR introduces -->

In the asset list we fetch the generated chain list to get display metadata (decimals, symbol) for alt gas tokens on other chains. However, this is not populated for Osmosis since it has a dynamic fee market. This causes some alt gas tokens on Osmosis to not be returned with metadata.

Instead, if the gas token is on Osmosis (withdrawal), use the asset list instead to get gas token metadata. It will be more reliably up to date.

This could prevent some unnecessary queries of generated chain list as well, in the case of withdraws.

cc @JeremyParish69  expressed hesitation with populating Osmosis gas tokens in generated chain list

### Linear Task

<!-- > Add a link to the linear task that this PR is addressing. TIP: go to the linear task and use Ctrl/⌘ + C to copy a link. -->
[FE-959: Use asset list for getting gas token for Osmosis](https://linear.app/osmosis/issue/FE-959/use-asset-list-for-getting-gas-token-for-osmosis)

## Brief Changelog

- Check asset list for alt fee token denom match (fee token on Osmosis) before generated chain list (fee token on counterparty chain)

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

Tested locally
