### PR TITLE
move legacy pools query to local from edge

### DIFF
--- a/packages/web/pages/api/pools/[id].ts
+++ b/packages/web/pages/api/pools/[id].ts
@@ -50,5 +50,5 @@ export default async function pools(req: Request) {
 }
 
 export const config = {
-  runtime: "edge",
+  runtime: "local",
 };


### PR DESCRIPTION
## What is the purpose of the change:

Moves legacy pools query from edge to local
