### PR TITLE
fix: amino signing for withdraw position message

### DIFF
--- a/packages/proto-codecs/src/codegen/osmosis/concentratedliquidity/v1beta1/tx.ts
+++ b/packages/proto-codecs/src/codegen/osmosis/concentratedliquidity/v1beta1/tx.ts
@@ -1025,10 +1025,11 @@ export const MsgWithdrawPosition = {
     if (message.sender !== "") {
       writer.uint32(18).string(message.sender);
     }
+    // NOTE: Withdraw postion will break if we regenerate protos
+    // if you see this line being removed in a PR, flag it!
+    // TODO: Abstract to an override function.
     if (message.liquidityAmount !== "") {
-      writer
-        .uint32(26)
-        .string(Decimal.fromUserInput(message.liquidityAmount, 18).atomics);
+      writer.uint32(26).string(message.liquidityAmount.replace(".", ""));
     }
     return writer;
   },

--- a/packages/stores/src/account/amino-converters.ts
+++ b/packages/stores/src/account/amino-converters.ts
@@ -1,4 +1,8 @@
 import type { AminoMsgTransfer } from "@cosmjs/stargate";
+import type {
+  MsgWithdrawPosition,
+  MsgWithdrawPositionAmino,
+} from "@osmosis-labs/proto-codecs/build/codegen/osmosis/concentratedliquidity/v1beta1/tx";
 import type { MsgTransfer } from "cosmjs-types/ibc/applications/transfer/v1/tx";
 import Long from "long";
 
@@ -45,6 +49,45 @@ export async function getAminoConverters() {
             ? cosmos.base.v1beta1.Coin.fromAmino(msg.shares_to_convert)
             : undefined,
         }),
+      },
+      "/osmosis.concentratedliquidity.v1beta1.MsgWithdrawPosition": {
+        ...originalOsmosisAminoConverters[
+          "/osmosis.concentratedliquidity.v1beta1.MsgWithdrawPosition"
+        ],
+        aminoType: "osmosis/cl-withdraw-position",
+        fromAmino(object: MsgWithdrawPositionAmino): MsgWithdrawPosition {
+          const message = {
+            positionId: BigInt(0),
+            sender: "",
+            liquidityAmount: "",
+          };
+          if (object.position_id !== undefined && object.position_id !== null) {
+            message.positionId = BigInt(object.position_id);
+          }
+          if (object.sender !== undefined && object.sender !== null) {
+            message.sender = object.sender;
+          }
+          if (
+            object.liquidity_amount !== undefined &&
+            object.liquidity_amount !== null
+          ) {
+            message.liquidityAmount = object.liquidity_amount.replace(".", "");
+          }
+          return message;
+        },
+        toAmino(message: MsgWithdrawPosition): MsgWithdrawPositionAmino {
+          const obj: any = {};
+          obj.position_id =
+            message.positionId !== BigInt(0)
+              ? message.positionId.toString()
+              : undefined;
+          obj.sender = message.sender === "" ? undefined : message.sender;
+          obj.liquidity_amount =
+            message.liquidityAmount === ""
+              ? undefined
+              : message.liquidityAmount.replace(".", "");
+          return obj;
+        },
       },
     };
 

--- a/packages/stores/src/account/base.ts
+++ b/packages/stores/src/account/base.ts
@@ -832,15 +832,12 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
       return typeUrl;
     };
 
-    // TODO - update proto codec
+    // @osmosis-labs/proto-codec has been updated for "/osmosis.concentratedliquidity.v1beta1.MsgWithdrawPosition"
+    // TODO: Copy what's been done there for this message below
     const doesTxNeedDirectSigning = messages.some(
       (message) =>
         message.typeUrl ===
-          getTypeUrl(
-            "/osmosis.concentratedliquidity.v1beta1.MsgWithdrawPosition"
-          ) ||
-        message.typeUrl ===
-          getTypeUrl("/osmosis.valsetpref.v1beta1.MsgSetValidatorSetPreference")
+        getTypeUrl("/osmosis.valsetpref.v1beta1.MsgSetValidatorSetPreference")
     );
 
     const forceSignDirect = doesTxNeedDirectSigning;


### PR DESCRIPTION
## What is the purpose of the change:

Due to the v0.50 upgrade there were some changes with how signing works,

This only effects the proto fields defined as `"cosmossdk.io/math.LegacyDec"`

Before the FE was signing something like "123.123456789123456789" where it should be signing "123123456789123456789".

The PR fixes the most used messages so end users can now use ledgers to sign withdraw position messages on the FE.

### How to test

- create a cl position in any cl pool
- withdraw a position :tada: 

Other tests of note:
- please test ledger as well :pray: 


