### PR TITLE
fix: :lipstick: Add new chart event onDataPointHover that triggers only on data point change

### DIFF
--- a/packages/web/components/chart/historical-chart.tsx
+++ b/packages/web/components/chart/historical-chart.tsx
@@ -121,7 +121,7 @@ export const HistoricalChart = memo((props: HistoricalChartProps) => {
           data,
         },
       ]}
-      onCrosshairMove={(params) => {
+      onDataPointHover={(params) => {
         if (params.seriesData.size > 0) {
           const [data] = [...params.seriesData.values()] as AreaData[];
 

--- a/packages/web/components/chart/historical-volume-chart.tsx
+++ b/packages/web/components/chart/historical-volume-chart.tsx
@@ -95,7 +95,7 @@ export const HistoricalVolumeChart = memo(
             data,
           },
         ]}
-        onCrosshairMove={(params) => {
+        onDataPointHover={(params) => {
           if (params.seriesData.size > 0) {
             const [data] = [...params.seriesData.values()] as AreaData[];
 

--- a/packages/web/components/chart/light-weight-charts/chart.tsx
+++ b/packages/web/components/chart/light-weight-charts/chart.tsx
@@ -11,6 +11,7 @@ import {
 import React, {
   memo,
   PropsWithChildren,
+  useCallback,
   useEffect,
   useRef,
   useState,
@@ -196,6 +197,7 @@ interface ChartProps<T extends TimeChartOptions, K extends Time> {
     params: ChartControllerParams<TimeChartOptions, K>
   ) => ChartController<TimeChartOptions, K>;
   onCrosshairMove?: (params: MouseEventParams<K>) => void;
+  onDataPointHover?: (params: MouseEventParams<K>) => void;
 }
 
 export const Chart = memo(
@@ -207,10 +209,25 @@ export const Chart = memo(
       children,
       series,
       onCrosshairMove,
+      onDataPointHover,
       Controller,
     } = props;
     const [container, setContainer] = useState<HTMLDivElement | null>(null);
     const chart = useRef<ChartController<TimeChartOptions, K>>();
+    const lastHoverDataPointLogicalIndex =
+      useRef<MouseEventParams<K>["logical"]>(undefined);
+
+    const onCrosshairMoveInternal = useCallback(
+      (params: MouseEventParams<K>) => {
+        onCrosshairMove?.(params);
+
+        if (lastHoverDataPointLogicalIndex.current !== params.logical) {
+          onDataPointHover?.(params);
+        }
+        lastHoverDataPointLogicalIndex.current = params.logical;
+      },
+      [onCrosshairMove, onDataPointHover]
+    );
 
     useSyncExternalStore(
       resizeSubscribe,
@@ -228,7 +245,7 @@ export const Chart = memo(
         },
         series,
         container,
-        onCrosshairMove,
+        onCrosshairMove: onCrosshairMoveInternal,
       });
     }
 


### PR DESCRIPTION
Current onCrosshairMove triggers multiple times for small mouse movements even if the mouse is kept on the same data point. Added an event that triggers only when the logical data point id changes

## What is the purpose of the change:

Fixes an "infinite render" that in reality was an hover event triggered each millisecond the mouse was hovering the element instead of triggering on enter

### Linear Task

https://linear.app/osmosis/issue/FE-1272/fix-infinite-rendering-of-portfolio-chartheader-in-osmosis-fe

## Brief Changelog

- Create new higher level event in the Chart base component
- Used said event for historical-chart and portfolio historical chart

## Notes

The other charts did not display such an issue because they update a mobx store that was filtering rerenders when no data was changed. That said it is best to implement this new event at the base chart and use it for future components to avoid such issues in the future
