### PR TITLE
Improve humanize time accuracy

### DIFF
--- a/packages/web/components/bridge/deposit-address-screen.tsx
+++ b/packages/web/components/bridge/deposit-address-screen.tsx
@@ -28,6 +28,7 @@ import { useClipboard } from "~/hooks/use-clipboard";
 import { useHumanizedRemainingTime } from "~/hooks/use-humanized-remaining-time";
 import { BridgeChainWithDisplayInfo } from "~/server/api/routers/bridge-transfer";
 import { useStore } from "~/stores";
+import { displayHumanizedTime } from "~/utils/date";
 import { trimPlaceholderZeros } from "~/utils/number";
 import { api, RouterOutputs } from "~/utils/trpc";
 
@@ -593,8 +594,7 @@ const RemainingTime = ({ unix }: { unix: number }) => {
 
   return (
     <span className="text-inherit">
-      {humanizedRemainingTime?.value}{" "}
-      {t(humanizedRemainingTime?.unitTranslationKey)}
+      {displayHumanizedTime({ humanizedTime: humanizedRemainingTime, t })}
     </span>
   );
 };

--- a/packages/web/components/nomic/nomic-pending-transfers.tsx
+++ b/packages/web/components/nomic/nomic-pending-transfers.tsx
@@ -20,7 +20,7 @@ import { useClipboard } from "~/hooks/use-clipboard";
 import { ModalBase } from "~/modals";
 import { BridgeChainWithDisplayInfo } from "~/server/api/routers/bridge-transfer";
 import { useStore } from "~/stores";
