### PR TITLE
(Deposit/Withdrawal) Fix Withdrawing POL

### DIFF
--- a/packages/stores/src/account/amino-converters.ts
+++ b/packages/stores/src/account/amino-converters.ts
@@ -98,7 +98,7 @@ export async function getAminoConverters() {
                     : undefined,
               }
             : {},
-          timeout_timestamp: timeoutTimestamp.toString(),
+          timeout_timestamp: timeoutTimestamp?.toString(),
         }),
         fromAmino: ({
           source_port,

--- a/packages/stores/src/account/amino-converters.ts
+++ b/packages/stores/src/account/amino-converters.ts
@@ -79,6 +79,7 @@ export async function getAminoConverters() {
           sender,
           receiver,
           timeoutHeight,
+          timeoutTimestamp,
         }: MsgTransfer): MsgTransferAmino => ({
           source_port: sourcePort,
           source_channel: sourceChannel,
@@ -97,6 +98,7 @@ export async function getAminoConverters() {
                     : undefined,
               }
             : {},
+          timeout_timestamp: timeoutTimestamp.toString(),
         }),
         fromAmino: ({
           source_port,


### PR DESCRIPTION
## What is the purpose of the change:

To fix the POL withdrawal issue, update the amino converters to include the timeout_timestamp. The absence of this field caused a mismatch between the signed amino message and the original message.

### Linear Task

https://linear.app/osmosis/issue/FE-1174/error-encountered-when-withdrawing-pol

## Testing and Verifying

-  [ ] Can withdraw POL
