### PR TITLE
Increase base fee multiplier from 1.5 to 1.65

### DIFF
--- a/packages/tx/src/__tests__/gas.spec.ts
+++ b/packages/tx/src/__tests__/gas.spec.ts
@@ -13,6 +13,7 @@ import { ApiClientError } from "@osmosis-labs/utils";
 import type { Any } from "cosmjs-types/google/protobuf/any";
 
 import {
+    defaultBaseFeeMultiplier,
   getDefaultGasPrice,
   getGasFeeAmount,
   getGasPriceByFeeDenom,
@@ -322,7 +323,7 @@ describe("getGasFeeAmount", () => {
       })
     )[0];
 
-    const expectedGasAmount = new Dec(baseFee * gasMultiplier)
+    const expectedGasAmount = new Dec(baseFee * defaultBaseFeeMultiplier)
       .quo(new Dec(spotPrice))
       .mul(new Dec(1.01))
       .mul(new Dec(gasLimit))
@@ -419,7 +420,7 @@ describe("getGasFeeAmount", () => {
       })
     )[0];
 
-    const expectedGasAmount = new Dec(baseFee * gasMultiplier)
+    const expectedGasAmount = new Dec(baseFee * defaultBaseFeeMultiplier)
       .quo(new Dec(spotPrice))
       .mul(new Dec(1.01))
       .mul(new Dec(gasLimit))
@@ -506,7 +507,7 @@ describe("getGasFeeAmount", () => {
       })
     )[0];
 
-    const expectedGasAmount = new Dec(baseFee * gasMultiplier)
+    const expectedGasAmount = new Dec(baseFee * defaultBaseFeeMultiplier)
       .quo(new Dec(spotPrice))
       .mul(new Dec(1.01))
       .mul(new Dec(gasLimit))
@@ -592,7 +593,7 @@ describe("getGasFeeAmount", () => {
       })
     )[0];
 
-    const expectedGasAmount = new Dec(baseFee * gasMultiplier)
+    const expectedGasAmount = new Dec(baseFee * defaultBaseFeeMultiplier)
       .quo(new Dec(spotPrice))
       .mul(new Dec(1.01))
       .mul(new Dec(gasLimit))
@@ -679,7 +680,7 @@ describe("getGasFeeAmount", () => {
       })
     )[0];
 
-    const expectedGasAmount = new Dec(baseFee * gasMultiplier)
+    const expectedGasAmount = new Dec(baseFee * defaultBaseFeeMultiplier)
       .quo(new Dec(spotPrice))
       .mul(new Dec(1.01))
       .mul(new Dec(gasLimit))
@@ -795,7 +796,7 @@ describe("getGasFeeAmount", () => {
     )[0];
 
     const expectedGasAmount = new Dec(baseFee)
-      .mul(new Dec(gasMultiplier))
+      .mul(new Dec(defaultBaseFeeMultiplier))
       .quo(new Dec(lowEnoughSpotPrice))
       .mul(new Dec(1.01))
       .mul(new Dec(gasLimit))
@@ -1053,7 +1054,6 @@ describe("getGasPriceByFeeDenom", () => {
   const chainId = "osmosis-1";
   const chainList = MockChains;
   const feeDenom = "uion";
-  const gasMultiplier = 1.5;
 
   it("should return the correct gas price with fee market module", async () => {
     const baseFee = 0.01;
@@ -1070,13 +1070,12 @@ describe("getGasPriceByFeeDenom", () => {
       chainId,
       chainList,
       feeDenom,
-      gasMultiplier,
     });
 
     const expectedGasPrice = new Dec(baseFee)
       .quo(new Dec(spotPrice))
       .mul(new Dec(1.01))
-      .mul(new Dec(gasMultiplier));
+      .mul(new Dec(defaultBaseFeeMultiplier));
 
     expect(result.gasPrice.toString()).toBe(expectedGasPrice.toString());
 
@@ -1103,7 +1102,6 @@ describe("getGasPriceByFeeDenom", () => {
       chainId,
       chainList: chainListWithoutFeeMarket,
       feeDenom: "uosmo",
-      gasMultiplier,
     });
 
     expect(result.gasPrice.toString()).toBe(defaultGasPrice.toString());
@@ -1125,7 +1123,6 @@ describe("getGasPriceByFeeDenom", () => {
       chainId,
       chainList: chainListWithoutFeeMarket,
       feeDenom,
-      gasMultiplier,
     });
 
     expect(result.gasPrice.toString()).toBe(new Dec(0.004).toString());
@@ -1145,7 +1142,6 @@ describe("getGasPriceByFeeDenom", () => {
         chainId,
         chainList: chainListWithoutFeeMarket,
         feeDenom,
-        gasMultiplier,
       })
     ).rejects.toThrow("Fee token not found: uion");
 
@@ -1159,7 +1155,6 @@ describe("getGasPriceByFeeDenom", () => {
         chainId: "non-existent-chain",
         chainList,
         feeDenom,
-        gasMultiplier,
       })
     ).rejects.toThrow("Chain not found: non-existent-chain");
 
@@ -1182,7 +1177,6 @@ describe("getGasPriceByFeeDenom", () => {
         chainId,
         chainList,
         feeDenom,
-        gasMultiplier,
       })
     ).rejects.toThrow(`Failed to fetch spot price for fee token ${feeDenom}.`);
 
@@ -1207,7 +1201,6 @@ describe("getGasPriceByFeeDenom", () => {
         chainId,
         chainList,
         feeDenom,
-        gasMultiplier,
       })
     ).rejects.toThrow("Invalid base fee: invalid");
   });

