### PR TITLE
(Token Details) Hide APR column if there's no available space

### DIFF
--- a/packages/web/components/complex/pools-table.tsx
+++ b/packages/web/components/complex/pools-table.tsx
@@ -341,12 +341,16 @@ export const PoolsTable = (props: PropsWithChildren<PoolsTableProps>) => {
     const collapsedColIds: string[] = [];
     if (width < Breakpoint.xxl && shouldDisplayFeesData)
       collapsedColIds.push("market.feesSpent7dUsd");
+    if (width < Breakpoint.xlhalf && width > Breakpoint.xl)
+      collapsedColIds.push("aprBreakdown.total");
     if (width < Breakpoint.xlg) collapsedColIds.push("totalFiatValueLocked");
     if (width < Breakpoint.lg && shouldDisplayVolumeData)
       collapsedColIds.push("market.volume24hUsd");
     if (width < Breakpoint.md) collapsedColIds.push("poolQuickActions");
     return columns.filter(({ id }) => id && !collapsedColIds.includes(id));
   }, [columns, width, shouldDisplayVolumeData, shouldDisplayFeesData]);
+
+  console.log(collapsedColumns);
 
   const table = useReactTable({
     data: poolsData,

--- a/packages/web/components/complex/pools-table.tsx
+++ b/packages/web/components/complex/pools-table.tsx
@@ -350,8 +350,6 @@ export const PoolsTable = (props: PropsWithChildren<PoolsTableProps>) => {
     return columns.filter(({ id }) => id && !collapsedColIds.includes(id));
   }, [columns, width, shouldDisplayVolumeData, shouldDisplayFeesData]);
 
-  console.log(collapsedColumns);
-
   const table = useReactTable({
     data: poolsData,
     columns: collapsedColumns,


### PR DESCRIPTION
## What is the purpose of the change:

Before

![image](https://github.com/user-attachments/assets/51da403d-f4c1-4c3e-93f8-e77171c7231c)

After

![image](https://github.com/user-attachments/assets/6472a7a2-cf19-479f-9eb6-ca78d037f48d)

### Linear Task

https://linear.app/osmosis/issue/FE-967/ui-elements-overlap-when-browser-window-is-slightly-wider-than-half-of
