### PR TITLE
Mattupham/fe 784 portfolio v2 open orders / limit orders

### DIFF
--- a/packages/web/components/complex/portfolio/open-orders.tsx
+++ b/packages/web/components/complex/portfolio/open-orders.tsx
@@ -34,7 +34,7 @@ export const OpenOrders: FunctionComponent = () => {
   return (
     <div className="flex w-full flex-col py-3">
       <div className="flex cursor-pointer items-center justify-between gap-3">
-        <h6 className="py-3">Open Orders</h6>
+        <h6 className="py-3">{t("portfolio.openOrders")}</h6>
         <LinkButton
           href="/transactions?tab=orders"
           className="-mx-2 text-osmoverse-400"
@@ -98,8 +98,8 @@ export const OpenOrders: FunctionComponent = () => {
 
             const buySellText =
               order_direction === "bid"
-                ? t("limitOrders.buy")
-                : t("limitOrders.sell");
+                ? t("portfolio.buy")
+                : t("portfolio.sell");
 
             return (
               <div key={index} className="-mx-2 flex justify-between gap-4 p-2">

--- a/packages/web/components/complex/portfolio/open-orders.tsx
+++ b/packages/web/components/complex/portfolio/open-orders.tsx
@@ -1,0 +1,83 @@
+import { Dec } from "@keplr-wallet/unit";
+import { MappedLimitOrder } from "@osmosis-labs/server";
+import classNames from "classnames";
+import { FunctionComponent, useEffect, useState } from "react";
+
+import { FallbackImg, Icon } from "~/components/assets";
+import { Breakpoint, useWindowSize } from "~/hooks";
+
+export const OpenOrders: FunctionComponent<{
+  orders?: MappedLimitOrder[];
+}> = ({ orders }) => {
+  const openOrders = orders?.filter((order) => order.status === "open");
+
+  console.log("openOrders", openOrders);
+
+  const { width } = useWindowSize();
+
+  const [isOpen, setIsOpen] = useState(true);
+
+  useEffect(() => {
+    if (width > Breakpoint.xl) {
+      setIsOpen(true);
+    }
+  }, [width]);
+
+  if (!openOrders) return null;
+
+  return (
+    <div className="flex w-full flex-col py-3">
+      <div
+        className="flex cursor-pointer items-center justify-between py-3"
+        onClick={() => setIsOpen((prev) => !prev)}
+      >
+        <h6>Open Orders</h6>
+        {width > Breakpoint.xl && (
+          <Icon
+            id="chevron-down"
+            className={classNames("transition-transform", {
+              "rotate-180": isOpen,
+            })}
+          />
+        )}
+      </div>
+      {isOpen && (
+        <>
+          <div className="flex flex-col space-y-3">
+            {openOrders.map(
+              ({ baseAsset, quoteAsset, quantity, price }, index) => {
+                const assetAmount = new Dec(quantity).toString();
+                const assetDenom = baseAsset?.symbol;
+                const fiatValue = new Dec(quantity).mul(price).toString();
+                return (
+                  <div
+                    key={baseAsset?.symbol}
+                    className="body2 flex w-full justify-between"
+                  >
+                    <div className="flex items-center space-x-1">
+                      <FallbackImg
+                        src={baseAsset?.rawAsset.logoURIs.svg}
+                        alt={baseAsset?.symbol}
+                        fallbacksrc="/icons/question-mark.svg"
+                        width={20}
+                        height={20}
+                        className="inline-block"
+                      />
+                      <span>{baseAsset?.currency?.coinDenom}</span>
+                      <span className="text-osmoverse-400">
+                        {`${assetAmount} ${assetDenom}`}
+                      </span>
+                    </div>
+                    <div>
+                      {/* {displayFiatPrice(fiatValue, quoteAsset.symbol, t)} */}
+                    </div>
+                  </div>
+                );
+              }
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+};

--- a/packages/web/components/complex/portfolio/open-orders.tsx
+++ b/packages/web/components/complex/portfolio/open-orders.tsx
@@ -1,156 +1,145 @@
 import { CoinPretty, Dec, Int, PricePretty } from "@keplr-wallet/unit";
 import { DEFAULT_VS_CURRENCY, MappedLimitOrder } from "@osmosis-labs/server";
-import classNames from "classnames";
-import React, { FunctionComponent, useEffect, useState } from "react";
+import React, { FunctionComponent } from "react";
 
-import { FallbackImg, Icon } from "~/components/assets";
-import { Breakpoint, useTranslation, useWindowSize } from "~/hooks";
+import { FallbackImg } from "~/components/assets";
+import { LinkButton } from "~/components/buttons/link-button";
+import { Skeleton } from "~/components/ui/skeleton";
+import { useTranslation } from "~/hooks";
 import { formatFiatPrice } from "~/utils/formatter";
 import { formatPretty } from "~/utils/formatter";
+
+const OPEN_ORDERS_LIMIT = 2;
+
+const OpenOrdersSkeleton = () => {
+  return (
+    <>
+      {Array.from({ length: OPEN_ORDERS_LIMIT }).map((_, index) => (
+        <div key={index} className="-mx-2 flex justify-between gap-4 p-2">
+          <Skeleton className="h-9 w-1/3 " />
+          <Skeleton className="h-9 w-1/5" />
+        </div>
+      ))}
+    </>
+  );
+};
 
 export const OpenOrders: FunctionComponent<{
   orders?: MappedLimitOrder[];
 }> = ({ orders }) => {
-  const openOrders = orders?.filter((order) => order.status === "open");
-
-  console.log("openOrders", openOrders);
-
-  const { width } = useWindowSize();
-
-  const [isOpen, setIsOpen] = useState(true);
+  const openOrders = orders
+    ?.filter((order) => order.status === "open")
+    .slice(0, OPEN_ORDERS_LIMIT);
 
   const { t } = useTranslation();
 
-  useEffect(() => {
-    if (width > Breakpoint.xl) {
-      setIsOpen(true);
-    }
-  }, [width]);
-
-  if (!openOrders) return null;
-
   return (
     <div className="flex w-full flex-col py-3">
-      <div
-        className="flex cursor-pointer items-center justify-between py-3"
-        onClick={() => setIsOpen((prev) => !prev)}
-      >
+      <div className="flex cursor-pointer items-center justify-between gap-3 py-3">
         <h6>Open Orders</h6>
-        {width > Breakpoint.xl && (
-          <Icon
-            id="chevron-down"
-            className={classNames("transition-transform", {
-              "rotate-180": isOpen,
-            })}
-          />
+        <LinkButton
+          href="/transactions"
+          className="-mx-2 text-osmoverse-400"
+          label={t("portfolio.seeAll")}
+          ariaLabel={t("portfolio.seeAll")}
+          size="md"
+        />
+      </div>
+      <div className="flex flex-col">
+        {openOrders?.map(
+          (
+            {
+              baseAsset,
+              quoteAsset,
+              quantity,
+              price,
+              order_direction,
+              output,
+              placed_quantity,
+            },
+            index
+          ) => {
+            const baseAssetLogo =
+              baseAsset?.rawAsset.logoURIs.svg ??
+              baseAsset?.rawAsset.logoURIs.png ??
+              "";
+
+            // example: 0.01 OSMO
+            const formattedBuySellToken = formatPretty(
+              new CoinPretty(
+                {
+                  coinDecimals: baseAsset?.decimals ?? 0,
+                  coinDenom: baseAsset?.symbol ?? "",
+                  coinMinimalDenom: baseAsset?.coinMinimalDenom ?? "",
+                },
+                order_direction === "ask" ? placed_quantity : output
+              )
+            );
+
+            // example: $0.01
+            const formattedFiatPrice = formatFiatPrice(
+              new PricePretty(
+                DEFAULT_VS_CURRENCY,
+                order_direction === "bid"
+                  ? placed_quantity /
+                    Number(
+                      new Dec(10)
+                        .pow(new Int(quoteAsset?.decimals ?? 0))
+                        .toString()
+                    )
+                  : output.quo(
+                      new Dec(10).pow(new Int(quoteAsset?.decimals ?? 0))
+                    )
+              ),
+              2
+            );
+
+            // example: 0.01 USDC
+            const formattedQuotAsset = formatPretty(
+              new CoinPretty(
+                {
+                  coinDecimals: quoteAsset?.decimals ?? 0,
+                  coinDenom: quoteAsset?.symbol ?? "",
+                  coinMinimalDenom: quoteAsset?.coinMinimalDenom ?? "",
+                },
+                order_direction === "ask" ? output : placed_quantity
+              )
+            );
+
+            const buySellText =
+              order_direction === "bid"
+                ? t("limitOrders.buy")
+                : t("limitOrders.sell");
+
+            return (
+              <div key={index} className="body2 -mx-2 flex w-full gap-3 p-2">
+                <FallbackImg
+                  src={baseAssetLogo}
+                  alt={`${baseAsset?.symbol} icon`}
+                  fallbacksrc="/icons/question-mark.svg"
+                  width={32}
+                  height={32}
+                  className="inline-block"
+                />
+                <div className="flex h-full flex-col justify-between overflow-hidden whitespace-nowrap">
+                  <span className="overflow-hidden overflow-ellipsis">
+                    {buySellText} {baseAsset?.currency?.coinDenom}{" "}
+                  </span>
+                  <span className="caption overflow-hidden overflow-ellipsis text-osmoverse-300">
+                    {formattedBuySellToken}
+                  </span>
+                </div>
+                <div className="ooverflow-ellipsis ml-auto flex h-full flex-col justify-between whitespace-nowrap text-right">
+                  {formattedFiatPrice}
+                  <span className="caption text-osmoverse-300">
+                    {formattedQuotAsset}
+                  </span>
+                </div>
+              </div>
+            );
+          }
         )}
       </div>
-      {isOpen && (
-        <>
-          <div className="flex flex-col space-y-3">
-            {openOrders.map(
-              (
-                {
-                  baseAsset,
-                  quoteAsset,
-                  quantity,
-                  price,
-                  order_direction,
-                  output,
-                  placed_quantity,
-                },
-                index
-              ) => {
-                const assetAmount = new Dec(quantity).toString();
-                const assetDenom = baseAsset?.symbol;
-                const fiatValue = new Dec(quantity).mul(price).toString();
-
-                const baseAssetLogo =
-                  baseAsset?.rawAsset.logoURIs.svg ??
-                  baseAsset?.rawAsset.logoURIs.png ??
-                  "";
-
-                return (
-                  <div
-                    key={baseAsset?.symbol}
-                    className="body2 flex w-full justify-between space-x-3"
-                  >
-                    <div className="flex items-center space-x-1">
-                      <FallbackImg
-                        src={baseAssetLogo}
-                        alt={`${baseAsset?.symbol} icon`}
-                        fallbacksrc="/icons/question-mark.svg"
-                        width={32}
-                        height={32}
-                        className="inline-block"
-                      />
-                      <div className="flex flex-col">
-                        <span>
-                          {order_direction === "bid"
-                            ? t("limitOrders.buy")
-                            : t("limitOrders.sell")}{" "}
-                          {baseAsset?.currency?.coinDenom}
-                        </span>
-                        <span className="text-osmoverse-400">
-                          {formatPretty(
-                            new CoinPretty(
-                              {
-                                coinDecimals: baseAsset?.decimals ?? 0,
-                                coinDenom: baseAsset?.symbol ?? "",
-                                coinMinimalDenom:
-                                  baseAsset?.coinMinimalDenom ?? "",
-                              },
-                              order_direction === "ask"
-                                ? placed_quantity
-                                : output
-                            )
-                          )}
-                        </span>
-                      </div>
-                    </div>
-                    <div className="flex flex-col">
-                      <span>
-                        {formatFiatPrice(
-                          new PricePretty(
-                            DEFAULT_VS_CURRENCY,
-                            order_direction === "bid"
-                              ? placed_quantity /
-                                Number(
-                                  new Dec(10)
-                                    .pow(new Int(quoteAsset?.decimals ?? 0))
-                                    .toString()
-                                )
-                              : output.quo(
-                                  new Dec(10).pow(
-                                    new Int(quoteAsset?.decimals ?? 0)
-                                  )
-                                )
-                          ),
-                          2
-                        )}
-                      </span>
-
-                      <span>
-                        {formatPretty(
-                          new CoinPretty(
-                            {
-                              coinDecimals: quoteAsset?.decimals ?? 0,
-                              coinDenom: quoteAsset?.symbol ?? "",
-                              coinMinimalDenom:
-                                quoteAsset?.coinMinimalDenom ?? "",
-                            },
-                            order_direction === "ask" ? output : placed_quantity
-                          )
-                        )}
-                      </span>
-                    </div>
-                  </div>
-                );
-              }
-            )}
-          </div>
-        </>
-      )}
     </div>
   );
 };

--- a/packages/web/components/complex/portfolio/open-orders.tsx
+++ b/packages/web/components/complex/portfolio/open-orders.tsx
@@ -13,6 +13,8 @@ import { formatPretty } from "~/utils/formatter";
 const OPEN_ORDERS_LIMIT = 5;
 
 export const OpenOrders: FunctionComponent = () => {
+  const { t } = useTranslation();
+
   const { accountStore } = useStore();
   const wallet = accountStore.getWallet(accountStore.osmosisChainId);
 
@@ -21,20 +23,18 @@ export const OpenOrders: FunctionComponent = () => {
     pageSize: 100,
   });
 
-  const hasOrders = orders?.length > 0;
-
   const openOrders = orders
     ?.filter((order) => order.status === "open")
     .slice(0, OPEN_ORDERS_LIMIT);
 
-  const { t } = useTranslation();
+  const hasOpenOrders = openOrders?.length > 0;
 
-  if (isLoading || !hasOrders) return null;
+  if (isLoading || !hasOpenOrders) return null;
 
   return (
     <div className="flex w-full flex-col py-3">
-      <div className="flex cursor-pointer items-center justify-between gap-3 py-3">
-        <h6>Open Orders</h6>
+      <div className="flex cursor-pointer items-center justify-between gap-3">
+        <h6 className="py-3">Open Orders</h6>
         <LinkButton
           href="/transactions?tab=orders"
           className="-mx-2 text-osmoverse-400"

--- a/packages/web/components/complex/portfolio/open-orders.tsx
+++ b/packages/web/components/complex/portfolio/open-orders.tsx
@@ -85,7 +85,7 @@ export const OpenOrders: FunctionComponent = () => {
             );
 
             // example: 0.01 USDC
-            const formattedQuotAsset = formatPretty(
+            const formattedQuoteAsset = formatPretty(
               new CoinPretty(
                 {
                   coinDecimals: quoteAsset?.decimals ?? 0,
@@ -122,7 +122,7 @@ export const OpenOrders: FunctionComponent = () => {
                 <div className="body2 ml-auto flex h-full flex-col justify-between overflow-ellipsis whitespace-nowrap text-right">
                   {formattedFiatPrice}
                   <span className="caption text-osmoverse-300">
-                    {formattedQuotAsset}
+                    {formattedQuoteAsset}
                   </span>
                 </div>
               </div>

--- a/packages/web/components/complex/portfolio/portfolio-page.tsx
+++ b/packages/web/components/complex/portfolio/portfolio-page.tsx
@@ -20,7 +20,6 @@ import {
   useTranslation,
   useWalletSelect,
 } from "~/hooks";
-import { useOrderbookAllActiveOrders } from "~/hooks/limit-orders/use-orderbook";
 import { useStore } from "~/stores";
 import { api } from "~/utils/trpc";
 
@@ -35,11 +34,6 @@ export const PortfolioPage: FunctionComponent = observer(() => {
 
   useAmplitudeAnalytics({
     onLoadEvent: [EventName.Portfolio.pageViewed],
-  });
-
-  const { orders, isLoading: isLoadingOrders } = useOrderbookAllActiveOrders({
-    userAddress: wallet?.address ?? "",
-    pageSize: 20,
   });
 
   const {
@@ -173,7 +167,7 @@ export const PortfolioPage: FunctionComponent = observer(() => {
                 <Allocation allocation={allocation} />
               )}
             </div>
-            <OpenOrders orders={orders} />
+            <OpenOrders />
             <RecentActivity />
           </aside>
         </>

--- a/packages/web/components/complex/portfolio/portfolio-page.tsx
+++ b/packages/web/components/complex/portfolio/portfolio-page.tsx
@@ -5,6 +5,7 @@ import { FunctionComponent } from "react";
 
 import { Allocation } from "~/components/complex/portfolio/allocation";
 import { AssetsOverview } from "~/components/complex/portfolio/assets-overview";
+import { OpenOrders } from "~/components/complex/portfolio/open-orders";
 import { UserPositionsSection } from "~/components/complex/portfolio/user-positions";
 import { UserZeroBalanceTableSplash } from "~/components/complex/portfolio/user-zero-balance-table-splash";
 import { WalletDisconnectedSplash } from "~/components/complex/portfolio/wallet-disconnected-splash";
@@ -19,6 +20,7 @@ import {
   useTranslation,
   useWalletSelect,
 } from "~/hooks";
+import { useOrderbookAllActiveOrders } from "~/hooks/limit-orders/use-orderbook";
 import { useStore } from "~/stores";
 import { api } from "~/utils/trpc";
 
@@ -33,6 +35,11 @@ export const PortfolioPage: FunctionComponent = observer(() => {
 
   useAmplitudeAnalytics({
     onLoadEvent: [EventName.Portfolio.pageViewed],
+  });
+
+  const { orders, isLoading: isLoadingOrders } = useOrderbookAllActiveOrders({
+    userAddress: wallet?.address ?? "",
+    pageSize: 20,
   });
 
   const {
@@ -166,6 +173,7 @@ export const PortfolioPage: FunctionComponent = observer(() => {
                 <Allocation allocation={allocation} />
               )}
             </div>
+            <OpenOrders orders={orders} />
             <RecentActivity />
           </aside>
         </>

--- a/packages/web/components/complex/portfolio/portfolio-page.tsx
+++ b/packages/web/components/complex/portfolio/portfolio-page.tsx
@@ -167,8 +167,10 @@ export const PortfolioPage: FunctionComponent = observer(() => {
                 <Allocation allocation={allocation} />
               )}
             </div>
-            <OpenOrders />
-            <RecentActivity />
+            <div className="flex w-full flex-col">
+              {featureFlags.limitOrders && <OpenOrders />}
+              <RecentActivity />
+            </div>
           </aside>
         </>
       ) : (

--- a/packages/web/components/transactions/recent-activity/recent-activity.tsx
+++ b/packages/web/components/transactions/recent-activity/recent-activity.tsx
@@ -53,8 +53,8 @@ export const RecentActivity: FunctionComponent = observer(() => {
 
   return (
     <div className="flex w-full flex-col py-3">
-      <div className="flex cursor-pointer items-center justify-between gap-3 py-3">
-        <h6>{t("portfolio.recentActivity")}</h6>
+      <div className="flex cursor-pointer items-center justify-between gap-3">
+        <h6 className="py-3">{t("portfolio.recentActivity")}</h6>
         <LinkButton
           href="/transactions"
           className="-mx-2 text-osmoverse-400"

--- a/packages/web/components/transactions/recent-activity/recent-activity.tsx
+++ b/packages/web/components/transactions/recent-activity/recent-activity.tsx
@@ -15,7 +15,7 @@ const ACTIVITY_LIMIT = 5;
 const RecentActivitySkeleton = () => {
   return (
     <>
-      {Array.from({ length: 5 }).map((_, index) => (
+      {Array.from({ length: ACTIVITY_LIMIT }).map((_, index) => (
         <div key={index} className="-mx-2 flex justify-between gap-4 p-2">
           <Skeleton className="h-9 w-1/3 " />
           <Skeleton className="h-9 w-1/5" />

--- a/packages/web/localizations/de.json
+++ b/packages/web/localizations/de.json
@@ -254,6 +254,7 @@
   },
   "portfolio": {
     "buy": "Kaufen",
+    "sell": "Verkaufen",
     "yourBalances": "Ihre Guthaben",
     "yourPositions": "Ihre Positionen",
     "searchBalances": "Guthaben suchen",
@@ -279,7 +280,8 @@
     "hideSmallBalances": "Kleine Guthaben verbergen",
     "cypherSpend": "Osmose-Bezahlung",
     "cypherOrder": "Bestellen Sie jetzt Ihre Karte",
-    "cypherBeta": "Beta"
+    "cypherBeta": "Beta",
+    "openOrders": "Offene Bestellungen"
   },
   "buyTokens": "Kaufen Sie Token",
   "components": {

--- a/packages/web/localizations/en.json
+++ b/packages/web/localizations/en.json
@@ -254,6 +254,7 @@
   },
   "portfolio": {
     "buy": "Buy",
+    "sell": "Sell",
     "yourBalances": "Your balances",
     "yourPositions": "Your positions",
     "searchBalances": "Search balances",
@@ -279,7 +280,8 @@
     "hideSmallBalances": "Hide small balances",
     "cypherSpend": "Osmosis Pay",
     "cypherOrder": "Order your card now",
-    "cypherBeta": "Beta"
+    "cypherBeta": "Beta",
+    "openOrders": "Open Orders"
   },
   "buyTokens": "Buy tokens",
   "components": {

--- a/packages/web/localizations/es.json
+++ b/packages/web/localizations/es.json
@@ -254,6 +254,7 @@
   },
   "portfolio": {
     "buy": "Comprar",
+    "sell": "Vender",
     "yourBalances": "Sus saldos",
     "yourPositions": "Tus posiciones",
     "searchBalances": "Buscar saldos",
@@ -279,7 +280,8 @@
     "hideSmallBalances": "Ocultar pequeños saldos",
     "cypherSpend": "Pago por ósmosis",
     "cypherOrder": "Pide tu tarjeta ahora",
-    "cypherBeta": "Beta"
+    "cypherBeta": "Beta",
+    "openOrders": "Órdenes abiertas"
   },
   "buyTokens": "Comprar fichas",
   "components": {

--- a/packages/web/localizations/fa.json
+++ b/packages/web/localizations/fa.json
@@ -254,6 +254,7 @@
   },
   "portfolio": {
     "buy": "خرید کنید",
+    "sell": "فروش",
     "yourBalances": "موجودی شما",
     "yourPositions": "موقعیت های شما",
     "searchBalances": "جستجوی موجودی",
@@ -279,7 +280,8 @@
     "hideSmallBalances": "توازن های کوچک را پنهان کنید",
     "cypherSpend": "اسمز پرداخت",
     "cypherOrder": "همین الان کارت خود را سفارش دهید",
-    "cypherBeta": "بتا"
+    "cypherBeta": "بتا",
+    "openOrders": "باز کردن سفارشات"
   },
   "buyTokens": "خرید توکن",
   "components": {

--- a/packages/web/localizations/fr.json
+++ b/packages/web/localizations/fr.json
@@ -254,6 +254,7 @@
   },
   "portfolio": {
     "buy": "Acheter",
+    "sell": "Vendre",
     "yourBalances": "Vos soldes",
     "yourPositions": "Vos postes",
     "searchBalances": "Rechercher des soldes",
@@ -279,7 +280,8 @@
     "hideSmallBalances": "Masquer les petits soldes",
     "cypherSpend": "Paiement par osmose",
     "cypherOrder": "Commandez votre carte maintenant",
-    "cypherBeta": "Bêta"
+    "cypherBeta": "Bêta",
+    "openOrders": "Commandes ouvertes"
   },
   "buyTokens": "Acheter jetons",
   "components": {

--- a/packages/web/localizations/gu.json
+++ b/packages/web/localizations/gu.json
@@ -254,6 +254,7 @@
   },
   "portfolio": {
     "buy": "ખરીદો",
+    "sell": "વેચો",
     "yourBalances": "તમારું બેલેન્સ",
     "yourPositions": "તમારી સ્થિતિ",
     "searchBalances": "બેલેન્સ શોધો",
@@ -279,7 +280,8 @@
     "hideSmallBalances": "નાના બેલેન્સ છુપાવો",
     "cypherSpend": "ઓસ્મોસિસ પે",
     "cypherOrder": "હવે તમારું કાર્ડ ઓર્ડર કરો",
-    "cypherBeta": "બેટા"
+    "cypherBeta": "બેટા",
+    "openOrders": "ઓર્ડર ખોલો"
   },
   "buyTokens": "ટોકન્સ ખરીદો",
   "components": {

--- a/packages/web/localizations/hi.json
+++ b/packages/web/localizations/hi.json
@@ -254,6 +254,7 @@
   },
   "portfolio": {
     "buy": "खरीदना",
+    "sell": "बेचना",
     "yourBalances": "आपका शेष",
     "yourPositions": "आपके पद",
     "searchBalances": "शेष राशि खोजें",
@@ -279,7 +280,8 @@
     "hideSmallBalances": "छोटे शेष राशि छिपाएँ",
     "cypherSpend": "ऑस्मोसिस पे",
     "cypherOrder": "अपना कार्ड अभी ऑर्डर करें",
-    "cypherBeta": "बीटा"
+    "cypherBeta": "बीटा",
+    "openOrders": "खुले आदेश"
   },
   "buyTokens": "टोकन खरीदें",
   "components": {

--- a/packages/web/localizations/ja.json
+++ b/packages/web/localizations/ja.json
@@ -254,6 +254,7 @@
   },
   "portfolio": {
     "buy": "買う",
+    "sell": "売る",
     "yourBalances": "残高",
     "yourPositions": "あなたの立場",
     "searchBalances": "残高を検索",
@@ -279,7 +280,8 @@
     "hideSmallBalances": "少額残高を非表示にする",
     "cypherSpend": "オズモーシスペイ",
     "cypherOrder": "今すぐカードを注文する",
-    "cypherBeta": "ベータ"
+    "cypherBeta": "ベータ",
+    "openOrders": "オープン注文"
   },
   "buyTokens": "トークンを購入する",
   "components": {

--- a/packages/web/localizations/ko.json
+++ b/packages/web/localizations/ko.json
@@ -254,6 +254,7 @@
   },
   "portfolio": {
     "buy": "구입하다",
+    "sell": "팔다",
     "yourBalances": "잔액",
     "yourPositions": "귀하의 직위",
     "searchBalances": "잔액 검색",
@@ -279,7 +280,8 @@
     "hideSmallBalances": "소액 잔액 숨기기",
     "cypherSpend": "오스모시스 페이",
     "cypherOrder": "지금 카드를 주문하세요",
-    "cypherBeta": "베타"
+    "cypherBeta": "베타",
+    "openOrders": "미결 주문"
   },
   "buyTokens": "토큰 구매",
   "components": {

--- a/packages/web/localizations/pl.json
+++ b/packages/web/localizations/pl.json
@@ -254,6 +254,7 @@
   },
   "portfolio": {
     "buy": "Kupić",
+    "sell": "Sprzedać",
     "yourBalances": "Twoje saldo",
     "yourPositions": "Twoje pozycje",
     "searchBalances": "Wyszukaj salda",
@@ -279,7 +280,8 @@
     "hideSmallBalances": "Ukryj małe salda",
     "cypherSpend": "Osmoza Płaca",
     "cypherOrder": "Zamów swoją kartę już teraz",
-    "cypherBeta": "Beta"
+    "cypherBeta": "Beta",
+    "openOrders": "Otwarte zamówienia"
   },
   "buyTokens": "Kup tokeny",
   "components": {

--- a/packages/web/localizations/pt-br.json
+++ b/packages/web/localizations/pt-br.json
@@ -254,6 +254,7 @@
   },
   "portfolio": {
     "buy": "Comprar",
+    "sell": "Vender",
     "yourBalances": "Seus saldos",
     "yourPositions": "Suas posições",
     "searchBalances": "Pesquisar saldos",
@@ -279,7 +280,8 @@
     "hideSmallBalances": "Ocultar pequenos saldos",
     "cypherSpend": "Pagamento por osmose",
     "cypherOrder": "Peça já o seu cartão",
-    "cypherBeta": "Beta"
+    "cypherBeta": "Beta",
+    "openOrders": "Ordens abertas"
   },
   "buyTokens": "Comprar tokens",
   "components": {

--- a/packages/web/localizations/ro.json
+++ b/packages/web/localizations/ro.json
@@ -254,6 +254,7 @@
   },
   "portfolio": {
     "buy": "Cumpără",
+    "sell": "Vinde",
     "yourBalances": "Soldurile tale",
     "yourPositions": "Pozițiile tale",
     "searchBalances": "Căutați solduri",
@@ -279,7 +280,8 @@
     "hideSmallBalances": "Ascunde soldurile mici",
     "cypherSpend": "Plată osmoză",
     "cypherOrder": "Comanda cardul tau acum",
-    "cypherBeta": "Beta"
+    "cypherBeta": "Beta",
+    "openOrders": "Comenzi deschise"
   },
   "buyTokens": "Cumpărați jetoane",
   "components": {

--- a/packages/web/localizations/ru.json
+++ b/packages/web/localizations/ru.json
@@ -254,6 +254,7 @@
   },
   "portfolio": {
     "buy": "Купить",
+    "sell": "Продавать",
     "yourBalances": "Ваши балансы",
     "yourPositions": "Ваши позиции",
     "searchBalances": "Поиск остатков",
@@ -279,7 +280,8 @@
     "hideSmallBalances": "Скрыть небольшие остатки",
     "cypherSpend": "Платить за осмос",
     "cypherOrder": "Закажите карту сейчас",
-    "cypherBeta": "Бета"
+    "cypherBeta": "Бета",
+    "openOrders": "Открытые заказы"
   },
   "buyTokens": "Купить токены",
   "components": {

--- a/packages/web/localizations/tr.json
+++ b/packages/web/localizations/tr.json
@@ -254,6 +254,7 @@
   },
   "portfolio": {
     "buy": "Satın almak",
+    "sell": "Satmak",
     "yourBalances": "Bakiyeleriniz",
     "yourPositions": "Pozisyonlarınız",
     "searchBalances": "Bakiyeleri ara",
@@ -279,7 +280,8 @@
     "hideSmallBalances": "Küçük bakiyeleri gizle",
     "cypherSpend": "Osmoz Ödeme",
     "cypherOrder": "Kartınızı şimdi sipariş edin",
-    "cypherBeta": "Beta"
+    "cypherBeta": "Beta",
+    "openOrders": "Açık Siparişler"
   },
   "buyTokens": "jeton satın al",
   "components": {

--- a/packages/web/localizations/zh-cn.json
+++ b/packages/web/localizations/zh-cn.json
@@ -254,6 +254,7 @@
   },
   "portfolio": {
     "buy": "买",
+    "sell": "卖",
     "yourBalances": "您的余额",
     "yourPositions": "您的职位",
     "searchBalances": "搜索余额",
@@ -279,7 +280,8 @@
     "hideSmallBalances": "隐藏小额余额",
     "cypherSpend": "渗透支付",
     "cypherOrder": "立即订购您的卡",
-    "cypherBeta": "测试版"
+    "cypherBeta": "测试版",
+    "openOrders": "未结订单"
   },
   "buyTokens": "购买代币",
   "components": {

--- a/packages/web/localizations/zh-hk.json
+++ b/packages/web/localizations/zh-hk.json
@@ -254,6 +254,7 @@
   },
   "portfolio": {
     "buy": "買",
+    "sell": "賣",
     "yourBalances": "您的餘額",
     "yourPositions": "您的職位",
     "searchBalances": "搜尋餘額",
@@ -279,7 +280,8 @@
     "hideSmallBalances": "隱藏小額餘額",
     "cypherSpend": "滲透支付",
     "cypherOrder": "立即訂購您的卡",
-    "cypherBeta": "貝塔"
+    "cypherBeta": "貝塔",
+    "openOrders": "未結訂單"
   },
   "buyTokens": "購買代幣",
   "components": {

--- a/packages/web/localizations/zh-tw.json
+++ b/packages/web/localizations/zh-tw.json
@@ -254,6 +254,7 @@
   },
   "portfolio": {
     "buy": "買",
+    "sell": "賣",
     "yourBalances": "您的餘額",
     "yourPositions": "您的職位",
     "searchBalances": "搜尋餘額",
@@ -279,7 +280,8 @@
     "hideSmallBalances": "隱藏小額餘額",
     "cypherSpend": "滲透支付",
     "cypherOrder": "立即訂購您的卡",
-    "cypherBeta": "貝塔"
+    "cypherBeta": "貝塔",
+    "openOrders": "未結訂單"
   },
   "buyTokens": "購買代幣",
   "components": {


### PR DESCRIPTION
## What is the purpose of the change:

- add limit orders to portfolio page

### Linear Task

https://linear.app/osmosis/issue/FE-784/portfolio-v2-open-orders
https://linear.app/osmosis/issue/FE-1044/portfolio-v2-show-up-to-5-open-orders

## Brief Changelog

- add top 5 recent open limit orders to portfolio page
- add to new section, with link to limit orders on transactions page
- responsive
- i18n

## Testing and Verifying

<img width="1514" alt="Screenshot 2024-08-22 at 11 40 14 AM" src="https://github.com/user-attachments/assets/7bd679d9-884b-4bc2-a60e-a136210b61cc">
<img width="1162" alt="Screenshot 2024-08-22 at 11 40 07 AM" src="https://github.com/user-attachments/assets/4efa593e-36b4-482e-b5d8-8b99fccbf3bb">
<img width="421" alt="Screenshot 2024-08-22 at 11 34 42 AM" src="https://github.com/user-attachments/assets/3dadd025-618f-432f-b77e-65c47ae6c152">
<img width="311" alt="Screenshot 2024-08-22 at 11 50 08 AM" src="https://github.com/user-attachments/assets/239c0290-2ab5-49ad-862c-e99fdfbd60f3">
