### PR TITLE
Deposit/Withdraw: IBC provider: fix Osmosis gas asset list denom check

### DIFF
--- a/packages/bridge/src/ibc/index.ts
+++ b/packages/bridge/src/ibc/index.ts
@@ -99,7 +99,10 @@ export class IbcBridgeProvider implements BridgeProvider {
     try {
       const assetListAsset = this.ctx.assetLists
         .flatMap((list) => list.assets)
-        .find((a) => a.coinMinimalDenom === asset.address);
+        .find(
+          (a) =>
+            a.coinMinimalDenom.toLowerCase() === asset.address.toLowerCase()
+        );
 
       const ibcTransferMethod = assetListAsset?.transferMethods.find(
         ({ type }) => type === "ibc"
@@ -224,7 +227,9 @@ export class IbcBridgeProvider implements BridgeProvider {
     // try to get asset list fee asset first, or otherwise the chain fee currency
     const assetListAsset = this.ctx.assetLists
       .flatMap(({ assets }) => assets)
-      .find((asset) => asset.coinMinimalDenom.toLowerCase() === denom);
+      .find(
+        (asset) => asset.coinMinimalDenom.toLowerCase() === denom.toLowerCase()
+      );
 
     if (assetListAsset) {
       return {
@@ -238,7 +243,8 @@ export class IbcBridgeProvider implements BridgeProvider {
     const chains = await this.getChains();
     const chain = chains.find((c) => c.chain_id === fromChainId);
     const feeCurrency = chain?.feeCurrencies.find(
-      ({ chainSuggestionDenom }) => chainSuggestionDenom === denom
+      ({ chainSuggestionDenom }) =>
+        chainSuggestionDenom.toLowerCase() === denom.toLowerCase()
     );
 
     if (feeCurrency) {

--- a/packages/bridge/src/nitro/index.ts
+++ b/packages/bridge/src/nitro/index.ts
@@ -119,7 +119,10 @@ export class NitroBridgeProvider implements BridgeProvider {
     const setTokenParam = (asset: BridgeAsset, param: string) => {
       if (asset.address.includes("alloyed")) {
         const assets = this.ctx.assetLists.flatMap(({ assets }) => assets);
-        const alloy = assets.find((a) => a.coinMinimalDenom === asset.address);
+        const alloy = assets.find(
+          (a) =>
+            a.coinMinimalDenom.toLowerCase() === asset.address.toLowerCase()
+        );
         const variant = assets.find(
           (a) =>
             a.variantGroupKey === alloy?.variantGroupKey &&

--- a/packages/bridge/src/squid/index.ts
+++ b/packages/bridge/src/squid/index.ts
@@ -315,7 +315,10 @@ export class SquidBridgeProvider implements BridgeProvider {
       // asset list counterparties
       const assetListAsset = this.ctx.assetLists
         .flatMap(({ assets }) => assets)
-        .find((a) => a.coinMinimalDenom === asset.address);
+        .find(
+          (a) =>
+            a.coinMinimalDenom.toLowerCase() === asset.address.toLowerCase()
+        );
 
       for (const counterparty of assetListAsset?.counterparty ?? []) {
         // check if supported by squid


### PR DESCRIPTION
## What is the purpose of the change:

<!-- > Add a description of the overall background and high level changes that this PR introduces -->

### Linear Task

<!-- > Add a link to the linear task that this PR is addressing. TIP: go to the linear task and use Ctrl/⌘ + C to copy a link. -->

In the IBC provider, the gas token was checked with only one comparison denom being cast to lower case. This was generally not an issue because we would then query the generated chain list to check for gas tokens there. However, for some Osmosis gas tokens, this caused the queried gas token denom to not be found in the asset list. With that, this bug would only be present if the generated asset list also does not contain the denom.

## Brief Changelog

- Cast denoms to lower case before comparison for getting Osmosis gas token in IBC bridge provider

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->

Tested locally
