### PR TITLE
[In Given Out]: Default input adjustments

### DIFF
--- a/packages/web/components/place-limit-tool/index.tsx
+++ b/packages/web/components/place-limit-tool/index.tsx
@@ -125,13 +125,15 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
 
     const setBase = useCallback((base: string) => set({ from: base }), [set]);
 
-    if (from === quote) {
-      if (quote === "USDC") {
-        set({ quote: "USDT" });
-      } else {
-        set({ quote: "USDC" });
+    useEffect(() => {
+      if (from === quote) {
+        if (quote === "USDC") {
+          set({ quote: "USDT" });
+        } else {
+          set({ quote: "USDC" });
+        }
       }
-    }
+    }, [from, quote, set]);
 
     const orderDirection = useMemo(
       () => (tab === "buy" ? "bid" : "ask"),

--- a/packages/web/components/place-limit-tool/index.tsx
+++ b/packages/web/components/place-limit-tool/index.tsx
@@ -217,14 +217,12 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
     const isMarketLoading = useMemo(() => {
       return (
         swapState.isMarket &&
-        (swapState.marketState.isQuoteLoading ||
-          swapState.marketState.isLoadingNetworkFee) &&
+        swapState.marketState.isQuoteLoading &&
         !Boolean(swapState.marketState.error)
       );
     }, [
       swapState.isMarket,
       swapState.marketState.isQuoteLoading,
-      swapState.marketState.isLoadingNetworkFee,
       swapState.marketState.error,
     ]);
 
@@ -631,7 +629,7 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
               </AssetFieldsetHeaderLabel>
               <AssetFieldsetHeaderBalance
                 availableBalance={
-                  focused === "fiat"
+                  focused === "fiat" || tab === "buy"
                     ? formatFiatPrice(
                         fiatBalance ?? new PricePretty(DEFAULT_VS_CURRENCY, "0")
                       )

--- a/packages/web/components/place-limit-tool/index.tsx
+++ b/packages/web/components/place-limit-tool/index.tsx
@@ -309,6 +309,7 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
         tab,
         type,
         resetSlippage,
+        featureFlags.inGivenOut,
       ]
     );
 
@@ -455,6 +456,7 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
           Boolean(swapState.marketState.networkFeeError)
         );
       }
+
       return Boolean(swapState.error) || !swapState.isBalancesFetched;
     }, [
       swapState.error,
@@ -569,6 +571,7 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
       fiatAmount,
       focused,
     ]);
+
     return (
       <>
         <div>

--- a/packages/web/hooks/limit-orders/use-place-limit.ts
+++ b/packages/web/hooks/limit-orders/use-place-limit.ts
@@ -13,6 +13,7 @@ import {
 } from "~/hooks/input/use-amount-input";
 import { useOrderbook } from "~/hooks/limit-orders/use-orderbook";
 import { mulPrice } from "~/hooks/queries/assets/use-coin-fiat-value";
+import { usePrice } from "~/hooks/queries/assets/use-price";
 import { useAmplitudeAnalytics } from "~/hooks/use-amplitude-analytics";
 import { useEstimateTxFees } from "~/hooks/use-estimate-tx-fees";
 import { QuoteType, useSwap, useSwapAssets } from "~/hooks/use-swap";
@@ -115,6 +116,10 @@ export const usePlaceLimit = ({
     () => new PricePretty(DEFAULT_VS_CURRENCY, new Dec(1)),
     []
   );
+
+  const { price: baseAssetPrice } = usePrice({
+    coinMinimalDenom: baseAsset?.coinMinimalDenom ?? "",
+  });
 
   /**
    * Calculates the amount of tokens to be sent with the order.
@@ -608,6 +613,7 @@ export const usePlaceLimit = ({
     marketState,
     isMarket,
     quoteAssetPrice,
+    baseAssetPrice,
     reset,
     error,
     feeUsdValue,

--- a/packages/web/hooks/limit-orders/use-place-limit.ts
+++ b/packages/web/hooks/limit-orders/use-place-limit.ts
@@ -144,8 +144,7 @@ export const usePlaceLimit = ({
     }
 
     // Determine the outgoing fiat amount the user wants to buy
-    const outgoingFiatValue =
-      marketState.inAmountInput.amount?.toDec() ?? new Dec(0);
+    const outgoingFiatValue = inAmountInput.amount?.toDec() ?? new Dec(0);
 
     // Determine the amount of quote asset tokens to send by dividing the outgoing fiat amount by the current quote asset price
     // Multiply by 10^n where n is the amount of decimals for the quote asset


### PR DESCRIPTION
## What is the purpose of the change:
These changes fix a bug with placing limit orders if the market input is empty. The default input for the sell tab is now fiat and the available balance display changes with the input selected.
