### PR TITLE
(Datadog) Add dev service and disable otel in previews 

### DIFF
--- a/packages/web/instrumentation.ts
+++ b/packages/web/instrumentation.ts
@@ -3,12 +3,25 @@ import { registerOTel } from "@vercel/otel";
 import { getOpentelemetryServiceName } from "~/utils/service-name";
 
 export function register() {
+  const serviceName = getOpentelemetryServiceName();
+
+  // Skip registering the service if it's a preview deployment
+  if (serviceName.includes("preview")) {
+    console.info("Skipping OTel registration for preview deployment");
+    return;
+  }
+
   registerOTel({
-    serviceName: getOpentelemetryServiceName(),
+    serviceName,
     instrumentationConfig: {
       fetch: {
         propagateContextUrls: ["*"],
       },
+    },
+    attributes: {
+      env: serviceName.includes("stage")
+        ? "stage"
+        : process.env.NEXT_PUBLIC_VERCEL_ENV,
     },
   });
 }

--- a/packages/web/utils/service-name.ts
+++ b/packages/web/utils/service-name.ts
@@ -1,4 +1,7 @@
-export function getOpentelemetryServiceName(): string {
+export function getOpentelemetryServiceName() {
+  const isDev =
+    process.env.NEXT_PUBLIC_VERCEL_PROJECT_PRODUCTION_URL?.includes("dev");
+
   const branchUrl = process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL;
   const urlParts = branchUrl?.split("-");
 
@@ -9,8 +12,11 @@ export function getOpentelemetryServiceName(): string {
     gitIndex !== -1 &&
     urlParts?.[gitIndex + 1] === "stage";
 
+  if (isDev) {
+    return "osmosis-frontend-dev";
+  }
+
   return isStage
     ? "osmosis-frontend-stage" // If it does, return "stage"
-    : `osmosis-frontend-${process.env.NEXT_PUBLIC_VERCEL_ENV}` ?? // Otherwise, return the Vercel environment (production, preview, or development)
-        "fallback-osmosis-frontend-service-name";
+    : `osmosis-frontend-${process.env.NEXT_PUBLIC_VERCEL_ENV}`; // Otherwise, return the Vercel environment (production, preview, or development);
 }


### PR DESCRIPTION
## What is the purpose of the change:

- Add osmosis-frontend-dev service name
- Remove osmosis-frontend-preview service name
- Add env:stage attribute

### Linear Task

https://linear.app/osmosis/issue/FE-1036/datadog-improvements
