### PR TITLE
[Limit Orders]: Feature Flag for SQS Active Orders

### DIFF
--- a/packages/web/components/complex/orders-history/index.tsx
+++ b/packages/web/components/complex/orders-history/index.tsx
@@ -84,7 +84,7 @@ export const OrderHistory = observer(() => {
   } = useOrderbookAllActiveOrders({
     userAddress: wallet?.address ?? "",
     pageSize: 20,
-    refetchInterval: 10000,
+    refetchInterval: featureFlags.sqsActiveOrders ? 10000 : 30000,
   });
   const groupedOrders = useMemo(() => groupOrdersByStatus(orders), [orders]);
   const groups = useMemo(
@@ -123,7 +123,7 @@ export const OrderHistory = observer(() => {
     useOrderbookClaimableOrders({
       userAddress: wallet?.address ?? "",
       disabled: isLoading || filledOrdersInDisplay.length === 0 || isRefetching,
-      refetchInterval: 10000,
+      refetchInterval: featureFlags.sqsActiveOrders ? 10000 : 30000,
     });
 
   const claimOrders = useCallback(async () => {

--- a/packages/web/hooks/use-feature-flags.ts
+++ b/packages/web/hooks/use-feature-flags.ts
@@ -30,7 +30,8 @@ export type AvailableFlags =
   | "advancedChart"
   | "cypherCard"
   | "newPortfolioPage"
-  | "inGivenOut";
+  | "inGivenOut"
+  | "sqsActiveOrders";
 
 const defaultFlags: Record<AvailableFlags, boolean> = {
   staking: true,
@@ -56,6 +57,7 @@ const defaultFlags: Record<AvailableFlags, boolean> = {
   cypherCard: false,
   newPortfolioPage: false,
   inGivenOut: false,
+  sqsActiveOrders: false,
 };
 
 const LIMIT_ORDER_COUNTRY_CODES =
@@ -67,7 +69,6 @@ export function useFeatureFlags() {
   const launchdarklyFlags: Record<AvailableFlags, boolean> = useFlags();
   const { isMobile } = useWindowSize();
   const [isInitialized, setIsInitialized] = useState(false);
-
   const client = useLDClient();
 
   const { data: levanaGeoblock } = useQuery(


### PR DESCRIPTION
## What is the purpose of the change:
These changes add integration of an `sqsActiveOrders` feature flag that can enable/disable the use of the SQS passthrough query.

## Brief Changelog

- Active and Claimable orders query enable/disable depending on feature flag status

## Testing and Verifying
Tested locally using launch darkly UI to toggle feature flag on and off