-import { humanizeTime } from "~/utils/date";
+import { displayHumanizedTime, humanizeTime } from "~/utils/date";
 import { api, RouterOutputs } from "~/utils/trpc";
 
 interface NomicPendingTransfersProps {
@@ -287,9 +287,10 @@ const TransactionDetailsModal = ({
                 </h2>
                 <p className="body1 text-osmoverse-300">
                   {t("transfer.nomic.estimatedAboutTime", {
-                    time: `${humanizedEstimatedTime.value} ${t(
-                      humanizedEstimatedTime.unitTranslationKey
-                    )}`,
+                    time: displayHumanizedTime({
+                      humanizedTime: humanizedEstimatedTime,
+                      t,
+                    }),
                   })}
                 </p>
                 <ProgressBar

--- a/packages/web/components/one-click-trading/one-click-remaining-time.tsx
+++ b/packages/web/components/one-click-trading/one-click-remaining-time.tsx
@@ -4,7 +4,7 @@ import dayjs from "dayjs";
 import { FunctionComponent, useEffect, useState } from "react";
 
 import { useOneClickTradingSession, useTranslation } from "~/hooks";
-import { humanizeTime } from "~/utils/date";
+import { displayHumanizedTime, humanizeTime } from "~/utils/date";
 
 export const OneClickTradingRemainingTime: FunctionComponent<{
   className?: string;
@@ -55,8 +55,7 @@ export const OneClickTradingRemainingTime: FunctionComponent<{
 
   return (
     <p className={classNames("body1 text-wosmongton-200", className)}>
-      {humanizedTime.value} {t(humanizedTime.unitTranslationKey)}{" "}
-      {t("remaining")}
+      {displayHumanizedTime({ humanizedTime, t })} {t("remaining")}
     </p>
   );
 };

--- a/packages/web/hooks/mutations/one-click-trading/use-create-one-click-trading-session.tsx
+++ b/packages/web/hooks/mutations/one-click-trading/use-create-one-click-trading-session.tsx
@@ -28,7 +28,7 @@ import { EventName, SPEND_LIMIT_CONTRACT_ADDRESS } from "~/config";
 import { useTranslation } from "~/hooks/language";
 import { useAmplitudeAnalytics } from "~/hooks/use-amplitude-analytics";
 import { useStore } from "~/stores";
-import { humanizeTime } from "~/utils/date";
+import { displayHumanizedTime, humanizeTime } from "~/utils/date";
 import { api, RouterInputs, RouterOutputs } from "~/utils/trpc";
 
 export class CreateOneClickSessionError extends Error {
@@ -238,8 +238,7 @@ export async function onAdd1CTSession({
       titleTranslationKey: "oneClickTrading.toast.oneClickTradingActive",
       captionElement: (
         <p className="text-sm text-osmoverse-300 md:text-xs">
-          {humanizedTime.value} {t(humanizedTime.unitTranslationKey)}{" "}
-          {t("remaining")}
+          {displayHumanizedTime({ humanizedTime, t })} {t("remaining")}
         </p>
       ),
     },

--- a/packages/web/stores/__tests__/transfer-history.spec.tsx
+++ b/packages/web/stores/__tests__/transfer-history.spec.tsx
@@ -15,6 +15,12 @@ describe("PendingTransferCaption", () => {
     if (key === "timeUnits.seconds") {
       return "seconds";
     }
+    if (key === "timeUnits.minutes") {
+      return "minutes";
+    }
+    if (key === "timeUnits.hours") {
+      return "hours";
+    }
     if (key === "transfer.amountToChain") {
       return `Transfer ${options.amount} to ${options.chain}`;
     }
@@ -85,5 +91,25 @@ describe("PendingTransferCaption", () => {
     jest.advanceTimersByTime(296000); // Advance time by 4 minutes and 56 seconds
 
     expect(screen.getByText(/About 5 seconds remaining/)).toBeInTheDocument();
+  });
+
+  it.only("displays the hours and minutes", () => {
+    const estimatedArrivalUnix = dayjs()
+      .add(3, "hours")
+      .add(59, "minutes")
+      .unix();
+
+    render(
+      <PendingTransferCaption
+        isWithdraw={true}
+        amount="10 OSMO"
+        chainPrettyName="Osmosis"
+        estimatedArrivalUnix={estimatedArrivalUnix}
+      />
+    );
+
+    expect(
+      screen.getByText(/Estimated 3 hours and 58 minutes remaining/)
+    ).toBeInTheDocument();
   });
 });

--- a/packages/web/stores/transfer-history.tsx
+++ b/packages/web/stores/transfer-history.tsx
@@ -23,7 +23,7 @@ import { FunctionComponent, useEffect, useRef } from "react";
 import { displayToast, ToastType } from "~/components/alert";
 import { RadialProgress } from "~/components/radial-progress";
 import { useTranslation } from "~/hooks";
-import { humanizeTime } from "~/utils/date";
+import { displayHumanizedTime, humanizeTime } from "~/utils/date";
 import { formatPretty } from "~/utils/formatter";
 
 export const TRANSFER_HISTORY_STORE_KEY = "transfer_history";
@@ -440,9 +440,10 @@ export const PendingTransferCaption: FunctionComponent<{
             ? t("aboutSecondsRemaining", {
                 seconds: "5 " + t("timeUnits.seconds"),
               })
-            : `${t("estimated")} ${humanizedTime.value} ${t(
-                humanizedTime.unitTranslationKey
-              )} ${t("remaining")}`;
+            : `${t("estimated")} ${displayHumanizedTime({
+                humanizedTime,
+                t,
+              })} ${t("remaining")}`;
       }
     };
 

--- a/packages/web/utils/__tests__/date.spec.ts
+++ b/packages/web/utils/__tests__/date.spec.ts
@@ -15,56 +15,62 @@ cases(
   (opts) => {
     const inputDate = dayjs().add(opts.input, "second");
     const result = humanizeTime(inputDate);
-    expect(result.value).toEqual(opts.expected.value);
-    if (opts.expected.unit !== "") {
-      expect(result.unitTranslationKey).toEqual(
-        `timeUnits.${opts.expected.unit}`
-      );
+
+    // Check the first time unit
+    for (const [index, expectedUnit] of opts.expected.entries()) {
+      expect(result[index].value).toEqual(expectedUnit.value);
+      if (expectedUnit.unit !== "") {
+        expect(result[index].unitTranslationKey).toEqual(
+          `timeUnits.${expectedUnit.unit}`
+        );
+      }
     }
   },
   [
     {
       name: "should return seconds for less than a minute",
       input: 30, // 30 seconds from now
-      expected: { value: 30, unit: "seconds" },
+      expected: [{ value: 30, unit: "seconds" }],
     },
     {
       name: "should return a single second",
       input: 1, // 1 second from now
-      expected: { value: 1, unit: "second" },
+      expected: [{ value: 1, unit: "second" }],
     },
     {
       name: "should return minutes for less than an hour",
       input: 120, // 2 minutes from now
-      expected: { value: 2, unit: "minutes" },
+      expected: [{ value: 2, unit: "minutes" }],
     },
     {
       name: "should return a single minute",
       input: 60, // 1 minute from now
-      expected: { value: 1, unit: "minute" },
+      expected: [{ value: 1, unit: "minute" }],
     },
     {
       name: "should return 59 minutes",
       input: 59 * 60, // 59 minutes from now
-      expected: { value: 59, unit: "minutes" },
+      expected: [{ value: 59, unit: "minutes" }],
     },
     {
-      name: "should return hours for less than a day",
-      input: 2 * 60 * 60, // 2 hours from now
-      expected: { value: 2, unit: "hours" },
+      name: "should return hours and minutes for less than a day",
+      input: 2 * 60 * 60 + 30 * 60, // 2 hours and 30 minutes from now
+      expected: [
+        { value: 2, unit: "hours" },
+        { value: 30, unit: "minutes" },
+      ],
     },
     {
       name: "should return a single hour",
       input: 60 * 60, // 1 hour from now
-      expected: { value: 1, unit: "hour" },
+      expected: [{ value: 1, unit: "hour" }],
     },
     {
       name: "should return formatted date for more than a day",
-      input: 25 * 60 * 60, // 25 hours from now
-      expected: {
-        value: 1,
-        unit: "day", // No unit expected for dates
-      },
+      input: 32 * 24 * 60 * 60, // 32 days from now
+      expected: [
+        { value: dayjs().add(32, "days").format("MMM D, YYYY"), unit: "" },
+      ],
     },
   ]
 );

--- a/packages/web/utils/date.ts
+++ b/packages/web/utils/date.ts
@@ -6,68 +6,102 @@ export function humanizeTime(
 ): {
   value: number | string;
   unitTranslationKey: string;
-} {
+}[] {
   // If less than a minute, show seconds
   const secondsDiff = date.diff(dayjs(), "seconds");
   if (secondsDiff < 60) {
-    return {
-      value: Math.max(secondsDiff, 0),
-      unitTranslationKey:
-        secondsDiff === 1
-          ? useShortTimeUnits
-            ? "timeUnitsShort.second"
-            : "timeUnits.second"
-          : useShortTimeUnits
-          ? "timeUnitsShort.seconds"
-          : "timeUnits.seconds",
-    };
+    return [
+      {
+        value: Math.max(secondsDiff, 0),
+        unitTranslationKey:
+          secondsDiff === 1
+            ? useShortTimeUnits
+              ? "timeUnitsShort.second"
+              : "timeUnits.second"
+            : useShortTimeUnits
+            ? "timeUnitsShort.seconds"
+            : "timeUnits.seconds",
+      },
+    ];
   }
 
   const minutesDiff = date.diff(dayjs(), "minutes");
   if (minutesDiff < 60) {
-    return {
-      value: minutesDiff,
-      unitTranslationKey:
-        minutesDiff === 1
-          ? useShortTimeUnits
-            ? "timeUnitsShort.minute"
-            : "timeUnits.minute"
-          : useShortTimeUnits
-          ? "timeUnitsShort.minutes"
-          : "timeUnits.minutes",
-    };
+    return [
+      {
+        value: minutesDiff,
+        unitTranslationKey:
+          minutesDiff === 1
+            ? useShortTimeUnits
+              ? "timeUnitsShort.minute"
+              : "timeUnits.minute"
+            : useShortTimeUnits
+            ? "timeUnitsShort.minutes"
+            : "timeUnits.minutes",
+      },
+    ];
   }
 
   const hoursDiff = date.diff(dayjs(), "hours");
   if (hoursDiff < 24) {
-    return {
-      value: hoursDiff,
-      unitTranslationKey:
-        hoursDiff === 1
-          ? useShortTimeUnits
-            ? "timeUnitsShort.hour"
-            : "timeUnits.hour"
-          : useShortTimeUnits
-          ? "timeUnitsShort.hours"
-          : "timeUnits.hours",
-    };
+    const minutes = date.diff(dayjs(), "minutes") % 60;
+    return [
+      {
+        value: hoursDiff,
+        unitTranslationKey:
+          hoursDiff === 1
+            ? useShortTimeUnits
+              ? "timeUnitsShort.hour"
+              : "timeUnits.hour"
+            : useShortTimeUnits
+            ? "timeUnitsShort.hours"
+            : "timeUnits.hours",
+      },
+      {
+        value: minutes,
+        unitTranslationKey:
+          minutes === 1
+            ? useShortTimeUnits
+              ? "timeUnitsShort.minute"
+              : "timeUnits.minute"
+            : useShortTimeUnits
+            ? "timeUnitsShort.minutes"
+            : "timeUnits.minutes",
+      },
+    ];
   }
 
   const daysDiff = date.diff(dayjs(), "days");
   if (daysDiff < 30) {
-    return {
-      value: daysDiff,
-      unitTranslationKey:
-        daysDiff === 1
-          ? useShortTimeUnits
-            ? "timeUnitsShort.day"
-            : "timeUnits.day"
-          : useShortTimeUnits
-          ? "timeUnitsShort.days"
-          : "timeUnits.days",
-    };
+    return [
+      {
+        value: daysDiff,
+        unitTranslationKey:
+          daysDiff === 1
+            ? useShortTimeUnits
+              ? "timeUnitsShort.day"
+              : "timeUnits.day"
+            : useShortTimeUnits
+            ? "timeUnitsShort.days"
+            : "timeUnits.days",
+      },
+    ];
   }
 
   // For months and years, since it's formatted differently, you might need to handle it separately in your translation logic
-  return { value: date.format("MMM D, YYYY"), unitTranslationKey: "" };
+  return [{ value: date.format("MMM D, YYYY"), unitTranslationKey: "" }];
+}
+
+export function displayHumanizedTime({
+  humanizedTime,
+  t,
+  delimitedBy = " and ",
+}: {
+  humanizedTime: ReturnType<typeof humanizeTime>;
+  t: (key: string) => string;
+  delimitedBy?: string;
+}) {
+  return humanizedTime
+    .map((time) => `${time.value} ${t(time.unitTranslationKey)}`)
+    .join(delimitedBy);
 }


### PR DESCRIPTION
## What is the purpose of the change:

Currently, the “humanize time” function only displays the remaining hours, ignoring the minutes. This can be misleading, as a duration like 3 hours and 59 minutes is displayed simply as 3 hours. 

### Linear Task

https://linear.app/osmosis/issue/FE-1257/improve-humanize-time-accuracy

## Testing and Verifying

- [ ] Shows the correct estimated time for 1-Click Trading
- [ ] Shows correct estimated time for transfers 