### PR TITLE
feat: add account address to txn scan endpoint

### DIFF
--- a/packages/server/src/queries/blockaid/transaction.ts
+++ b/packages/server/src/queries/blockaid/transaction.ts
@@ -13,6 +13,7 @@ export interface TransactionScanRequest {
    * Tx hex bytes
    */
   transaction: string;
+  account_address: string;
   metadata: { [key: string]: string };
 }
 

--- a/packages/web/pages/api/transaction-scan.ts
+++ b/packages/web/pages/api/transaction-scan.ts
@@ -37,6 +37,7 @@ export default async function transactionScanHandler(
       chain: "osmosis",
       transaction: unsignedTx,
       options: ["validation", "simulation"],
+      account_address: bech32Address,
       metadata: {
         type: "in_app",
       },


### PR DESCRIPTION
## What is the purpose of the change:

Adding `account_address` to the txn scan endpoint, to match the API by request from blockaid

See:
https://docs.blockaid.io/reference/cosmos_scan_transaction_v0_transaction_scan__post
