### PR TITLE
(Pool details) Hide pool weights for concentrated pools in mobile

### DIFF
--- a/packages/web/components/chart/asset-breakdown.tsx
+++ b/packages/web/components/chart/asset-breakdown.tsx
@@ -19,7 +19,13 @@ export const AssetBreakdownChart: FunctionComponent<{
   }[];
   totalWeight: IntPretty;
   colorCycle?: typeof ColorCycle;
-}> = ({ assets, totalWeight, colorCycle = ColorCycle }) => {
+  hideWeights?: boolean;
+}> = ({
+  assets,
+  totalWeight,
+  colorCycle = ColorCycle,
+  hideWeights = false,
+}) => {
   const { isMobile, width } = useWindowSize();
 
   const assetPercentages = assets.map(({ weight }) =>
@@ -55,8 +61,8 @@ export const AssetBreakdownChart: FunctionComponent<{
                 className="subtitle1 md:body2 text-osmoverse-400"
                 title={amount.currency.coinDenom}
               >
-                {truncate(amount.currency.coinDenom, isMobile ? 6 : 12)}:{" "}
-                {assetPercentages[index].toString()}%
+                {truncate(amount.currency.coinDenom, isMobile ? 6 : 12)}
+                {!hideWeights && <>: {assetPercentages[index].toString()}%</>}
               </span>
             </div>
             <h6 className="md:subtitle2 text-osmoverse-100">

--- a/packages/web/components/pool-detail/base-pool.tsx
+++ b/packages/web/components/pool-detail/base-pool.tsx
@@ -95,6 +95,7 @@ export const BasePoolDetails: FunctionComponent<{
                   amount: coin,
                 }))}
                 totalWeight={new IntPretty(pool.reserveCoins.length)}
+                hideWeights={pool.type === "concentrated"}
               />
             </div>
           </div>


### PR DESCRIPTION
## What is the purpose of the change:

Before
![image](https://github.com/user-attachments/assets/3cb9f62c-0bb6-43de-99df-367b9012e9c3)

After
![image](https://github.com/user-attachments/assets/886601f2-7082-40f0-8e6f-1a212d93e1b0)

### Linear Task

https://linear.app/osmosis/issue/FE-1293/incorrect-pool-liquidity-display-on-mobile-for-pool-1942

