### PR TITLE
perf: move epochs query to local router from edge

### DIFF
--- a/packages/server/src/queries/complex/osmosis/epochs.ts
+++ b/packages/server/src/queries/complex/osmosis/epochs.ts
@@ -24,6 +24,7 @@ export function getEpochs({
     cache: epochsCache,
     key: "epochs",
     ttl: 1000 * 60 * 3, // 3 minutes
+    staleWhileRevalidate: 500, // Return stale data for 500ms while revalidating
     getFreshValue: () =>
       queryEpochs({ chainList }).then(({ epochs }) =>
         epochs.map((e) => {

--- a/packages/server/src/queries/complex/osmosis/epochs.ts
+++ b/packages/server/src/queries/complex/osmosis/epochs.ts
@@ -23,7 +23,7 @@ export function getEpochs({
   return cachified({
     cache: epochsCache,
     key: "epochs",
-    ttl: 1000 * 60, // 60 seconds
+    ttl: 1000 * 60 * 3, // 3 minutes
     getFreshValue: () =>
       queryEpochs({ chainList }).then(({ epochs }) =>
         epochs.map((e) => {

--- a/packages/web/components/overview/pools.tsx
+++ b/packages/web/components/overview/pools.tsx
@@ -24,7 +24,7 @@ export const PoolsOverview: FunctionComponent<
       coinMinimalDenom: "uosmo",
     }
   );
-  const { data: epochs } = api.edge.params.getEpochs.useQuery();
+  const { data: epochs } = api.local.params.getEpochs.useQuery();
 
   // update time every second
   const [timeRemaining, setTimeRemaining] = useState<string | null>(null);

--- a/packages/web/server/api/edge-router.ts
+++ b/packages/web/server/api/edge-router.ts
@@ -4,7 +4,6 @@ import {
   createTRPCRouter,
   earnRouter,
   orderbookRouter,
-  paramsRouter,
   poolsRouter,
   stakingRouter,
   transactionsRouter,
@@ -19,5 +18,4 @@ export const edgeRouter = createTRPCRouter({
   transactions: transactionsRouter,
   orderbooks: orderbookRouter,
   chains: chainsRouter,
-  params: paramsRouter,
 });

--- a/packages/web/server/api/local-router.ts
+++ b/packages/web/server/api/local-router.ts
@@ -4,6 +4,7 @@ import {
   concentratedLiquidityRouter,
   createTRPCRouter,
   oneClickTradingRouter,
+  paramsRouter,
   portfolioRouter,
   swapRouter,
 } from "@osmosis-labs/trpc";
@@ -21,4 +22,5 @@ export const localRouter = createTRPCRouter({
   cms: cmsRouter,
   bridgeTransfer: localBridgeTransferRouter,
   portfolio: portfolioRouter,
+  params: paramsRouter,
 });


### PR DESCRIPTION
## What is the purpose of the change:

The epochs query frequently appears as the bottleneck in profiles of the pools page refresh
![image](https://github.com/user-attachments/assets/1ff33ee6-52d8-4dc3-a999-d44976acb8b7)

This latency is unpredictable and is likely due to Vercel edge.

To mitigate this, we move the query to the local tRPC router and also 3x the cache ttl.

Given the move to local router, we can also add a `staleWhileRevalidate` cache flag which only works outside of the edge cache. With this flag and value of 500ms, an old epoch value would be returned while a new value is fetched. 

The new latency is on average si sub-300ms
![image](https://github.com/user-attachments/assets/0f9cc57d-36aa-4294-9ab9-e53288646ef1)


Before, there would be frequent spikes > 700ms