### PR TITLE
FE-1281 | Move pools router into local tRPC router

### DIFF
--- a/packages/web/components/complex/add-conc-liquidity.tsx
+++ b/packages/web/components/complex/add-conc-liquidity.tsx
@@ -76,7 +76,7 @@ export const AddConcLiquidity: FunctionComponent<
     const { queryQuasarVaults } = queriesExternalStore;
     const { vaults: quasarVaults } = queryQuasarVaults.get(poolId);
 
-    const { data: pool } = api.edge.pools.getPool.useQuery({
+    const { data: pool } = api.local.pools.getPool.useQuery({
       poolId,
     });
 

--- a/packages/web/components/complex/pools-table.tsx
+++ b/packages/web/components/complex/pools-table.tsx
@@ -129,7 +129,7 @@ export const PoolsTable = (props: PropsWithChildren<PoolsTableProps>) => {
     isFetchingNextPage,
     hasNextPage,
     fetchNextPage,
-  } = api.edge.pools.getPools.useInfiniteQuery(
+  } = api.local.pools.getPools.useInfiniteQuery(
     {
       limit,
       search: filters.searchQuery

--- a/packages/web/components/complex/portfolio/user-positions.tsx
+++ b/packages/web/components/complex/portfolio/user-positions.tsx
@@ -96,7 +96,7 @@ function useUserPositionsData(address: string | undefined) {
   const hasPositions = Boolean(positions?.length);
 
   const { data: allMyPoolDetails, isLoading: isLoadingMyPoolDetails } =
-    api.edge.pools.getUserPools.useQuery(
+    api.local.pools.getUserPools.useQuery(
       {
         userOsmoAddress: address ?? "",
       },

--- a/packages/web/hooks/ui-config/use-add-concentrated-liquidity-config.ts
+++ b/packages/web/hooks/ui-config/use-add-concentrated-liquidity-config.ts
@@ -61,7 +61,7 @@ export function useAddConcentratedLiquidityConfig(
   const address = account?.address ?? "";
 
   const { data: pool, isFetched: isPoolFetched } =
-    api.edge.pools.getPool.useQuery(
+    api.local.pools.getPool.useQuery(
       { poolId },
       {
         refetchInterval: 5_000, // 5 seconds

--- a/packages/web/hooks/ui-config/use-historical-and-depth-data.ts
+++ b/packages/web/hooks/ui-config/use-historical-and-depth-data.ts
@@ -33,7 +33,7 @@ export function useHistoricalAndLiquidityData(
     [config]
   );
 
-  const { data: pool } = api.edge.pools.getPool.useQuery(
+  const { data: pool } = api.local.pools.getPool.useQuery(
     {
       poolId,
     },

--- a/packages/web/modals/add-liquidity.tsx
+++ b/packages/web/modals/add-liquidity.tsx
@@ -49,7 +49,7 @@ export const AddLiquidityModal: FunctionComponent<
     useAddConcentratedLiquidityConfig(chainStore, chainId, poolId);
 
   // initialize pool data stores once root pool store is loaded
-  const { data: pool } = api.edge.pools.getPool.useQuery({ poolId });
+  const { data: pool } = api.local.pools.getPool.useQuery({ poolId });
 
   const config =
     pool?.type === "concentrated" ? addConliqConfig : addLiquidityConfig;

--- a/packages/web/pages/pool/[id].tsx
+++ b/packages/web/pages/pool/[id].tsx
@@ -26,7 +26,7 @@ const Pool: FunctionComponent<Props> = ({
   const { t } = useTranslation();
   const { isMobile } = useWindowSize();
 
-  const { data: pool, isError } = api.edge.pools.getPool.useQuery({ poolId });
+  const { data: pool, isError } = api.local.pools.getPool.useQuery({ poolId });
 
   const [showTradeModal, setShowTradeModal] = useState(false);
 

--- a/packages/web/server/api/local-router.ts
+++ b/packages/web/server/api/local-router.ts
@@ -8,6 +8,7 @@ import {
   paramsRouter,
   portfolioRouter,
   swapRouter,
+  poolsRouter,
 } from "@osmosis-labs/trpc";
 
 import { localBridgeTransferRouter } from "~/server/api/routers/local-bridge-transfer";
@@ -25,4 +26,5 @@ export const localRouter = createTRPCRouter({
   portfolio: portfolioRouter,
   params: paramsRouter,
   orderbooks: orderbookRouter,
+  pools: poolsRouter,
 });


### PR DESCRIPTION
## What is the purpose of the change:

Moves pools router into local tRPC router for following methods:

- getUserPools
- getPools
- getPool

### Linear Task

https://linear.app/osmosis/issue/FE-1281/move-pools-router-into-local-trpc-router

## Brief Changelog

- Imported existing poolsRouter into local-router
- Replaced in the source code to use local router for `getUserPools`, `getPools`, `getPool` instead of egde

## Testing and Verifying

<!-- _(Please pick either of the following options)_

This change has been tested locally by rebuilding the website and verified content and links are expected