### PR TITLE
Use quantity check for limit order

### DIFF
--- a/packages/web/e2e/tests/monitoring.wallet.spec.ts
+++ b/packages/web/e2e/tests/monitoring.wallet.spec.ts
@@ -50,7 +50,7 @@ test.describe("Test Filled Order feature", () => {
     await tradePage.openLimit();
     await tradePage.selectAsset("OSMO");
     await tradePage.enterAmount("2.99");
-    await tradePage.setLimitPriceChange("2%");
+    await tradePage.setLimitPriceChange("Market");
     const { msgContentAmount } = await tradePage.limitSellAndGetWalletMsg(
       context
     );
@@ -76,7 +76,7 @@ test.describe("Test Filled Order feature", () => {
       context
     );
     expect(msgContentAmount).toBeTruthy();
-    expect(msgContentAmount).toContain("1.05 USDC (Noble/channel-750)");
+    expect(msgContentAmount).toContain('"quantity": "1050000"');
     expect(msgContentAmount).toContain("place_limit");
     expect(msgContentAmount).toContain('"order_direction": "bid"');
     await tradePage.isTransactionSuccesful();


### PR DESCRIPTION
Looks like Keplr waller sometimes fails to show human readable format for USDC, so switching to check the quantity of an order.