### PR TITLE
(DevX) Create lock file to manage asset list image cache

### DIFF
--- a/packages/web/config/generate-lists.ts
+++ b/packages/web/config/generate-lists.ts
@@ -19,6 +19,7 @@ import type {
   IbcTransferMethod,
 } from "@osmosis-labs/types";
 import { isNil } from "@osmosis-labs/utils";
+import * as fs from "fs";
 
 import { generateTsFile } from "~/utils/codegen";
 
@@ -31,6 +32,7 @@ import {
   OSMOSIS_CHAIN_NAME_OVERWRITE,
 } from "./env";
 import {
+  codegenDir,
   getChainList,
   getImageRelativeFilePath,
   getOsmosisChainId,
@@ -44,7 +46,6 @@ interface ResponseAssetList {
 }
 
 const repo = "osmosis-labs/assetlists";
-const codegenDir = "config/generated";
 
 function getFilePath({
   chainId,
@@ -335,6 +336,10 @@ async function getLatestCommitHash() {
 }
 
 async function main() {
+  if (!fs.existsSync(codegenDir)) {
+    fs.mkdirSync(codegenDir);
+  }
+
   const mainnetOsmosisChainId = getOsmosisChainId("mainnet");
   const testnetOsmosisChainId = getOsmosisChainId("testnet");
 

--- a/packages/web/config/utils.ts
+++ b/packages/web/config/utils.ts
@@ -71,7 +71,7 @@ export function writeCurrentAssetListHash(hash: string): void {
 
 /**
  * Download an image from the provided URL and save it to the local file system.
- * Only saves images if the current asset list hash differs from the stored hash.
+ * Only saves images if the current asset list hash differs from the stored hash or the file doesn't exist.
  * @param params An object containing the image URL, asset information, and current asset list hash.
  * @returns The filename of the saved image or null if skipped.
  */

--- a/packages/web/config/utils.ts
+++ b/packages/web/config/utils.ts
@@ -37,11 +37,10 @@ function getNodeImageRelativeFilePath(imageUrl: string, symbol: string) {
   return path.join("/public", tokensDir, `${symbol.toLowerCase()}.${fileType}`);
 }
 
+export const codegenDir = "config/generated";
+
 // Path to the lock file
-const lockFilePath = path.join(
-  path.resolve(),
-  "/config/generated/asset-lock.json"
-);
+const lockFilePath = path.join(path.resolve(), `${codegenDir}/asset-lock.json`);
 
 /**
  * Read the stored asset list hash from the lock file.

--- a/packages/web/config/utils.ts
+++ b/packages/web/config/utils.ts
@@ -37,15 +37,53 @@ function getNodeImageRelativeFilePath(imageUrl: string, symbol: string) {
   return path.join("/public", tokensDir, `${symbol.toLowerCase()}.${fileType}`);
 }
 
+// Path to the lock file
+const lockFilePath = path.join(
+  path.resolve(),
+  "/config/generated/asset-lock.json"
+);
+
+/**
+ * Read the stored asset list hash from the lock file.
+ * @returns The stored hash or null if the lock file doesn't exist.
+ */
+function readStoredAssetListHash(): string | null {
+  if (!fs.existsSync(lockFilePath)) {
+    return null;
+  }
+  const data = fs.readFileSync(lockFilePath, "utf-8");
+  try {
+    const parsed = JSON.parse(data);
+    return parsed.assetListHash || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write the current asset list hash to the lock file.
+ * @param hash The hash to store.
+ */
+export function writeCurrentAssetListHash(hash: string): void {
+  const data = { assetListHash: hash };
+  fs.writeFileSync(lockFilePath, JSON.stringify(data, null, 2), "utf-8");
+}
+
 /**
  * Download an image from the provided URL and save it to the local file system.
- * @param imageUrl The URL of the image to download.
- * @returns The filename of the saved image.
+ * Only saves images if the current asset list hash differs from the stored hash.
+ * @param params An object containing the image URL, asset information, and current asset list hash.
+ * @returns The filename of the saved image or null if skipped.
  */
-export async function saveAssetImageToTokensDir(
-  imageUrl: string,
-  asset: Pick<Asset, "symbol">
-) {
+export async function saveAssetImageToTokensDir({
+  imageUrl,
+  asset,
+  currentAssetListHash,
+}: {
+  imageUrl: string;
+  asset: Pick<Asset, "symbol">;
+  currentAssetListHash: string;
+}) {
   // Ensure the tokens directory exists.
   if (!fs.existsSync(path.resolve() + "/public" + tokensDir)) {
     fs.mkdirSync(path.resolve() + "/public" + tokensDir, { recursive: true });
@@ -56,6 +94,16 @@ export async function saveAssetImageToTokensDir(
 
   if (process.env.NODE_ENV === "test") {
     console.info("Skipping image download for test environment");
+    return null;
+  }
+
+  const storedHash = readStoredAssetListHash();
+
+  /**
+   * Skip saving the image if the current asset list hash matches the stored hash.
+   */
+  if (storedHash === currentAssetListHash && fs.existsSync(filePath)) {
+    return null;
   }
 
   // Fetch the image from the URL.
@@ -80,7 +128,7 @@ export async function saveAssetImageToTokensDir(
     ).pipe(fileStream)
   );
 
-  // verify the image has been added
+  // Verify the image has been added
   if (!fs.existsSync(filePath)) {
     throw new Error(`Failed to save image to ${filePath}`);
   }

--- a/packages/web/next-env.d.ts
+++ b/packages/web/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/packages/web/utils/codegen.ts
+++ b/packages/web/utils/codegen.ts
@@ -24,10 +24,6 @@ export async function generateTsFile(
 
     const filePath = path.join(dirPath, fileName);
 
-    if (!fs.existsSync(dirPath)) {
-      fs.mkdirSync(dirPath);
-    }
-
     if (overwriteFile) {
       fs.writeFileSync(filePath, formatted, {
         encoding: "utf8",


### PR DESCRIPTION
## What is the purpose of the change:

Previously, we disabled caching to avoid token image conflicts when switching environments. However, since waiting for image downloads to start the server is time-consuming and tedious, we propose creating a lock file inside the generated folder. This lock file will store the current asset list hash and override the cache if the hash changes.

### Linear Task

https://linear.app/osmosis/issue/FE-1228/create-lock-file-to-manage-asset-list-images-cache

## Testing and Verifying

- [ ] Asset list is generated correctly