### PR TITLE
feat(osmosis-pay-toast): update for mobile

### DIFF
--- a/packages/web/components/alert/cypher-card-toast.tsx
+++ b/packages/web/components/alert/cypher-card-toast.tsx
@@ -49,21 +49,31 @@ export function CypherCardToast() {
           <Image
             src="/images/cypher-card-intro.svg"
             alt={t("cypherCard.cypherSpend")}
-            width={136}
-            height={136}
+            width={isMobile ? 100 : 136}
+            height={isMobile ? 100 : 136}
           />
 
           <div className="mr-3 flex flex-col gap-2">
-            <Pill className="!px-2">{t("cypherCard.newPill")}</Pill>
+            <Pill className={classNames("!px-2", "sm:py-1 sm:text-caption")}>
+              {t("cypherCard.newPill")}
+            </Pill>
 
-            <div className="flex w-[16.875rem] max-w-[16.875rem] items-center justify-between">
+            <div className="flex w-[16.875rem] max-w-[16.875rem] items-center justify-between sm:w-fit sm:max-w-fit">
               <div className="flex flex-col gap-2">
-                <h1 className="flex-shrink-0 text-h6 font-h6">
+                <h1
+                  className={classNames(
+                    "flex-shrink-0 text-h6 font-h6",
+                    "sm:text-subtitle1 sm:font-subtitle1"
+                  )}
+                >
                   {t("cypherCard.cypherSpend")}
                 </h1>
                 <Link
                   href={CYPHER_CARD_URL}
-                  className="text-subtitle1 font-subtitle1 text-wosmongton-300 hover:underline"
+                  className={classNames(
+                    "text-wrap text-subtitle1 font-subtitle1 text-wosmongton-300 hover:underline",
+                    "sm:text-left sm:text-caption sm:font-caption"
+                  )}
                   onClick={(e) => {
                     e.stopPropagation();
                     onClose();


### PR DESCRIPTION
## What is the purpose of the change:

- Osmosis Pay toast, some clean up on smallest mobile screen size - 320px

https://linear.app/osmosis/issue/FE-1176/deploy-osmosis-pay-toast-and-deprecate-limit-orders-toast

<!-- > Add a link to the linear task that this PR is addressing. TIP: go to the linear task and use Ctrl/⌘ + C to copy a link. -->

## Testing and Verifying

mobile

<img width="631" alt="Screenshot 2024-10-23 at 8 54 14 AM" src="https://github.com/user-attachments/assets/1a3d9306-bb6e-4563-8d27-f3c04c7f19b0">
<img width="549" alt="Screenshot 2024-10-23 at 8 54 17 AM" src="https://github.com/user-attachments/assets/17a69ac4-6014-431f-9c8e-11b28b68096e">
<img width="631" alt="Screenshot 2024-10-23 at 8 54 20 AM" src="https://github.com/user-attachments/assets/8008ca61-41dd-4647-8eb5-bc07eddc52d0">

tablet / desktop
<img width="688" alt="Screenshot 2024-10-23 at 8 54 23 AM" src="https://github.com/user-attachments/assets/6ff46403-c856-4e24-861e-5634f01cb295">
