### PR TITLE
(Deposit/Withdraw) Handle UI pending state when estimated time reaches 0

### DIFF
--- a/packages/trpc/src/assets.ts
+++ b/packages/trpc/src/assets.ts
@@ -632,7 +632,7 @@ export const assetsRouter = createTRPCRouter({
                   if (
                     !isNil(asset.variantGroupKey) &&
                     !variantsNotToBeExcluded.includes(
-                      asset.variantGroupKey as (typeof variantsNotToBeExcluded)[number]
+                      asset.coinDenom as (typeof variantsNotToBeExcluded)[number]
                     )
                   ) {
                     return asset.variantGroupKey === asset.coinMinimalDenom;

--- a/packages/web/components/bridge/asset-select-screen.tsx
+++ b/packages/web/components/bridge/asset-select-screen.tsx
@@ -13,9 +13,7 @@ import { Spinner } from "~/components/loaders";
 import { Tooltip } from "~/components/tooltip";
 import {
   MainnetAssetSymbols,
-  MainnetVariantGroupKeys,
   TestnetAssetSymbols,
-  TestnetVariantGroupKeys,
 } from "~/config/generated/asset-lists";
 import { useTranslation, useWindowSize } from "~/hooks";
 import { useKeyboardNavigation } from "~/hooks/use-keyboard-navigation";
@@ -26,9 +24,10 @@ import { UnverifiedAssetsState } from "~/stores/user-settings/unverified-assets"
 import { formatPretty } from "~/utils/formatter";
 import { api, RouterOutputs } from "~/utils/trpc";
 
-const variantsNotToBeExcluded = [
-  "factory/osmo1z0qrq605sjgcqpylfl4aa6s90x738j7m58wyatt0tdzflg2ha26q67k743/wbtc",
-] satisfies (MainnetVariantGroupKeys | TestnetVariantGroupKeys)[];
+const variantsNotToBeExcluded = ["WBTC"] satisfies (
+  | MainnetAssetSymbols
+  | TestnetAssetSymbols
+)[];
 const prioritizedDenoms = [
   "USDC",
   "ETH",


### PR DESCRIPTION
## What is the purpose of the change:

Since WBTC will now use “allBtc” as its variant group key, we want to ensure it remains visible in the deposit list, even though it’s categorized as a variant. This is important because users may deposit WBTC from networks other than Bitcoin, such as Ethereum.

### Linear Task

https://linear.app/osmosis/issue/FE-1225/use-denom-to-avoid-excluding-variants-in-deposits

## Brief Changelog

- Use denom to avoid excluding asset from deposit list

## Testing and Verifying

- [ ] Can see WBTC in deposit list after asset list update 