### PR TITLE
Use timeout_height from signed amino doc

### DIFF
--- a/packages/stores/src/account/base.ts
+++ b/packages/stores/src/account/base.ts
@@ -1111,7 +1111,7 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
         return res;
       }),
       memo: signed.memo,
-      timeoutHeight: BigInt(signDoc.timeout_height ?? "0"),
+      timeoutHeight: BigInt(signed.timeout_height ?? "0"),
     });
 
     const signedGasLimit = Int53.fromString(String(signed.fee.gas)).toNumber();


### PR DESCRIPTION
## What is the purpose of the change:

In institutional cases, the signature process may take a while.

This is why we override:

```
  sequence: signedSequence
```

Since maybe the sequence number has changes since the dApp sent its requested sign doc to the wallet - the wallet may update the sequence number to a new value, and the dApp should use the returned value - which was signed on.

The same reasoning should follow for `timeout_height` which is a newer addition to the protocol than sequence number.


<!-- > Add a description of the overall background and high level changes that this PR introduces -->

### Linear Task

N/A

## Brief Changelog

Use timeout_height from signed amino doc

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

This change has been tested locally using our own extension wallet that modifies timeout height
