### PR TITLE
Fix: increase exit pool slippage with high precision amounts

### DIFF
--- a/packages/stores/src/account/osmosis/index.ts
+++ b/packages/stores/src/account/osmosis/index.ts
@@ -1473,8 +1473,6 @@ export class OsmosisAccountImpl {
           };
         });
 
-    console.log({ tokenOutMins });
-
     const msg = await makeExitPoolMsg({
       poolId: BigInt(poolId),
       sender: this.address,

--- a/packages/stores/src/account/osmosis/index.ts
+++ b/packages/stores/src/account/osmosis/index.ts
@@ -1415,7 +1415,7 @@ export class OsmosisAccountImpl {
    * https://docs.osmosis.zone/developing/modules/spec-gamm.html#exit-pool
    * @param poolId Id of pool to exit.
    * @param shareInAmount LP shares to redeem.
-   * @param maxSlippage Max tolerated slippage. Default: 5.
+   * @param maxSlippage Max tolerated slippage. Default: 2.5, 15 with high precision amounts.
    * @param memo Transaction memo.
    * @param onFulfill Callback to handle tx fullfillment given raw response.
    */

--- a/packages/stores/src/account/osmosis/index.ts
+++ b/packages/stores/src/account/osmosis/index.ts
@@ -51,6 +51,7 @@ import { DeliverTxResponse, SignOptions } from "../types";
 import { findNewClPositionId } from "./tx-response";
 
 const DEFAULT_SLIPPAGE = "2.5";
+const HIGH_DEFAULT_SLIPPAGE = "15";
 
 export interface OsmosisAccount {
   osmosis: OsmosisAccountImpl;
@@ -1414,7 +1415,7 @@ export class OsmosisAccountImpl {
    * https://docs.osmosis.zone/developing/modules/spec-gamm.html#exit-pool
    * @param poolId Id of pool to exit.
    * @param shareInAmount LP shares to redeem.
-   * @param maxSlippage Max tolerated slippage. Default: 2.5.
+   * @param maxSlippage Max tolerated slippage. Default: 5.
    * @param memo Transaction memo.
    * @param onFulfill Callback to handle tx fullfillment given raw response.
    */
@@ -1444,6 +1445,12 @@ export class OsmosisAccountImpl {
       makeExitPoolMsg.shareCoinDecimals
     );
 
+    // If the token amount is very large, indicating high precision,
+    // increase slippage tolerance to allow for the high precision.
+    if (poolAssets.some(({ amount }) => amount.length > 18)) {
+      maxSlippage = HIGH_DEFAULT_SLIPPAGE;
+    }
+
     const maxSlippageDec = new Dec(maxSlippage).quo(
       DecUtils.getTenExponentNInPrecisionRange(2)
     );
@@ -1465,6 +1472,8 @@ export class OsmosisAccountImpl {
               .toString(),
           };
         });
+
+    console.log({ tokenOutMins });
 
     const msg = await makeExitPoolMsg({
       poolId: BigInt(poolId),


### PR DESCRIPTION
## What is the purpose of the change:

<!-- > Add a description of the overall background and high level changes that this PR introduces -->

### Linear Task

<!-- > Add a link to the linear task that this PR is addressing. TIP: go to the linear task and use Ctrl/⌘ + C to copy a link. -->

Fixes [FE-1089: Troubleshoot error removing lp from pool 1016](https://linear.app/osmosis/issue/FE-1089/troubleshoot-error-removing-lp-from-pool-1016)

## Brief Changelog

- If the amount is high precision, increase default slippage tolerance

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->
Tested locally