### PR TITLE
[Limit Orders]: Fix date display for active orders from node

### DIFF
--- a/packages/server/src/queries/complex/orderbooks/active-orders.ts
+++ b/packages/server/src/queries/complex/orderbooks/active-orders.ts
@@ -193,7 +193,7 @@ async function getTickInfoAndTransformOrders(
       output,
       quoteAsset,
       baseAsset,
-      placed_at: dayjs(o.placed_at / 1000).unix(),
+      placed_at: dayjs(Math.floor(o.placed_at / 1000000)).unix(),
     };
   });
 }

--- a/packages/web/components/complex/orders-history/index.tsx
+++ b/packages/web/components/complex/orders-history/index.tsx
@@ -456,8 +456,8 @@ const TableOrderRow = memo(
         case "partiallyFilled":
           return <OrderProgressBar order={order} />;
         case "cancelled":
-          const dayDiff = dayjs(new Date()).diff(dayjs(placed_at), "d");
-          const hourDiff = dayjs(new Date()).diff(dayjs(placed_at), "h");
+          const dayDiff = dayjs(new Date()).diff(placedAt, "d");
+          const hourDiff = dayjs(new Date()).diff(placedAt, "h");
 
           return (
             <span className="body2 md:caption text-osmoverse-300">


### PR DESCRIPTION
## What is the purpose of the change:
After merging Limit Order related PRs the date display for active orders when fetched from a node was incorrect. There was also a minor issue with the historical orders not using a correct unix timestamp.

### Linear Task

[FE-1084](https://linear.app/osmosis/issue/FE-1084/fix-incorrect-date-display-of-jan-21-1970)

## Brief Changelog

- Fixed date conversion for active orders when fetched from node
