### PR TITLE
fix(disable-link-on-pools-card): disable link so when user clicks car…

### DIFF
--- a/packages/web/components/assets/pool-assets-name.tsx
+++ b/packages/web/components/assets/pool-assets-name.tsx
@@ -7,8 +7,8 @@ export const PoolAssetsName: FunctionComponent<{
   size?: "sm" | "md";
   assetDenoms?: string[];
   className?: string;
-  withLink?: boolean;
-}> = ({ size = "md", assetDenoms, className, withLink = true }) => {
+  withAssetInfoLink?: boolean;
+}> = ({ size = "md", assetDenoms, className, withAssetInfoLink = true }) => {
   const formatAssetName = useMemo(() => {
     return (asset: string) => {
       if (asset.startsWith("ibc/")) return truncate(asset);
@@ -26,7 +26,7 @@ export const PoolAssetsName: FunctionComponent<{
       <>
         {assetDenoms.map((asset, index) => (
           <Fragment key={asset}>
-            {withLink ? (
+            {withAssetInfoLink ? (
               <Link href={`/assets/${asset}`}>{formatAssetName(asset)}</Link>
             ) : (
               formatAssetName(asset)

--- a/packages/web/components/cards/my-position/index.tsx
+++ b/packages/web/components/cards/my-position/index.tsx
@@ -117,7 +117,7 @@ export const MyPositionCard: FunctionComponent<{
               <PoolAssetsName
                 size="md"
                 assetDenoms={currentCoins.map((asset) => asset.denom)}
-                withLink={false}
+                withAssetInfoLink={false}
               />
               <SkeletonLoader isLoaded={!isLoadingPositionDetails}>
                 {!hasPositionDetailsError && (

--- a/packages/web/components/cards/pool-card.tsx
+++ b/packages/web/components/cards/pool-card.tsx
@@ -50,7 +50,7 @@ export const PoolCard: FunctionComponent<
             <PoolAssetsName
               size="md"
               assetDenoms={poolAssets.map((asset) => asset.coinDenom)}
-              withLink={false}
+              withAssetInfoLink={false}
             />
             <div className="subtitle1 flex items-center gap-1 text-white-mid">
               {t("pools.poolId", { id: poolId })}


### PR DESCRIPTION
…d, it navigates to the pool instead of the asset

## What is the purpose of the change:

- users would frequently click an asset in their position card, which would navigate them to the assets page instead of the position

### Linear Task

https://linear.app/osmosis/issue/FE-926/if-i-click-on-the-solusdc-text-instead-of-being-taken-to-the-asset

## Brief Changelog

- since we reuse PoolAssetsName frequently, add a withLink prop that defaults to true, and removes the link if explicitly set to false

## Testing and Verifying

- example of navigating to pool instead of asset when withLink is set to false

https://github.com/user-attachments/assets/c10a49ee-b333-4885-a175-8b4faf1d34c8

- example of navigating to assets when withLink is true by default

https://github.com/user-attachments/assets/fb433813-2129-4e17-8aba-2ce72623146b