### PR TITLE
Add Skip API key

### DIFF
--- a/packages/bridge/src/skip/client.ts
+++ b/packages/bridge/src/skip/client.ts
@@ -31,7 +31,7 @@ export class SkipApiClient {
       url.searchParams.append("only_testnets", "true");
     }
 
-    const data = await apiClient<{
+    const data = await this.authorizedApiClient<{
       chain_to_assets_map: Record<string, { assets: SkipAsset[] }>;
     }>(url.toString());
 
@@ -47,7 +47,7 @@ export class SkipApiClient {
       url.searchParams.append("only_testnets", "true");
     }
 
-    const data = await apiClient<{
+    const data = await this.authorizedApiClient<{
       chains: SkipChain[];
     }>(url.toString());
 
@@ -55,24 +55,30 @@ export class SkipApiClient {
   }
 
   async route(options: SkipRouteRequest) {
-    return apiClient<SkipRouteResponse>(`${this.baseUrl}/v2/fungible/route`, {
-      method: "POST",
-      body: JSON.stringify({
-        ...options,
-        cumulative_affiliate_fee_bps:
-          options.cumulative_affiliate_fee_bps ?? "0",
-      }),
-    });
+    return this.authorizedApiClient<SkipRouteResponse>(
+      `${this.baseUrl}/v2/fungible/route`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          ...options,
+          cumulative_affiliate_fee_bps:
+            options.cumulative_affiliate_fee_bps ?? "0",
+        }),
+      }
+    );
   }
 
   async messages(options: SkipMsgsRequest) {
-    return apiClient<SkipMsgsResponse>(`${this.baseUrl}/v2/fungible/msgs`, {
-      method: "POST",
-      body: JSON.stringify({
-        ...options,
-        slippage_tolerance_percent: options.slippage_tolerance_percent ?? "0",
-      }),
-    });
+    return this.authorizedApiClient<SkipMsgsResponse>(
+      `${this.baseUrl}/v2/fungible/msgs`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          ...options,
+          slippage_tolerance_percent: options.slippage_tolerance_percent ?? "0",
+        }),
+      }
+    );
   }
 
   async trackTransaction({
@@ -82,13 +88,16 @@ export class SkipApiClient {
     chainID: string;
     txHash: string;
   }) {
-    return apiClient<{ tx_id: string }>(`${this.baseUrl}/v2/tx/track`, {
-      method: "POST",
-      body: JSON.stringify({
-        chain_id: chainID,
-        tx_hash: txHash,
-      }),
-    });
+    return this.authorizedApiClient<{ tx_id: string }>(
+      `${this.baseUrl}/v2/tx/track`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          chain_id: chainID,
+          tx_hash: txHash,
+        }),
+      }
+    );
   }
 
   async transactionStatus({
@@ -103,6 +112,21 @@ export class SkipApiClient {
     url.searchParams.append("chain_id", chainID);
     url.searchParams.append("tx_hash", txHash);
 
-    return apiClient<SkipTxStatusResponse>(url.toString());
+    return this.authorizedApiClient<SkipTxStatusResponse>(url.toString());
+  }
+
+  protected authorizedApiClient<Response>(
+    ...args: Parameters<typeof apiClient>
+  ) {
+    const key = process.env.SKIP_API_KEY;
+
+    if (!key) throw new Error("SKIP_API_KEY is not set");
+
+    return apiClient<Response>(args[0], {
+      ...args[1],
+      headers: {
+        Authorization: `${key}`,
+      },
+    });
   }
 }

--- a/packages/bridge/src/skip/client.ts
+++ b/packages/bridge/src/skip/client.ts
@@ -125,7 +125,8 @@ export class SkipApiClient {
     return apiClient<Response>(args[0], {
       ...args[1],
       headers: {
-        Authorization: `${key}`,
+        // This is the format confirmed by Skip team
+        Authorization: key,
       },
     });
   }

--- a/packages/bridge/src/skip/client.ts
+++ b/packages/bridge/src/skip/client.ts
@@ -118,13 +118,17 @@ export class SkipApiClient {
   protected authorizedApiClient<Response>(
     ...args: Parameters<typeof apiClient>
   ) {
-    const key = process.env.SKIP_API_KEY;
+    if (process.env.NODE_ENV === "test") {
+      return apiClient<Response>(args[0], args[1]);
+    }
 
+    const key = process.env.SKIP_API_KEY;
     if (!key) throw new Error("SKIP_API_KEY is not set");
 
     return apiClient<Response>(args[0], {
       ...args[1],
       headers: {
+        ...args[1]?.headers,
         // This is the format confirmed by Skip team
         Authorization: key,
       },

--- a/packages/bridge/src/skip/index.ts
+++ b/packages/bridge/src/skip/index.ts
@@ -28,7 +28,6 @@ import {
   BridgeAsset,
   BridgeChain,
   BridgeCoin,
-  BridgeDepositAddress,
   BridgeExternalUrl,
   BridgeProvider,
   BridgeProviderContext,
@@ -39,7 +38,6 @@ import {
   GetBridgeExternalUrlParams,
   GetBridgeQuoteParams,
   GetBridgeSupportedAssetsParams,
-  GetDepositAddressParams,
 } from "../interface";
 import { BridgeAssetMap } from "../utils";
 import { SkipApiClient } from "./client";
@@ -55,9 +53,6 @@ export class SkipBridgeProvider implements BridgeProvider {
   constructor(protected readonly ctx: BridgeProviderContext) {
     this.skipClient = new SkipApiClient(ctx.env);
   }
-  getDepositAddress?:
-    | ((params: GetDepositAddressParams) => Promise<BridgeDepositAddress>)
-    | undefined;
 
   async getQuote(params: GetBridgeQuoteParams): Promise<BridgeQuote> {
     const {

--- a/packages/bridge/src/skip/index.ts
+++ b/packages/bridge/src/skip/index.ts
@@ -42,7 +42,7 @@ import {
   GetDepositAddressParams,
 } from "../interface";
 import { BridgeAssetMap } from "../utils";
-import { SkipApiClient } from "./queries";
+import { SkipApiClient } from "./client";
 import { SkipEvmTx, SkipMsg, SkipMultiChainMsg } from "./types";
 
 export class SkipBridgeProvider implements BridgeProvider {

--- a/packages/bridge/src/skip/transfer-status.ts
+++ b/packages/bridge/src/skip/transfer-status.ts
@@ -10,7 +10,7 @@ import type {
   TransferStatusReceiver,
 } from "../interface";
 import { SkipBridgeProvider } from ".";
-import { SkipApiClient } from "./queries";
+import { SkipApiClient } from "./client";
 
 /** Tracks (polls skip endpoint) and reports status updates on Skip bridge transfers. */
 export class SkipTransferStatusProvider implements TransferStatusProvider {

--- a/packages/bridge/src/skip/transfer-status.ts
+++ b/packages/bridge/src/skip/transfer-status.ts
@@ -9,8 +9,8 @@ import type {
   TransferStatusProvider,
   TransferStatusReceiver,
 } from "../interface";
-import { SkipBridgeProvider } from ".";
 import { SkipApiClient } from "./client";
+import { SkipBridgeProvider } from "./index";
 
 /** Tracks (polls skip endpoint) and reports status updates on Skip bridge transfers. */
 export class SkipTransferStatusProvider implements TransferStatusProvider {

--- a/packages/bridge/src/squid/index.ts
+++ b/packages/bridge/src/squid/index.ts
@@ -34,7 +34,6 @@ import { BridgeQuoteError } from "../errors";
 import {
   BridgeAsset,
   BridgeChain,
-  BridgeDepositAddress,
   BridgeExternalUrl,
   BridgeProvider,
   BridgeProviderContext,
@@ -45,7 +44,6 @@ import {
   GetBridgeExternalUrlParams,
   GetBridgeQuoteParams,
   GetBridgeSupportedAssetsParams,
-  GetDepositAddressParams,
 } from "../interface";
 import { BridgeAssetMap } from "../utils";
 import { getSquidErrors } from "./error";
@@ -72,9 +70,6 @@ export class SquidBridgeProvider implements BridgeProvider {
         ? "https://axelarscan.io"
         : "https://testnet.axelarscan.io";
   }
-  getDepositAddress?:
-    | ((params: GetDepositAddressParams) => Promise<BridgeDepositAddress>)
-    | undefined;
 
   async getQuote({
     fromAmount,


### PR DESCRIPTION
[Context](https://osmosis-network.slack.com/archives/C046V54UZC6/p1724714961228419)

Skip has requested that we start using an API key. The `SKIP_API_KEY` has been added to Vercel, and @osmosis-labs/front-end devs need to add it to their `.env.local`. Reach out to @niccoloraspa for the key.