### PR TITLE
fix: keyboard reopening denom selection modal for buy/sell

### DIFF
--- a/packages/web/components/complex/asset-fieldset.tsx
+++ b/packages/web/components/complex/asset-fieldset.tsx
@@ -240,9 +240,10 @@ const AssetFieldsetTokenSelector = ({
         type="button"
         className="flex max-w-[50%] items-center gap-1 rounded-[64px] bg-osmoverse-850 py-3 pl-3 pr-4 transition-colors hover:bg-osmoverse-800 sm:px-3"
         onClick={(e) => {
+          e.stopPropagation();
+          e.currentTarget.blur();
           if (onSelectorClick) return onSelectorClick();
 
-          e.stopPropagation();
           if (
             !isModalExternal &&
             selectableAssets &&


### PR DESCRIPTION
## What is the purpose of the change:

These changes fix an issue when a user selects a denom in buy/sell tab using the keyboard upon pressing enter the modal reopens itself.

### Linear Task

[LIM-286](https://linear.app/osmosis/issue/LIM-286/keyboard-navigation-issue-with-asset-selection-modal)

## Brief Changelog

- Button for opening token selection is blurred when opened
