### PR TITLE
Filter out additional incorrect TVL pools

### DIFF
--- a/packages/server/src/queries/complex/pools/index.ts
+++ b/packages/server/src/queries/complex/pools/index.ts
@@ -19,7 +19,7 @@ const allPooltypes = [
 ] as const;
 export type PoolType = (typeof allPooltypes)[number];
 
-const FILTERABLE_IDS = IS_TESTNET ? [] : ["2159"];
+const FILTERABLE_IDS = IS_TESTNET ? [] : ["2159","2217","2218"];
 
 // PoolMarketMetrics is a partial type that contains the market metrics of a pool.
 type PoolMarketMetrics = Partial<{


### PR DESCRIPTION
## What is the purpose of the change:
Similar to https://github.com/osmosis-labs/osmosis-frontend/pull/3864
This pool was noticed to be filtered and so 2 new ones were made with the same singlesided tactic, skewing displayed TVL.

### Linear Task

<!-- > Add a link to the linear task that this PR is addressing. TIP: go to the linear task and use Ctrl/⌘ + C to copy a link. -->

## Brief Changelog

Adds 2 pools to list

## Testing and Verifying

This change has not been tested locally
