### PR TITLE
Convert variants: check for large difference in amount

### DIFF
--- a/packages/web/components/table/portfolio-asset-balances.tsx
+++ b/packages/web/components/table/portfolio-asset-balances.tsx
@@ -572,7 +572,7 @@ const AssetActionsCell: AssetCellComponent<{
       {needsActivation && (
         <Button
           variant="secondary"
-          className="max-h-12 mx-auto w-[108px] rounded-[48px] bg-osmoverse-alpha-850 hover:bg-osmoverse-alpha-800"
+          className="max-h-12 rounded-[48px] bg-osmoverse-alpha-850 hover:bg-osmoverse-alpha-800"
           onClick={(e) => {
             e.stopPropagation();
             e.preventDefault();
@@ -587,7 +587,7 @@ const AssetActionsCell: AssetCellComponent<{
           {showConvertButton ? (
             <Button
               variant="secondary"
-              className="max-h-12 w-[108px] rounded-[48px] bg-osmoverse-alpha-850 hover:bg-osmoverse-alpha-800"
+              className="max-h-12 rounded-[48px] bg-osmoverse-alpha-850 hover:bg-osmoverse-alpha-800"
               onClick={(e) => {
                 e.stopPropagation();
                 e.preventDefault();

--- a/packages/web/hooks/__tests__/use-convert-variant.test.ts
+++ b/packages/web/hooks/__tests__/use-convert-variant.test.ts
@@ -1,0 +1,21 @@
+import { Dec } from "@keplr-wallet/unit";
+
+import { checkLargeAmountDiff } from "../use-convert-variant";
+
+describe("isLargeAmountDiff", () => {
+  test("returns false when input amount is zero", () => {
+    expect(checkLargeAmountDiff(new Dec("0"), new Dec("100"))).toBe(false);
+  });
+
+  test("returns false when output is 95% or more of input", () => {
+    expect(checkLargeAmountDiff(new Dec("100"), new Dec("95"))).toBe(false);
+    expect(checkLargeAmountDiff(new Dec("100"), new Dec("96"))).toBe(false);
+    expect(checkLargeAmountDiff(new Dec("100"), new Dec("100"))).toBe(false);
+  });
+
+  test("returns true when output is less than 95% of input", () => {
+    expect(checkLargeAmountDiff(new Dec("100"), new Dec("94"))).toBe(true);
+    expect(checkLargeAmountDiff(new Dec("100"), new Dec("90"))).toBe(true);
+    expect(checkLargeAmountDiff(new Dec("100"), new Dec("50"))).toBe(true);
+  });
+});

--- a/packages/web/hooks/use-convert-variant.ts
+++ b/packages/web/hooks/use-convert-variant.ts
@@ -151,14 +151,10 @@ export function useConvertVariant(
   const { fiatValue: feeFiatValue } = useCoinFiatValue(quote?.feeAmount);
 
   // Check for large difference in amount of in v out
-  // Include decimals, but we know the amounts should be priced 1:1
   const isLargeAmountDiff = useMemo(() => {
-    // toDec should include decimals
     const inAmount = variant?.amount.toDec();
     const outAmount = quote?.amount.toDec();
-    if (!inAmount || !outAmount || inAmount.isZero()) return false;
-    // Out amount should be 95% or more of the input amount
-    return outAmount.quo(inAmount).lt(new Dec("0.95"));
+    return checkLargeAmountDiff(inAmount, outAmount);
   }, [variant, quote?.amount]);
 
   return {
@@ -221,4 +217,14 @@ export async function getConvertVariantMessages(
     tokenInCoinDecimals: variant.amount.currency?.coinDecimals ?? 0,
     userOsmoAddress: address,
   });
+}
+
+/**
+ * Checks if there is a large difference between input and output amounts
+ * Returns true if output amount is less than 95% of input amount
+ */
+export function checkLargeAmountDiff(inAmount?: Dec, outAmount?: Dec): boolean {
+  if (!inAmount || !outAmount || inAmount.isZero()) return false;
+  // Out amount should be 95% or more of the input amount
+  return outAmount.quo(inAmount).lt(new Dec("0.95"));
 }


### PR DESCRIPTION
## What is the purpose of the change:

Add more user protection imposing a limit on price impact when converting non-alloy variants, such as USDC.

If the _amounts_ in vs out differ by more than 5% in the quote, block the conversion tx from being possible. Since we're converting like kinds, we can assume the amounts (with respective decimals in place) should be about the same. This is instead of comparing USD values, which may not be accurate if there's issues getting prices.

### Linear Task

Hot fix.

## Brief Changelog

- Include in/out amount diff slippage check in isError flag

## Testing and Verifying

Tested small change locally