### PR TITLE
(Transaction History) Use new Numia messageType filter to avoid polluting transaction history list

### DIFF
--- a/packages/server/src/queries/complex/transactions/transactions.ts
+++ b/packages/server/src/queries/complex/transactions/transactions.ts
@@ -141,6 +141,12 @@ export async function getTransactions({
         address,
         page,
         pageSize,
+        messageTypes: [
+          "/osmosis.poolmanager.v1beta1.MsgSwapExactAmountIn",
+          "/osmosis.poolmanager.v1beta1.MsgSplitRouteSwapExactAmountIn",
+          "/osmosis.poolmanager.v1beta1.MsgSwapExactAmountOut",
+          "/osmosis.poolmanager.v1beta1.MsgSplitRouteSwapExactAmountOut",
+        ],
       });
 
       // if the length of the data is equal to the page size, there is a next page

--- a/packages/server/src/queries/data-services/transactions.ts
+++ b/packages/server/src/queries/data-services/transactions.ts
@@ -83,15 +83,20 @@ export async function queryTransactions({
   address,
   page,
   pageSize,
+  messageTypes,
 }: {
   address: string;
   page: string;
   pageSize: string;
+  messageTypes: string[];
 }): Promise<Transaction[]> {
   const url = new URL(`/v2/txs/${address}`, HISTORICAL_DATA_URL);
 
   url.searchParams.append("page", page);
   url.searchParams.append("pageSize", pageSize);
+  if (messageTypes.length > 0) {
+    url.searchParams.append("messageTypes", messageTypes.join(","));
+  }
 
   const headers = {
     Authorization: `Bearer ${process.env.NUMIA_API_KEY}`,

--- a/packages/web/server/api/local-router.ts
+++ b/packages/web/server/api/local-router.ts
@@ -6,9 +6,9 @@ import {
   oneClickTradingRouter,
   orderbookRouter,
   paramsRouter,
+  poolsRouter,
   portfolioRouter,
   swapRouter,
-  poolsRouter,
 } from "@osmosis-labs/trpc";
 
 import { localBridgeTransferRouter } from "~/server/api/routers/local-bridge-transfer";


### PR DESCRIPTION
## What is the purpose of the change:

The `/v2/txs/{address}` endpoint currently retrieves all transaction messages, including those not relevant to specific use cases. This has led to issues with empty pages in the transaction history table due to the inclusion of unused message types.

To address this we'll use the messageType filter now that the txs endpoint supports filtering transactions using query parameters. 

### Linear Task

https://linear.app/osmosis/issue/FE-1288/use-new-numia-messagetype-filter-to-avoid-polluting-transaction

## Testing and Verifying

- [ ] Does not display blank tx pages because they were filtered