### PR TITLE
(Swap) Decrease Default Slippage

### DIFF
--- a/packages/web/components/place-limit-tool/index.tsx
+++ b/packages/web/components/place-limit-tool/index.tsx
@@ -30,6 +30,7 @@ import { TradeDetails } from "~/components/swap-tool/trade-details";
 import { GenericDisclaimer } from "~/components/tooltip/generic-disclaimer";
 import { Button } from "~/components/ui/button";
 import { EventPage } from "~/config";
+import { DefaultSlippage } from "~/config/swap";
 import {
   useDisclosure,
   useFeatureFlags,
@@ -170,7 +171,7 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
     const { onOpenWalletSelect } = useWalletSelect();
 
     const slippageConfig = useSlippageConfig({
-      defaultSlippage: quoteType === "in-given-out" ? "0.5" : "0.5",
+      defaultSlippage: quoteType === "in-given-out" ? "0.1" : "0.1",
       selectedIndex: quoteType === "in-given-out" ? 0 : 0,
     });
 
@@ -187,7 +188,8 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
     });
 
     const resetSlippage = useCallback(() => {
-      const defaultSlippage = quoteType === "in-given-out" ? "0.5" : "0.5";
+      const defaultSlippage =
+        quoteType === "in-given-out" ? DefaultSlippage : DefaultSlippage;
       if (
         slippageConfig.slippage.toDec() ===
         new Dec(defaultSlippage).quo(DecUtils.getTenExponentN(2))

--- a/packages/web/components/swap-tool/alt.tsx
+++ b/packages/web/components/swap-tool/alt.tsx
@@ -30,6 +30,7 @@ import { TradeDetails } from "~/components/swap-tool/trade-details";
 import { GenericDisclaimer } from "~/components/tooltip/generic-disclaimer";
 import { Button } from "~/components/ui/button";
 import { EventName, EventPage, OUTLIER_USD_VALUE_THRESHOLD } from "~/config";
+import { DefaultSlippage } from "~/config/swap";
 import {
   useAmplitudeAnalytics,
   useDisclosure,
@@ -113,7 +114,8 @@ export const AltSwapTool: FunctionComponent<SwapToolProps> = observer(
 
     const account = accountStore.getWallet(chainId);
     const slippageConfig = useSlippageConfig({
-      defaultSlippage: quoteType === "in-given-out" ? "0.5" : "0.5",
+      defaultSlippage:
+        quoteType === "in-given-out" ? DefaultSlippage : DefaultSlippage,
       selectedIndex: quoteType === "in-given-out" ? 0 : 0,
     });
 
@@ -189,7 +191,8 @@ export const AltSwapTool: FunctionComponent<SwapToolProps> = observer(
     }, [setBuyOpen, setSellOpen]);
 
     const resetSlippage = useCallback(() => {
-      const defaultSlippage = quoteType === "in-given-out" ? "0.5" : "0.5";
+      const defaultSlippage =
+        quoteType === "in-given-out" ? DefaultSlippage : DefaultSlippage;
       if (
         slippageConfig.slippage.toDec() ===
         new Dec(defaultSlippage).quo(DecUtils.getTenExponentN(2))

--- a/packages/web/config/swap.ts
+++ b/packages/web/config/swap.ts
@@ -1,0 +1,1 @@
+export const DefaultSlippage = "0.1";

--- a/packages/web/hooks/ui-config/use-slippage-config.ts
+++ b/packages/web/hooks/ui-config/use-slippage-config.ts
@@ -1,10 +1,12 @@
 import { ObservableSlippageConfig } from "@osmosis-labs/stores";
 import { useEffect, useState } from "react";
 
+import { DefaultSlippage } from "~/config/swap";
+
 /** Maintains a single instance of `ObservableSlippageConfig` for React view lifecycle.
  */
 export function useSlippageConfig({
-  defaultSlippage = "0.5",
+  defaultSlippage = DefaultSlippage,
   selectedIndex = 0,
 }: Partial<{
   defaultSlippage: string;


### PR DESCRIPTION
## What is the purpose of the change:

Change default slippage from `0.5%` to `0.1%` 

### Linear Task

https://linear.app/osmosis/issue/FE-1131/review-default-slippage-percentage-setting-in-system

## Testing and Verifying

- [ ] Swap slippage should be 0.1%  