### PR TITLE
Update Portfolio value change calculation

### DIFF
--- a/packages/web/components/complex/portfolio/assets-overview.tsx
+++ b/packages/web/components/complex/portfolio/assets-overview.tsx
@@ -128,6 +128,15 @@ export const AssetsOverview: FunctionComponent<
     },
     {
       enabled: Boolean(wallet?.isWalletConnected && wallet?.address),
+      onSuccess: (data) => {
+        if (data && data.length > 0) {
+          const lastDataPoint = data[data.length - 1];
+          setDataPoint({
+            time: timeToLocal(lastDataPoint.time) as Time,
+            value: lastDataPoint.value,
+          });
+        }
+      },
     }
   );
 


### PR DESCRIPTION
## What is the purpose of the change:

- fixes percent change on default

### Linear Task

https://linear.app/osmosis/issue/FE-1038/portfolio-value-change-calculation-is-wrongconfusing

## Brief Changelog

- update dataPoint with the last value in portfolio over time data on response

## Testing and Verifying


<img width="854" alt="Screenshot 2024-08-21 at 7 55 00 AM" src="https://github.com/user-attachments/assets/30c8845a-f3af-4ef3-8908-d9c5823210b0">
<img width="816" alt="Screenshot 2024-08-21 at 7 54 45 AM" src="https://github.com/user-attachments/assets/f6b41ef5-a81d-4c66-b2b8-8605970756ae">
