### PR TITLE
[Limit Orders]: Price to Tick Crash Handler

### DIFF
--- a/packages/web/components/swap-tool/alt.tsx
+++ b/packages/web/components/swap-tool/alt.tsx
@@ -229,6 +229,7 @@ export const AltSwapTool: FunctionComponent<SwapToolProps> = observer(
         feeValueUsd: Number(swapState.totalFee?.toString() ?? "0"),
         page,
         quoteTimeMilliseconds: swapState.quote?.timeMs,
+        swapSource: "swap" as "swap" | "market",
       };
       logEvent([EventName.Swap.swapStarted, baseEvent]);
       setIsSendingTx(true);

--- a/packages/web/config/analytics-events.ts
+++ b/packages/web/config/analytics-events.ts
@@ -70,6 +70,7 @@ export type EventProperties = {
   isRecommendedVariant: boolean;
   walletName: string;
   transferDirection: "deposit" | "withdraw";
+  swapSource: "market" | "swap";
 };
 
 export type UserProperties = {

--- a/packages/web/hooks/limit-orders/use-place-limit.ts
+++ b/packages/web/hooks/limit-orders/use-place-limit.ts
@@ -300,6 +300,7 @@ export const usePlaceLimit = ({
         feeValueUsd: Number(marketState.totalFee?.toString() ?? "0"),
         page,
         quoteTimeMilliseconds: marketState.quote?.timeMs,
+        swapSource: "market" as "swap" | "market",
       };
       try {
         logEvent([EventName.Swap.swapStarted, baseEvent]);

--- a/packages/web/hooks/limit-orders/use-place-limit.ts
+++ b/packages/web/hooks/limit-orders/use-place-limit.ts
@@ -225,21 +225,26 @@ export const usePlaceLimit = ({
       return;
     }
 
-    // The requested price must account for the ratio between the quote and base asset as the base asset may not be a stablecoin.
-    // To account for this we divide by the quote asset price.
-    const tickId = priceToTick(
-      priceState.price.quo(quoteAssetPrice.toDec()).mul(normalizationFactor)
-    );
-    const msg = {
-      place_limit: {
-        tick_id: parseInt(tickId.toString()),
-        order_direction: orderDirection,
-        quantity,
-        claim_bounty: CLAIM_BOUNTY,
-      },
-    };
+    try {
+      // The requested price must account for the ratio between the quote and base asset as the base asset may not be a stablecoin.
+      // To account for this we divide by the quote asset price.
+      const tickId = priceToTick(
+        priceState.price.quo(quoteAssetPrice.toDec()).mul(normalizationFactor)
+      );
+      const msg = {
+        place_limit: {
+          tick_id: parseInt(tickId.toString()),
+          order_direction: orderDirection,
+          quantity,
+          claim_bounty: CLAIM_BOUNTY,
+        },
+      };
 
-    return msg;
+      return msg;
+    } catch (error) {
+      console.error("Error attempting to place limit order", error);
+      return;
+    }
   }, [
     orderDirection,
     priceState.price,


### PR DESCRIPTION
## What is the purpose of the change:
These changes address an issue that causes the app to crash when swapping between limit order denoms. It also includes a new field for amplitude swap events.

### Linear Task

[LIM-282](https://linear.app/osmosis/issue/LIM-282/add-swap-type-marketswap-to-amplitude-event-details)
[FE-1086](https://linear.app/osmosis/issue/FE-1086/unable-to-place-sellbuy-limit-orders-for-arch)

## Brief Changelog

- Added `trycatch` handler for `priceToTick`
- Added `swapSource` field to swap events for amplitude
