### PR TITLE
🧹 (Dust to OSMO): Feature implementation

### DIFF
--- a/packages/types/src/feature-flags-types.ts
+++ b/packages/types/src/feature-flags-types.ts
@@ -25,4 +25,5 @@ export type AvailableFlags =
   | "sqsActiveOrders"
   | "alloyedAssets"
   | "bridgeDepositAddress"
-  | "nomicWithdrawAmount";
+  | "nomicWithdrawAmount"
+  | "dustToOsmo";

--- a/packages/web/.env
+++ b/packages/web/.env
@@ -49,3 +49,6 @@ BLOCKAID_BASE_URL=http://api.blockaid.io:80
 # BLOCKAID_API_KEY=
 
 NEXT_PUBLIC_SPEND_LIMIT_CONTRACT_ADDRESS=osmo10xqv8rlpkflywm92k5wdmplzy7khtasl9c2c08psmvlu543k724sy94k74
+
+# Feature flag for dust to osmo
+# NEXT_PUBLIC_SHOW_DUST_TO_OSMO=true

--- a/packages/web/components/complex/dust-to-osmo/dust-to-osmo.tsx
+++ b/packages/web/components/complex/dust-to-osmo/dust-to-osmo.tsx
@@ -47,6 +47,18 @@ export function DustToOsmo({ onComplete }: { onComplete?: () => void }) {
     onComplete && onComplete();
   }, [onComplete]);
 
