### PR TITLE
Fix: Unbond from weighted pools TX

### DIFF
--- a/packages/stores/src/account/amino-converters.ts
+++ b/packages/stores/src/account/amino-converters.ts
@@ -3,6 +3,10 @@ import type {
   MsgWithdrawPosition,
   MsgWithdrawPositionAmino,
 } from "@osmosis-labs/proto-codecs/build/codegen/osmosis/concentratedliquidity/v1beta1/tx";
+import type {
+  MsgBeginUnlocking,
+  MsgBeginUnlockingAmino,
+} from "@osmosis-labs/proto-codecs/build/codegen/osmosis/lockup/tx";
 import type { MsgTransfer } from "cosmjs-types/ibc/applications/transfer/v1/tx";
 import Long from "long";
 
@@ -86,6 +90,19 @@ export async function getAminoConverters() {
             message.liquidityAmount === ""
               ? undefined
               : message.liquidityAmount.replace(".", "");
+          return obj;
+        },
+      },
+      "/osmosis.lockup.MsgBeginUnlocking": {
+        ...originalOsmosisAminoConverters["/osmosis.lockup.MsgBeginUnlocking"],
+        toAmino(message: MsgBeginUnlocking): MsgBeginUnlockingAmino {
+          const obj =
+            originalOsmosisAminoConverters[
+              "/osmosis.lockup.MsgBeginUnlocking"
+            ].toAmino(message);
+          if (obj.coins?.length === 0) {
+            delete obj.coins;
+          }
           return obj;
         },
       },


### PR DESCRIPTION
## What is the purpose of the change:

This PR resolves an issue with unbonding from a weighted pool by updating the proto codecs. The update ensures that the coins array is excluded when it’s empty, as the new version of the SDK does not support empty arrays. The bug was introduced following the upgrade to Cosmos SDK after the Osmosis v26 upgrade.

### Linear Task

https://linear.app/osmosis/issue/FE-1143/fix-pool-creation-and-unboding-weighted-pools-tx

## Testing and Verifying

- [ ] Can unbond from weighted pools