### PR TITLE
Update background colors - transactions modal

### DIFF
--- a/packages/web/components/transactions/transaction-details/transaction-details-modal.tsx
+++ b/packages/web/components/transactions/transaction-details/transaction-details-modal.tsx
@@ -12,7 +12,7 @@ export const TransactionDetailsModal: FunctionComponent<
     <ModalBase
       isOpen={isOpen}
       onRequestClose={onRequestClose}
-      className="max-w-[32.25rem] sm:h-full sm:max-h-[100vh] sm:!rounded-none sm:py-0 sm:pt-2" // 516px
+      className="max-w-[32.25rem] !bg-osmoverse-1000 xl:!bg-osmoverse-850 sm:h-full sm:max-h-[100vh] sm:!rounded-none sm:py-0 sm:pt-2" // 516px
     >
       <TransactionDetailsContent
         onRequestClose={onRequestClose}


### PR DESCRIPTION
## What is the purpose of the change:

- we turned on limit orders, need to update transactions modal colors

### Linear Task

https://linear.app/osmosis/issue/FE-1019/qa-fix-modal-background-color

## Brief Changelog

- update colors for modal

## Testing and Verifying

<img width="922" alt="Screenshot 2024-08-19 at 6 20 34 PM" src="https://github.com/user-attachments/assets/130ffbf8-b070-4ce0-9a2e-e77abb5c4e8d">

