### PR TITLE
(Swap Tool) Add top gainers

### DIFF
--- a/packages/web/components/assets/highlights-categories.tsx
+++ b/packages/web/components/assets/highlights-categories.tsx
@@ -94,7 +94,7 @@ const HighlightsGrid: FunctionComponent<HighlightsProps> = ({
   );
 };
 
-function highlightPrice24hChangeAsset(asset: PriceChange24hAsset) {
+export function highlightPrice24hChangeAsset(asset: PriceChange24hAsset) {
   return {
     asset: {
       ...asset,
@@ -129,7 +129,7 @@ function highlightUpcomingReleaseAsset(asset: UpcomingReleaseAsset) {
   };
 }
 
-const AssetHighlights: FunctionComponent<
+export const AssetHighlights: FunctionComponent<
   {
     title: string;
     subtitle?: string;

--- a/packages/web/components/table/asset-info.tsx
+++ b/packages/web/components/table/asset-info.tsx
@@ -19,6 +19,7 @@ import {
   useMemo,
   useState,
 } from "react";
+import { useMount } from "react-use";
 
 import { HighlightsCategories } from "~/components/assets/highlights-categories";
 import { AssetCell } from "~/components/table/cells/asset";
@@ -39,6 +40,7 @@ import { UnverifiedAssetsState } from "~/stores/user-settings";
 import { theme } from "~/tailwind.config";
 import { formatPretty } from "~/utils/formatter";
 import { api, RouterInputs, RouterOutputs } from "~/utils/trpc";
+import { removeQueryParam } from "~/utils/url";
 
 import { AssetCategoriesSelectors } from "../assets/categories";
 import { HistoricalPriceSparkline, PriceChange } from "../assets/price";
@@ -65,8 +67,6 @@ export const AssetsInfoTable: FunctionComponent<{
   const router = useRouter();
   const { t } = useTranslation();
   const { logEvent } = useAmplitudeAnalytics();
-
-  // State
 
   // category
   const [selectedCategory, setCategory] = useState<string | undefined>();
@@ -96,6 +96,15 @@ export const AssetsInfoTable: FunctionComponent<{
         : undefined,
     [selectedCategory]
   );
+
+  useMount(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const category = urlParams.get("category");
+    if (category) {
+      setCategory(category);
+      removeQueryParam("category");
+    }
+  });
 
   // search
   const [searchQuery, setSearchQuery] = useState<Search | undefined>();

--- a/packages/web/pages/index.tsx
+++ b/packages/web/pages/index.tsx
@@ -75,7 +75,7 @@ const TopGainers = () => {
 
   const { data: topGainerAssets, isLoading: isTopGainerAssetsLoading } =
     api.edge.assets.getTopGainerAssets.useQuery({
-      topN: 5,
+      topN: 4,
     });
 
   return (

--- a/packages/web/pages/index.tsx
+++ b/packages/web/pages/index.tsx
@@ -1,14 +1,25 @@
 import dayjs from "dayjs";
 import { observer } from "mobx-react-lite";
 import Image from "next/image";
+import { useRouter } from "next/router";
 import { useLocalStorage } from "react-use";
 
 import { AdBanners } from "~/components/ad-banner";
+import {
+  AssetHighlights,
+  highlightPrice24hChangeAsset,
+} from "~/components/assets/highlights-categories";
 import { ClientOnly } from "~/components/client-only";
 import { ErrorBoundary } from "~/components/error/error-boundary";
 import { TradeTool } from "~/components/trade-tool";
 import { EventName } from "~/config";
-import { useAmplitudeAnalytics, useFeatureFlags } from "~/hooks";
+import {
+  Breakpoint,
+  useAmplitudeAnalytics,
+  useFeatureFlags,
+  useTranslation,
+  useWindowSize,
+} from "~/hooks";
 import { api } from "~/utils/trpc";
 
 export const SwapPreviousTradeKey = "swap-previous-trade";
@@ -52,10 +63,38 @@ const Home = () => {
                 setPreviousTrade={setPreviousTrade}
               />
             </ClientOnly>
+            <TopGainers />
           </div>
         </div>
       </div>
     </main>
+  );
+};
+
+const TopGainers = () => {
+  const { t } = useTranslation();
+  const { width } = useWindowSize();
+  const router = useRouter();
+
+  const isLargeTablet = width < Breakpoint.xl && width > Breakpoint.lg;
+
+  const { data: topGainerAssets, isLoading: isTopGainerAssetsLoading } =
+    api.edge.assets.getTopGainerAssets.useQuery({
+      topN: isLargeTablet ? 8 : undefined,
+    });
+
+  return (
+    <AssetHighlights
+      className="bg-osmoverse-1000/40 px-2"
+      title={t("assets.highlights.topGainers")}
+      subtitle="24h"
+      isLoading={isTopGainerAssetsLoading}
+      assets={(topGainerAssets ?? []).map(highlightPrice24hChangeAsset)}
+      onClickSeeAll={() => {
+        router.push(`/assets?category=topGainers`);
+      }}
+      highlight="topGainers"
+    />
   );
 };
 

--- a/packages/web/pages/index.tsx
+++ b/packages/web/pages/index.tsx
@@ -14,11 +14,9 @@ import { ErrorBoundary } from "~/components/error/error-boundary";
 import { TradeTool } from "~/components/trade-tool";
 import { EventName } from "~/config";
 import {
-  Breakpoint,
   useAmplitudeAnalytics,
   useFeatureFlags,
   useTranslation,
-  useWindowSize,
 } from "~/hooks";
 import { api } from "~/utils/trpc";
 
@@ -73,14 +71,11 @@ const Home = () => {
 
 const TopGainers = () => {
   const { t } = useTranslation();
-  const { width } = useWindowSize();
   const router = useRouter();
-
-  const isLargeTablet = width < Breakpoint.xl && width > Breakpoint.lg;
 
   const { data: topGainerAssets, isLoading: isTopGainerAssetsLoading } =
     api.edge.assets.getTopGainerAssets.useQuery({
-      topN: isLargeTablet ? 8 : undefined,
+      topN: 5,
     });
 
   return (


### PR DESCRIPTION
## What is the purpose of the change:

https://github.com/user-attachments/assets/a08c5479-fc08-4d22-bc6a-050f20a0a4a9

### Linear Task

https://linear.app/osmosis/issue/FE-1229/add-trending-tab-to-the-trade-page

## Testing and Verifying

- [ ] Can see top gainers below swap tool    