### PR TITLE
(Deposit/Withdraw) Truncate decimals to a maximum of 6 digits in transfer toast and better Squid transfer status error handling

### DIFF
--- a/packages/web/components/bridge/review-screen.tsx
+++ b/packages/web/components/bridge/review-screen.tsx
@@ -315,8 +315,8 @@ const AssetBox: FunctionComponent<{
           </div>
           <div className="body1 md:caption text-osmoverse-300">
             {type === "to" && "~"}{" "}
-            {formatPretty(coin.inequalitySymbol(false), {
-              maxDecimals: 10,
+            {formatPretty(coin, {
+              maxDecimals: 6,
             })}
           </div>
         </div>

--- a/packages/web/components/bridge/use-bridge-quotes.ts
+++ b/packages/web/components/bridge/use-bridge-quotes.ts
@@ -167,7 +167,7 @@ export const useBridgeQuotes = ({
         accountStore.getWallet(fromChain.chainId)?.txTypeInProgress
       );
     } else if (fromChain.chainType === "evm") {
-      return isEthTxPending;
+      return isEthTxPending || isBroadcastingTx;
     }
     return false;
   })();
@@ -546,11 +546,10 @@ export const useBridgeQuotes = ({
           hash: approveTxHash,
         });
 
-        setIsApprovingToken(false);
-
         for (const quoteResult of quoteResults) {
           await quoteResult.refetch();
         }
+        setIsApprovingToken(false);
       }
 
       const sendTxHash = await sendTransactionAsync({

--- a/packages/web/stores/transfer-history.tsx
+++ b/packages/web/stores/transfer-history.tsx
@@ -24,6 +24,7 @@ import { displayToast, ToastType } from "~/components/alert";
 import { RadialProgress } from "~/components/radial-progress";
 import { useTranslation } from "~/hooks";
 import { humanizeTime } from "~/utils/date";
+import { formatPretty } from "~/utils/formatter";
 
 export const TRANSFER_HISTORY_STORE_KEY = "transfer_history";
 
@@ -143,14 +144,19 @@ export class TransferHistoryStore implements TransferStatusReceiver {
             ) : undefined,
           captionElement: (
             <PendingTransferCaption
-              amount={new CoinPretty(
+              amount={formatPretty(
+                new CoinPretty(
+                  {
+                    coinDecimals: fromAsset.decimals,
+                    coinMinimalDenom: fromAsset.address,
+                    coinDenom: fromAsset.denom,
+                  },
+                  new Dec(fromAsset.amount)
+                ),
                 {
-                  coinDecimals: fromAsset.decimals,
-                  coinMinimalDenom: fromAsset.address,
-                  coinDenom: fromAsset.denom,
-                },
-                new Dec(fromAsset.amount)
-              ).toString()}
+                  maxDecimals: 6,
+                }
+              )}
               chainPrettyName={
                 direction === "deposit"
                   ? fromChain?.prettyName ?? ""
@@ -186,8 +192,6 @@ export class TransferHistoryStore implements TransferStatusReceiver {
       (snapshot) => snapshot.sendTxHash === sendTxHash
     );
 
-    console.log(snapshot);
-
     if (!snapshot) {
       console.error("Couldn't find tx snapshot when receiving tx status");
       return;
@@ -210,14 +214,19 @@ export class TransferHistoryStore implements TransferStatusReceiver {
 
     const amountLogo =
       direction === "withdraw" ? toAsset?.imageUrl : fromAsset.imageUrl;
-    const amount = new CoinPretty(
+    const amount = formatPretty(
+      new CoinPretty(
+        {
+          coinDecimals: fromAsset.decimals,
+          coinMinimalDenom: fromAsset.address,
+          coinDenom: fromAsset.denom,
+        },
+        new Dec(fromAsset.amount)
+      ),
       {
-        coinDecimals: fromAsset.decimals,
-        coinMinimalDenom: fromAsset.address,
-        coinDenom: fromAsset.denom,
-      },
-      new Dec(fromAsset.amount)
-    ).toString();
+        maxDecimals: 6,
+      }
+    );
 
     const chainPrettyName =
       direction === "deposit"


### PR DESCRIPTION
### Linear Task

https://linear.app/osmosis/issue/FE-1207/truncate-decimals-to-a-maximum-of-6-digits

## Testing and Verifying

- [ ] Displays a maximum of 6 decimals in the transfer toast 