### PR TITLE
add pr notification yaml

### DIFF
--- a/.github/workflows/pr-notification.yml
+++ b/.github/workflows/pr-notification.yml
@@ -1,0 +1,20 @@
+name: PR Notification
+on:
+  pull_request:
+    types: [opened, reopened]
+    branches:
+      - master
+jobs:
+  slack-notification:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slack Notification
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          text: New PR opened to master branch
+          author_name: GitHub Action
+          fields: repo,message,commit,author,action,eventName,ref,workflow
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ANNOUNCEMENT_WEBHOOK_URL }}


### PR DESCRIPTION
## What is the purpose of the change:

Adding a yaml file to auto notify slack when someone opens a PR to master

### Linear Task

https://linear.app/osmosis/issue/FE-1048/add-github-action-to-automatically-post-to-deployment-announcements

## Brief Changelog

- add yaml file to auto notify slack when someone opens a PR to master
