### PR TITLE
[Limit Orders]: Post Launch QA 2

### DIFF
--- a/packages/web/components/chart/light-weight-charts/advanced-chart.tsx
+++ b/packages/web/components/chart/light-weight-charts/advanced-chart.tsx
@@ -1,45 +1,12 @@
 import { useEffect, useRef, useState } from "react";
 
+import { useFeatureFlags } from "~/hooks";
 import type {
   ChartingLibraryWidgetOptions,
   IChartingLibraryWidget,
   ResolutionString,
 } from "~/public/tradingview";
 import { theme } from "~/tailwind.config";
-
-const themeOptions: Partial<ChartingLibraryWidgetOptions> = {
-  theme: "dark",
-  overrides: {
-    "paneProperties.background": theme.colors.osmoverse[900],
-    "paneProperties.horzGridProperties.color": theme.colors.osmoverse[900],
-    "paneProperties.vertGridProperties.color": theme.colors.osmoverse[900],
-    "linetoolarc.backgroundColor": theme.colors.osmoverse[850],
-    "linetoolnote.backgroundColor": theme.colors.osmoverse[850],
-    "linetooltext.backgroundColor": theme.colors.osmoverse[850],
-    "linetoolbrush.backgroundColor": theme.colors.osmoverse[850],
-    "paneProperties.crossHairProperties.style": 1,
-    "paneProperties.legendProperties.showBarChange": false,
-    "paneProperties.backgroundType": "solid",
-
-    "mainSeriesProperties.style": 1,
-    "mainSeriesProperties.candleStyle.upColor": theme.colors.bullish[400],
-    "mainSeriesProperties.candleStyle.borderUpColor": theme.colors.bullish[400],
-    "mainSeriesProperties.candleStyle.wickUpColor": theme.colors.bullish[400],
-    "mainSeriesProperties.statusViewStyle.symbolTextSource": "ticker",
-
-    "scalesProperties.textColor": theme.colors.white.full,
-    "scalesProperties.backgroundColor": theme.colors.osmoverse[900],
-    "scalesProperties.lineColor": theme.colors.osmoverse[900],
-  },
-  studies_overrides: {
-    "volume.volume.color.1": theme.colors.bullish[400],
-    "volume.volume ma.visible": false,
-  },
-  loading_screen: {
-    backgroundColor: theme.colors.osmoverse[900],
-    foregroundColor: theme.colors.osmoverse[900],
-  },
-};
 
 type AdvancedChartProps = Omit<
   Partial<ChartingLibraryWidgetOptions>,