--- a/packages/tx/src/__tests__/gas.spec.ts
+++ b/packages/tx/src/__tests__/gas.spec.ts
@@ -1243,15 +1243,15 @@ describe("getDefaultGasPrice", () => {
       base_fee: baseFee.toString(),
     } as Awaited<ReturnType<typeof queryFeesBaseGasPrice>>);
 
-    const gasMultiplier = 1.5;
+    const baseFeeMultiplier = 1.65;
     const result = await getDefaultGasPrice({
       chainId,
       chainList,
-      gasMultiplier,
+      baseFeeMultiplier: baseFeeMultiplier,
     });
 
     expect(result.gasPrice.toString()).toBe(
-      new Dec(baseFee * gasMultiplier).toString()
+      new Dec(baseFee * baseFeeMultiplier).toString()
     );
     expect(result.feeDenom).toBe("uosmo");
 

--- a/packages/tx/src/gas.ts
+++ b/packages/tx/src/gas.ts
@@ -498,7 +498,6 @@ export async function getGasPriceByFeeDenom({
   chainId,
   chainList,
   feeDenom,
-  gasMultiplier = 1.5,
   defaultGasPrice = 0.025,
 }: {
   chainId: string;

--- a/packages/tx/src/gas.ts
+++ b/packages/tx/src/gas.ts
@@ -48,7 +48,7 @@ export type QuoteStdFee = {
 // We have experienced instabilities with the base fee query. To avoid debugging its stability
 // for the sake of time, we have opted in to increase the base fee multiplier to 1.65 from the original
 // value of 1.5 which was equal to the gas multiplier. The update was applied on 2024-10-27.
-const defaultBaseFeeMultiplier = 1.65;
+export const defaultBaseFeeMultiplier = 1.65;
 
 /** Tx body portions relevant for simulation */
 export type SimBody = Partial<

--- a/packages/tx/src/gas.ts
+++ b/packages/tx/src/gas.ts
@@ -45,6 +45,11 @@ export type QuoteStdFee = {
   }[];
 };
 
+// We have experienced instabilities with the base fee query. To avoid debugging its stability
+// for the sake of time, we have opted in to increase the base fee multiplier to 1.65 from the original
+// value of 1.5 which was equal to the gas multiplier. The update was applied on 2024-10-27.
+const defaultBaseFeeMultiplier = 1.65;
+
 /** Tx body portions relevant for simulation */
 export type SimBody = Partial<
   Pick<
@@ -114,7 +119,7 @@ export async function estimateGasFee({
     const { feeDenom, gasPrice } = await getDefaultGasPrice({
       chainId,
       chainList,
-      gasMultiplier,
+      baseFeeMultiplier: defaultBaseFeeMultiplier,
     });
     return {
       gas: gasLimit,
@@ -513,7 +518,7 @@ export async function getGasPriceByFeeDenom({
   const defaultFee = await getDefaultGasPrice({
     chainId,
     chainList,
-    gasMultiplier,
+    baseFeeMultiplier: defaultBaseFeeMultiplier,
   });
 
   if (defaultFee.feeDenom === feeDenom) {
@@ -557,13 +562,13 @@ export async function getGasPriceByFeeDenom({
 export async function getDefaultGasPrice({
   chainId,
   chainList,
-  gasMultiplier = 1.5,
+  baseFeeMultiplier = defaultBaseFeeMultiplier,
   defaultGasPrice = 0.025,
 }: {
   chainId: string;
   chainList: ChainWithFeatures[];
-  gasMultiplier?: number;
   defaultGasPrice?: number;
+  baseFeeMultiplier?: number;
 }) {
   const chain = chainList.find(({ chain_id }) => chain_id === chainId);
   if (!chain) throw new Error("Chain not found: " + chainId);
@@ -586,7 +591,7 @@ export async function getDefaultGasPrice({
 
     feeDenom = baseDenom;
     // Add slippage multiplier to account for shifting gas prices in gas market
-    gasPrice = baseFeePrice.mul(new Dec(gasMultiplier));
+    gasPrice = baseFeePrice.mul(new Dec(baseFeeMultiplier));
   } else {
     // registry
 


### PR DESCRIPTION
## What is the purpose of the change:

We have experienced instabilities with the base fee query. To avoid debugging its stability
for the sake of time, we have opted in to increase the base fee multiplier to 1.65 from the original
value of 1.5 which was equal to the gas multiplier. The update was applied on 2024-10-27.

More context: https://osmosis-network.slack.com/archives/C06QAMXGTJ5/p1730045591060839