### PR TITLE
(1CT) Split txs for Ledger in swap review modal

### DIFF
--- a/packages/stores/src/account/base.ts
+++ b/packages/stores/src/account/base.ts
@@ -515,7 +515,7 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
     fee?: StdFee,
     signOptions?: SignOptions,
     onTxEvents?:
-      | ((tx: DeliverTxResponse) => void)
+      | ((tx: DeliverTxResponse) => void | Promise<void>)
       | {
           onBroadcastFailed?: (e?: Error) => void;
           onBroadcasted?: (txHash: Uint8Array) => void;
@@ -709,7 +709,7 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
       }
 
       if (onFulfill) {
-        onFulfill(tx);
+        await onFulfill(tx);
       }
     } catch (e) {
       const error = e as Error | AccountStoreNoBroadcastErrorEvent;

--- a/packages/web/hooks/limit-orders/use-place-limit.ts
+++ b/packages/web/hooks/limit-orders/use-place-limit.ts
@@ -289,7 +289,7 @@ export const usePlaceLimit = ({
     use1CTSwapReviewMessages();
 
   /**
-   * Default isLedger to True, just in case the wallet does
+   * Default isLedger to true, just in case the wallet does
    * not return the correct value
    */
   const { value: isLedger } = useAsync(async () => {
@@ -297,7 +297,7 @@ export const usePlaceLimit = ({
       accountStore.osmosisChainId
     );
     return result?.isNanoLedger ?? true;
-    // Disable deps to include account address in order to recompute the value as the other are memoized mobx values
+    // Disable deps to include account address in order to recompute the value as the others are memoized mobx values
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [account, account?.address, accountStore.osmosisChainId]);
 

--- a/packages/web/hooks/limit-orders/use-place-limit.ts
+++ b/packages/web/hooks/limit-orders/use-place-limit.ts
@@ -288,7 +288,7 @@ export const usePlaceLimit = ({
   const { oneClickMessages, isLoadingOneClickMessages, shouldSend1CTTx } =
     use1CTSwapReviewMessages();
 
-  const isLedger = true ?? account?.walletInfo?.mode === "ledger";
+  const isLedger = account?.walletInfo?.mode === "ledger";
 
   const limitMessages = useMemo(() => {
     if (isLedger) return encodedMsg && !isMarket ? [encodedMsg] : [];

--- a/packages/web/hooks/use-swap.tsx
+++ b/packages/web/hooks/use-swap.tsx
@@ -334,9 +334,12 @@ export function useSwap(
   const { oneClickMessages, isLoadingOneClickMessages, shouldSend1CTTx } =
     use1CTSwapReviewMessages();
 
+  const isLedger = account?.walletInfo?.mode === "ledger";
+
   const messages = useMemo(() => {
+    if (isLedger) return quote?.messages ?? [];
     return [...(quote?.messages ?? []), ...(oneClickMessages?.msgs ?? [])];
-  }, [quote?.messages, oneClickMessages?.msgs]);
+  }, [isLedger, quote?.messages, oneClickMessages?.msgs]);
 
   const {
     data: networkFee,
@@ -520,73 +523,177 @@ export function useSwap(
 
           const { routes } = txParams;
           const typedRoutes = routes as SwapTxRouteOutGivenIn[];
-          accountStore
-            .signAndBroadcast(
-              chainStore.osmosis.chainId,
-              quoteType === "out-given-in"
-                ? routes.length === 1
-                  ? "swapExactAmountIn"
-                  : "splitRouteSwapExactAmountIn"
-                : routes.length === 1
-                ? "swapExactAmountOut"
-                : "splitRouteSwapExactAmountOut",
-              messages,
-              undefined,
-              signOptions?.fee,
-              signOptions,
-              (tx) => {
-                const { code } = tx;
-                if (code) {
-                  reject(
-                    new Error("Failed to send swap exact amount in message")
-                  );
-                } else {
-                  if (
-                    shouldSend1CTTx &&
-                    oneClickMessages &&
-                    oneClickMessages.type === "create-1ct-session"
-                  ) {
-                    onAdd1CTSession({
-                      privateKey: oneClickMessages.key,
-                      tx,
-                      userOsmoAddress: account?.address ?? "",
-                      fallbackGetAuthenticatorId:
-                        apiUtils.local.oneClickTrading.getSessionAuthenticator
-                          .fetch,
-                      accountStore,
-                      allowedMessages: oneClickMessages.allowedMessages,
-                      sessionPeriod: oneClickMessages.sessionPeriod,
-                      spendLimitTokenDecimals:
-                        oneClickMessages.spendLimitTokenDecimals,
-                      transaction1CTParams:
-                        oneClickMessages.transaction1CTParams,
-                      allowedAmount: oneClickMessages.allowedAmount,
-                      t,
-                      logEvent,
-                    });
-                  } else if (
-                    shouldSend1CTTx &&
-                    oneClickMessages &&
-                    oneClickMessages.type === "remove-1ct-session"
-                  ) {
-                    onEnd1CTSession({
-                      accountStore,
-                      authenticatorId: oneClickMessages.authenticatorId,
-                      logEvent,
-                    });
-                  }
 
-                  resolve(
-                    routes.length === 1
-                      ? typedRoutes[0].pools.length === 1
-                        ? "exact-in"
-                        : "multihop"
-                      : "multiroute"
-                  );
+          /**
+           * If it's ledger and we have one-click messages, we need to add a 1CT session
+           * before broadcasting the transaction as there is a payload limit on ledger
+           */
+          if (
+            isLedger &&
+            oneClickMessages &&
+            oneClickMessages.msgs &&
+            shouldSend1CTTx
+          ) {
+            await accountStore
+              .signAndBroadcast(
+                chainStore.osmosis.chainId,
+                "Add 1CT session",
+                oneClickMessages.msgs,
+                undefined,
+                undefined,
+                undefined,
+                async (tx) => {
+                  const { code } = tx;
+                  if (code) {
+                    reject(
+                      new Error("Failed to send swap exact amount in message")
+                    );
+                  } else {
+                    if (
+                      oneClickMessages &&
+                      oneClickMessages.type === "create-1ct-session"
+                    ) {
+                      await onAdd1CTSession({
+                        privateKey: oneClickMessages.key,
+                        tx,
+                        userOsmoAddress: account?.address ?? "",
+                        fallbackGetAuthenticatorId:
+                          apiUtils.local.oneClickTrading.getSessionAuthenticator
+                            .fetch,
+                        accountStore,
+                        allowedMessages: oneClickMessages.allowedMessages,
+                        sessionPeriod: oneClickMessages.sessionPeriod,
+                        spendLimitTokenDecimals:
+                          oneClickMessages.spendLimitTokenDecimals,
+                        transaction1CTParams:
+                          oneClickMessages.transaction1CTParams,
+                        allowedAmount: oneClickMessages.allowedAmount,
+                        t,
+                        logEvent,
+                      });
+                    } else if (
+                      shouldSend1CTTx &&
+                      oneClickMessages &&
+                      oneClickMessages.type === "remove-1ct-session"
+                    ) {
+                      await onEnd1CTSession({
+                        accountStore,
+                        authenticatorId: oneClickMessages.authenticatorId,
+                        logEvent,
+                      });
+                    }
+                  }
                 }
-              }
-            )
-            .catch(reject);
+              )
+              .catch(reject);
+
+            await accountStore
+              .signAndBroadcast(
+                chainStore.osmosis.chainId,
+                quoteType === "out-given-in"
+                  ? routes.length === 1
+                    ? "swapExactAmountIn"
+                    : "splitRouteSwapExactAmountIn"
+                  : routes.length === 1
+                  ? "swapExactAmountOut"
+                  : "splitRouteSwapExactAmountOut",
+                messages,
+                undefined,
+                undefined,
+                {
+                  ...signOptions,
+                  useOneClickTrading:
+                    await accountStore.shouldBeSignedWithOneClickTrading({
+                      messages,
+                    }),
+                },
+                (tx) => {
+                  const { code } = tx;
+                  if (code) {
+                    reject(
+                      new Error("Failed to send swap exact amount in message")
+                    );
+                  } else {
+                    resolve(
+                      routes.length === 1
+                        ? typedRoutes[0].pools.length === 1
+                          ? "exact-in"
+                          : "multihop"
+                        : "multiroute"
+                    );
+                  }
+                }
+              )
+              .catch(reject);
+          } else {
+            accountStore
+              .signAndBroadcast(
+                chainStore.osmosis.chainId,
+                quoteType === "out-given-in"
+                  ? routes.length === 1
+                    ? "swapExactAmountIn"
+                    : "splitRouteSwapExactAmountIn"
+                  : routes.length === 1
+                  ? "swapExactAmountOut"
+                  : "splitRouteSwapExactAmountOut",
+                messages,
+                undefined,
+                signOptions?.fee,
+                signOptions,
+                (tx) => {
+                  const { code } = tx;
+                  if (code) {
+                    reject(
+                      new Error("Failed to send swap exact amount in message")
+                    );
+                  } else {
+                    if (
+                      shouldSend1CTTx &&
+                      oneClickMessages &&
+                      oneClickMessages.type === "create-1ct-session"
+                    ) {
+                      onAdd1CTSession({
+                        privateKey: oneClickMessages.key,
+                        tx,
+                        userOsmoAddress: account?.address ?? "",
+                        fallbackGetAuthenticatorId:
+                          apiUtils.local.oneClickTrading.getSessionAuthenticator
+                            .fetch,
+                        accountStore,
+                        allowedMessages: oneClickMessages.allowedMessages,
+                        sessionPeriod: oneClickMessages.sessionPeriod,
+                        spendLimitTokenDecimals:
+                          oneClickMessages.spendLimitTokenDecimals,
+                        transaction1CTParams:
+                          oneClickMessages.transaction1CTParams,
+                        allowedAmount: oneClickMessages.allowedAmount,
+                        t,
+                        logEvent,
+                      });
+                    } else if (
+                      shouldSend1CTTx &&
+                      oneClickMessages &&
+                      oneClickMessages.type === "remove-1ct-session"
+                    ) {
+                      onEnd1CTSession({
+                        accountStore,
+                        authenticatorId: oneClickMessages.authenticatorId,
+                        logEvent,
+                      });
+                    }
+
+                    resolve(
+                      routes.length === 1
+                        ? typedRoutes[0].pools.length === 1
+                          ? "exact-in"
+                          : "multihop"
+                        : "multiroute"
+                    );
+                  }
+                }
+              )
+              .catch(reject);
+          }
         }
       ).finally(() => {
         inAmountInput.reset();
@@ -600,7 +707,9 @@ export function useSwap(
       featureFlags.swapToolSimulateFee,
       hasOverSpendLimitError,
       inAmountInput,
+      isLedger,
       isOneClickTradingEnabled,
+      logEvent,
       maxSlippage,
       messages,
       networkFee,

--- a/packages/web/hooks/use-swap.tsx
+++ b/packages/web/hooks/use-swap.tsx
@@ -335,7 +335,7 @@ export function useSwap(
     use1CTSwapReviewMessages();
 
   /**
-   * Default isLedger to True, just in case the wallet does
+   * Default isLedger to true, just in case the wallet does
    * not return the correct value
    */
   const { value: isLedger } = useAsync(async () => {
@@ -343,7 +343,7 @@ export function useSwap(
       accountStore.osmosisChainId
     );
     return result?.isNanoLedger ?? true;
-    // Disable deps to include account address in order to recompute the value as the other are memoized mobx values
+    // Disable deps to include account address in order to recompute the value as the others are memoized mobx values
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [account, account?.address, accountStore.osmosisChainId]);
 

--- a/packages/web/hooks/use-swap.tsx
+++ b/packages/web/hooks/use-swap.tsx
@@ -335,24 +335,24 @@ export function useSwap(
     use1CTSwapReviewMessages();
 
   /**
-   * Compute the negative first so we can default to the ledger case,
-   * just in case the wallet does not return the correct value
+   * Default isLedger to True, just in case the wallet does
+   * not return the correct value
    */
-  const { value: isNotLedger } = useAsync(async () => {
+  const { value: isLedger } = useAsync(async () => {
     const result = await account?.client?.getAccount?.(
       accountStore.osmosisChainId
     );
-    return !(result?.isNanoLedger ?? false);
+    return result?.isNanoLedger ?? true;
     // Disable deps to include account address in order to recompute the value as the other are memoized mobx values
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [account, account?.address, accountStore.osmosisChainId]);
 
   const messages = useMemo(() => {
-    if (isNotLedger) {
-      return [...(quote?.messages ?? []), ...(oneClickMessages?.msgs ?? [])];
+    if (isLedger) {
+      return quote?.messages ?? [];
     }
-    return quote?.messages ?? [];
-  }, [isNotLedger, quote?.messages, oneClickMessages?.msgs]);
+    return [...(quote?.messages ?? []), ...(oneClickMessages?.msgs ?? [])];
+  }, [isLedger, quote?.messages, oneClickMessages?.msgs]);
 
   const {
     data: networkFee,
@@ -542,7 +542,7 @@ export function useSwap(
            * before broadcasting the transaction as there is a payload limit on ledger
            */
           if (
-            !isNotLedger &&
+            isLedger &&
             oneClickMessages &&
             oneClickMessages.msgs &&
             shouldSend1CTTx
@@ -723,7 +723,7 @@ export function useSwap(
       featureFlags.swapToolSimulateFee,
       hasOverSpendLimitError,
       inAmountInput,
-      isNotLedger,
+      isLedger,
       isOneClickTradingEnabled,
       logEvent,
       maxSlippage,


### PR DESCRIPTION
## What is the purpose of the change:

Due to the payload limit of Ledgers, it is sometimes impossible to initiate 1CT and perform a swap within the same transaction. As a result, we need to sign each tx individually when using a Ledger

### Linear Task

https://linear.app/osmosis/issue/FE-1253/handle-ledger-1ct-activation-from-swap-review

## Testing and Verifying

- [ ] Can start 1CT session and swap from Ledger