### PR TITLE
Fix trxs number and cancel limit order

### DIFF
--- a/packages/web/e2e/pages/transactions-page.ts
+++ b/packages/web/e2e/pages/transactions-page.ts
@@ -71,7 +71,7 @@ export class TransactionsPage extends BasePage {
   ) {
     const cancelBtn = `//td//span[.='${amount}']/../../../../..//td//p[.='$${price}']/../../..//button`;
     console.log("Use locator for a cancel btn: " + cancelBtn);
-    await this.page.locator(cancelBtn).click();
+    await this.page.locator(cancelBtn).first().click();
     const pageApprove = context.waitForEvent("page");
     const approvePage = await pageApprove;
     await approvePage.waitForLoadState();

--- a/packages/web/e2e/tests/trade.wallet.spec.ts
+++ b/packages/web/e2e/tests/trade.wallet.spec.ts
@@ -79,18 +79,25 @@ test.describe("Test Trade feature", () => {
 
   test("User should be able to limit sell ATOM", async () => {
     await tradePage.goto();
+    const amount = "0.25";
     await tradePage.openSellTab();
     await tradePage.openLimit();
     await tradePage.selectAsset("ATOM");
-    await tradePage.enterAmount("0.25");
+    await tradePage.enterAmount(amount);
     await tradePage.setLimitPriceChange("5%");
+    const limitPrice = await tradePage.getLimitPrice();
     const { msgContentAmount } = await tradePage.limitSellAndGetWalletMsg(
       context
     );
     expect(msgContentAmount).toBeTruthy();
-    expect(msgContentAmount).toContain("0.25 ATOM (Cosmos Hub/channel-0)");
+    expect(msgContentAmount).toContain(amount + " ATOM (Cosmos Hub/channel-0)");
     expect(msgContentAmount).toContain("place_limit");
     expect(msgContentAmount).toContain('"order_direction": "ask"');
+    await tradePage.isTransactionSuccesful();
+    await tradePage.getTransactionUrl();
+    await tradePage.gotoOrdersHistory();
+    const trxPage = new TransactionsPage(context.pages()[0]);
+    await trxPage.cancelLimitOrder(`${amount} ATOM`, limitPrice, context);
     await tradePage.isTransactionSuccesful();
     await tradePage.getTransactionUrl();
   });
@@ -112,6 +119,7 @@ test.describe("Test Trade feature", () => {
     expect(msgContentAmount).toContain("place_limit");
     expect(msgContentAmount).toContain('"order_direction": "ask"');
     await tradePage.isTransactionSuccesful();
+    await tradePage.getTransactionUrl();
     await tradePage.gotoOrdersHistory();
     const trxPage = new TransactionsPage(context.pages()[0]);
     await trxPage.cancelLimitOrder(`${amount} OSMO`, limitPrice, context);

--- a/packages/web/e2e/tests/transactions.wallet.spec.ts
+++ b/packages/web/e2e/tests/transactions.wallet.spec.ts
@@ -58,7 +58,7 @@ test.describe("Test Transactions feature", () => {
     await transactionsPage.viewTransactionByNumber(20);
     await transactionsPage.viewOnExplorerIsVisible();
     await transactionsPage.closeTransaction();
-    await transactionsPage.viewTransactionByNumber(55);
+    await transactionsPage.viewTransactionByNumber(45);
     await transactionsPage.viewOnExplorerIsVisible();
     await transactionsPage.closeTransaction();
   });


### PR DESCRIPTION
## What is the purpose of the change:

- Transaction page has only 46 swaps on it, fixed number in a test
- Canceling limit order to reduce number of open orders after the test