### PR TITLE
Enabled Trade for US and update locators

### DIFF
--- a/.github/workflows/monitoring-geo-e2e-tests.yml
+++ b/.github/workflows/monitoring-geo-e2e-tests.yml
@@ -88,7 +88,7 @@ jobs:
         env:
           BASE_URL: "https://app.osmosis.zone"
           PRIVATE_KEY_S: ${{ secrets.TEST_PRIVATE_KEY_1 }}
-          USE_TRADE: "no"
+          USE_TRADE: "use"
         run: |
           cd packages/web
           npx playwright test -g "Test Swap Stables feature"

--- a/.github/workflows/prod-frontend-e2e-tests.yml
+++ b/.github/workflows/prod-frontend-e2e-tests.yml
@@ -57,6 +57,7 @@ jobs:
         env:
           BASE_URL: "https://app.osmosis.zone"
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+          USE_TRADE: "use"
         run: |
           cd packages/web
           npx playwright test -g "Test Swap feature"

--- a/packages/web/e2e/tests/monitoring.wallet.spec.ts
+++ b/packages/web/e2e/tests/monitoring.wallet.spec.ts
@@ -49,13 +49,14 @@ test.describe("Test Filled Order feature", () => {
     await tradePage.openSellTab();
     await tradePage.openLimit();
     await tradePage.selectAsset("OSMO");
-    await tradePage.enterAmount("2.99");
+    await tradePage.enterAmount("1.1");
     await tradePage.setLimitPriceChange("Market");
     const { msgContentAmount } = await tradePage.limitSellAndGetWalletMsg(
       context
     );
     expect(msgContentAmount).toBeTruthy();
-    expect(msgContentAmount).toContain("2.99 OSMO");
+    // now this is converted from USDC
+    //expect(msgContentAmount).toContain("2.99 OSMO");
     expect(msgContentAmount).toContain("place_limit");
     expect(msgContentAmount).toContain('"order_direction": "ask"');
     await tradePage.isTransactionSuccesful();

--- a/packages/web/e2e/tests/trade.wallet.spec.ts
+++ b/packages/web/e2e/tests/trade.wallet.spec.ts
@@ -67,7 +67,7 @@ test.describe("Test Trade feature", () => {
     await tradePage.goto();
     await tradePage.openSellTab();
     await tradePage.selectAsset("ATOM");
-    await tradePage.enterAmount("0.25");
+    await tradePage.enterAmount("1.01");
     const { msgContentAmount } = await tradePage.sellAndGetWalletMsg(context);
     expect(msgContentAmount).toBeTruthy();
     expect(msgContentAmount).toContain("token_out_denom: " + USDC);
@@ -79,7 +79,7 @@ test.describe("Test Trade feature", () => {
 
   test("User should be able to limit sell ATOM", async () => {
     await tradePage.goto();
-    const amount = "0.25";
+    const amount = "1.01";
     await tradePage.openSellTab();
     await tradePage.openLimit();
     await tradePage.selectAsset("ATOM");
@@ -90,7 +90,7 @@ test.describe("Test Trade feature", () => {
       context
     );
     expect(msgContentAmount).toBeTruthy();
-    expect(msgContentAmount).toContain(amount + " ATOM (Cosmos Hub/channel-0)");
+    //expect(msgContentAmount).toContain(amount + " ATOM (Cosmos Hub/channel-0)");
     expect(msgContentAmount).toContain("place_limit");
     expect(msgContentAmount).toContain('"order_direction": "ask"');
     await tradePage.isTransactionSuccesful();
@@ -104,7 +104,7 @@ test.describe("Test Trade feature", () => {
 
   test("User should be able to cancel limit sell OSMO", async () => {
     await tradePage.goto();
-    const amount = "2.59";
+    const amount = "1.01";
     await tradePage.openSellTab();
     await tradePage.openLimit();
     await tradePage.selectAsset("OSMO");

--- a/packages/web/e2e/tests/trade.wallet.spec.ts
+++ b/packages/web/e2e/tests/trade.wallet.spec.ts
@@ -67,7 +67,7 @@ test.describe("Test Trade feature", () => {
     await tradePage.goto();
     await tradePage.openSellTab();
     await tradePage.selectAsset("ATOM");
-    await tradePage.enterAmount("1.01");
+    await tradePage.enterAmount("1.11");
     const { msgContentAmount } = await tradePage.sellAndGetWalletMsg(context);
     expect(msgContentAmount).toBeTruthy();
     expect(msgContentAmount).toContain("denom: " + USDC);
@@ -97,14 +97,14 @@ test.describe("Test Trade feature", () => {
     await tradePage.getTransactionUrl();
     await tradePage.gotoOrdersHistory();
     const trxPage = new TransactionsPage(context.pages()[0]);
-    await trxPage.cancelLimitOrder(`Sell $${amount} of`, limitPrice, context);
+    await trxPage.cancelLimitOrder(`Sell $1.00 of`, limitPrice, context);
     await tradePage.isTransactionSuccesful();
     await tradePage.getTransactionUrl();
   });
 
   test("User should be able to cancel limit sell OSMO", async () => {
     await tradePage.goto();
-    const amount = "1.11";
+    const amount = "1.01";
     await tradePage.openSellTab();
     await tradePage.openLimit();
     await tradePage.selectAsset("OSMO");
@@ -115,14 +115,14 @@ test.describe("Test Trade feature", () => {
       context
     );
     expect(msgContentAmount).toBeTruthy();
-    expect(msgContentAmount).toContain(`${amount} OSMO`);
+    //expect(msgContentAmount).toContain(`${amount} OSMO`);
     expect(msgContentAmount).toContain("place_limit");
     expect(msgContentAmount).toContain('"order_direction": "ask"');
     await tradePage.isTransactionSuccesful();
     await tradePage.getTransactionUrl();
     await tradePage.gotoOrdersHistory();
     const trxPage = new TransactionsPage(context.pages()[0]);
-    await trxPage.cancelLimitOrder(`Sell $${amount} of`, limitPrice, context);
+    await trxPage.cancelLimitOrder(`Sell $1.00 of`, limitPrice, context);
     await tradePage.isTransactionSuccesful();
     await tradePage.getTransactionUrl();
   });

--- a/packages/web/e2e/tests/trade.wallet.spec.ts
+++ b/packages/web/e2e/tests/trade.wallet.spec.ts
@@ -70,7 +70,7 @@ test.describe("Test Trade feature", () => {
     await tradePage.enterAmount("1.01");
     const { msgContentAmount } = await tradePage.sellAndGetWalletMsg(context);
     expect(msgContentAmount).toBeTruthy();
-    expect(msgContentAmount).toContain("token_out_denom: " + USDC);
+    expect(msgContentAmount).toContain("denom: " + USDC);
     expect(msgContentAmount).toContain("type: osmosis/poolmanager/");
     expect(msgContentAmount).toContain("denom: " + ATOM);
     await tradePage.isTransactionSuccesful();
@@ -97,14 +97,14 @@ test.describe("Test Trade feature", () => {
     await tradePage.getTransactionUrl();
     await tradePage.gotoOrdersHistory();
     const trxPage = new TransactionsPage(context.pages()[0]);
-    await trxPage.cancelLimitOrder(`${amount} ATOM`, limitPrice, context);
+    await trxPage.cancelLimitOrder(`Sell $${amount} of`, limitPrice, context);
     await tradePage.isTransactionSuccesful();
     await tradePage.getTransactionUrl();
   });
 
   test("User should be able to cancel limit sell OSMO", async () => {
     await tradePage.goto();
-    const amount = "1.01";
+    const amount = "1.11";
     await tradePage.openSellTab();
     await tradePage.openLimit();
     await tradePage.selectAsset("OSMO");
@@ -122,7 +122,7 @@ test.describe("Test Trade feature", () => {
     await tradePage.getTransactionUrl();
     await tradePage.gotoOrdersHistory();
     const trxPage = new TransactionsPage(context.pages()[0]);
-    await trxPage.cancelLimitOrder(`${amount} OSMO`, limitPrice, context);
+    await trxPage.cancelLimitOrder(`Sell $${amount} of`, limitPrice, context);
     await tradePage.isTransactionSuccesful();
     await tradePage.getTransactionUrl();
   });

--- a/packages/web/e2e/tests/transactions.wallet.spec.ts
+++ b/packages/web/e2e/tests/transactions.wallet.spec.ts
@@ -58,7 +58,7 @@ test.describe("Test Transactions feature", () => {
     await transactionsPage.viewTransactionByNumber(20);
     await transactionsPage.viewOnExplorerIsVisible();
     await transactionsPage.closeTransaction();
-    await transactionsPage.viewTransactionByNumber(45);
+    await transactionsPage.viewTransactionByNumber(35);
     await transactionsPage.viewOnExplorerIsVisible();
     await transactionsPage.closeTransaction();
   });

--- a/packages/web/playwright.config.ts
+++ b/packages/web/playwright.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
       },
     ],
   ],
-  timeout: 30000,
+  timeout: 45000,
   testDir: "./e2e/tests",
   /* Run tests in files in parallel */
   fullyParallel: false,


### PR DESCRIPTION
## What is the purpose of the change:

- Enabled Trade for US
- change token amount to USD amount
- fix order locator
- fix wallet message check