### PR TITLE
fix(portfolio): ordering favorites

### DIFF
--- a/packages/web/components/table/asset-balances.tsx
+++ b/packages/web/components/table/asset-balances.tsx
@@ -259,7 +259,6 @@ export const AssetBalancesTable: FunctionComponent<{
 
   const table = useReactTable({
     data: filteredAssetsData,
-    // @ts-expect-error
     columns: collapsedColumns,
     manualSorting: true,
     manualFiltering: true,


### PR DESCRIPTION
## What is the purpose of the change:

- favorites sorting
- mobile cleanup for buttons

### Linear Task

https://linear.app/osmosis/issue/FE-1122/portfolio-v3-favorites-order-deposit-and-withdraw-button-on-mobile

## Testing and Verifying


https://github.com/user-attachments/assets/57d756b4-369f-4946-b937-e477a6ef267b

<img width="1060" alt="Screenshot 2024-09-26 at 10 26 09 AM" src="https://github.com/user-attachments/assets/e2bf830d-85fa-4cbb-97dd-29b168590530">

<img width="860" alt="Screenshot 2024-09-26 at 10 26 13 AM" src="https://github.com/user-attachments/assets/65765497-03d2-444b-a143-952aca5921c9">
