### PR TITLE
Added pool search to tests

### DIFF
--- a/packages/web/e2e/pages/pools-page.ts
+++ b/packages/web/e2e/pages/pools-page.ts
@@ -10,6 +10,7 @@ export class PoolsPage extends BasePage {
   readonly viewMore: Locator;
   readonly poolsLink: Locator;
   readonly balance: Locator;
+  readonly searchInput: Locator;
 
   constructor(page: Page) {
     super(page);
@@ -19,6 +20,7 @@ export class PoolsPage extends BasePage {
     this.balance = page.locator(
       '//span[.="Total balance"]/..//h4[contains(@class, "text-osmoverse-100")]'
     );
+    this.searchInput = page.locator('//input[@id="search-input"]');
   }
 
   async goto() {
@@ -38,5 +40,11 @@ export class PoolsPage extends BasePage {
     await this.page.waitForTimeout(2000);
     await super.printUrl();
     return new PoolPage(this.page);
+  }
+
+  async searchForPool(poolName: string) {
+    await this.searchInput.fill(poolName);
+    // we expect that after 2 seconds tokens are loaded and any failure after this point should be considered a bug.
+    await this.page.waitForTimeout(2000);
   }
 }

--- a/packages/web/e2e/tests/pools.spec.ts
+++ b/packages/web/e2e/tests/pools.spec.ts
@@ -34,8 +34,10 @@ test.describe("Test Select Pool feature", () => {
   });
 
   test("User should be able to select ATOM/USDC pool", async () => {
+    const poolName = "ATOM/USDC";
     await poolsPage.goto();
-    const poolPage = await poolsPage.viewPool(1282, "ATOM/USDC");
+    await poolsPage.searchForPool(poolName);
+    const poolPage = await poolsPage.viewPool(1282, poolName);
     const balance = await poolPage.getBalance();
     expect(balance).toEqual("$0");
     const tradeModal = await poolPage.getTradeModal();
@@ -46,8 +48,10 @@ test.describe("Test Select Pool feature", () => {
   });
 
   test("User should be able to select OSMO/USDC pool", async () => {
+    const poolName = "OSMO/USDC";
     await poolsPage.goto();
-    const poolPage = await poolsPage.viewPool(1464, "OSMO/USDC");
+    await poolsPage.searchForPool(poolName);
+    const poolPage = await poolsPage.viewPool(1464, poolName);
     const balance = await poolPage.getBalance();
     expect(balance).toEqual("$0");
     const tradeModal = await poolPage.getTradeModal();


### PR DESCRIPTION
## What is the purpose of the change:

There are too many pools for OSMO and ATOM, so we need to filter by exact pair.