### PR TITLE
[Trade Tool]: Small QA Fixes

### DIFF
--- a/packages/web/components/place-limit-tool/index.tsx
+++ b/packages/web/components/place-limit-tool/index.tsx
@@ -519,13 +519,23 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
       const handleMarketTab = () => {
         if (tab === "sell") {
           return focused === "fiat"
-            ? getTrimmedAmount(swapState.marketState.inAmountInput.inputAmount)
+            ? transformAmount(
+                getTrimmedAmount(
+                  swapState.marketState.inAmountInput.inputAmount
+                ),
+                10
+              )
             : formatInputAsPrice(
                 swapState.marketState.outAmountInput.inputAmount
               );
         } else {
           return focused === "fiat"
-            ? getTrimmedAmount(swapState.marketState.outAmountInput.inputAmount)
+            ? transformAmount(
+                getTrimmedAmount(
+                  swapState.marketState.outAmountInput.inputAmount
+                ),
+                10
+              )
             : formatInputAsPrice(
                 swapState.marketState.inAmountInput.inputAmount
               );
@@ -536,7 +546,7 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
         return handleMarketTab();
       } else {
         return focused === "fiat"
-          ? swapState.inAmountInput.inputAmount
+          ? fixDecimalCount(swapState.inAmountInput.inputAmount, 10)
           : formatInputAsPrice(fiatAmount);
       }
     }, [

--- a/packages/web/components/place-limit-tool/index.tsx
+++ b/packages/web/components/place-limit-tool/index.tsx
@@ -363,6 +363,13 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
       const tokenValue = value
         ? new Dec(value).quo(swapState.priceState.price)
         : undefined;
+
+      // When setting the token amount for a sell we want to round up due to
+      // rounding occuring when dividing the fiat amount by the token price.
+      // Without rounding there is a common case where the user inputs $1
+      // but the actual token value is only $0.99 (0.999999....) and the
+      // user is unable to place the order. With rounding we overestimate by a value of
+      // 1*10^(-tokenDecimals).
       setAmountSafe(
         "token",
         tokenValue ? tokenValue.toString() : undefined,

--- a/packages/web/components/place-limit-tool/index.tsx
+++ b/packages/web/components/place-limit-tool/index.tsx
@@ -57,12 +57,26 @@ export interface PlaceLimitToolProps {
   onOrderSuccess?: (baseDenom?: string, quoteDenom?: string) => void;
 }
 
+/* Roundes a given number to the given precision
+ * i.e. roundUpToDecimal(0.23456, 2) = 0.24
+ */
+function roundUpToDecimal(value: number, precision: number) {
+  const multiplier = Math.pow(10, precision || 0);
+  return Math.ceil(value * multiplier) / multiplier;
+}
+
+/**
+ * Fixes a given string representation of a number to the given decimal count
+ * Rounds to the decimal count if rounding is true
+ */
 const fixDecimalCount = (
   value: string,
   decimalCount = 18,
   rounding = false
 ) => {
-  if (rounding) return parseFloat(value).toFixed(decimalCount);
+  if (rounding) {
+    return roundUpToDecimal(parseFloat(value), decimalCount).toString();
+  }
   const split = value.split(".");
   const result =
     split[0] +
@@ -70,6 +84,10 @@ const fixDecimalCount = (
   return result;
 };
 
+/**
+ * Transforms a given amount to the given decimal count and handles period inputs
+ * Rounds to the decimal count if rounding is true
+ */
 const transformAmount = (
   value: string,
   decimalCount = 18,

--- a/packages/web/components/place-limit-tool/index.tsx
+++ b/packages/web/components/place-limit-tool/index.tsx
@@ -391,10 +391,17 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
       setAmountSafe(
         "token",
         tokenValue ? tokenValue.toString() : undefined,
-        undefined,
+        swapState.baseAsset?.coinDecimals,
         true
       );
-    }, [fiatAmount, setAmountSafe, focused, swapState.priceState.price, type]);
+    }, [
+      fiatAmount,
+      setAmountSafe,
+      focused,
+      swapState.priceState.price,
+      type,
+      swapState.baseAsset?.coinDecimals,
+    ]);
 
     const toggleMax = useCallback(() => {
       if (tab === "buy") {

--- a/packages/web/e2e/tests/trade.wallet.spec.ts
+++ b/packages/web/e2e/tests/trade.wallet.spec.ts
@@ -97,7 +97,7 @@ test.describe("Test Trade feature", () => {
     await tradePage.getTransactionUrl();
     await tradePage.gotoOrdersHistory();
     const trxPage = new TransactionsPage(context.pages()[0]);
-    await trxPage.cancelLimitOrder(`Sell $1.00 of`, limitPrice, context);
+    await trxPage.cancelLimitOrder(`Sell $${amount} of`, limitPrice, context);
     await tradePage.isTransactionSuccesful();
     await tradePage.getTransactionUrl();
   });
@@ -122,7 +122,7 @@ test.describe("Test Trade feature", () => {
     await tradePage.getTransactionUrl();
     await tradePage.gotoOrdersHistory();
     const trxPage = new TransactionsPage(context.pages()[0]);
-    await trxPage.cancelLimitOrder(`Sell $1.00 of`, limitPrice, context);
+    await trxPage.cancelLimitOrder(`Sell $${amount} of`, limitPrice, context);
     await tradePage.isTransactionSuccesful();
     await tradePage.getTransactionUrl();
   });


### PR DESCRIPTION
## What is the purpose of the change:
These changes adjust the following for the buy/sell tab:
- Non focused token amount restricted to 10 decimals (only when non-focused)
- Sell tab fiat input now rounds up to avoid payment fiat value not matching fiat input amount for limit orders
