### PR TITLE
fix: BOOT token invalid swaps

### DIFF
--- a/packages/web/hooks/use-swap.tsx
+++ b/packages/web/hooks/use-swap.tsx
@@ -166,6 +166,7 @@ export function useSwap(
     !account?.txTypeInProgress &&
     !isWalletLoading &&
     quoteType === "in-given-out";
+
   const {
     data: outGivenInQuote,
     isLoading: isQuoteLoading_,

--- a/packages/web/hooks/use-swap.tsx
+++ b/packages/web/hooks/use-swap.tsx
@@ -166,7 +166,6 @@ export function useSwap(
     !account?.txTypeInProgress &&
     !isWalletLoading &&
     quoteType === "in-given-out";
-
   const {
     data: outGivenInQuote,
     isLoading: isQuoteLoading_,
@@ -1532,7 +1531,6 @@ function useQueryRouterBestQuote(
 
   const quoteResult =
     quoteType === "out-given-in" ? outGivenInQuote : inGivenOutQuote;
-
   const {
     data: quote,
     isSuccess,
@@ -1543,7 +1541,13 @@ function useQueryRouterBestQuote(
   }, [quoteResult]);
 
   const acceptedQuote = useMemo(() => {
-    if (!quote || !input.tokenIn || !input.tokenOut) return;
+    if (
+      !quote ||
+      !input.tokenIn ||
+      !input.tokenOut ||
+      quote.amount.toDec().isZero()
+    )
+      return;
     return {
       ...quote,
       amountIn:
@@ -1564,17 +1568,17 @@ function useQueryRouterBestQuote(
     const tokenOutCoinMinimalDenom = input.tokenOut?.coinMinimalDenom;
     if (
       !quote ||
-      !tokenOutCoinDecimals ||
+      typeof tokenOutCoinDecimals === "undefined" ||
       !tokenInCoinMinimalDenom ||
       !tokenOutCoinMinimalDenom ||
-      !tokenInCoinDecimals
+      typeof tokenInCoinDecimals === "undefined"
     )
       return undefined;
     const messages = await getSwapMessages({
       quote: quote,
       tokenOutCoinMinimalDenom,
-      tokenInCoinDecimals,
-      tokenOutCoinDecimals,
+      tokenInCoinDecimals: tokenInCoinDecimals!,
+      tokenOutCoinDecimals: tokenOutCoinDecimals!,
       tokenInCoinMinimalDenom,
       maxSlippage: input.maxSlippage?.toString(),
       coinAmount: input.tokenInAmount,


### PR DESCRIPTION
## What is the purpose of the change:
These changes fix an issue when a coin with 0 decimal places is used for a quote.

### Linear Task

[FE-1073](https://linear.app/osmosis/issue/FE-1073/%5Bhttpsforumosmosiszonetissue-with-boot-token-accessibility-on-the)

## Brief Changelog

- Altered `tokenInCoinDecimals/tokenOutCoinDecimals` check to check type rather than existence
