### PR TITLE
prevent mouse wheel from changing input on add liquidity step

### DIFF
--- a/packages/web/components/input/input-box.tsx
+++ b/packages/web/components/input/input-box.tsx
@@ -117,6 +117,7 @@ export const InputBox: FunctionComponent<Props> = ({
                 inputRef.current = ref;
               }
             }}
+            onWheel={(e) => (e.target as HTMLInputElement).blur()}
             inputClassName={inputClassName_}
             minWidth={0}
             value={inputValue}
@@ -139,6 +140,7 @@ export const InputBox: FunctionComponent<Props> = ({
             placeholder={placeholder ?? ""}
             autoComplete="off"
             type={type}
+            onWheel={(e) => (e.target as HTMLInputElement).blur()}
             onBlur={(e: any) => {
               setInputFocused(false);
               onBlur && onBlur(e);


### PR DESCRIPTION
## What is the purpose of the change:

We want to prevent the liquidity input from changing when user uses the mouse scroll

### Linear Task

https://linear.app/osmosis/issue/FE-1187/disable-mouse-scroll-wheel-for-liquidity-amount-input

## Brief Changelog

- disable mouse scroll for add liquidity amount

## Testing and Verifying

This change has been tested locally by rebuilding the website and verified content and links are expected
