### PR TITLE
(Pool creation) Supercharged Pool creation is missing several assets

### DIFF
--- a/packages/trpc/src/concentrated-liquidity.ts
+++ b/packages/trpc/src/concentrated-liquidity.ts
@@ -106,34 +106,42 @@ export const concentratedLiquidityRouter = createTRPCRouter({
   getLiquidityPerTickRange: publicProcedure
     .input(z.object({ poolId: z.string() }))
     .query(({ ctx, input }) => getLiquidityPerTickRange({ ...ctx, ...input })),
-  getBaseTokens: publicProcedure.query(({ ctx }) =>
-    getAssets({
-      assetLists: ctx.assetLists,
-      onlyVerified: true,
-    })
-      .map((asset) => {
-        const assetListAsset = getAssetFromAssetList({
-          assetLists: ctx.assetLists,
-          coinMinimalDenom: asset.coinMinimalDenom,
-        });
-
-        if (!assetListAsset) return;
-
-        return {
-          chainName: assetListAsset.rawAsset.chainName,
-          token: new CoinPretty(
-            {
-              coinDenom: asset.coinDenom,
-              coinDecimals: asset.coinDecimals,
-              coinMinimalDenom: asset.coinMinimalDenom,
-              coinImageUrl: asset.coinImageUrl,
-            },
-            0
-          ).currency,
-        };
+  getBaseTokens: publicProcedure
+    .input(
+      z.object({
+        onlyVerified: z.boolean().default(false),
+        includePreview: z.boolean().default(false),
       })
-      .filter((asset): asset is NonNullable<typeof asset> => Boolean(asset))
-  ),
+    )
+    .query(({ ctx, input }) =>
+      getAssets({
+        assetLists: ctx.assetLists,
+        onlyVerified: input.onlyVerified,
+        includePreview: input.includePreview,
+      })
+        .map((asset) => {
+          const assetListAsset = getAssetFromAssetList({
+            assetLists: ctx.assetLists,
+            coinMinimalDenom: asset.coinMinimalDenom,
+          });
+
+          if (!assetListAsset) return;
+
+          return {
+            chainName: assetListAsset.rawAsset.chainName,
+            token: new CoinPretty(
+              {
+                coinDenom: asset.coinDenom,
+                coinDecimals: asset.coinDecimals,
+                coinMinimalDenom: asset.coinMinimalDenom,
+                coinImageUrl: asset.coinImageUrl,
+              },
+              0
+            ).currency,
+          };
+        })
+        .filter((asset): asset is NonNullable<typeof asset> => Boolean(asset))
+    ),
   getQuoteTokens: publicProcedure.query(async ({ ctx }) => {
     const {
       params: { authorized_quote_denoms: authorizedQuoteDenoms },

--- a/packages/web/components/complex/pool/create/cl/set-base-info.tsx
+++ b/packages/web/components/complex/pool/create/cl/set-base-info.tsx
@@ -18,8 +18,10 @@ import { SelectionToken } from "~/components/complex/pool/create/cl-pool";
 import { SkeletonLoader, Spinner } from "~/components/loaders";
 import { Button } from "~/components/ui/button";
 import { useDisclosure, useFilteredData, useTranslation } from "~/hooks";
+import { useShowPreviewAssets } from "~/hooks/use-show-preview-assets";
 import { TokenSelectModal } from "~/modals";
 import { useStore } from "~/stores";
+import { UnverifiedAssetsState } from "~/stores/user-settings";
 import { formatPretty } from "~/utils/formatter";
 import { api } from "~/utils/trpc";
 
@@ -43,12 +45,24 @@ export const SetBaseInfos = observer(
   }: SetBaseInfosProps) => {
     const { t } = useTranslation();
 
-    const { accountStore } = useStore();
+    const { accountStore, userSettings } = useStore();
 
     const account = accountStore.getWallet(accountStore.osmosisChainId);
+    const { showPreviewAssets } = useShowPreviewAssets();
+
+    const showUnverifiedAssetsSetting =
+      userSettings.getUserSettingById<UnverifiedAssetsState>(
+        "unverified-assets"
+      );
+    const showUnverifiedAssets = Boolean(
+      showUnverifiedAssetsSetting?.state.showUnverifiedAssets
+    );
 
     const { data: baseTokens, isLoading: isLoadingBaseTokens } =
-      api.local.concentratedLiquidity.getBaseTokens.useQuery();
+      api.local.concentratedLiquidity.getBaseTokens.useQuery({
+        includePreview: showPreviewAssets,
+        onlyVerified: showUnverifiedAssets === false,
+      });
     const { data: quoteTokens, isLoading: isLoadingQuoteTokens } =
       api.local.concentratedLiquidity.getQuoteTokens.useQuery();
     const { data: clParams } =


### PR DESCRIPTION
## What is the purpose of the change:

The supercharged pool creation interface currently lacks several assets due to the absence of the `onlyVerified` and `showPreviewAssets` inputs. This PR addresses the issue by ensuring assets are displayed according to the user’s preferences.

### Linear Task

https://linear.app/osmosis/issue/FE-964/supercharged-pool-creation-is-missing-several-assets

## Testing and Verifying

- [ ] Can see preview and unverified assets based on users' preference in the create supercharged pool asset select   