### PR TITLE
Fix getPublicKeyTypeUrl sign order

### DIFF
--- a/packages/stores/src/account/utils.ts
+++ b/packages/stores/src/account/utils.ts
@@ -101,16 +101,16 @@ export function getPublicKeyTypeUrl({
   const chainIsStratos = chainId.startsWith("stratos");
   const useEthereumSign = chainFeatures.includes("eth-key-sign");
 
-  if (!useEthereumSign) {
-    return "/cosmos.crypto.secp256k1.PubKey";
-  }
-
   if (chainIsInjective) {
     return "/injective.crypto.v1beta1.ethsecp256k1.PubKey";
   }
 
   if (chainIsStratos) {
     return "/stratos.crypto.v1.ethsecp256k1.PubKey";
+  }
+
+  if (!useEthereumSign) {
+    return "/cosmos.crypto.secp256k1.PubKey";
   }
 
   return "/ethermint.crypto.v1.ethsecp256k1.PubKey";


### PR DESCRIPTION
## What is the purpose of the change:

Fix `getPublicKeyTypeUrl` with correct detection order

### Linear Task

Сontinuation of:
https://github.com/osmosis-labs/assetlists/pull/1946#issuecomment-2417400492
https://github.com/osmosis-labs/osmosis-frontend/pull/3896

## Brief Changelog

Updated function `getPublicKeyTypeUrl`

## Testing and Verifying

Tested locally with `yarn dev`, screenshots applied

![Screenshot 2024-10-18 at 18 23 54](https://github.com/user-attachments/assets/18e131bb-8faf-41fe-8886-22c161d85924)
![Screenshot 2024-10-18 at 18 24 04](https://github.com/user-attachments/assets/078d2cea-8338-4f39-a181-1a693d60c160)

