### PR TITLE
Add Transmuter Contract Codes

### DIFF
--- a/packages/server/src/queries/complex/pools/env.ts
+++ b/packages/server/src/queries/complex/pools/env.ts
@@ -1,7 +1,7 @@
 import { IS_TESTNET } from "../../../env";
 
 /** Cosmwasm Code Ids confirmed to be transmuter pools in current env. */
-const TransmuterPoolCodeIds = IS_TESTNET ? ["3084"] : ["148"];
+const TransmuterPoolCodeIds = IS_TESTNET ? ["3084"] : ["148", "814", "867", "996"];
 const AstroportPclPoolCodeIds = IS_TESTNET ? ["8611"] : ["842"];
 const WhitewhalePoolCodeIds = IS_TESTNET ? ["?"] : ["503", "641"];
 

--- a/packages/web/config/feature-flag.ts
+++ b/packages/web/config/feature-flag.ts
@@ -4,6 +4,7 @@ import { IS_TESTNET } from "./env";
 export const BlacklistedPoolIds: string[] = ["895"];
 
 /** Cosmwasm Code Ids confirmed to be transmuter pools in current env. */
+// @deprecated use packages/server/src/queries/complex/pools/env.ts
 export const TransmuterPoolCodeIds = IS_TESTNET ? ["3084"] : ["148"];
 
 export const RecommendedSwapDenoms = [

--- a/packages/web/config/feature-flag.ts
+++ b/packages/web/config/feature-flag.ts
@@ -3,8 +3,10 @@ import { IS_TESTNET } from "./env";
 /** Blacklists pools out at the query level. Marks them as non existant. */
 export const BlacklistedPoolIds: string[] = ["895"];
 
-/** Cosmwasm Code Ids confirmed to be transmuter pools in current env. */
-// @deprecated use packages/server/src/queries/complex/pools/env.ts
+/** 
+* Cosmwasm Code Ids confirmed to be transmuter pools in current env. 
+* @deprecated use packages/server/src/queries/complex/pools/env.ts 
+*/
 export const TransmuterPoolCodeIds = IS_TESTNET ? ["3084"] : ["148"];
 
 export const RecommendedSwapDenoms = [

--- a/packages/web/config/feature-flag.ts
+++ b/packages/web/config/feature-flag.ts
@@ -4,7 +4,7 @@ import { IS_TESTNET } from "./env";
 export const BlacklistedPoolIds: string[] = ["895"];
 
 /** Cosmwasm Code Ids confirmed to be transmuter pools in current env. */
-export const TransmuterPoolCodeIds = IS_TESTNET ? ["3084"] : ["148","814","867","996"];
+export const TransmuterPoolCodeIds = IS_TESTNET ? ["3084"] : ["148"];
 
 export const RecommendedSwapDenoms = [
   "OSMO",

--- a/packages/web/config/feature-flag.ts
+++ b/packages/web/config/feature-flag.ts
@@ -4,7 +4,7 @@ import { IS_TESTNET } from "./env";
 export const BlacklistedPoolIds: string[] = ["895"];
 
 /** Cosmwasm Code Ids confirmed to be transmuter pools in current env. */
-export const TransmuterPoolCodeIds = IS_TESTNET ? ["3084"] : ["148"];
+export const TransmuterPoolCodeIds = IS_TESTNET ? ["3084"] : ["148","814","867","996"];
 
 export const RecommendedSwapDenoms = [
   "OSMO",


### PR DESCRIPTION
Adding the 3 other contract uploads for Transmuter pools so that these can be filtered out in the pools list if wanted.

Transmuter 1.0 already listed
Transmuter 2.0 was never instantiated
This adds 3.0, 3.1 and 3.2 which are the alloyed asset pools - but also are transmuters and often dominate the volume charts.