### PR TITLE
feat: :sparkles: change cache buster to invalidate old cache

### DIFF
--- a/packages/web/utils/trpc.ts
+++ b/packages/web/utils/trpc.ts
@@ -101,7 +101,7 @@ export const api = createTRPCNext<AppRouter>({
       // and data respecting the new model is fetched from the server.
       // Otherwise, the old data will be served from cache
       // and unexpected data structures will be run through the app.
-      buster: "v1",
+      buster: "v2",
     });
 
     return {


### PR DESCRIPTION
## What is the purpose of the change:

On prod we wanna invalidate some old cache, it seems like we accumulated a lot of old cache that cause some performances delays.

### Linear Task

-

## Brief Changelog

-