@@ -52,14 +19,60 @@ export const AdvancedChart = (props: AdvancedChartProps) => {
   const [container, setContainer] = useState<HTMLDivElement | null>(null);
   const chart = useRef<IChartingLibraryWidget>();
 
-  if (container && chart.current === undefined) {
+  const featureFlags = useFeatureFlags();
+  const themeOptions: Partial<ChartingLibraryWidgetOptions> = {
+    theme: "dark",
+    overrides: {
+      "paneProperties.background":
+        theme.colors.osmoverse[featureFlags.limitOrders ? 1000 : 900],
+      "paneProperties.horzGridProperties.color":
+        theme.colors.osmoverse[featureFlags.limitOrders ? 1000 : 900],
+      "paneProperties.vertGridProperties.color":
+        theme.colors.osmoverse[featureFlags.limitOrders ? 1000 : 900],
+      "linetoolarc.backgroundColor": theme.colors.osmoverse[850],
+      "linetoolnote.backgroundColor": theme.colors.osmoverse[850],
+      "linetooltext.backgroundColor": theme.colors.osmoverse[850],
+      "linetoolbrush.backgroundColor": theme.colors.osmoverse[850],
+      "paneProperties.crossHairProperties.style": 1,
+      "paneProperties.legendProperties.showBarChange": false,
+      "paneProperties.backgroundType": "solid",
+
+      "mainSeriesProperties.style": 1,
+      "mainSeriesProperties.candleStyle.upColor": theme.colors.bullish[400],
+      "mainSeriesProperties.candleStyle.borderUpColor":
+        theme.colors.bullish[400],
+      "mainSeriesProperties.candleStyle.wickUpColor": theme.colors.bullish[400],
+      "mainSeriesProperties.statusViewStyle.symbolTextSource": "ticker",
+
+      "scalesProperties.textColor": theme.colors.white.full,
+      "scalesProperties.backgroundColor":
+        theme.colors.osmoverse[featureFlags.limitOrders ? 1000 : 900],
+      "scalesProperties.lineColor":
+        theme.colors.osmoverse[featureFlags.limitOrders ? 1000 : 900],
+    },
+    studies_overrides: {
+      "volume.volume.color.1": theme.colors.bullish[400],
+      "volume.volume ma.visible": false,
+    },
+
+    loading_screen: {
+      backgroundColor:
+        theme.colors.osmoverse[featureFlags.limitOrders ? 1000 : 900],
+      foregroundColor:
+        theme.colors.osmoverse[featureFlags.limitOrders ? 1000 : 900],
+    },
+  };
+
+  if (container && chart.current === undefined && featureFlags._isInitialized) {
     const widgetOptions: ChartingLibraryWidgetOptions = {
       symbol: props.coinDenom,
       datafeed: props.datafeed!,
       interval: "1d" as ResolutionString,
       container,
       library_path: "/tradingview/",
-      custom_css_url: "/tradingview/custom.css",
+      custom_css_url: featureFlags.limitOrders
+        ? "/tradingview/custom-limit.css"
+        : "/tradingview/custom.css",
       custom_font_family: '"Inter", sans-serif',
       locale: "en",
       disabled_features: [

--- a/packages/web/components/place-limit-tool/index.tsx
+++ b/packages/web/components/place-limit-tool/index.tsx
@@ -99,12 +99,8 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
     const inputRef = useRef<HTMLInputElement>(null);
 
     const [{ from, quote, tab, type }, set] = useQueryStates({
-      from: parseAsString.withDefault(
-        !!initialBaseDenom ? initialBaseDenom : "ATOM"
-      ),
-      quote: parseAsString.withDefault(
-        !!initialQuoteDenom ? initialQuoteDenom : "USDC"
-      ),
+      from: parseAsString.withDefault(initialBaseDenom || "ATOM"),
+      quote: parseAsString.withDefault(initialQuoteDenom || "USDC"),
       type: parseAsStringLiteral(TRADE_TYPES).withDefault("market"),
       tab: parseAsString,
       to: parseAsString,

--- a/packages/web/components/place-limit-tool/index.tsx
+++ b/packages/web/components/place-limit-tool/index.tsx
@@ -44,6 +44,9 @@ import { countDecimals, trimPlaceholderZeros } from "~/utils/number";
 
 export interface PlaceLimitToolProps {
   page: EventPage;
+  initialBaseDenom?: string;
+  initialQuoteDenom?: string;
+  onOrderSuccess?: (baseDenom?: string, quoteDenom?: string) => void;
 }
 
 const fixDecimalCount = (value: string, decimalCount = 18) => {
@@ -79,7 +82,12 @@ const NON_DISPLAY_ERRORS = [
 ];
 
 export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
-  ({ page }: PlaceLimitToolProps) => {
+  ({
+    page,
+    initialBaseDenom = "ATOM",
+    initialQuoteDenom = "USDC",
+    onOrderSuccess,
+  }: PlaceLimitToolProps) => {
     const { accountStore } = useStore();
     const { t } = useTranslation();
     const [reviewOpen, setReviewOpen] = useState<boolean>(false);
@@ -91,8 +99,12 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
     const inputRef = useRef<HTMLInputElement>(null);
 
     const [{ from, quote, tab, type }, set] = useQueryStates({
-      from: parseAsString.withDefault("ATOM"),
-      quote: parseAsString.withDefault("USDC"),
+      from: parseAsString.withDefault(
+        !!initialBaseDenom ? initialBaseDenom : "ATOM"
+      ),
+      quote: parseAsString.withDefault(
+        !!initialQuoteDenom ? initialQuoteDenom : "USDC"
+      ),
       type: parseAsStringLiteral(TRADE_TYPES).withDefault("market"),
       tab: parseAsString,
       to: parseAsString,
@@ -555,7 +567,10 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
                     )}
                 </span>
               </button>
-              <PriceSelector />
+              <PriceSelector
+                initialBaseDenom={initialBaseDenom}
+                initialQuoteDenom={initialQuoteDenom}
+              />
             </AssetFieldsetFooter>
           </AssetFieldset>
           {type === "limit" && (
@@ -613,6 +628,10 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
             setAmountSafe("fiat", "");
             setReviewOpen(false);
             setIsSendingTx(false);
+            onOrderSuccess?.(
+              swapState.baseAsset?.coinDenom,
+              swapState.quoteAsset?.coinDenom
+            );
           }}
           outAmountLessSlippage={outAmountLessSlippage}
           outFiatAmountLessSlippage={outFiatAmountLessSlippage}

--- a/packages/web/components/place-limit-tool/index.tsx
+++ b/packages/web/components/place-limit-tool/index.tsx
@@ -614,7 +614,12 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
             treatAsStable={tab === "buy" ? "in" : "out"}
             tab={tab as "buy" | "sell"}
             priceOverride={
-              type === "limit" ? swapState.priceState.priceFiat : undefined
+              type === "limit"
+                ? new PricePretty(
+                    DEFAULT_VS_CURRENCY,
+                    swapState.priceState.spotPrice
+                  )
+                : undefined
             }
           />
         </div>

--- a/packages/web/components/swap-tool/alt.tsx
+++ b/packages/web/components/swap-tool/alt.tsx
@@ -545,8 +545,10 @@ export const AltSwapTool: FunctionComponent<SwapToolProps> = observer(
                   (account?.walletStatus === WalletStatus.Connected &&
                     (swapState.inAmountInput.isEmpty ||
                       !Boolean(swapState.quote) ||
+                      isSwapToolLoading ||
                       Boolean(swapState.error) ||
-                      account?.txTypeInProgress !== ""))
+                      (Boolean(swapState.networkFeeError) &&
+                        !swapState.hasOverSpendLimitError)))
                 }
                 isLoading={
                   /**
@@ -575,8 +577,7 @@ export const AltSwapTool: FunctionComponent<SwapToolProps> = observer(
                 data-testid="trade-button-swap"
               >
                 <h6>
-                  {account?.walletStatus === WalletStatus.Connected ||
-                  isSwapToolLoading
+                  {account?.walletStatus === WalletStatus.Connected
                     ? buttonText
                     : t("connectWallet")}
                 </h6>

--- a/packages/web/components/swap-tool/order-type-selector.tsx
+++ b/packages/web/components/swap-tool/order-type-selector.tsx
@@ -33,11 +33,11 @@ export const OrderTypeSelector = ({
   );
   const [base] = useQueryState(
     "from",
-    parseAsString.withDefault(!!initialBaseDenom ? initialBaseDenom : "ATOM")
+    parseAsString.withDefault(initialBaseDenom || "ATOM")
   );
   const [quote, setQuote] = useQueryState(
     "quote",
-    parseAsString.withDefault(!!initialQuoteDenom ? initialQuoteDenom : "USDC")
+    parseAsString.withDefault(initialQuoteDenom || "USDC")
   );
 
   const { selectableBaseAssets, selectableQuoteDenoms, isLoading } =

--- a/packages/web/components/swap-tool/order-type-selector.tsx
+++ b/packages/web/components/swap-tool/order-type-selector.tsx
@@ -13,9 +13,17 @@ interface UITradeType {
   disabled: boolean;
 }
 
+interface OrderTypeSelectorProps {
+  initialQuoteDenom?: string;
+  initialBaseDenom?: string;
+}
+
 export const TRADE_TYPES = ["market", "limit"] as const;
 
-export const OrderTypeSelector = () => {
+export const OrderTypeSelector = ({
+  initialQuoteDenom,
+  initialBaseDenom,
+}: OrderTypeSelectorProps) => {
   const { t } = useTranslation();
   const { logEvent } = useAmplitudeAnalytics();
 
@@ -23,13 +31,16 @@ export const OrderTypeSelector = () => {
     "type",
     parseAsStringLiteral(TRADE_TYPES).withDefault("market")
   );
-  const [base] = useQueryState("from", parseAsString.withDefault("ATOM"));
+  const [base] = useQueryState(
+    "from",
+    parseAsString.withDefault(!!initialBaseDenom ? initialBaseDenom : "ATOM")
+  );
   const [quote, setQuote] = useQueryState(
     "quote",
-    parseAsString.withDefault("USDC")
+    parseAsString.withDefault(!!initialQuoteDenom ? initialQuoteDenom : "USDC")
   );
 
-  const { selectableBaseAssets, selectableQuoteDenoms } =
+  const { selectableBaseAssets, selectableQuoteDenoms, isLoading } =
     useOrderbookSelectableDenoms();
 
   const hasOrderbook = useMemo(
@@ -42,7 +53,7 @@ export const OrderTypeSelector = () => {
   }, [base, selectableQuoteDenoms]);
 
   useEffect(() => {
-    if (type === "limit" && !hasOrderbook) {
+    if (type === "limit" && !hasOrderbook && !isLoading) {
       setType("market");
     } else if (
       type === "limit" &&
@@ -51,7 +62,15 @@ export const OrderTypeSelector = () => {
     ) {
       setQuote(selectableQuotes[0].coinDenom);
     }
-  }, [hasOrderbook, setType, type, selectableQuotes, setQuote, quote]);
+  }, [
+    hasOrderbook,
+    setType,
+    type,
+    selectableQuotes,
+    setQuote,
+    quote,
+    isLoading,
+  ]);
 
   useEffect(() => {
     switch (type) {
@@ -80,10 +99,10 @@ export const OrderTypeSelector = () => {
       {
         id: "limit",
         title: t("limitOrders.limit"),
-        disabled: !hasOrderbook,
+        disabled: isLoading || !hasOrderbook,
       },
     ],
-    [hasOrderbook, t]
+    [hasOrderbook, isLoading, t]
   );
 
   return (
@@ -96,7 +115,9 @@ export const OrderTypeSelector = () => {
             disabled={!disabled}
             title={t("limitOrders.unavailable", { denom: base })}
             key={`order-type-selector-${id}`}
-            containerClassName="!w-fit"
+            containerClassName={classNames("!w-fit", {
+              hidden: isLoading,
+            })}
           >
             <button
               onClick={() => setType(id)}

--- a/packages/web/components/swap-tool/price-selector.tsx
+++ b/packages/web/components/swap-tool/price-selector.tsx
@@ -71,13 +71,11 @@ export const PriceSelector = memo(
     const [tab, setTab] = useQueryState("tab");
     const [quote] = useQueryState(
       "quote",
-      parseAsString.withDefault(
-        !!initialQuoteDenom ? initialQuoteDenom : "USDC"
-      )
+      parseAsString.withDefault(initialQuoteDenom || "USDC")
     );
     const [base, setBase] = useQueryState(
       "from",
-      parseAsString.withDefault(!!initialBaseDenom ? initialBaseDenom : "ATOM")
+      parseAsString.withDefault(initialBaseDenom || "ATOM")
     );
     const [_, setSellOpen] = useQueryState(
       "sellOpen",

--- a/packages/web/components/swap-tool/price-selector.tsx
+++ b/packages/web/components/swap-tool/price-selector.tsx
@@ -56,230 +56,283 @@ function sortByAmount(
     : 1;
 }
 
-export const PriceSelector = memo(() => {
-  const { t } = useTranslation();
+interface PriceSelectorProps {
+  initialBaseDenom: string;
+  initialQuoteDenom: string;
+}
 
-  const [tab, setTab] = useQueryState("tab");
-  const [quote] = useQueryState("quote", parseAsString.withDefault("USDC"));
-  const [base, setBase] = useQueryState(
-    "from",
-    parseAsString.withDefault("OSMO")
-  );
-  const [_, setSellOpen] = useQueryState(
-    "sellOpen",
-    parseAsBoolean.withDefault(false)
-  );
+export const PriceSelector = memo(
+  ({
+    initialBaseDenom = "ATOM",
+    initialQuoteDenom = "USDC",
+  }: PriceSelectorProps) => {
+    const { t } = useTranslation();
 
-  const [__, setBuyOpen] = useQueryState(
-    "buyOpen",
-    parseAsBoolean.withDefault(false)
-  );
+    const [tab, setTab] = useQueryState("tab");
+    const [quote] = useQueryState(
+      "quote",
+      parseAsString.withDefault(
+        !!initialQuoteDenom ? initialQuoteDenom : "USDC"
+      )
+    );
+    const [base, setBase] = useQueryState(
+      "from",
+      parseAsString.withDefault(!!initialBaseDenom ? initialBaseDenom : "ATOM")
+    );
+    const [_, setSellOpen] = useQueryState(
+      "sellOpen",
+      parseAsBoolean.withDefault(false)
+    );
 
-  const { selectableQuoteDenoms } = useOrderbookSelectableDenoms();
+    const [__, setBuyOpen] = useQueryState(
+      "buyOpen",
+      parseAsBoolean.withDefault(false)
+    );
 
-  const quoteAsset = useMemo(
-    () =>
-      getAssetFromAssetList({ assetLists: AssetLists, symbol: quote })
-        ?.rawAsset as Asset | undefined,
-    [quote]
-  );
+    const { selectableQuoteDenoms } = useOrderbookSelectableDenoms();
 
-  useEffect(() => {
-    if (quote === base) {
-      setBase("OSMO");
-    }
-  }, [base, quote, setBase]);
+    const quoteAsset = useMemo(
+      () =>
+        getAssetFromAssetList({ assetLists: AssetLists, symbol: quote })
+          ?.rawAsset as Asset | undefined,
+      [quote]
+    );
 
-  const { accountStore } = useStore();
-  const wallet = accountStore.getWallet(accountStore.osmosisChainId);
+    useEffect(() => {
+      if (quote === base) {
+        setBase("ATOM");
+      }
+    }, [base, quote, setBase]);
 
-  const defaultQuotes = useMemo(
-    () =>
-      UI_DEFAULT_QUOTES.map(
-        (symbol) =>
-          getAssetFromAssetList({
-            assetLists: AssetLists,
-            symbol,
-          })?.rawAsset
-      ).filter(Boolean) as Asset[],
-    []
-  );
+    const { accountStore } = useStore();
+    const wallet = accountStore.getWallet(accountStore.osmosisChainId);
 
-  const { data: userQuotes } = api.edge.assets.getUserAssets.useQuery(
-    { userOsmoAddress: wallet?.address },
-    {
-      enabled: !!wallet?.address,
-      select: (data) =>
-        data.items
-          .map((walletAsset) => {
-            if (
-              !(tab === "sell" ? UI_DEFAULT_QUOTES : VALID_QUOTES).includes(
-                walletAsset.coinDenom as MainnetAssetSymbols
-              )
-            ) {
-              return undefined;
-            }
-
-            const asset = getAssetFromAssetList({
+    const defaultQuotes = useMemo(
+      () =>
+        UI_DEFAULT_QUOTES.map(
+          (symbol) =>
+            getAssetFromAssetList({
               assetLists: AssetLists,
-              symbol: walletAsset.coinDenom,
-            });
+              symbol,
+            })?.rawAsset
+        ).filter(Boolean) as Asset[],
+      []
+    );
 
-            // Extrapolate the rawAsset and return the amount and usdValue
-            const returnAsset: AssetWithBalance = {
-              ...asset!.rawAsset,
-              amount: walletAsset.amount,
-            };
-            // In the future, we might want to pass every coin instead of just stables.
-            return asset?.rawAsset.categories.includes("stablecoin")
-              ? returnAsset
-              : undefined;
-          })
-          .filter(Boolean)
-          .toSorted(sortByAmount)
-          .toSorted((assetA) => {
-            const isAssetAAvailable = selectableQuoteDenoms[base]?.some(
-              (asset) => asset.coinDenom === assetA?.symbol
-            );
+    const { data: userQuotes } = api.edge.assets.getUserAssets.useQuery(
+      { userOsmoAddress: wallet?.address },
+      {
+        enabled: !!wallet?.address,
+        select: (data) =>
+          data.items
+            .map((walletAsset) => {
+              if (
+                !(tab === "sell" ? UI_DEFAULT_QUOTES : VALID_QUOTES).includes(
+                  walletAsset.coinDenom as MainnetAssetSymbols
+                )
+              ) {
+                return undefined;
+              }
 
-            return isAssetAAvailable ? -1 : 1;
-          }) as AssetWithBalance[],
-    }
-  );
+              const asset = getAssetFromAssetList({
+                assetLists: AssetLists,
+                symbol: walletAsset.coinDenom,
+              });
 
-  const userQuotesWithoutBalances = useMemo(
-    () =>
-      (userQuotes ?? [])
-        .map(({ amount, usdValue, ...props }) => ({ ...props }))
-        .filter(Boolean) as Asset[],
-    [userQuotes]
-  );
+              // Extrapolate the rawAsset and return the amount and usdValue
+              const returnAsset: AssetWithBalance = {
+                ...asset!.rawAsset,
+                amount: walletAsset.amount,
+              };
+              // In the future, we might want to pass every coin instead of just stables.
+              return asset?.rawAsset.categories.includes("stablecoin")
+                ? returnAsset
+                : undefined;
+            })
+            .filter(Boolean)
+            .toSorted(sortByAmount)
+            .toSorted((assetA) => {
+              const isAssetAAvailable = selectableQuoteDenoms[base]?.some(
+                (asset) => asset.coinDenom === assetA?.symbol
+              );
 
-  /**
-   * Stablecoin balances or Add funds CTA not shown in Sell trade mode.
-   * Sell trades limited to canonical USDC and alloyed USDT.
-   */
-  const defaultQuotesWithBalances = useMemo(
-    () =>
-      userQuotes?.filter(({ amount, symbol }) => {
-        if (UI_DEFAULT_QUOTES.includes(symbol as MainnetAssetSymbols))
-          return true;
-        return amount?.toDec().gt(new Dec(0)) ?? false;
-      }) ?? [],
-    [userQuotes]
-  );
+              return isAssetAAvailable ? -1 : 1;
+            }) as AssetWithBalance[],
+      }
+    );
 
-  const selectableQuotes = useMemo(() => {
-    return wallet?.isWalletConnected
-      ? tab === "sell"
-        ? userQuotesWithoutBalances
-        : defaultQuotesWithBalances
-      : defaultQuotes;
-  }, [
-    defaultQuotes,
-    defaultQuotesWithBalances,
-    tab,
-    userQuotesWithoutBalances,
-    wallet?.isWalletConnected,
-  ]);
+    const userQuotesWithoutBalances = useMemo(
+      () =>
+        (userQuotes ?? [])
+          .map(({ amount, usdValue, ...props }) => ({ ...props }))
+          .filter(Boolean) as Asset[],
+      [userQuotes]
+    );
 
-  const {
-    isOpen: isAddFundsModalOpen,
-    onClose: closeAddFundsModal,
-    onOpen: openAddFundsModal,
-  } = useDisclosure();
+    /**
+     * Stablecoin balances or Add funds CTA not shown in Sell trade mode.
+     * Sell trades limited to canonical USDC and alloyed USDT.
+     */
+    const defaultQuotesWithBalances = useMemo(
+      () =>
+        userQuotes?.filter(({ amount, symbol }) => {
+          if (UI_DEFAULT_QUOTES.includes(symbol as MainnetAssetSymbols))
+            return true;
+          return amount?.toDec().gt(new Dec(0)) ?? false;
+        }) ?? [],
+      [userQuotes]
+    );
 
-  const { isMobile } = useWindowSize(Breakpoint.sm);
+    const selectableQuotes = useMemo(() => {
+      return wallet?.isWalletConnected
+        ? tab === "sell"
+          ? userQuotesWithoutBalances
+          : defaultQuotesWithBalances
+        : defaultQuotes;
+    }, [
+      defaultQuotes,
+      defaultQuotesWithBalances,
+      tab,
+      userQuotesWithoutBalances,
+      wallet?.isWalletConnected,
+    ]);
 
-  return (
-    <>
-      <Menu as="div" className="relative inline-block">
-        {({ open }) => (
-          <>
-            <Menu.Button className="flex items-center justify-between">
-              <div className="flex flex-1 items-center justify-between">
-                {quoteAsset && (
-                  <div className="flex items-center gap-1 transition-opacity sm:gap-0">
-                    <span className="body2 sm:caption whitespace-nowrap text-osmoverse-300">
-                      {tab === "buy"
-                        ? t("limitOrders.payWith")
-                        : t("limitOrders.receive")}
-                    </span>
-                    <div className="flex items-center gap-2 py-1 pl-1 pr-3 sm:gap-1 sm:py-1.5">
-                      {quoteAsset.logoURIs && (
-                        <Image
-                          src={
-                            quoteAsset.logoURIs.svg ||
-                            quoteAsset.logoURIs.png ||
-                            ""
-                          }
-                          alt={`${quoteAsset.symbol} icon`}
-                          width={isMobile ? 20 : 24}
-                          height={isMobile ? 20 : 24}
-                          priority
-                        />
-                      )}
-                      <span className="md:caption body2 text-left">
-                        {quoteAsset.symbol}
+    const {
+      isOpen: isAddFundsModalOpen,
+      onClose: closeAddFundsModal,
+      onOpen: openAddFundsModal,
+    } = useDisclosure();
+
+    const { isMobile } = useWindowSize(Breakpoint.sm);
+
+    return (
+      <>
+        <Menu as="div" className="relative inline-block">
+          {({ open }) => (
+            <>
+              <Menu.Button className="flex items-center justify-between">
+                <div className="flex flex-1 items-center justify-between">
+                  {quoteAsset && (
+                    <div className="flex items-center gap-1 transition-opacity sm:gap-0">
+                      <span className="body2 sm:caption whitespace-nowrap text-osmoverse-300">
+                        {tab === "buy"
+                          ? t("limitOrders.payWith")
+                          : t("limitOrders.receive")}
                       </span>
-                      <Icon
-                        id="chevron-down"
-                        className={classNames(
-                          "h-[7px] w-3 text-wosmongton-200 transition-transform",
-                          {
-                            "rotate-180": open,
-                          }
+                      <div className="flex items-center gap-2 py-1 pl-1 pr-3 sm:gap-1 sm:py-1.5">
+                        {quoteAsset.logoURIs && (
+                          <Image
+                            src={
+                              quoteAsset.logoURIs.svg ||
+                              quoteAsset.logoURIs.png ||
+                              ""
+                            }
+                            alt={`${quoteAsset.symbol} icon`}
+                            width={isMobile ? 20 : 24}
+                            height={isMobile ? 20 : 24}
+                            priority
+                          />
                         )}
-                      />
+                        <span className="md:caption body2 text-left">
+                          {quoteAsset.symbol}
+                        </span>
+                        <Icon
+                          id="chevron-down"
+                          className={classNames(
+                            "h-[7px] w-3 text-wosmongton-200 transition-transform",
+                            {
+                              "rotate-180": open,
+                            }
+                          )}
+                        />
+                      </div>
                     </div>
-                  </div>
-                )}
-              </div>
-            </Menu.Button>
-            <Transition
-              as={Fragment}
-              enter="transition ease-out duration-100"
-              enterFrom="transform opacity-0 scale-95"
-              enterTo="transform opacity-100 scale-100"
-              leave="transition ease-in duration-75"
-              leaveFrom="transform opacity-100 scale-100"
-              leaveTo="transform opacity-0 scale-95"
-            >
-              <Menu.Items className="absolute right-0 z-50 flex w-[384px] max-w-[calc(100vw-2.5rem)] origin-top-left flex-col rounded-xl border border-solid border-osmoverse-700 bg-osmoverse-800">
-                <div className="flex max-h-[336px] flex-col overflow-y-auto border-b border-osmoverse-700 p-2">
-                  <SelectableQuotes
-                    selectableQuotes={selectableQuotes}
-                    userQuotes={userQuotes}
-                  />
+                  )}
                 </div>
-                <div className="flex flex-col px-5 py-2">
-                  {wallet?.isWalletConnected && tab === "buy" && (
+              </Menu.Button>
+              <Transition
+                as={Fragment}
+                enter="transition ease-out duration-100"
+                enterFrom="transform opacity-0 scale-95"
+                enterTo="transform opacity-100 scale-100"
+                leave="transition ease-in duration-75"
+                leaveFrom="transform opacity-100 scale-100"
+                leaveTo="transform opacity-0 scale-95"
+              >
+                <Menu.Items className="absolute right-0 z-50 flex w-[384px] max-w-[calc(100vw-2.5rem)] origin-top-left flex-col rounded-xl border border-solid border-osmoverse-700 bg-osmoverse-800">
+                  <div className="flex max-h-[336px] flex-col overflow-y-auto border-b border-osmoverse-700 p-2">
+                    <SelectableQuotes
+                      selectableQuotes={selectableQuotes}
+                      userQuotes={userQuotes}
+                    />
+                  </div>
+                  <div className="flex flex-col px-5 py-2">
+                    {wallet?.isWalletConnected && tab === "buy" && (
+                      <button
+                        type="button"
+                        onClick={openAddFundsModal}
+                        className="flex w-full items-center justify-between py-3"
+                      >
+                        <span className="subtitle1 text-left font-semibold text-wosmongton-200">
+                          {t("limitOrders.addFunds")}
+                        </span>
+                        <div className="flex items-center gap-1">
+                          <div className="relative flex items-center">
+                            {/** Here we just display default quotes */}
+                            {defaultQuotes.map(({ symbol, logoURIs }, i) => {
+                              return (
+                                <Image
+                                  key={`${symbol}-logo`}
+                                  alt=""
+                                  src={logoURIs.svg || logoURIs.png || ""}
+                                  width={24}
+                                  height={24}
+                                  className={classNames("h-6 w-6", {
+                                    "-ml-2": i > 0,
+                                  })}
+                                />
+                              );
+                            })}
+                          </div>
+                          <div className="flex h-6 w-6 items-center justify-center">
+                            <Icon
+                              id="chevron-right"
+                              className="h-3 w-[7px] text-osmoverse-300"
+                            />
+                          </div>
+                        </div>
+                      </button>
+                    )}
                     <button
-                      type="button"
-                      onClick={openAddFundsModal}
+                      onClick={() => {
+                        if (tab === "buy") {
+                          setSellOpen(true);
+                        } else {
+                          setBuyOpen(true);
+                        }
+                        setTab("swap");
+                      }}
                       className="flex w-full items-center justify-between py-3"
                     >
-                      <span className="subtitle1 text-left font-semibold text-wosmongton-200">
-                        {t("limitOrders.addFunds")}
+                      <span className="subtitle1 max-w-[200px] text-left font-semibold text-wosmongton-200">
+                        {tab === "buy"
+                          ? t("limitOrders.swapFromAnotherAsset")
+                          : t("limitOrders.swapToAnotherAsset")}
                       </span>
                       <div className="flex items-center gap-1">
-                        <div className="relative flex items-center">
-                          {/** Here we just display default quotes */}
-                          {defaultQuotes.map(({ symbol, logoURIs }, i) => {
-                            return (
-                              <Image
-                                key={`${symbol}-logo`}
-                                alt=""
-                                src={logoURIs.svg || logoURIs.png || ""}
-                                width={24}
-                                height={24}
-                                className={classNames("h-6 w-6", {
-                                  "-ml-2": i > 0,
-                                })}
-                              />
-                            );
-                          })}
-                        </div>
+                        {wallet?.address ? (
+                          <HighestBalanceAssetsIcons
+                            userOsmoAddress={wallet.address}
+                          />
+                        ) : (
+                          <Image
+                            src={"/images/quote-swap-from-another-asset.png"}
+                            alt=""
+                            width={176}
+                            height={48}
+                            className="h-6 w-[88px]"
+                          />
+                        )}
                         <div className="flex h-6 w-6 items-center justify-center">
                           <Icon
                             id="chevron-right"
@@ -288,59 +341,21 @@ export const PriceSelector = memo(() => {
                         </div>
                       </div>
                     </button>
-                  )}
-                  <button
-                    onClick={() => {
-                      if (tab === "buy") {
-                        setSellOpen(true);
-                      } else {
-                        setBuyOpen(true);
-                      }
-                      setTab("swap");
-                    }}
-                    className="flex w-full items-center justify-between py-3"
-                  >
-                    <span className="subtitle1 max-w-[200px] text-left font-semibold text-wosmongton-200">
-                      {tab === "buy"
-                        ? t("limitOrders.swapFromAnotherAsset")
-                        : t("limitOrders.swapToAnotherAsset")}
-                    </span>
-                    <div className="flex items-center gap-1">
-                      {wallet?.address ? (
-                        <HighestBalanceAssetsIcons
-                          userOsmoAddress={wallet.address}
-                        />
-                      ) : (
-                        <Image
-                          src={"/images/quote-swap-from-another-asset.png"}
-                          alt=""
-                          width={176}
-                          height={48}
-                          className="h-6 w-[88px]"
-                        />
-                      )}
-                      <div className="flex h-6 w-6 items-center justify-center">
-                        <Icon
-                          id="chevron-right"
-                          className="h-3 w-[7px] text-osmoverse-300"
-                        />
-                      </div>
-                    </div>
-                  </button>
-                </div>
-              </Menu.Items>
-            </Transition>
-          </>
-        )}
-      </Menu>
-      <AddFundsModal
-        isOpen={isAddFundsModalOpen}
-        onRequestClose={closeAddFundsModal}
-        from="buy"
-      />
-    </>
-  );
-});
+                  </div>
+                </Menu.Items>
+              </Transition>
+            </>
+          )}
+        </Menu>
+        <AddFundsModal
+          isOpen={isAddFundsModalOpen}
+          onRequestClose={closeAddFundsModal}
+          from="buy"
+        />
+      </>
+    );
+  }
+);
 
 function HighestBalanceAssetsIcons({
   userOsmoAddress,

--- a/packages/web/components/swap-tool/trade-details.tsx
+++ b/packages/web/components/swap-tool/trade-details.tsx
@@ -49,7 +49,7 @@ export const TradeDetails = observer(
     const { t } = useTranslation();
     const routesVisDisclosure = useDisclosure();
 
-    const [outAsBase, setOutAsBase] = useState(!tab || tab === "buy");
+    const [outAsBase, setOutAsBase] = useState(tab === "buy");
 
     const [details, { height: detailsHeight }] = useMeasure<HTMLDivElement>();
 

--- a/packages/web/hooks/limit-orders/use-orderbook.ts
+++ b/packages/web/hooks/limit-orders/use-orderbook.ts
@@ -204,14 +204,12 @@ export const useOrderbook = ({
   const error = useMemo(() => {
     if (
       !isOrderbookLoading &&
-      (!Boolean(orderbook) ||
-        !Boolean(orderbook!.poolId) ||
-        orderbook!.poolId === "")
+      (!orderbook || !orderbook!.poolId || orderbook!.poolId === "")
     ) {
       return "errors.noOrderbook";
     }
 
-    if (Boolean(makerFeeError)) {
+    if (makerFeeError) {
       return makerFeeError?.message;
     }
   }, [orderbook, makerFeeError, isOrderbookLoading]);

--- a/packages/web/hooks/limit-orders/use-orderbook.ts
+++ b/packages/web/hooks/limit-orders/use-orderbook.ts
@@ -203,9 +203,10 @@ export const useOrderbook = ({
 
   const error = useMemo(() => {
     if (
-      !Boolean(orderbook) ||
-      !Boolean(orderbook!.poolId) ||
-      orderbook!.poolId === ""
+      !isOrderbookLoading &&
+      (!Boolean(orderbook) ||
+        !Boolean(orderbook!.poolId) ||
+        orderbook!.poolId === "")
     ) {
       return "errors.noOrderbook";
     }
@@ -213,7 +214,7 @@ export const useOrderbook = ({
     if (Boolean(makerFeeError)) {
       return makerFeeError?.message;
     }
-  }, [orderbook, makerFeeError]);
+  }, [orderbook, makerFeeError, isOrderbookLoading]);
 
   return {
     orderbook,

--- a/packages/web/hooks/use-feature-flags.ts
+++ b/packages/web/hooks/use-feature-flags.ts
@@ -115,10 +115,10 @@ export const useFeatureFlags = () => {
       launchdarklyFlags.oneClickTrading,
     _isInitialized: isDevModeWithoutClientID ? true : isInitialized,
     _isClientIDPresent: !!process.env.NEXT_PUBLIC_LAUNCH_DARKLY_CLIENT_SIDE_ID,
-    limitOrders: false,
-    // isInitialized &&
-    // launchdarklyFlags.limitOrders &&
-    // (LIMIT_ORDER_COUNTRY_CODES.length === 0 ||
-    //   LIMIT_ORDER_COUNTRY_CODES.includes(levanaGeoblock?.countryCode ?? "")),
+    limitOrders:
+      isInitialized &&
+      launchdarklyFlags.limitOrders &&
+      (LIMIT_ORDER_COUNTRY_CODES.length === 0 ||
+        LIMIT_ORDER_COUNTRY_CODES.includes(levanaGeoblock?.countryCode ?? "")),
   } as Record<ModifiedFlags, boolean>;
 };

--- a/packages/web/hooks/use-feature-flags.ts
+++ b/packages/web/hooks/use-feature-flags.ts
@@ -115,10 +115,10 @@ export const useFeatureFlags = () => {
       launchdarklyFlags.oneClickTrading,
     _isInitialized: isDevModeWithoutClientID ? true : isInitialized,
     _isClientIDPresent: !!process.env.NEXT_PUBLIC_LAUNCH_DARKLY_CLIENT_SIDE_ID,
-    limitOrders:
-      isInitialized &&
-      launchdarklyFlags.limitOrders &&
-      (LIMIT_ORDER_COUNTRY_CODES.length === 0 ||
-        LIMIT_ORDER_COUNTRY_CODES.includes(levanaGeoblock?.countryCode ?? "")),
+    limitOrders: false,
+    // isInitialized &&
+    // launchdarklyFlags.limitOrders &&
+    // (LIMIT_ORDER_COUNTRY_CODES.length === 0 ||
+    //   LIMIT_ORDER_COUNTRY_CODES.includes(levanaGeoblock?.countryCode ?? "")),
   } as Record<ModifiedFlags, boolean>;
 };

--- a/packages/web/modals/review-order.tsx
+++ b/packages/web/modals/review-order.tsx
@@ -599,6 +599,7 @@ export function ReviewOrder({
               <RecapRow
                 left={t("swap.gas.additionalNetworkFee")}
                 right={
+                  // Do not show skeleton unless there has been no estimation/error yet
                   !(isGasLoading && !(!!gasAmount || !!gasError)) ? (
                     GasEstimation
                   ) : (

--- a/packages/web/modals/review-order.tsx
+++ b/packages/web/modals/review-order.tsx
@@ -599,7 +599,7 @@ export function ReviewOrder({
               <RecapRow
                 left={t("swap.gas.additionalNetworkFee")}
                 right={
-                  !isGasLoading ? (
+                  !(isGasLoading && !(!!gasAmount || !!gasError)) ? (
                     GasEstimation
                   ) : (
                     <Skeleton className="h-5 w-16" />

--- a/packages/web/pages/assets/[denom].tsx
+++ b/packages/web/pages/assets/[denom].tsx
@@ -17,7 +17,7 @@ import Script from "next/script";
 import { NextSeo } from "next-seo";
 import { useQueryState } from "nuqs";
 import { FunctionComponent, useEffect, useMemo } from "react";
-import { useUnmount } from "react-use";
+import { useLocalStorage, useUnmount } from "react-use";
 
 import { AlloyedAssetsSection } from "~/components/alloyed-assets";
 import { LinkButton } from "~/components/buttons/link-button";
@@ -44,6 +44,7 @@ import {
 } from "~/hooks";
 import { useAssetInfo } from "~/hooks/use-asset-info";
 import { AssetInfoViewProvider } from "~/hooks/use-asset-info-view";
+import { PreviousTrade, SwapPreviousTradeKey } from "~/pages";
 import { SUPPORTED_LANGUAGES } from "~/stores/user-settings";
 import { trpcHelpers } from "~/utils/helpers";
 
@@ -75,6 +76,8 @@ const AssetInfoView: FunctionComponent<AssetInfoPageStaticProps> = observer(
     const { t } = useTranslation();
     const router = useRouter();
     const featureFlags = useFeatureFlags();
+    const [previousTrade, setPreviousTrade] =
+      useLocalStorage<PreviousTrade>(SwapPreviousTradeKey);
 
     const { title, details, coinGeckoId, asset: asset } = useAssetInfo();
 
@@ -145,7 +148,17 @@ const AssetInfoView: FunctionComponent<AssetInfoPageStaticProps> = observer(
     );
 
     const SwapTool_ = featureFlags.limitOrders ? (
-      <TradeTool page="Token Info Page" swapToolProps={swapToolProps} />
+      <TradeTool
+        page="Token Info Page"
+        swapToolProps={swapToolProps}
+        setPreviousTrade={setPreviousTrade}
+        previousTrade={{
+          baseDenom: asset.coinDenom,
+          sendTokenDenom: swapToolProps.initialSendTokenDenom ?? "",
+          outTokenDenom: swapToolProps.initialOutTokenDenom ?? "",
+          quoteDenom: previousTrade?.quoteDenom ?? "",
+        }}
+      />
     ) : (
       <SwapTool {...swapToolProps} page="Token Info Page" />
     );

--- a/packages/web/pages/index.tsx
+++ b/packages/web/pages/index.tsx
@@ -16,6 +16,8 @@ export const SwapPreviousTradeKey = "swap-previous-trade";
 export type PreviousTrade = {
   sendTokenDenom: string;
   outTokenDenom: string;
+  baseDenom: string;
+  quoteDenom: string;
 };
 
 const Home = () => {
@@ -26,6 +28,9 @@ const Home = () => {
 
 const HomeNew = () => {
   const featureFlags = useFeatureFlags();
+
+  const [previousTrade, setPreviousTrade] =
+    useLocalStorage<PreviousTrade>(SwapPreviousTradeKey);
 
   useAmplitudeAnalytics({
     onLoadEvent: [EventName.Swap.pageViewed, { isOnHome: true }],
@@ -48,7 +53,11 @@ const HomeNew = () => {
         <div className="absolute inset-0 top-[104px] flex h-auto w-full justify-center md:top-0">
           <div className="flex w-[512px] flex-col gap-4 lg:mx-auto md:mt-5 md:w-full md:px-5">
             {featureFlags.swapsAdBanner && <SwapAdsBanner />}
-            <TradeTool page="Swap Page" />
+            <TradeTool
+              page="Swap Page"
+              previousTrade={previousTrade}
+              setPreviousTrade={setPreviousTrade}
+            />
           </div>
         </div>
       </div>
@@ -102,7 +111,12 @@ const HomeV1 = () => {
             useQueryParams
             useOtherCurrencies
             onSwapSuccess={({ sendTokenDenom, outTokenDenom }) => {
-              setPreviousTrade({ sendTokenDenom, outTokenDenom });
+              setPreviousTrade({
+                sendTokenDenom,
+                outTokenDenom,
+                baseDenom: previousTrade?.baseDenom ?? "",
+                quoteDenom: previousTrade?.quoteDenom ?? "",
+              });
             }}
             initialSendTokenDenom={previousTrade?.sendTokenDenom}
             initialOutTokenDenom={previousTrade?.outTokenDenom}

--- a/packages/web/public/tradingview/custom-limit.css
+++ b/packages/web/public/tradingview/custom-limit.css
@@ -1,0 +1,64 @@
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap");
+
+:root {
+  --tv-color-platform-background: #0a0824;
+  --tv-color-pane-background: #0a0824;
+  --tv-color-toolbar-toggle-button-background-active: #201b43;
+  --tv-color-toolbar-toggle-button-background-active-hover: #201b43;
+  --tv-color-toolbar-button-text: #b0aadc;
+  --tv-color-toolbar-button-text-hover: #462adf;
+  --tv-color-toolbar-button-text-active: #462adf;
+  --tv-color-toolbar-button-text-active-hover: #462adf;
+  --tv-color-toolbar-button-background-active: #201b43;
+  --tv-color-toolbar-button-background-hover: #201b43;
+  --tv-color-toolbar-button-background-expanded: #201b43;
+  --tv-toolbar-opened-element-hover-border-radius: 6px;
+
+  --tv-color-popup-background: #201b43;
+  --tv-color-popup-element-background-active: #0a0824;
+  --tv-color-popup-element-background-hover: #0a0824;
+  --tv-color-popup-element-toolbox-background-hover: #201b43;
+  --tv-color-popup-element-toolbox-background-active-hover: #201b43;
+}
+
+// POPUP SETTINGS CONFIG
+html.theme-dark .title-BZKENkhT {
+  color: #fff;
+}
+
+html.theme-dark .dialog-aRAWUDhF {
+  background: #201b43;
+}
+
+html.theme-dark .withSidebar-F0WBLDV5 .content-F0WBLDV5,
+html.theme-dark .container-nGEmjtaX,
+html.theme-dark .footer-PhMf7PhQ {
+  border-color: #0a0824;
+}
+
+html.theme-dark .color-brand-D4RPB3ZC.variant-primary-D4RPB3ZC {
+  --ui-lib-button-default-color-border: #0a0824 !important;
+  --ui-lib-button-default-color-bg: #0a0824 !important;
+  --ui-lib-button-default-color-content: #fff !important;
+}
+
+html.theme-dark .color-brand-D4RPB3ZC.variant-secondary-D4RPB3ZC {
+  --ui-lib-button-default-color-border: #b0aadc !important;
+  --ui-lib-button-default-color-content: #b0aadc !important;
+  --ui-lib-button-default-color-bg: transparent !important;
+}
+
+html.theme-dark .container-WDZ0PRNh {
+  --ui-lib-intent-color: #b0aadc !important;
+  --ui-lib-control-default-slot-color: #b0aadc !important;
+}
+
+html.theme-dark .accessible-nGEmjtaX.active-nGEmjtaX {
+  background-color: #282750;
+}
+
+@media (any-hover: hover) {
+  html.theme-dark .accessible-nGEmjtaX:hover {
+    background-color: #282750;
+  }
+}


### PR DESCRIPTION
## What is the purpose of the change:
These changes fix some small issues and some preferred UX changes.

### Linear Task

[FE-996](https://linear.app/osmosis/issue/FE-996/buy-and-sell-tabs-show-atom-instead-of-asset-on-asset-info-pages)
[FE-1004](https://linear.app/osmosis/issue/FE-1004/fix-background-of-advanced-chart)
[FE-1005](https://linear.app/osmosis/issue/FE-1005/the-rate-should-be-flipped-for-better-user-experience-1-from-asset-=-x)
[LIM-270](https://linear.app/osmosis/issue/LIM-270/reverted-old-swap-modal-ux-ask-need-to-remember-last-traded-asset-pair)

## Brief Changelog

- Readded the `PreviousSwap` local storage object and wired it in to new trade tool
- Fixed the advanced asset price chart background (extra CSS should be removed when feature flag removed)
- Inverted ratio ordering for swap tab
- Fixed limit orders showing wrong asset on asset page