+  useEffect(() => {
+    // Stop loading if there are no dust assets
+    if (convertDust && isFetchedDust && dustAssets?.length === 0) {
+      // Prevent a flash of the button if the dust assets are fetched quickly
+      const timer = setTimeout(() => {
+        setConvertDust(false);
+      }, 500);
+
+      return () => clearTimeout(timer);
+    }
+  }, [convertDust, dustAssets, isFetchedDust]);
+
   return (
     <>
       <Button
@@ -59,7 +71,7 @@ export function DustToOsmo({ onComplete }: { onComplete?: () => void }) {
         <Icon id="dust-broom" className="h-6 w-6" />
         {t("dustToOsmo.mainButton")}
       </Button>
-      {convertDust && isSuccessDust && (
+      {convertDust && isSuccessDust && dustAssets.length > 0 && (
         <SequentialSwapExecutor
           dustAssets={dustAssets}
           onComplete={handleConvertDustComplete}

--- a/packages/web/components/complex/dust-to-osmo/dust-to-osmo.tsx
+++ b/packages/web/components/complex/dust-to-osmo/dust-to-osmo.tsx
@@ -22,19 +22,25 @@ export function DustToOsmo() {
 
   const [convertDust, setConvertDust] = useState(false);
 
-  const { data: dustAssets, isSuccess: isSuccessDust } =
-    api.edge.assets.getUserDustAssets.useQuery(
-      {
-        userOsmoAddress: account?.address ?? "",
-        // TODO(Greg): the dust threshold has changed to 0.02.
-        // Is it ok to use this or should I use the 0.01 which was specified?
-        dustThreshold: HideDustUserSetting.DUST_THRESHOLD,
-      },
-      {
-        enabled: !isLoadingWallet && Boolean(account?.address) && convertDust,
-        cacheTime: 0,
-      }
-    );
+  const {
+    data: dustAssets,
+    isSuccess: isSuccessDust,
+    isFetched: isFetchedDust,
+  } = api.edge.assets.getUserDustAssets.useQuery(
+    {
+      userOsmoAddress: account?.address ?? "",
+      // TODO(Greg): the dust threshold has changed to 0.02.
+      // Is it ok to use this or should I use the 0.01 which was specified?
+      dustThreshold: HideDustUserSetting.DUST_THRESHOLD,
+    },
+    {
+      enabled: !isLoadingWallet && Boolean(account?.address) && convertDust,
+      cacheTime: 0,
+      refetchOnWindowFocus: false,
+      refetchOnMount: false,
+      refetchOnReconnect: false,
+    }
+  );
 
   return (
     <>

--- a/packages/web/components/complex/dust-to-osmo/dust-to-osmo.tsx
+++ b/packages/web/components/complex/dust-to-osmo/dust-to-osmo.tsx
@@ -26,6 +26,7 @@ export function DustToOsmo({ onComplete }: { onComplete?: () => void }) {
     data: dustAssets,
     isSuccess: isSuccessDust,
     isFetched: isFetchedDust,
+    refetch: refetchDust,
   } = api.edge.assets.getUserDustAssets.useQuery(
     {
       userOsmoAddress: account?.address ?? "",
@@ -36,6 +37,7 @@ export function DustToOsmo({ onComplete }: { onComplete?: () => void }) {
     {
       enabled: !isLoadingWallet && Boolean(account?.address) && convertDust,
       cacheTime: 0,
+      staleTime: 0,
       refetchOnWindowFocus: false,
       refetchOnMount: false,
       refetchOnReconnect: false,
@@ -44,8 +46,10 @@ export function DustToOsmo({ onComplete }: { onComplete?: () => void }) {
 
   const handleConvertDustComplete = useCallback(() => {
     setConvertDust(false);
+    // Refetch to ensure the dust assets are up to date
+    refetchDust();
     onComplete && onComplete();
-  }, [onComplete]);
+  }, [onComplete, refetchDust]);
 
   useEffect(() => {
     // Stop loading if there are no dust assets

--- a/packages/web/components/complex/dust-to-osmo/dust-to-osmo.tsx
+++ b/packages/web/components/complex/dust-to-osmo/dust-to-osmo.tsx
@@ -2,7 +2,7 @@ import { Dec } from "@keplr-wallet/unit";
 import { useMutation, UseMutationResult } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
-import { Icon } from "~/components/assets";
+import { FallbackImg, Icon } from "~/components/assets";
 import { Button } from "~/components/ui/button";
 import { DefaultSlippage } from "~/config/swap";
 import { useTranslation, useWalletSelect } from "~/hooks";
@@ -163,6 +163,8 @@ function SwapHandler({
   ) => void;
 }) {
   const {
+    fromAsset,
+    toAsset,
     inAmountInput: { setAmount: setInAmount },
     isReadyToSwap,
     sendTradeTokenInTx,
@@ -197,5 +199,34 @@ function SwapHandler({
     onSendSwapTxStatusChange(fromDenom, sendSwapTxStatus);
   }, [fromDenom, sendSwapTxStatus, onSendSwapTxStatusChange]);
 
-  return <></>;
+  return (
+    <>
+      {shouldExecuteSwap &&
+        fromAsset?.amount?.currency.coinImageUrl &&
+        toAsset?.amount?.currency.coinImageUrl && (
+          <div className="flex lg:hidden items-center justify-end transition-colors duration-200 ease-in-out">
+            <FallbackImg
+              alt={fromAsset?.amount?.denom}
+              src={fromAsset?.amount?.currency.coinImageUrl}
+              fallbacksrc="/icons/question-mark.svg"
+              height={32}
+              width={32}
+            />
+            <Icon
+              id="arrow-right"
+              width={16}
+              height={16}
+              className="my-[8px] mx-[4px] text-osmoverse-500"
+            />
+            <FallbackImg
+              alt={toAsset?.amount?.denom}
+              src={toAsset?.amount?.currency.coinImageUrl}
+              fallbacksrc="/icons/question-mark.svg"
+              height={32}
+              width={32}
+            />
+          </div>
+        )}
+    </>
+  );
 }

--- a/packages/web/components/complex/dust-to-osmo/dust-to-osmo.tsx
+++ b/packages/web/components/complex/dust-to-osmo/dust-to-osmo.tsx
@@ -1,0 +1,55 @@
+import { useState } from "react";
+
+import { Icon } from "~/components/assets";
+import { Button } from "~/components/ui/button";
+import { useTranslation, useWalletSelect } from "~/hooks";
+import { useStore } from "~/stores";
+import { HideDustUserSetting } from "~/stores/user-settings";
+import { api } from "~/utils/trpc";
+
+export function DustToOsmo() {
+  const { t } = useTranslation();
+
+  const { accountStore } = useStore();
+  const account = accountStore.getWallet(accountStore.osmosisChainId);
+  const { isLoading: isLoadingWallet } = useWalletSelect();
+
+  const [loadDustAssets, setLoadDustAssets] = useState(false);
+
+  const { data: dustAssets, isLoading: isLoadingDust } =
+    api.edge.assets.getUserDustAssets.useQuery(
+      {
+        userOsmoAddress: account?.address ?? "",
+        // TODO(Greg): the dust threshold has changed to 0.02.
+        // Is it ok to use this or should I use the 0.01 which was specified?
+        dustThreshold: HideDustUserSetting.DUST_THRESHOLD,
+      },
+      {
+        enabled:
+          !isLoadingWallet && Boolean(account?.address) && loadDustAssets,
+        cacheTime: 0,
+      }
+    );
+
+  return (
+    <>
+      <Button
+        className="gap-2 !border !border-osmoverse-700 !py-2 !px-4 !text-wosmongton-200"
+        variant="outline"
+        size="lg-full"
+        isLoading={isLoadingDust}
+        onClick={() => setLoadDustAssets(true)}
+      >
+        <Icon id="dust-broom" className="h-6 w-6" />
+        {t("dustToOsmo.mainButton")}
+      </Button>
+      {dustAssets && dustAssets.length > 0 && (
+        <div className="flex flex-col gap-2">
+          {dustAssets.map((asset) => (
+            <div key={asset.coinDenom}>{asset.coinDenom}</div>
+          ))}
+        </div>
+      )}
+    </>
+  );
+}

--- a/packages/web/components/complex/dust-to-osmo/dust-to-osmo.tsx
+++ b/packages/web/components/complex/dust-to-osmo/dust-to-osmo.tsx
@@ -13,7 +13,7 @@ import { api } from "~/utils/trpc";
 
 const maxSlippage = new Dec(DefaultSlippage);
 
-export function DustToOsmo() {
+export function DustToOsmo({ onComplete }: { onComplete?: () => void }) {
   const { t } = useTranslation();
 
   const { accountStore } = useStore();
@@ -42,6 +42,11 @@ export function DustToOsmo() {
     }
   );
 
+  const handleConvertDustComplete = useCallback(() => {
+    setConvertDust(false);
+    onComplete && onComplete();
+  }, [onComplete]);
+
   return (
     <>
       <Button
@@ -57,7 +62,7 @@ export function DustToOsmo() {
       {convertDust && isSuccessDust && (
         <SequentialSwapExecutor
           dustAssets={dustAssets}
-          onComplete={() => setConvertDust(false)}
+          onComplete={handleConvertDustComplete}
         />
       )}
     </>

--- a/packages/web/components/complex/dust-to-osmo/dust-to-osmo.tsx
+++ b/packages/web/components/complex/dust-to-osmo/dust-to-osmo.tsx
@@ -155,7 +155,9 @@ function SwapHandler({
     useQueryParams: false,
     maxSlippage,
     quoteType: "out-given-in",
-    inputDebounceMs: 0,
+    // Swap needs a bit of time to stabilize
+    // otherwise account seq errors can happen
+    inputDebounceMs: 100,
   });
 
   useEffect(() => {
@@ -176,7 +178,7 @@ function SwapHandler({
 
   useEffect(() => {
     onSendSwapTxStatusChange(fromDenom, sendSwapTxStatus);
-  }, [sendSwapTxStatus, onSendSwapTxStatusChange, fromDenom]);
+  }, [fromDenom, sendSwapTxStatus, onSendSwapTxStatusChange]);
 
   return <></>;
 }

--- a/packages/web/components/complex/dust-to-osmo/dust-to-osmo.tsx
+++ b/packages/web/components/complex/dust-to-osmo/dust-to-osmo.tsx
@@ -1,11 +1,17 @@
-import { useState } from "react";
+import { Dec } from "@keplr-wallet/unit";
+import { useMutation, UseMutationResult } from "@tanstack/react-query";
+import { useCallback, useEffect, useState } from "react";
 
 import { Icon } from "~/components/assets";
 import { Button } from "~/components/ui/button";
+import { DefaultSlippage } from "~/config/swap";
 import { useTranslation, useWalletSelect } from "~/hooks";
+import { useSwap } from "~/hooks/use-swap";
 import { useStore } from "~/stores";
 import { HideDustUserSetting } from "~/stores/user-settings";
 import { api } from "~/utils/trpc";
+
+const maxSlippage = new Dec(DefaultSlippage);
 
 export function DustToOsmo() {
   const { t } = useTranslation();
@@ -14,9 +20,30 @@ export function DustToOsmo() {
   const account = accountStore.getWallet(accountStore.osmosisChainId);
   const { isLoading: isLoadingWallet } = useWalletSelect();
 
-  const [loadDustAssets, setLoadDustAssets] = useState(false);
+  const [convertDust, setConvertDust] = useState(false);
 
-  const { data: dustAssets, isLoading: isLoadingDust } =
+  const [isSendingSwapTxs, setIsSendingSwapTxs] = useState(0);
+
+  const onSendSwapTxStatus = useCallback(
+    (status: UseMutationResult["status"]) => {
+      switch (status) {
+        case "loading":
+          setIsSendingSwapTxs((prev) => prev + 1);
+          break;
+        case "error":
+        case "success":
+          // We are being cheerfully neglectful with error handling here
+          setIsSendingSwapTxs((prev) => prev - 1);
+          break;
+        case "idle":
+        default:
+          break;
+      }
+    },
+    []
+  );
+
+  const { data: dustAssets, isSuccess: isSuccessDust } =
     api.edge.assets.getUserDustAssets.useQuery(
       {
         userOsmoAddress: account?.address ?? "",
@@ -25,8 +52,7 @@ export function DustToOsmo() {
         dustThreshold: HideDustUserSetting.DUST_THRESHOLD,
       },
       {
-        enabled:
-          !isLoadingWallet && Boolean(account?.address) && loadDustAssets,
+        enabled: !isLoadingWallet && Boolean(account?.address) && convertDust,
         cacheTime: 0,
       }
     );
@@ -37,19 +63,71 @@ export function DustToOsmo() {
         className="gap-2 !border !border-osmoverse-700 !py-2 !px-4 !text-wosmongton-200"
         variant="outline"
         size="lg-full"
-        isLoading={isLoadingDust}
-        onClick={() => setLoadDustAssets(true)}
+        isLoading={convertDust && isSendingSwapTxs > 0}
+        onClick={() => setConvertDust(true)}
       >
         <Icon id="dust-broom" className="h-6 w-6" />
         {t("dustToOsmo.mainButton")}
       </Button>
-      {dustAssets && dustAssets.length > 0 && (
-        <div className="flex flex-col gap-2">
-          {dustAssets.map((asset) => (
-            <div key={asset.coinDenom}>{asset.coinDenom}</div>
-          ))}
-        </div>
-      )}
+      {isSuccessDust &&
+        dustAssets.map((dustAsset) => (
+          <SwapHandler
+            key={dustAsset.coinDenom}
+            fromDenom={dustAsset.coinDenom}
+            amount={dustAsset.amount.toDec().toString()}
+            onSendSwapTxStatus={onSendSwapTxStatus}
+          />
+        ))}
     </>
   );
+}
+
+function SwapHandler({
+  fromDenom,
+  amount,
+  onSendSwapTxStatus,
+}: {
+  fromDenom: string;
+  amount: string;
+  onSendSwapTxStatus: (status: UseMutationResult["status"]) => void;
+}) {
+  const {
+    inAmountInput: { setAmount: setInAmount },
+    isReadyToSwap,
+    sendTradeTokenInTx,
+  } = useSwap({
+    initialFromDenom: fromDenom,
+    initialToDenom: "OSMO",
+    useQueryParams: false,
+    maxSlippage,
+    quoteType: "out-given-in",
+    inputDebounceMs: 0,
+  });
+
+  useEffect(() => {
+    setInAmount(amount);
+  }, [setInAmount, amount]);
+
+  const {
+    mutate: sendSwapTx,
+    isIdle: isSendSwapTxIdle,
+    status: sendSwapTxStatus,
+  } = useMutation(sendTradeTokenInTx);
+
+  useEffect(() => {
+    if (isReadyToSwap && isSendSwapTxIdle) {
+      sendSwapTx();
+    }
+  }, [isReadyToSwap, isSendSwapTxIdle, sendSwapTx]);
+
+  useEffect(() => {
+    if (sendSwapTxStatus !== "idle") {
+      // useSwap needs a bit of time to be ready so we send loading first
+      onSendSwapTxStatus("loading");
+    } else {
+      onSendSwapTxStatus(sendSwapTxStatus);
+    }
+  }, [sendSwapTxStatus, onSendSwapTxStatus]);
+
+  return <></>;
 }

--- a/packages/web/components/table/portfolio-asset-balances.tsx
+++ b/packages/web/components/table/portfolio-asset-balances.tsx
@@ -126,6 +126,7 @@ export const PortfolioAssetBalancesTable: FunctionComponent<{
     isPreviousData,
     isFetchingNextPage,
     fetchNextPage,
+    refetch,
   } = api.edge.assets.getUserBridgeAssets.useInfiniteQuery(
     {
       userOsmoAddress: account?.address,
@@ -441,7 +442,7 @@ export const PortfolioAssetBalancesTable: FunctionComponent<{
       </table>
       {assetsData.length > 0 && (
         <div className="flex gap-4 py-2 px-4">
-          {featureFlags.dustToOsmo && <DustToOsmo />}
+          {featureFlags.dustToOsmo && <DustToOsmo onComplete={refetch} />}
           <Button
             onClick={() => setHideDust(!hideDust)}
             className="ml-auto gap-2 !border !border-osmoverse-700 !py-2 !px-4 !text-wosmongton-200"

--- a/packages/web/components/table/portfolio-asset-balances.tsx
+++ b/packages/web/components/table/portfolio-asset-balances.tsx
@@ -21,6 +21,7 @@ import {
   useState,
 } from "react";
 
+import { DustToOsmo } from "~/components/complex/dust-to-osmo/dust-to-osmo";
 import { AssetCell } from "~/components/table/cells/asset";
 import { SpriteIconId } from "~/config";
 import {
@@ -74,6 +75,7 @@ export const PortfolioAssetBalancesTable: FunctionComponent<{
   const { width, isMobile } = useWindowSize();
   const router = useRouter();
   const { t } = useTranslation();
+  const featureFlags = useFeatureFlags();
 
   // #region search
   const [searchQuery, setSearchQuery] = useState<Search | undefined>();
@@ -438,10 +440,11 @@ export const PortfolioAssetBalancesTable: FunctionComponent<{
         </tbody>
       </table>
       {assetsData.length > 0 && (
-        <div className="flex items-center justify-end gap-4 py-2 px-4">
+        <div className="flex gap-4 py-2 px-4">
+          {featureFlags.dustToOsmo && <DustToOsmo />}
           <Button
             onClick={() => setHideDust(!hideDust)}
-            className="gap-2 !border !border-osmoverse-700 !py-2 !px-4 !text-wosmongton-200"
+            className="ml-auto gap-2 !border !border-osmoverse-700 !py-2 !px-4 !text-wosmongton-200"
             variant="outline"
             size="lg-full"
           >

--- a/packages/web/config/env.ts
+++ b/packages/web/config/env.ts
@@ -25,3 +25,7 @@ export const GITHUB_API_TOKEN = process.env.GITHUB_API_TOKEN;
 
 export const SPEND_LIMIT_CONTRACT_ADDRESS =
   process.env.NEXT_PUBLIC_SPEND_LIMIT_CONTRACT_ADDRESS;
+
+// TODO(Greg): add this flag to LaunchDarkly and drop the .env config
+export const SHOW_DUST_TO_OSMO =
+  process.env.NEXT_PUBLIC_SHOW_DUST_TO_OSMO === "true";

--- a/packages/web/hooks/use-feature-flags.ts
+++ b/packages/web/hooks/use-feature-flags.ts
@@ -2,6 +2,7 @@ import { AvailableFlags } from "@osmosis-labs/types";
 import { useFlags, useLDClient } from "launchdarkly-react-client-sdk";
 import { useEffect, useState } from "react";
 
+import { SHOW_DUST_TO_OSMO } from "~/config";
 import { useWindowSize } from "~/hooks";
 
 const defaultFlags: Record<AvailableFlags, boolean> = {
@@ -32,6 +33,8 @@ const defaultFlags: Record<AvailableFlags, boolean> = {
   alloyedAssets: false,
   bridgeDepositAddress: false,
   nomicWithdrawAmount: false,
+  // TODO(Greg): add this flag to LaunchDarkly and drop the .env config
+  dustToOsmo: SHOW_DUST_TO_OSMO,
 };
 
 export function useFeatureFlags() {

--- a/packages/web/hooks/use-swap.tsx
+++ b/packages/web/hooks/use-swap.tsx
@@ -75,6 +75,9 @@ type SwapOptions = {
   forceSwapInPoolId?: string;
   maxSlippage: Dec | undefined;
   quoteType?: QuoteDirection;
+  /** Set to the number of milliseconds to debounce the input amount for both input and output.
+   *  Defaults to 200ms. */
+  inputDebounceMs?: number;
 };
 
 // Note: For computing spot price between token in and out, we use this multiplier
@@ -102,6 +105,7 @@ export function useSwap(
     forceSwapInPoolId,
     maxSlippage,
     quoteType = "out-given-in",
+    inputDebounceMs,
   }: SwapOptions = { maxSlippage: undefined }
 ) {
   const { chainStore, accountStore } = useStore();
@@ -132,12 +136,14 @@ export function useSwap(
     forceSwapInPoolId,
     maxSlippage,
     swapAssets,
+    inputDebounceMs,
   });
 
   const outAmountInput = useSwapAmountInput({
     forceSwapInPoolId,
     maxSlippage,
     swapAssets: reverseSwapAssets,
+    inputDebounceMs,
   });
 
   // load flags
@@ -986,10 +992,12 @@ function useSwapAmountInput({
   swapAssets,
   forceSwapInPoolId,
   maxSlippage,
+  inputDebounceMs = 200,
 }: {
   swapAssets: ReturnType<typeof useSwapAssets>;
   forceSwapInPoolId: string | undefined;
   maxSlippage: Dec | undefined;
+  inputDebounceMs?: number;
 }) {
   const { chainStore, accountStore } = useStore();
   const account = accountStore.getWallet(chainStore.osmosis.chainId);
@@ -1002,6 +1010,7 @@ function useSwapAmountInput({
   const inAmountInput = useAmountInput({
     currency: swapAssets.fromAsset,
     gasAmount: gasAmount,
+    inputDebounceMs,
   });
 
   const balanceQuoteQueryEnabled =

--- a/packages/web/hooks/use-swap.tsx
+++ b/packages/web/hooks/use-swap.tsx
@@ -709,18 +709,41 @@ export function useSwap(
     outAmountInput.fiatValue,
   ]);
 
+  const quoteToReturn =
+    isQuoteLoading || inAmountInput.isTyping
+      ? positivePrevQuote
+      : !quoteErrorMsg
+      ? quote
+      : undefined;
+
+  const inAmount = inAmountInput.amount?.toDec();
+  const inDebouncedAmount = inAmountInput.debouncedInAmount?.toDec();
+  const outAmount = outAmountInput.amount?.toDec();
+  const outDebouncedAmount = outAmountInput.debouncedInAmount?.toDec();
+
+  const isReadyToSwap =
+    maxSlippage?.isPositive() &&
+    account &&
+    swapAssets.fromAsset &&
+    swapAssets.toAsset &&
+    inAmount?.isPositive() &&
+    inDebouncedAmount?.isPositive() &&
+    inAmount?.equals(inDebouncedAmount) &&
+    outAmount?.isPositive() &&
+    outDebouncedAmount?.isPositive() &&
+    outAmount?.equals(outDebouncedAmount) &&
+    quoteToReturn &&
+    !precedentError &&
+    !hasOverSpendLimitError &&
+    !isSlippageOverBalance;
+
   return {
     ...swapAssets,
     inAmountInput,
     outAmountInput,
     tokenOutFiatValue,
     tokenInFeeAmountFiatValue,
-    quote:
-      isQuoteLoading || inAmountInput.isTyping
-        ? positivePrevQuote
-        : !quoteErrorMsg
-        ? quote
-        : undefined,
+    quote: quoteToReturn,
     inBaseOutQuoteSpotPrice,
     totalFee: sum([
       tokenInFeeAmountFiatValue,
@@ -739,6 +762,7 @@ export function useSwap(
     hasOverSpendLimitError,
     isSlippageOverBalance,
     quoteType,
+    isReadyToSwap,
   };
 }
 

--- a/packages/web/localizations/de.json
+++ b/packages/web/localizations/de.json
@@ -200,6 +200,9 @@
     "acceptedEverywhere": "Ihr OSMO, jetzt überall akzeptiert",
     "newPill": "Neu"
   },
+  "dustToOsmo": {
+    "mainButton": "Staub in OSMO umwandeln"
+  },
   "portfolio": {
     "buy": "Kaufen",
     "sell": "Verkaufen",

--- a/packages/web/localizations/en.json
+++ b/packages/web/localizations/en.json
@@ -200,6 +200,9 @@
     "acceptedEverywhere": "Your OSMO, now accepted everywhere",
     "newPill": "New"
   },
+  "dustToOsmo": {
+    "mainButton": "Convert dust to OSMO"
+  },
   "portfolio": {
     "buy": "Buy",
     "sell": "Sell",

--- a/packages/web/localizations/es.json
+++ b/packages/web/localizations/es.json
@@ -200,6 +200,9 @@
     "acceptedEverywhere": "Tu OSMO, ahora aceptado en todas partes",
     "newPill": "Nuevo"
   },
+  "dustToOsmo": {
+    "mainButton": "Convertir polvo a OSMO"
+  },
   "portfolio": {
     "buy": "Comprar",
     "sell": "Vender",

--- a/packages/web/localizations/fa.json
+++ b/packages/web/localizations/fa.json
@@ -200,6 +200,9 @@
     "acceptedEverywhere": "OSMO شما، اکنون در همه جا پذیرفته شده است",
     "newPill": "جدید"
   },
+  "dustToOsmo": {
+    "mainButton": "گرد و غبار را به OSMO تبدیل کنید"
+  },
   "portfolio": {
     "buy": "خرید کنید",
     "sell": "فروش",

--- a/packages/web/localizations/fr.json
+++ b/packages/web/localizations/fr.json
@@ -200,6 +200,9 @@
     "acceptedEverywhere": "Votre OSMO, désormais accepté partout",
     "newPill": "Nouveau"
   },
+  "dustToOsmo": {
+    "mainButton": "Convertir la poussière en OSMO"
+  },
   "portfolio": {
     "buy": "Acheter",
     "sell": "Vendre",

--- a/packages/web/localizations/gu.json
+++ b/packages/web/localizations/gu.json
@@ -200,6 +200,9 @@
     "acceptedEverywhere": "તમારું OSMO, હવે સર્વત્ર સ્વીકાર્ય છે",
     "newPill": "નવી"
   },
+  "dustToOsmo": {
+    "mainButton": "ધૂળને OSMO માં કન્વર્ટ કરો"
+  },
   "portfolio": {
     "buy": "ખરીદો",
     "sell": "વેચો",

--- a/packages/web/localizations/hi.json
+++ b/packages/web/localizations/hi.json
@@ -200,6 +200,9 @@
     "acceptedEverywhere": "आपका OSMO, अब हर जगह स्वीकार्य",
     "newPill": "नया"
   },
+  "dustToOsmo": {
+    "mainButton": "धूल को OSMO में परिवर्तित करें"
+  },
   "portfolio": {
     "buy": "खरीदना",
     "sell": "बेचना",

--- a/packages/web/localizations/ja.json
+++ b/packages/web/localizations/ja.json
@@ -200,6 +200,9 @@
     "acceptedEverywhere": "あなたのOSMOは今やどこでも受け入れられます",
     "newPill": "新しい"
   },
+  "dustToOsmo": {
+    "mainButton": "ほこりをOSMOに変換する"
+  },
   "portfolio": {
     "buy": "買う",
     "sell": "売る",

--- a/packages/web/localizations/ko.json
+++ b/packages/web/localizations/ko.json
@@ -200,6 +200,9 @@
     "acceptedEverywhere": "이제 어디서나 OSMO를 만나보세요",
     "newPill": "새로운"
   },
+  "dustToOsmo": {
+    "mainButton": "먼지를 OSMO로 변환"
+  },
   "portfolio": {
     "buy": "구입하다",
     "sell": "팔다",

--- a/packages/web/localizations/pl.json
+++ b/packages/web/localizations/pl.json
@@ -200,6 +200,9 @@
     "acceptedEverywhere": "Twoje OSMO, teraz akceptowane wszędzie",
     "newPill": "Nowy"
   },
+  "dustToOsmo": {
+    "mainButton": "Przekształć kurz w OSMO"
+  },
   "portfolio": {
     "buy": "Kupić",
     "sell": "Sprzedać",

--- a/packages/web/localizations/pt-br.json
+++ b/packages/web/localizations/pt-br.json
@@ -200,6 +200,9 @@
     "acceptedEverywhere": "Seu OSMO, agora aceito em todos os lugares",
     "newPill": "Novo"
   },
+  "dustToOsmo": {
+    "mainButton": "Converter poeira em OSMO"
+  },
   "portfolio": {
     "buy": "Comprar",
     "sell": "Vender",

--- a/packages/web/localizations/ro.json
+++ b/packages/web/localizations/ro.json
@@ -200,6 +200,9 @@
     "acceptedEverywhere": "OSMO dvs., acum acceptat peste tot",
     "newPill": "Nou"
   },
+  "dustToOsmo": {
+    "mainButton": "Transformați praful în OSMO"
+  },
   "portfolio": {
     "buy": "Cumpără",
     "sell": "Vinde",

--- a/packages/web/localizations/ru.json
+++ b/packages/web/localizations/ru.json
@@ -200,6 +200,9 @@
     "acceptedEverywhere": "Ваш OSMO теперь принимается везде",
     "newPill": "Новый"
   },
+  "dustToOsmo": {
+    "mainButton": "Преобразовать пыль в ОСМО"
+  },
   "portfolio": {
     "buy": "Купить",
     "sell": "Продавать",

--- a/packages/web/localizations/tr.json
+++ b/packages/web/localizations/tr.json
@@ -200,6 +200,9 @@
     "acceptedEverywhere": "OSMO'nuz artık her yerde kabul görüyor",
     "newPill": "Yeni"
   },
+  "dustToOsmo": {
+    "mainButton": "Tozu OSMO'ya dönüştürün"
+  },
   "portfolio": {
     "buy": "Satın almak",
     "sell": "Satmak",

--- a/packages/web/localizations/zh-cn.json
+++ b/packages/web/localizations/zh-cn.json
@@ -200,6 +200,9 @@
     "acceptedEverywhere": "您的 OSMO，现已随处可用",
     "newPill": "新的"
   },
+  "dustToOsmo": {
+    "mainButton": "将灰尘转换为 OSMO"
+  },
   "portfolio": {
     "buy": "买",
     "sell": "卖",

--- a/packages/web/localizations/zh-hk.json
+++ b/packages/web/localizations/zh-hk.json
@@ -200,6 +200,9 @@
     "acceptedEverywhere": "你的 OSMO，現在無所不在",
     "newPill": "新的"
   },
+  "dustToOsmo": {
+    "mainButton": "將灰塵轉換為 OSMO"
+  },
   "portfolio": {
     "buy": "買",
     "sell": "賣",

--- a/packages/web/localizations/zh-tw.json
+++ b/packages/web/localizations/zh-tw.json
@@ -200,6 +200,9 @@
     "acceptedEverywhere": "你的 OSMO，現在無所不在",
     "newPill": "新的"
   },
+  "dustToOsmo": {
+    "mainButton": "將灰塵轉換為 OSMO"
+  },
   "portfolio": {
     "buy": "買",
     "sell": "賣",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -69,6 +69,7 @@
     "@tanstack/match-sorter-utils": "^8.8.4",
     "@tanstack/query-async-storage-persister": "^4.36.1",
     "@tanstack/react-query": "^4.32.6",
+    "@tanstack/react-query-devtools": "^5.59.16",
     "@tanstack/react-query-persist-client": "^4.36.1",
     "@tanstack/react-table": "^8.10.3",
     "@tanstack/react-virtual": "^3.0.0-beta.63",

--- a/packages/web/pages/_app.tsx
+++ b/packages/web/pages/_app.tsx
@@ -3,6 +3,7 @@ import "../styles/globals.css"; // eslint-disable-line no-restricted-imports
 
 import { apiClient } from "@osmosis-labs/utils";
 import { useQuery } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import dayjs from "dayjs";
 import advancedFormat from "dayjs/plugin/advancedFormat";
@@ -49,7 +50,7 @@ import { useNewApps } from "~/hooks/use-new-apps";
 import { WalletSelectProvider } from "~/hooks/use-wallet-select";
 import { ExternalLinkModal, handleExternalLink } from "~/modals";
 import { SEO } from "~/next-seo.config";
-import { api } from "~/utils/trpc";
+import { api, queryClientTRPC } from "~/utils/trpc";
 
 // Note: for some reason, the above two icons were displaying black backgrounds when using sprite SVG.
 import dayjsLocaleEs from "../localizations/dayjs-locale-es.js";
@@ -74,32 +75,35 @@ function MyApp({ Component, pageProps }: AppProps) {
   useAmplitudeAnalytics({ init: true });
 
   return (
-    <WagmiProvider config={wagmiConfig}>
-      <MultiLanguageProvider
-        defaultLanguage={DEFAULT_LANGUAGE}
-        defaultTranslations={{ en }}
-      >
-        <StoreProvider>
-          <WalletSelectProvider>
-            <ErrorBoundary fallback={<ErrorFallback />}>
-              <SEO />
-              <SpeedInsights />
-              <ToastContainer
-                toastStyle={{
-                  backgroundColor: "#2d2755",
-                }}
-                transition={Bounce}
-                newestOnTop
-              />
-              <MainLayoutWrapper>
-                {Component && <Component {...pageProps} />}
-              </MainLayoutWrapper>
-              <ImmersiveBridge />
-            </ErrorBoundary>
-          </WalletSelectProvider>
-        </StoreProvider>
-      </MultiLanguageProvider>
-    </WagmiProvider>
+    <>
+      <ReactQueryDevtools client={queryClientTRPC} />
+      <WagmiProvider config={wagmiConfig}>
+        <MultiLanguageProvider
+          defaultLanguage={DEFAULT_LANGUAGE}
+          defaultTranslations={{ en }}
+        >
+          <StoreProvider>
+            <WalletSelectProvider>
+              <ErrorBoundary fallback={<ErrorFallback />}>
+                <SEO />
+                <SpeedInsights />
+                <ToastContainer
+                  toastStyle={{
+                    backgroundColor: "#2d2755",
+                  }}
+                  transition={Bounce}
+                  newestOnTop
+                />
+                <MainLayoutWrapper>
+                  {Component && <Component {...pageProps} />}
+                </MainLayoutWrapper>
+                <ImmersiveBridge />
+              </ErrorBoundary>
+            </WalletSelectProvider>
+          </StoreProvider>
+        </MultiLanguageProvider>
+      </WagmiProvider>
+    </>
   );
 }
 

--- a/packages/web/pages/_app.tsx
+++ b/packages/web/pages/_app.tsx
@@ -2,7 +2,11 @@ import "react-toastify/dist/ReactToastify.css"; // some styles overridden in glo
 import "../styles/globals.css"; // eslint-disable-line no-restricted-imports
 
 import { apiClient } from "@osmosis-labs/utils";
-import { useQuery } from "@tanstack/react-query";
+import {
+  QueryClient,
+  QueryClientProvider,
+  useQuery,
+} from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import dayjs from "dayjs";
@@ -71,38 +75,49 @@ enableStaticRendering(typeof window === "undefined");
 
 const DEFAULT_LANGUAGE = "en";
 
+// TODO(Greg): Consider using TanStack Query for asynchronous operations.
+// Should we do this? Do we want to do this? If so, should we use the same instance as trpc?
+// The 24-hour cache duration, persistance and combining different queries could be problematic
+// but it could also work well 🤷‍♂
+const queryClientGeneric = new QueryClient();
+
 function MyApp({ Component, pageProps }: AppProps) {
   useAmplitudeAnalytics({ init: true });
 
   return (
     <>
-      <ReactQueryDevtools client={queryClientTRPC} />
-      <WagmiProvider config={wagmiConfig}>
-        <MultiLanguageProvider
-          defaultLanguage={DEFAULT_LANGUAGE}
-          defaultTranslations={{ en }}
-        >
-          <StoreProvider>
-            <WalletSelectProvider>
-              <ErrorBoundary fallback={<ErrorFallback />}>
-                <SEO />
-                <SpeedInsights />
-                <ToastContainer
-                  toastStyle={{
-                    backgroundColor: "#2d2755",
-                  }}
-                  transition={Bounce}
-                  newestOnTop
-                />
-                <MainLayoutWrapper>
-                  {Component && <Component {...pageProps} />}
-                </MainLayoutWrapper>
-                <ImmersiveBridge />
-              </ErrorBoundary>
-            </WalletSelectProvider>
-          </StoreProvider>
-        </MultiLanguageProvider>
-      </WagmiProvider>
+      <QueryClientProvider client={queryClientGeneric}>
+        <ReactQueryDevtools
+          client={queryClientTRPC}
+          buttonPosition="top-left"
+        />
+        <WagmiProvider config={wagmiConfig}>
+          <MultiLanguageProvider
+            defaultLanguage={DEFAULT_LANGUAGE}
+            defaultTranslations={{ en }}
+          >
+            <StoreProvider>
+              <WalletSelectProvider>
+                <ErrorBoundary fallback={<ErrorFallback />}>
+                  <SEO />
+                  <SpeedInsights />
+                  <ToastContainer
+                    toastStyle={{
+                      backgroundColor: "#2d2755",
+                    }}
+                    transition={Bounce}
+                    newestOnTop
+                  />
+                  <MainLayoutWrapper>
+                    {Component && <Component {...pageProps} />}
+                  </MainLayoutWrapper>
+                  <ImmersiveBridge />
+                </ErrorBoundary>
+              </WalletSelectProvider>
+            </StoreProvider>
+          </MultiLanguageProvider>
+        </WagmiProvider>
+      </QueryClientProvider>
     </>
   );
 }

--- a/packages/web/utils/trpc.ts
+++ b/packages/web/utils/trpc.ts
@@ -42,6 +42,14 @@ const trpcLocalRouter = createTRPCRouter({
   local: localRouter,
 });
 
+export const queryClientTRPC = new QueryClient({
+  defaultOptions: {
+    queries: {
+      cacheTime: 1000 * 60 * 60 * 24, // 24 hours
+    },
+  },
+});
+
 /** A set of type-safe react-query hooks for your tRPC API. */
 export const api = createTRPCNext<AppRouter>({
   config() {
@@ -63,16 +71,8 @@ export const api = createTRPCNext<AppRouter>({
       deserialize: (cachedString) => superjson.parse(cachedString),
     });
 
-    const queryClient = new QueryClient({
-      defaultOptions: {
-        queries: {
-          cacheTime: 1000 * 60 * 60 * 24, // 24 hours
-        },
-      },
-    });
-
     persistQueryClient({
-      queryClient,
+      queryClient: queryClientTRPC,
       persister: localStoragePersister,
       dehydrateOptions: {
         shouldDehydrateQuery: (query) => {
@@ -97,7 +97,7 @@ export const api = createTRPCNext<AppRouter>({
     });
 
     return {
-      queryClient,
+      queryClient: queryClientTRPC,
       /**
        * Transformer used for data de-serialization from the server.
        *

--- a/yarn.lock
+++ b/yarn.lock
@@ -4409,7 +4409,29 @@
     buffer "^6.0.3"
     delay "^4.4.0"
 
-"@keplr-wallet/cosmos@0.10.24-ibc.go.v7.hot.fix", "@keplr-wallet/cosmos@0.12.12", "@keplr-wallet/cosmos@0.12.28":
+"@keplr-wallet/common@0.12.12":
+  version "0.12.12"
+  resolved "https://registry.yarnpkg.com/@keplr-wallet/common/-/common-0.12.12.tgz#55030d985b729eac582c0d7203190e25ea2cb3ec"
+  integrity sha512-AxpwmXdqs083lMvA8j0/V30oTGyobsefNaCou+lP4rCyDdYuXSEux+x2+1AGL9xB3yZfN+4jvEEKJdMwHYEHcQ==
+  dependencies:
+    "@keplr-wallet/crypto" "0.12.12"
+    "@keplr-wallet/types" "0.12.12"
+    buffer "^6.0.3"
+    delay "^4.4.0"
+    mobx "^6.1.7"
+
+"@keplr-wallet/common@0.12.28":
+  version "0.12.28"
+  resolved "https://registry.yarnpkg.com/@keplr-wallet/common/-/common-0.12.28.tgz#1d5d985070aced31a34a6426c9ac4b775081acca"
+  integrity sha512-ESQorPZw8PRiUXhsrxED+E1FEWkAdc6Kwi3Az7ce204gMBQDI2j0XJtTd4uCUp+C24Em9fk0samdHzdoB4caIg==
+  dependencies:
+    "@keplr-wallet/crypto" "0.12.28"
+    "@keplr-wallet/types" "0.12.28"
+    buffer "^6.0.3"
+    delay "^4.4.0"
+    mobx "^6.1.7"
+
+"@keplr-wallet/cosmos@0.10.24-ibc.go.v7.hot.fix":
   version "0.10.24-ibc.go.v7.hot.fix"
   resolved "https://registry.npmjs.org/@keplr-wallet/cosmos/-/cosmos-0.10.24-ibc.go.v7.hot.fix.tgz"
   integrity sha512-/A/wHyYo5gQIW5YkAQYZadEv/12EcAuDclO0KboIb9ti4XFJW6S4VY8LnA16R7DZyBx1cnQknyDm101fUrJfJQ==
@@ -4421,6 +4443,40 @@
     "@keplr-wallet/types" "0.10.24-ibc.go.v7.hot.fix"
     "@keplr-wallet/unit" "0.10.24-ibc.go.v7.hot.fix"
     axios "^0.27.2"
+    bech32 "^1.1.4"
+    buffer "^6.0.3"
+    long "^4.0.0"
+    protobufjs "^6.11.2"
+
+"@keplr-wallet/cosmos@0.12.12":
+  version "0.12.12"
+  resolved "https://registry.yarnpkg.com/@keplr-wallet/cosmos/-/cosmos-0.12.12.tgz#72c0505d2327bbf2f5cb51502acaf399b88b4ae3"
+  integrity sha512-9TLsefUIAuDqqf1WHBt9Bk29rPlkezmLM8P1eEsXGUaHBfuqUrO+RwL3eLA3HGcgNvdy9s8e0p/4CMInH/LLLQ==
+  dependencies:
+    "@ethersproject/address" "^5.6.0"
+    "@keplr-wallet/common" "0.12.12"
+    "@keplr-wallet/crypto" "0.12.12"
+    "@keplr-wallet/proto-types" "0.12.12"
+    "@keplr-wallet/simple-fetch" "0.12.12"
+    "@keplr-wallet/types" "0.12.12"
+    "@keplr-wallet/unit" "0.12.12"
+    bech32 "^1.1.4"
+    buffer "^6.0.3"
+    long "^4.0.0"
+    protobufjs "^6.11.2"
+
+"@keplr-wallet/cosmos@0.12.28":
+  version "0.12.28"
+  resolved "https://registry.yarnpkg.com/@keplr-wallet/cosmos/-/cosmos-0.12.28.tgz#d56e73468256e7276a66bb41f145449dbf11efa1"
+  integrity sha512-IuqmSBgKgIeWBA0XGQKKs28IXFeFMCrfadCbtiZccNc7qnNr5Y/Cyyk01BPC8Dd1ZyEyAByoICgrxvtGN0GGvA==
+  dependencies:
+    "@ethersproject/address" "^5.6.0"
+    "@keplr-wallet/common" "0.12.28"
+    "@keplr-wallet/crypto" "0.12.28"
+    "@keplr-wallet/proto-types" "0.12.28"
+    "@keplr-wallet/simple-fetch" "0.12.28"
+    "@keplr-wallet/types" "0.12.28"
+    "@keplr-wallet/unit" "0.12.28"
     bech32 "^1.1.4"
     buffer "^6.0.3"
     long "^4.0.0"
@@ -4498,10 +4554,26 @@
   resolved "https://registry.npmjs.org/@keplr-wallet/popup/-/popup-0.10.24-ibc.go.v7.hot.fix.tgz"
   integrity sha512-Q/teyV6vdmpH3SySGd1xrNc/mVGK/tCP5vFEG2I3Y4FDCSV1yD7vcVgUy+tN19Z8EM3goR57V2QlarSOidtdjQ==
 
-"@keplr-wallet/proto-types@0.10.24-ibc.go.v7.hot.fix", "@keplr-wallet/proto-types@0.12.12":
+"@keplr-wallet/proto-types@0.10.24-ibc.go.v7.hot.fix":
   version "0.10.24-ibc.go.v7.hot.fix"
   resolved "https://registry.npmjs.org/@keplr-wallet/proto-types/-/proto-types-0.10.24-ibc.go.v7.hot.fix.tgz"
   integrity sha512-fLUJEtDadYJIMBzhMSZpEDTvXqk8wW68TwnUCRAcAooEQEtXPwY5gfo3hcekQEiCYtIu8XqzJ9fg01rp2Z4d3w==
+  dependencies:
+    long "^4.0.0"
+    protobufjs "^6.11.2"
+
+"@keplr-wallet/proto-types@0.12.12":
+  version "0.12.12"
+  resolved "https://registry.yarnpkg.com/@keplr-wallet/proto-types/-/proto-types-0.12.12.tgz#24e0530af7604a90f33a397a82fe500865c76154"
+  integrity sha512-iAqqNlJpxu/8j+SwOXEH2ymM4W0anfxn+eNeWuqz2c/0JxGTWeLURioxQmCtewtllfHdDHHcoQ7/S+NmXiaEgQ==
+  dependencies:
+    long "^4.0.0"
+    protobufjs "^6.11.2"
+
+"@keplr-wallet/proto-types@0.12.28":
+  version "0.12.28"
+  resolved "https://registry.yarnpkg.com/@keplr-wallet/proto-types/-/proto-types-0.12.28.tgz#2fb2c37749ce7db974f01d07387e966c9b99027d"
+  integrity sha512-ukti/eCTltPUP64jxtk5TjtwJogyfKPqlBIT3KGUCGzBLIPeYMsffL5w5aoHsMjINzOITjYqzXyEF8LTIK/fmw==
   dependencies:
     long "^4.0.0"
     protobufjs "^6.11.2"
@@ -4581,12 +4653,32 @@
     deepmerge "^4.2.2"
     long "^4.0.0"
 
-"@keplr-wallet/router@0.10.24-ibc.go.v7.hot.fix", "@keplr-wallet/router@0.12.12", "@keplr-wallet/router@0.12.96":
+"@keplr-wallet/router@0.10.24-ibc.go.v7.hot.fix":
   version "0.10.24-ibc.go.v7.hot.fix"
   resolved "https://registry.npmjs.org/@keplr-wallet/router/-/router-0.10.24-ibc.go.v7.hot.fix.tgz"
   integrity sha512-bt9weexlbhlh8KsOvbDrvHJ8jtUXrXgB2LX+hEAwjclHQt7PMUhx9a5z0Obd19/ive5G/1M7/ccdPIWxRBpKQw==
 
-"@keplr-wallet/types@0.10.24-ibc.go.v7.hot.fix", "@keplr-wallet/types@0.12.107", "@keplr-wallet/types@0.12.12", "@keplr-wallet/types@0.12.96", "@keplr-wallet/types@^0.12.95":
+"@keplr-wallet/router@0.12.12":
+  version "0.12.12"
+  resolved "https://registry.yarnpkg.com/@keplr-wallet/router/-/router-0.12.12.tgz#92a2c006aec6945ed313575af6b0801f8e84e315"
+  integrity sha512-Aa1TiVRIEPaqs1t27nCNs5Kz6Ty4CLarVdfqcRWlFQL6zFq33GT46s6K9U4Lz2swVCwdmerSXaq308K/GJHTlw==
+
+"@keplr-wallet/router@0.12.96":
+  version "0.12.96"
+  resolved "https://registry.yarnpkg.com/@keplr-wallet/router/-/router-0.12.96.tgz#6a20ed2c90ba3ed4f3fc43ed7513f72d7055482d"
+  integrity sha512-O8izj032ZKQIoTus96BFqem+w6NpYHU3j6NEnSaQBh6Zncj9fgjoOVs0CKK+jsuLYUsOHx2t86BxMSKESsR0Ug==
+
+"@keplr-wallet/simple-fetch@0.12.12":
+  version "0.12.12"
+  resolved "https://registry.yarnpkg.com/@keplr-wallet/simple-fetch/-/simple-fetch-0.12.12.tgz#aacc5c3f22b7ab2804b39e864725294a32f858fd"
+  integrity sha512-lCOsaI8upMpbusfwJqEK8VIEX77+QE8+8MJVRqoCYwjOTqKGdUH7D1ieZWh+pzvzOnVgedM3lxqdmCvdgU91qw==
+
+"@keplr-wallet/simple-fetch@0.12.28":
+  version "0.12.28"
+  resolved "https://registry.yarnpkg.com/@keplr-wallet/simple-fetch/-/simple-fetch-0.12.28.tgz#44225df5b329c823076280df1ec9930a21b1373e"
+  integrity sha512-T2CiKS2B5n0ZA7CWw0CA6qIAH0XYI1siE50MP+i+V0ZniCGBeL+BMcDw64vFJUcEH+1L5X4sDAzV37fQxGwllA==
+
+"@keplr-wallet/types@0.10.24-ibc.go.v7.hot.fix":
   version "0.10.24-ibc.go.v7.hot.fix"
   resolved "https://registry.npmjs.org/@keplr-wallet/types/-/types-0.10.24-ibc.go.v7.hot.fix.tgz"
   integrity sha512-3KUjDMUCscYkvKnC+JsJh9+X0NHlsvBgAghP/uy2p5OGtiULqPBAjWiO+hnBbhis3ZEkzGcCROnnBOoccKd3CQ==
@@ -4597,12 +4689,65 @@
     long "^4.0.0"
     secretjs "^0.17.0"
 
+"@keplr-wallet/types@0.12.107":
+  version "0.12.107"
+  resolved "https://registry.yarnpkg.com/@keplr-wallet/types/-/types-0.12.107.tgz#8d6726d86e17a79131b4b6f4f114052d6384aa58"
+  integrity sha512-jBpjJO+nNL8cgsJLjZYoq84n+7nXHDdztTgRMVnnomFb+Vy0FVIEI8VUl89ImmHDUImDd0562ywsvA496/0yCA==
+  dependencies:
+    long "^4.0.0"
+
+"@keplr-wallet/types@0.12.12":
+  version "0.12.12"
+  resolved "https://registry.yarnpkg.com/@keplr-wallet/types/-/types-0.12.12.tgz#f4bd9e710d5e53504f6b53330abb45bedd9c20ae"
+  integrity sha512-fo6b8j9EXnJukGvZorifJWEm1BPIrvaTLuu5PqaU5k1ANDasm/FL1NaUuaTBVvhRjINtvVXqYpW/rVUinA9MBA==
+  dependencies:
+    long "^4.0.0"
+
+"@keplr-wallet/types@0.12.28":
+  version "0.12.28"
+  resolved "https://registry.yarnpkg.com/@keplr-wallet/types/-/types-0.12.28.tgz#eac3c2c9d4560856c5c403a87e67925992a04fbf"
+  integrity sha512-EcM9d46hYDm3AO4lf4GUbTSLRySONtTmhKb7p88q56OQOgJN3MMjRacEo2p9jX9gpPe7gRIjMUalhAfUiFpZoQ==
+  dependencies:
+    long "^4.0.0"
+
+"@keplr-wallet/types@0.12.96":
+  version "0.12.96"
+  resolved "https://registry.yarnpkg.com/@keplr-wallet/types/-/types-0.12.96.tgz#a7735051b1f7cbcdf9b8c29010b1c3c45d195c19"
+  integrity sha512-tr4tPjMrJCsfRXXhhmqnpb9DqH9auJp3uuj8SvDB3pQTTaYJNxkdonLv1tYmXZZ6J9oWtk9WVEDTVgBQN/wisw==
+  dependencies:
+    long "^4.0.0"
+
+"@keplr-wallet/types@^0.12.95":
+  version "0.12.149"
+  resolved "https://registry.yarnpkg.com/@keplr-wallet/types/-/types-0.12.149.tgz#866ec561312b339008bee710a5754f3216504e1a"
+  integrity sha512-FGBESvpXQbfFG7swIq5hRvj3AkCUvMmqQ0m5INA/FrProGoPFP/Pgc6+DyAlwvJttVFp6+zchAsA9RG5o6cHJA==
+  dependencies:
+    long "^4.0.0"
+
 "@keplr-wallet/unit@0.10.24-ibc.go.v7.hot.fix":
   version "0.10.24-ibc.go.v7.hot.fix"
   resolved "https://registry.npmjs.org/@keplr-wallet/unit/-/unit-0.10.24-ibc.go.v7.hot.fix.tgz"
   integrity sha512-XiOGAQEiYtd6B11B5JHXZHc9HOA2BKE+wL8mNc7vPQ8h73WiKhMAU2CkoS8LHsXkDJJy/Sq18WnJbGlu225/Ag==
   dependencies:
     "@keplr-wallet/types" "0.10.24-ibc.go.v7.hot.fix"
+    big-integer "^1.6.48"
+    utility-types "^3.10.0"
+
+"@keplr-wallet/unit@0.12.12":
+  version "0.12.12"
+  resolved "https://registry.yarnpkg.com/@keplr-wallet/unit/-/unit-0.12.12.tgz#2d7f2e38df4e09c8123dcc0784ffc4b5f4166217"
+  integrity sha512-fayJcfXWKUnbDZiRJHyuA9GMVS9DymjRlCzlpAJ0+xV0c4Kun/f+9FajL9OQAdPPhnJ7A3KevMI4VHZsd9Yw+A==
+  dependencies:
+    "@keplr-wallet/types" "0.12.12"
+    big-integer "^1.6.48"
+    utility-types "^3.10.0"
+
+"@keplr-wallet/unit@0.12.28":
+  version "0.12.28"
+  resolved "https://registry.yarnpkg.com/@keplr-wallet/unit/-/unit-0.12.28.tgz#907c7fa0b49a729cda207fca14fc0a38871cc6c4"
+  integrity sha512-kpXigHDBJGOmhtPkv9hqsQid9zkFo7OQPeKgO2n8GUlOINIXW6kWG5LXYTi/Yg9Uiw1CQF69gFMuZCJ8IzVHlA==
+  dependencies:
+    "@keplr-wallet/types" "0.12.28"
     big-integer "^1.6.48"
     utility-types "^3.10.0"
 
@@ -6761,12 +6906,24 @@
   resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-4.36.1.tgz#79f8c1a539d47c83104210be2388813a7af2e524"
   integrity sha512-DJSilV5+ytBP1FbFcEJovv4rnnm/CokuVvrBEtW/Va9DvuJ3HksbXUJEpI0aV1KtuL4ZoO9AVE6PyNLzF7tLeA==
 
+"@tanstack/query-devtools@5.58.0":
+  version "5.58.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-devtools/-/query-devtools-5.58.0.tgz#5c68ce90562e154004de4372bc0a28fcd94cdf31"
+  integrity sha512-iFdQEFXaYYxqgrv63ots+65FGI+tNp5ZS5PdMU1DWisxk3fez5HG3FyVlbUva+RdYS5hSLbxZ9aw3yEs97GNTw==
+
 "@tanstack/query-persist-client-core@4.36.1":
   version "4.36.1"
   resolved "https://registry.yarnpkg.com/@tanstack/query-persist-client-core/-/query-persist-client-core-4.36.1.tgz#4d7284994bdc2a15fe6cbe7161be21e03033fe12"
   integrity sha512-eocgCeI7D7TRv1IUUBMfVwOI0wdSmMkBIbkKhqEdTrnUHUQEeOaYac8oeZk2cumAWJdycu6P/wB+WqGynTnzXg==
   dependencies:
     "@tanstack/query-core" "4.36.1"
+
+"@tanstack/react-query-devtools@^5.59.16":
+  version "5.59.16"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query-devtools/-/react-query-devtools-5.59.16.tgz#f058e3ba146b97a4763b886074581d66cc1e5cf7"
+  integrity sha512-Dejo39QBXmDqXZ3vdrk7vHDvs7TvL573/AX2NveMBmRAufAPYuE3oWSKP/gGqkDfEqyr4CmldOj+v9cKskUchQ==
+  dependencies:
+    "@tanstack/query-devtools" "5.58.0"
 
 "@tanstack/react-query-persist-client@^4.36.1":
   version "4.36.1"


### PR DESCRIPTION
## What is the purpose of the change:

This PR is the v0 for the dust to OSMO feature. 

### Outline for the solution

- add a `Dust to OSMO` button to the portfolio page under the asset table 
- when the user clicks `Swap dust to OSMO`
  - loading spinner is added to the button
  - a swap is generated for every asset, and swaps are executed sequentially
  - user is prompted to sign every tx by the wallet
  - after all swap txs resulted in either success or error remove the loading spinner

### Linear Task

<details>
<summary>Brief for the task</summary>

>Currently, a user who regularly trades on the platform may have a number of small balances remaining in their portfolio due to the values of various tokens being incommensurate. These small remaining balances are known as 'dust' and often sit unused since the value is too low in order to justify transacting due to network fees. Your task is to write a function that converts the dust in a wallet (defined as values less than $0.01USD) to OSMO.
>
> Note that there are no designs for this task. You may either write a well tested function for review, or use your best judgement in adding UX to trigger the function.
>
> The task will involve reading and understanding how balances are fetched in the codebase, and understanding signing broadcasting transactions.

</details>

## Brief Changelog

- add a feature flag 
- add the dust to osmo button
- update `useSwap` to be easier to use programatically
- add `getUserDustAsset()` procedure
- on user action execute all the swaps sequentially either with manual signing or 1click trading
- add react query devtools for debugging 
- add a generic query client for non trpc async handling

## Testing and Verifying

This change has been tested locally by rebuilding the website and verified content and links are expected

- set `NEXT_PUBLIC_SHOW_DUST_TO_OSMO=true` in `packages/web/.env.local` 
- go to portfolio 
- make sure you have some dust in the currently connected wallet
- (1click trading off): click `Dust to OSMO` button
- (1click trading on): click `Dust to OSMO` button

## Backlog 

- set up the flag in launch darkly
- drop the environment variable from `.env` and `env.ts` and hardcode a default value in `web/hooks/use-feature-flags.ts`
- Resolve the  `TODO(Greg)` comments 

## To be discussed
- `TODO(Greg)` comments 
- Do we want an overview, confirmation, and error display user interface?
- Should we batch the swaps into a single tx so only 1 signature is necessary?
- Do we want to reduce dust sweep costs? 

## Demo 
### manual sign
![CleanShot 2024-11-05 at 09 09 36](https://github.com/user-attachments/assets/0ab32c8a-a856-4d8a-840d-0bc7453cdfe2)

### 1click trade
![CleanShot 2024-11-05 at 09 15 59](https://github.com/user-attachments/assets/a0db8a1c-9b7b-4f54-baa1-b2168705c77a)
