### PR TITLE
fix: TIA withdraws

### DIFF
--- a/packages/bridge/src/interface.ts
+++ b/packages/bridge/src/interface.ts
@@ -18,7 +18,7 @@ export interface BridgeProviderContext {
     chainId?: string;
     destinationAddress?: string;
   }): Promise<{
-    revisionNumber: string | undefined;
+    revisionNumber?: string;
     revisionHeight: string;
   }>;
 }

--- a/packages/server/src/queries/complex/get-timeout-height.ts
+++ b/packages/server/src/queries/complex/get-timeout-height.ts
@@ -54,7 +54,7 @@ export async function getTimeoutHeight({
      * Omit the revision_number if the chain's version is 0.
      * Sending the value as 0 will cause the transaction to fail.
      */
-    revisionNumber: revisionNumber !== "0" ? revisionNumber : undefined,
+    ...(revisionNumber !== "0" && { revisionNumber }),
     revisionHeight: new Int(latestBlockHeight).add(new Int("150")).toString(),
   };
 }

--- a/packages/stores/src/account/amino-converters.ts
+++ b/packages/stores/src/account/amino-converters.ts
@@ -1,4 +1,4 @@
-import type { AminoMsgTransfer } from "@cosmjs/stargate";
+import { MsgTransferAmino } from "@osmosis-labs/proto-codecs/build/codegen/ibc/applications/transfer/v1/tx";
 import {
   MsgBeginUnlocking,
   MsgBeginUnlockingAmino,
@@ -79,7 +79,7 @@ export async function getAminoConverters() {
           sender,
           receiver,
           timeoutHeight,
-        }: MsgTransfer) => ({
+        }: MsgTransfer): MsgTransferAmino => ({
           source_port: sourcePort,
           source_channel: sourceChannel,
           token: {
@@ -91,7 +91,10 @@ export async function getAminoConverters() {
           timeout_height: timeoutHeight
             ? {
                 revision_height: timeoutHeight.revisionHeight?.toString(),
-                revision_number: timeoutHeight.revisionNumber?.toString(),
+                revision_number:
+                  timeoutHeight.revisionNumber?.toString() !== "0"
+                    ? timeoutHeight.revisionNumber?.toString()
+                    : undefined,
               }
             : {},
         }),
@@ -103,16 +106,16 @@ export async function getAminoConverters() {
           receiver,
           timeout_height,
           timeout_timestamp,
-        }: AminoMsgTransfer["value"]): MsgTransfer => {
+        }: MsgTransferAmino): MsgTransfer => {
           return {
-            sourcePort: source_port,
-            sourceChannel: source_channel,
+            sourcePort: source_port ?? "",
+            sourceChannel: source_channel ?? "",
             token: {
               denom: token?.denom ?? "",
               amount: token?.amount ?? "",
             },
-            sender,
-            receiver,
+            sender: sender ?? "",
+            receiver: receiver ?? "",
             timeoutHeight: timeout_height
               ? {
                   revisionHeight: Long.fromString(

--- a/packages/web/stores/transfer-history.tsx
+++ b/packages/web/stores/transfer-history.tsx
@@ -372,7 +372,7 @@ const PendingTransferLoadingIcon: FunctionComponent<{
         const circles = progressRef.current.querySelectorAll("circle");
         const radius = 20;
         const circumference = 2 * Math.PI * radius;
-        const offset = (progressPercentage / 100) * circumference;
+        const offset = Math.max((progressPercentage / 100) * circumference, 7);
 
         circles.forEach((circle, index) => {
           if (index === 1) {


### PR DESCRIPTION
## What is the purpose of the change:

This PR fixes TIA withdrawal issues. The problem occurred because the TIA chain returns 0 as the revision number, causing transactions to fail. After implementing the decimal fix, the revision number was re-added to the transaction after normalizing the message. This fix updates the amino converters to omit the revision number if it’s 0

### Linear Task

https://linear.app/osmosis/issue/FE-1164/error-withdrawing-tia-due-to-unauthorized-transaction
## Brief Changelog


## Testing and Verifying

- [ ] Can withdraw TIA
- [ ] Can withdraw other IBC tokens