### PR TITLE
(Pools) Fix pools dropdown jumping to top of page

### DIFF
--- a/packages/web/components/complex/all-pools-table.tsx
+++ b/packages/web/components/complex/all-pools-table.tsx
@@ -108,8 +108,6 @@ const TableControls = () => {
 
   const { filters, setFilters } = useAllPoolsTable();
 
-  filters.poolTypesFilter;
-
   const onSearchInput = useCallback(
     (data: string) => {
       setFilters((state) => ({

--- a/packages/web/components/control/checkbox-select.tsx
+++ b/packages/web/components/control/checkbox-select.tsx
@@ -1,4 +1,4 @@
-import { Menu } from "@headlessui/react";
+import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/react";
 import { noop } from "@osmosis-labs/utils";
 import classNames from "classnames";
 import { FunctionComponent } from "react";
@@ -30,8 +30,8 @@ export const CheckboxSelect: FunctionComponent<
   return (
     <Menu>
       {({ open }) => (
-        <div className="relative">
-          <Menu.Button
+        <>
+          <MenuButton
             className={classNames(
               "relative flex h-10 shrink-0 cursor-pointer items-center justify-center gap-2 rounded-xl px-6 text-sm transition-colors md:w-full",
               "border border-osmoverse-500 hover:border-2 hover:border-osmoverse-200 hover:px-[23px]",
@@ -46,53 +46,51 @@ export const CheckboxSelect: FunctionComponent<
               height={isMobile ? 12 : 16}
               width={isMobile ? 12 : 16}
             />
-          </Menu.Button>
+          </MenuButton>
 
-          <Menu.Items
+          <MenuItems
             className={classNames(
-              "absolute -left-px top-full z-[1000] mt-2 flex w-max select-none flex-col overflow-hidden rounded-xl border border-osmoverse-700 bg-osmoverse-800 text-left",
+              "[--anchor-gap:8px] z-[1000] flex w-max select-none flex-col overflow-hidden rounded-xl border border-osmoverse-700 bg-osmoverse-800 text-left",
               menuItemsClassName
             )}
+            anchor="bottom end"
           >
             {options.map(({ id, display }, index) => {
               return (
-                <Menu.Item key={id}>
-                  {({ active }) => (
-                    <button
-                      className={classNames(
-                        "flex cursor-pointer items-center gap-3 px-4 py-2 text-left text-osmoverse-200 transition-colors",
-                        {
-                          "hover:bg-osmoverse-700": active,
-                          "rounded-b-xlinset": index === options.length - 1,
-                        }
-                      )}
+                <MenuItem key={id}>
+                  <button
+                    className={classNames(
+                      "flex cursor-pointer items-center gap-3 px-4 py-2 text-left text-osmoverse-200 transition-colors data-[active]:bg-osmoverse-700",
+                      {
+                        "rounded-b-xlinset": index === options.length - 1,
+                      }
+                    )}
+                    disabled={
+                      atLeastOneSelected &&
+                      selectedOptionIds?.length === 1 &&
+                      selectedOptionIds?.includes(id)
+                    }
+                    onClick={(e) => {
+                      e.preventDefault();
+                      onSelect(id);
+                    }}
+                  >
+                    <Checkbox
+                      checked={Boolean(selectedOptionIds?.includes(id))}
+                      onClick={noop}
                       disabled={
                         atLeastOneSelected &&
                         selectedOptionIds?.length === 1 &&
                         selectedOptionIds?.includes(id)
                       }
-                      onClick={(e) => {
-                        e.preventDefault();
-                        onSelect(id);
-                      }}
-                    >
-                      <Checkbox
-                        checked={Boolean(selectedOptionIds?.includes(id))}
-                        onClick={noop}
-                        disabled={
-                          atLeastOneSelected &&
-                          selectedOptionIds?.length === 1 &&
-                          selectedOptionIds?.includes(id)
-                        }
-                      />
-                      <span>{display}</span>
-                    </button>
-                  )}
-                </Menu.Item>
+                    />
+                    <span>{display}</span>
+                  </button>
+                </MenuItem>
               );
             })}
-          </Menu.Items>
-        </div>
+          </MenuItems>
+        </>
       )}
     </Menu>
   );

--- a/packages/web/components/layouts/main.tsx
+++ b/packages/web/components/layouts/main.tsx
@@ -84,9 +84,7 @@ export const MainLayout = observer(
           menus={menus}
           secondaryMenuItems={secondaryMenuItems}
         />
-        <div className="ml-sidebar h-content md:ml-0 md:h-content-mobile">
-          {children}
-        </div>
+        <div className="ml-sidebar md:ml-0">{children}</div>
         <AssetVariantsConversionModal />
       </React.Fragment>
     );

--- a/packages/web/pages/index.tsx
+++ b/packages/web/pages/index.tsx
@@ -30,7 +30,7 @@ const Home = () => {
   });
 
   return (
-    <main className="relative flex h-full overflow-auto pb-2 pt-8">
+    <main className="relative flex overflow-auto pb-2 pt-8 h-content md:h-content-mobile">
       <div className="fixed inset-0 h-full w-full overflow-y-scroll bg-cover xl:static">
         <div className="relative h-full w-full xl:hidden">
           <Image


### PR DESCRIPTION
## What is the purpose of the change:

We originally set a fixed height for the entire app layout, which conflicted with Headless UI’s behavior of locking the scroll when a dropdown menu is open. The solution is to remove this fixed height. This change shouldn’t impact other parts of the app, as containers dynamically adjust their height based on their contents. Moreover, setting a fixed height is generally best avoided unless necessary.

I noticed this height adjustment was specifically added for the swap tool page, so I moved it to that page to avoid breaking the its layout.

### Linear Task

https://linear.app/osmosis/issue/FE-1219/pools-page-dropdown-jumping-to-top-of-page

## Testing and Verifying

- [ ] Clicking on pool dropdowns should move the scroll to the start of the page

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected

_(or)_

This change has not been tested locally, because (to-be-explained-why...) -->
