### PR TITLE
refactor:  orders query usage and definition

### DIFF
--- a/packages/server/src/queries/complex/orderbooks/historical-orders.ts
+++ b/packages/server/src/queries/complex/orderbooks/historical-orders.ts
@@ -30,7 +30,7 @@ export function getOrderbookHistoricalOrders({
   return cachified({
     cache: orderbookHistoricalOrdersCache,
     key: `orderbookHistoricalOrders-${userOsmoAddress}`,
-    ttl: 1000 * 2, // 2 seconds
+    ttl: 1000 * 5, // 2 seconds
     getFreshValue: () =>
       queryHistoricalOrders(userOsmoAddress).then(async (data) => {
         const orders = data;

--- a/packages/trpc/src/orderbook-router.ts
+++ b/packages/trpc/src/orderbook-router.ts
@@ -22,7 +22,7 @@ const GetInfiniteLimitOrdersInputSchema = CursorPaginationSchema.merge(
   UserOsmoAddressSchema.required()
 ).merge(
   z.object({
-    filter: z.enum(["open", "filled", "historical"]).optional(),
+    filter: z.enum(["open", "filled", "historical", "active"]).optional(),
   })
 );
 
@@ -125,7 +125,10 @@ export const orderbookRouter = createTRPCRouter({
           const { userOsmoAddress, filter } = input;
 
           const shouldFetchActive =
-            !filter || filter === "open" || filter === "filled";
+            !filter ||
+            filter === "open" ||
+            filter === "filled" ||
+            filter === "active";
           const shouldFetchHistorical = !filter || filter === "historical";
           const promises: Promise<MappedLimitOrder[]>[] = [];
           if (shouldFetchActive) {
@@ -147,7 +150,7 @@ export const orderbookRouter = createTRPCRouter({
           }
           const orders = await Promise.all(promises);
           const allOrders = orders.flat().sort(defaultSortOrders);
-          if (filter === "filled") {
+          if (filter === "filled" || filter === "active") {
             return allOrders.filter((o) => o.status === "filled");
           }
           return allOrders;

--- a/packages/web/components/complex/orders-history/index.tsx
+++ b/packages/web/components/complex/orders-history/index.tsx
@@ -26,8 +26,8 @@ import {
   useWindowSize,
 } from "~/hooks";
 import {
-  useOrderbookAllActiveOrders,
   useOrderbookClaimableOrders,
+  useOrderbookOrders,
 } from "~/hooks/limit-orders/use-orderbook";
 import { useStore } from "~/stores";
 import {
@@ -81,7 +81,7 @@ export const OrderHistory = observer(() => {
     hasNextPage,
     refetch,
     isRefetching,
-  } = useOrderbookAllActiveOrders({
+  } = useOrderbookOrders({
     userAddress: wallet?.address ?? "",
     pageSize: 20,
     refetchInterval: featureFlags.sqsActiveOrders ? 10000 : 30000,

--- a/packages/web/components/complex/portfolio/open-orders.tsx
+++ b/packages/web/components/complex/portfolio/open-orders.tsx
@@ -5,7 +5,7 @@ import React, { FunctionComponent } from "react";
 import { FallbackImg } from "~/components/assets";
 import { LinkButton } from "~/components/buttons/link-button";
 import { useTranslation } from "~/hooks";
-import { useOrderbookAllActiveOrders } from "~/hooks/limit-orders/use-orderbook";
+import { useOrderbookOrders } from "~/hooks/limit-orders/use-orderbook";
 import { useStore } from "~/stores";
 import { formatFiatPrice } from "~/utils/formatter";
 import { formatPretty } from "~/utils/formatter";
@@ -18,9 +18,10 @@ export const OpenOrders: FunctionComponent = () => {
   const { accountStore } = useStore();
   const wallet = accountStore.getWallet(accountStore.osmosisChainId);
 
-  const { orders, isLoading } = useOrderbookAllActiveOrders({
+  const { orders, isLoading } = useOrderbookOrders({
     userAddress: wallet?.address ?? "",
     pageSize: 100,
+    filter: "open",
   });
 
   const openOrders = orders

--- a/packages/web/hooks/limit-orders/use-orderbook.ts
+++ b/packages/web/hooks/limit-orders/use-orderbook.ts
@@ -264,11 +264,13 @@ const useMakerFee = ({ orderbookAddress }: { orderbookAddress: string }) => {
 const useOrdersQuery = ({
   userAddress,
   pageSize = 10,
-  refetchInterval = 5000,
+  refetchInterval = 10000,
+  filter,
 }: {
   userAddress: string;
   pageSize?: number;
   refetchInterval?: number;
+  filter?: "active" | "filled" | "historical" | "open";
 }) => {
   const { sqsActiveOrders } = useFeatureFlags();
   const { orderbooks } = useOrderbooks();
@@ -286,6 +288,7 @@ const useOrdersQuery = ({
     {
       userOsmoAddress: userAddress,
       limit: pageSize,
+      filter,
     },
     {
       getNextPageParam: (lastPage) => lastPage.nextCursor,
@@ -355,14 +358,16 @@ const useOrdersQuery = ({
   };
 };
 
-export const useOrderbookAllActiveOrders = ({
+export const useOrderbookOrders = ({
   userAddress,
   pageSize = 10,
-  refetchInterval = 5000,
+  refetchInterval = 10000,
+  filter,
 }: {
   userAddress: string;
   pageSize?: number;
   refetchInterval?: number;
+  filter?: "active" | "filled" | "historical" | "open";
 }) => {
   const {
     data: orders,
@@ -373,7 +378,7 @@ export const useOrderbookAllActiveOrders = ({
     hasNextPage,
     refetch,
     isRefetching,
-  } = useOrdersQuery({ userAddress, pageSize, refetchInterval });
+  } = useOrdersQuery({ userAddress, pageSize, refetchInterval, filter });
 
   const allOrders = useMemo(() => {
     return orders?.pages.flatMap((page) => page.items) ?? [];
@@ -399,6 +404,7 @@ export const useOrderbookAllActiveOrders = ({
 /**
  * Queries for all claimable orders for a given user.
  * Swaps between using SQS passthrough and a direct node query based on feature flag.
+ * NOTE: CAN BE REMOVED WHEN SQSORDERS FEATURE FLAG IS REMOVED
  */
 const useClaimableOrdersQuery = ({
   userAddress,


### PR DESCRIPTION
## What is the purpose of the change:
These changes refactor the orderbook orders query/hook to allow one hook with a filter rather than separate hooks. It also removes an unnecessary call to a Numia endpoint for the portfolio page and increase the refetch interval on that page from 5 seconds to 10 seconds.

## Brief Changelog

- Renamed `useOrderbookActiveOrders` to `useOrderbookOrders`
- Added a `filter` field to `useOrderbookOrders`
- Increased default `refetchInterval` for `useOrderbookOrders` to 10 seconds
