### PR TITLE
LIghtweight Charts - Update line type

### DIFF
--- a/packages/web/components/chart/historical-chart.tsx
+++ b/packages/web/components/chart/historical-chart.tsx
@@ -46,7 +46,7 @@ const getSeriesOpt = (config: Style): DeepPartial<AreaSeriesOptions> => {
   return {
     lineColor,
     lineWidth: 2,
-    lineType: LineType.Curved,
+    lineType: LineType.Simple,
     topColor,
     bottomColor,
     priceLineVisible: false,


### PR DESCRIPTION
## What is the purpose of the change:

- Curved chart option exhibiting odd behavior with volatility, switching this to "Simple" smooths this out

### Linear Task

https://linear.app/osmosis/issue/FE-976/portfolio-v1-[feedback]-smooth-out-chart-spikes

## Brief Changelog

- update lightweight charts to "Simple" line type

## Testing and Verifying

<img width="203" alt="Curved - not ideal" src="https://github.com/user-attachments/assets/f8337e72-3616-4429-83d7-0763dcc38c3a">
<img width="192" alt="Simple - ideal" src="https://github.com/user-attachments/assets/6503f9ba-9a97-4b16-b23e-aab07343ce68">

