### PR TITLE
BE-664 | Fix: filter pools by denom in assets page

### DIFF
--- a/packages/server/src/queries/complex/pools/providers/sidecar.ts
+++ b/packages/server/src/queries/complex/pools/providers/sidecar.ts
@@ -36,6 +36,7 @@ export function getPoolsFromSidecar({
   notPoolIds,
   types,
   incentives,
+  denoms,
   minLiquidityUsd,
   withMarketIncentives = true,
   pagination,
@@ -48,6 +49,7 @@ export function getPoolsFromSidecar({
   notPoolIds?: string[];
   types?: PoolType[];
   incentives?: string[];
+  denoms?: string[];
   minLiquidityUsd?: number;
   withMarketIncentives?: boolean;
   search?: SearchType;
@@ -65,6 +67,7 @@ export function getPoolsFromSidecar({
       (notPoolIds?.join(",") ?? "") +
       (types?.join(",") ?? "") +
       (incentives?.join(",") ?? "") +
+      (denoms?.join(",") ?? "") +
       (minLiquidityUsd ?? "") +
       withMarketIncentives.toString() +
       (pagination ? JSON.stringify(pagination) : "") +
@@ -79,6 +82,7 @@ export function getPoolsFromSidecar({
             notPoolIds,
             types,
             incentives,
+            denoms,
             minLiquidityCap: minLiquidityUsd?.toString(),
             withMarketIncentives,
             search,

--- a/packages/server/src/queries/sidecar/pools.ts
+++ b/packages/server/src/queries/sidecar/pools.ts
@@ -155,6 +155,7 @@ export async function queryPools({
   notPoolIds,
   types,
   incentives,
+  denoms,
   minLiquidityCap,
   withMarketIncentives,
   search,
@@ -165,6 +166,7 @@ export async function queryPools({
   notPoolIds?: string[];
   types?: string[];
   incentives?: string[];
+  denoms?: string[];
   minLiquidityCap?: string;
   withMarketIncentives?: boolean;
   search?: SearchType;
@@ -191,6 +193,10 @@ export async function queryPools({
       "filter[incentive]",
       getIncentiveTypeIntegers(incentives).join(",")
     );
+  }
+
+  if (denoms) {
+    params.append("filter[denom]", denoms.join(","));
   }
 
   // Note: we do not want to filter the pools if we are in testnet because we do not have accurate pricing

--- a/packages/web/components/pages/asset-info-page/pools.tsx
+++ b/packages/web/components/pages/asset-info-page/pools.tsx
@@ -34,7 +34,7 @@ export const AssetPools: FunctionComponent<AssetPoolsProps> = (props) => {
   const filters = useMemo(
     () => ({
       ...defaultFilters,
-      searchQuery: denom,
+      denoms: [denom],
     }),
     [denom]
   );


### PR DESCRIPTION
## What is the purpose of the change:

Fixes filtering pools by denom name to use dedicated filter inside assets page instead of leveraging search feature for more precise results

### Linear Task

BE-664

## Brief Changelog

- Reverts https://github.com/osmosis-labs/osmosis-frontend/pull/3993
- Passes denoms filter to SQS

## Testing and Verifying

This change has been tested locally by rebuilding the website and verified content and links are expected