### PR TITLE
fix: hide insufficient balance when no wallet connected

### DIFF
--- a/packages/web/components/place-limit-tool/index.tsx
+++ b/packages/web/components/place-limit-tool/index.tsx
@@ -525,6 +525,13 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
     }, [swapState.isBalancesFetched]);
 
     const errorDisplay = useMemo(() => {
+      if (
+        swapState.error === "limitOrders.insufficientFunds" &&
+        !account?.isWalletConnected
+      ) {
+        return;
+      }
+
       if (swapState.error && !NON_DISPLAY_ERRORS.includes(swapState.error)) {
         if (swapState.error === "errors.generic") {
           return t("errors.uhOhSomethingWentWrong");


### PR DESCRIPTION
## What is the purpose of the change:
These changes hide the "Insufficient Balance" warning when no wallet is connected in the Buy/Sell tabs.

### Linear Task

[FE-1259](https://linear.app/osmosis/issue/FE-1259/only-show-insufficient-balance-error-when-wallet-connected)

## Brief Changelog

- Added exception to hide `"limitOrders.insufficientBalance"` errors when no wallet connected

## Testing and Verifying

Manually tested with/without wallet connected
