### PR TITLE
(Deposit/Withdraw) Fix Crypto Fiat Input Loading and Handle Provider Request Error 

### DIFF
--- a/packages/web/components/bridge/use-bridge-quotes.ts
+++ b/packages/web/components/bridge/use-bridge-quotes.ts
@@ -315,7 +315,9 @@ export const useBridgeQuotes = ({
 
     const bestQuote = quoteResults_
       // only those that have fetched
-      .filter((quoteResult) => Boolean(quoteResult.isFetched))
+      .filter(
+        (quoteResult) => Boolean(quoteResult.isFetched) && !quoteResult.isError
+      )
       // Sort by response time. The fastest and highest quality quote will be first.
       .sort((a, b) => {
         // This means the quote is for a basic IBC transfer:

--- a/packages/web/components/control/crypto-fiat-input.tsx
+++ b/packages/web/components/control/crypto-fiat-input.tsx
@@ -187,7 +187,7 @@ export const CryptoFiatInput: FunctionComponent<{
       let nextValue = value;
       if (!isValidNumericalRawInput(nextValue) && nextValue !== "") return;
 
-      if (assetPrice) {
+      if (assetPrice && assetWithBalance) {
         onUpdateRatio({
           assetPrice,
           nextValue,
@@ -205,11 +205,17 @@ export const CryptoFiatInput: FunctionComponent<{
         ? setFiatInputRaw(nextValue)
         : setCryptoInputRaw(nextValue);
     },
-    [onUpdateRatio, assetPrice, setFiatInputRaw, setCryptoInputRaw]
+    [
+      assetPrice,
+      assetWithBalance,
+      setFiatInputRaw,
+      setCryptoInputRaw,
+      onUpdateRatio,
+    ]
   );
 
   useEffect(() => {
-    if (pendingRatioUpdate && assetPrice) {
+    if (pendingRatioUpdate && assetWithBalance && assetPrice) {
       onUpdateRatio({
         assetPrice,
         nextValue: fiatInputRaw,
@@ -218,6 +224,7 @@ export const CryptoFiatInput: FunctionComponent<{
     }
   }, [
     assetPrice,
+    assetWithBalance,
     currentUnit,
     fiatInputRaw,
     onUpdateRatio,


### PR DESCRIPTION
## What is the purpose of the change:

- Fix the issue where the Crypto/Fiat input crypto button is not updated after fiat changes while loading.
- Fix the transfer details being hidden when the current selected provider's request fails by selecting the next viable option.

### Linear Task

https://linear.app/osmosis/issue/FE-968/crypto-button-not-being-updated-after-fiat-changes-while-loading-and

## Testing and Verifying

- [ ] Sometimes quotes transfer details become hidden when viewing Ethereum:USDC <> Osmosis:USDC. Let's ensure they remain visible.
