### PR TITLE
(Datadog) Use Vercel project production url

### DIFF
--- a/packages/web/utils/service-name.ts
+++ b/packages/web/utils/service-name.ts
@@ -3,7 +3,7 @@ export function getOpentelemetryServiceName(): string {
   return process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL?.includes(
     "stage."
   )
-    ? "stage" // If it does, return "stage"
-    : process.env.NEXT_PUBLIC_VERCEL_ENV ?? // Otherwise, return the Vercel environment (production, preview, or development)
+    ? "osmosis-frontend-stage" // If it does, return "stage"
+    : `osmosis-frontend-${process.env.NEXT_PUBLIC_VERCEL_ENV}` ?? // Otherwise, return the Vercel environment (production, preview, or development)
         "fallback-osmosis-frontend-service-name";
 }

--- a/packages/web/utils/service-name.ts
+++ b/packages/web/utils/service-name.ts
@@ -1,6 +1,9 @@
 export function getOpentelemetryServiceName(): string {
-  return (
-    process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL ??
-    "fallback-osmosis-frontend-service-name"
-  );
+  // Check if the production URL contains "stage."
+  return process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL?.includes(
+    "stage."
+  )
+    ? "stage" // If it does, return "stage"
+    : process.env.NEXT_PUBLIC_VERCEL_ENV ?? // Otherwise, return the Vercel environment (production, preview, or development)
+        "fallback-osmosis-frontend-service-name";
 }

--- a/packages/web/utils/service-name.ts
+++ b/packages/web/utils/service-name.ts
@@ -1,6 +1,6 @@
 export function getOpentelemetryServiceName(): string {
   return (
-    process.env.NEXT_PUBLIC_VERCEL_URL ??
+    process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL ??
     "fallback-osmosis-frontend-service-name"
   );
 }


### PR DESCRIPTION
## What is the purpose of the change:

Use Vercel's project production URL like 'app.osmosis' or 'stage.osmosis' instead of Vercel's generated URL, but it would also fall back to the latter on stage deployments. This will improve debugging experience in DD 
