### PR TITLE
Update Asset Symbol USDC.e.matic.axl, USDT.eth.rt

### DIFF
--- a/packages/web/components/swap-tool/price-selector.tsx
+++ b/packages/web/components/swap-tool/price-selector.tsx
@@ -35,7 +35,7 @@ const VALID_QUOTES: MainnetAssetSymbols[] = [
   "USDC.sol.wh",
   "USDC.eth.grv",
   "USDC.eth.wh",
-  "USDC.matic.axl",
+  "USDC.e.matic.axl",
   "USDC.avax.axl",
   "USDC.eth.axl",
   "USDT.eth.grv",

--- a/packages/web/config/ibc-overrides.ts
+++ b/packages/web/config/ibc-overrides.ts
@@ -361,7 +361,7 @@ const MainnetIBCAdditionalData: Partial<
     },
     fiatRamps: [{ rampKey: "layerswapcoinbase" as const, assetKey: "USDC" }],
   },
-  "USDC.matic.axl": {
+  "USDC.e.matic.axl": {
     sourceChainNameOverride: "Polygon",
     originBridgeInfo: {
       bridge: "axelar" as const,
@@ -766,7 +766,7 @@ const MainnetIBCAdditionalData: Partial<
     withdrawUrlOverride:
       "https://beta-mainnet.routernitro.com/swap?fromChain=osmosis-1&toChain=728126428&fromToken=factory%2Fosmo1myv2g72h8dan7n4hx7stt3mmust6ws03zh6gxc7vz4hpmgp5z3lq9aunm9%2FTRX.rt&toToken=0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
   },
-  "USDT.trx.rt": {
+  "USDT.eth.rt": {
     depositUrlOverride:
       "https://beta-mainnet.routernitro.com/swap?fromChain=728126428&toChain=osmosis-1&fromToken=0xA614F803B6FD780986A42C78EC9C7F77E6DED13C&toToken=factory%2Fosmo1myv2g72h8dan7n4hx7stt3mmust6ws03zh6gxc7vz4hpmgp5z3lq9aunm9%2FUSDT.rt",
     withdrawUrlOverride:


### PR DESCRIPTION
## What is the purpose of the change:

To update hardcoded Asset Symbols: USDC.e.matic.axl, USDT.eth.rt, as they were inaccurate before.

## Brief Changelog

Update web/config/ibc-overrides.ts to new symbols.
Update price selector USDC.matic.axl to USDC.e.matic.axl

## Testing and Verifying

This change has not been tested locally, because I can't run FE locally.
From what I can tell, the preview shows the updated symbol correctly: 
![image](https://github.com/user-attachments/assets/46ca181c-1909-40ef-bace-1be484b5d96f)

