### PR TITLE
feat: :wrench: Add CODE_ID 996 to Transmuter pool ids

### DIFF
--- a/packages/server/src/queries/complex/pools/env.ts
+++ b/packages/server/src/queries/complex/pools/env.ts
@@ -1,7 +1,7 @@
 import { IS_TESTNET } from "../../../env";
 
 /** Cosmwasm Code Ids confirmed to be transmuter pools in current env. */
-const TransmuterPoolCodeIds = IS_TESTNET ? ["3084"] : ["148"];
+const TransmuterPoolCodeIds = IS_TESTNET ? ["3084"] : ["148", "996"];
 const AstroportPclPoolCodeIds = IS_TESTNET ? ["8611"] : ["842"];
 const WhitewhalePoolCodeIds = IS_TESTNET ? ["?"] : ["503", "641"];
 


### PR DESCRIPTION
## What is the purpose of the change:

Add version 3.2 of the Transmuter contract to the transmuter code_id list

### Linear Task

https://linear.app/osmosis/issue/FE-1237/issue-with-dogeint3-asset-displaying-incorrectly-in-pools-page

## Brief Changelog

- Add version 3.2 of the Transmuter contract to the transmuter code_id list