### PR TITLE
Swap more OSMO to ATOM

### DIFF
--- a/packages/web/e2e/tests/swap.wallet.spec.ts
+++ b/packages/web/e2e/tests/swap.wallet.spec.ts
@@ -58,7 +58,7 @@ test.describe("Test Swap feature", () => {
   test("User should be able to swap OSMO to ATOM", async () => {
     await swapPage.goto();
     await swapPage.selectPair("OSMO", "ATOM");
-    await swapPage.enterAmount("0.01");
+    await swapPage.enterAmount("2.2");
     const { msgContentAmount } = await swapPage.swapAndGetWalletMsg(context);
     expect(msgContentAmount).toBeTruthy();
     expect(msgContentAmount).toContain("token_out_denom: " + ATOM);
@@ -71,7 +71,7 @@ test.describe("Test Swap feature", () => {
   test("User should be able to swap ATOM to OSMO", async () => {
     await swapPage.goto();
     await swapPage.selectPair("ATOM", "OSMO");
-    await swapPage.enterAmount("0.001");
+    await swapPage.enterAmount("0.01");
     await swapPage.showSwapInfo();
     const { msgContentAmount } = await swapPage.swapAndGetWalletMsg(context);
     expect(msgContentAmount).toBeTruthy();


### PR DESCRIPTION
## What is the purpose of the change:

Limit orders sell 1$ of ATOM and buy 1$ of OSMO. So, we need to move some OSMO back to ATOM.

- Swap more OSMO to ATOM