### PR TITLE
feat(portfolio-page---empty-wallet-edge-case): handle empty wallet st…

### DIFF
--- a/packages/web/components/complex/portfolio/assets-overview.tsx
+++ b/packages/web/components/complex/portfolio/assets-overview.tsx
@@ -111,8 +111,10 @@ const getLocalizedPortfolioOverTimeData = (
   // If there is only one data point, add 15 more points to the array to create a more accurate line
   if (portfolioOverTimeData.length <= 1 && portfolioOverTimeData[0]) {
     const baseDataPoint = portfolioOverTimeData[0];
+    const baseTime =
+      baseDataPoint.value === 0 ? Date.now() / 1000 : baseDataPoint.time;
     const additionalPoints = Array.from({ length: 15 }, (_, index) => ({
-      time: Date.now() / 1000 - 86400 * (index + 1),
+      time: baseTime - 86400 * (index + 1),
       value: baseDataPoint.value,
     }));
     return [...additionalPoints, baseDataPoint]

--- a/packages/web/components/complex/portfolio/assets-overview.tsx
+++ b/packages/web/components/complex/portfolio/assets-overview.tsx
@@ -47,6 +47,22 @@ const calculatePortfolioPerformance = (
   selectedDifferencePricePretty: PricePretty;
   totalPriceChange: number;
 } => {
+  // Check if all values are 0, for instance if a user created a new wallet and has no transactions
+  const hasAllZeroValues = data?.every((point) => point.value === 0);
+  if (
+    hasAllZeroValues &&
+    (dataPoint?.value === 0 || dataPoint?.value === undefined)
+  ) {
+    return {
+      selectedPercentageRatePretty: new RatePretty(new Dec(0)),
+      selectedDifferencePricePretty: new PricePretty(
+        DEFAULT_VS_CURRENCY,
+        new Dec(0)
+      ),
+      totalPriceChange: 0,
+    };
+  }
+
   const openingPrice = data?.[0]?.value;
   const openingPriceWithFallback = !openingPrice ? 1 : openingPrice; // handle first value being 0 or undefined
   const selectedDifference = (dataPoint?.value ?? 0) - openingPriceWithFallback;
@@ -85,6 +101,32 @@ const timeToLocal = (originalTime: number) => {
       d.getMilliseconds()
     ) / 1000
   );
+};
+
+const getLocalizedPortfolioOverTimeData = (
+  portfolioOverTimeData: ChartPortfolioOverTimeResponse[] | undefined
+) => {
+  if (!portfolioOverTimeData) return undefined;
+
+  // If there is only one data point, add 15 more points to the array to create a more accurate line
+  if (portfolioOverTimeData.length <= 1 && portfolioOverTimeData[0]) {
+    const baseDataPoint = portfolioOverTimeData[0];
+    const additionalPoints = Array.from({ length: 15 }, (_, index) => ({
+      time: Date.now() / 1000 - 86400 * (index + 1),
+      value: baseDataPoint.value,
+    }));
+    return [...additionalPoints, baseDataPoint]
+      .sort((a, b) => a.time - b.time)
+      .map((data) => ({
+        time: timeToLocal(data.time),
+        value: data.value,
+      }));
+  }
+
+  return portfolioOverTimeData.map((data) => ({
+    time: timeToLocal(data.time),
+    value: data.value,
+  }));
 };
 
 export const AssetsOverview: FunctionComponent<
@@ -160,13 +202,7 @@ export const AssetsOverview: FunctionComponent<
   const isChartMinimized = width < Breakpoint.lg ? false : _isChartMinimized;
 
   const localizedPortfolioOverTimeData = useMemo(
-    () =>
-      portfolioOverTimeData?.map((data) => {
-        return {
-          time: timeToLocal(data.time),
-          value: data.value,
-        };
-      }),
+    () => getLocalizedPortfolioOverTimeData(portfolioOverTimeData),
     [portfolioOverTimeData]
   );
 

--- a/packages/web/components/complex/portfolio/portfolio-page.tsx
+++ b/packages/web/components/complex/portfolio/portfolio-page.tsx
@@ -64,6 +64,9 @@ export const PortfolioPage: FunctionComponent = observer(() => {
 
   const { isLoading: isWalletLoading } = useWalletSelect();
 
+  const showZeroBalancesSplash =
+    userHasNoAssets === true || userHasNoAssets === undefined;
+
   return (
     <div
       className={classNames(
@@ -130,7 +133,7 @@ export const PortfolioPage: FunctionComponent = observer(() => {
                   <div className="mx-auto my-6 w-fit">
                     <Spinner />
                   </div>
-                ) : userHasNoAssets ? (
+                ) : showZeroBalancesSplash ? (
                   <UserZeroBalanceTableSplash />
                 ) : (
                   <TabPanels>

--- a/packages/web/components/transactions/recent-activity/recent-activity.tsx
+++ b/packages/web/components/transactions/recent-activity/recent-activity.tsx
@@ -33,7 +33,7 @@ export const RecentActivity: FunctionComponent = observer(() => {
 
   const { t } = useTranslation();
 
-  const { data: transactionsData, isLoading: isGetTransactionsLoading } =
+  const { data: transactionsData, isFetched: isGetTransactionsFetched } =
     api.edge.transactions.getTransactions.useQuery(
       {
         address: wallet?.address || "",
@@ -48,6 +48,8 @@ export const RecentActivity: FunctionComponent = observer(() => {
   const { transactions } = transactionsData ?? {
     transactions: [],
   };
+
+  const showNoTransactionsSplash = transactions.length === 0;
 
   const topActivity = transactions.slice(0, ACTIVITY_LIMIT);
 
@@ -64,9 +66,9 @@ export const RecentActivity: FunctionComponent = observer(() => {
         />
       </div>
       <div className="flex flex-col justify-between self-stretch py-2">
-        {isGetTransactionsLoading ? (
+        {!isGetTransactionsFetched ? (
           <RecentActivitySkeleton />
-        ) : topActivity?.length === 0 ? (
+        ) : showNoTransactionsSplash ? (
           <NoTransactionsSplash variant="transactions" />
         ) : (
           topActivity.map((activity) => {


### PR DESCRIPTION
## What is the purpose of the change:

- gracefully handle empty wallet states

### Linear Task

https://linear.app/osmosis/issue/FE-1132/display-issue-empty-wallet-value-shows-100percent

## Brief Changelog

- clean up total balance - should render zero
- clean up chart - should show a horizontal line, full width, all zero

note - lightweight charts won't display negative values by default, which is why the y-axis only shows positive values

before

<img width="1294" alt="Screenshot 2024-10-24 at 4 07 05 PM" src="https://github.com/user-attachments/assets/71a1ddcc-eb15-459a-98a5-7a3b4e13619f">

after 

<img width="1301" alt="Screenshot 2024-10-24 at 4 06 40 PM" src="https://github.com/user-attachments/assets/20898ba8-7a9f-41d8-83e8-d4850026dd5f">


