### PR TITLE
(1CT) Do not add the authenticator message if the 1CT swap tool CTA is hidden

### DIFF
--- a/packages/web/hooks/one-click-trading/use-one-click-trading-swap-review.ts
+++ b/packages/web/hooks/one-click-trading/use-one-click-trading-swap-review.ts
@@ -40,9 +40,9 @@ const use1CTSwapReviewStore = create<{
 }));
 
 export function useOneClickTradingSwapReview({
-  isModalOpen,
+  enabled,
 }: {
-  isModalOpen: boolean;
+  enabled: boolean;
 }) {
   const [previousIsOneClickEnabled, setPreviousIsOneClickEnabled] =
     useLocalStorage("previous-one-click-enabled", true);
@@ -76,36 +76,36 @@ export function useOneClickTradingSwapReview({
   const isLoading = isLoadingInfo;
 
   useEffect(() => {
-    if (isModalOpen) {
+    if (enabled) {
       use1CTSwapReviewStore
         .getState()
         .setTransaction1CTParams(transactionParams);
     }
-  }, [transactionParams, isModalOpen]);
+  }, [transactionParams, enabled]);
 
   useEffect(() => {
-    if (isModalOpen) {
+    if (enabled) {
       use1CTSwapReviewStore
         .getState()
         .setSpendLimitTokenDecimals(spendLimitTokenDecimals);
     }
-  }, [isModalOpen, spendLimitTokenDecimals]);
+  }, [enabled, spendLimitTokenDecimals]);
 
   useEffect(() => {
-    if (isModalOpen) {
+    if (enabled) {
       use1CTSwapReviewStore.getState().setChanges(changes);
     }
-  }, [isModalOpen, changes]);
+  }, [enabled, changes]);
 
   useEffect(() => {
-    if (!isModalOpen) {
+    if (!enabled) {
       const state = use1CTSwapReviewStore.getState();
       resetParams();
       state.setTransaction1CTParams(undefined);
       state.setSpendLimitTokenDecimals(undefined);
       state.setChanges(undefined);
     }
-  }, [isModalOpen, resetParams]);
+  }, [enabled, resetParams]);
 
   return {
     isEnabled,

--- a/packages/web/modals/review-order.tsx
+++ b/packages/web/modals/review-order.tsx
@@ -131,7 +131,7 @@ export function ReviewOrder({
     setTransactionParams: setTransaction1CTParams,
     resetParams: reset1CTParams,
     setPreviousIsOneClickEnabled,
-  } = useOneClickTradingSwapReview({ isModalOpen: isOpen });
+  } = useOneClickTradingSwapReview({ enabled: isOpen && show1CT });
 
   const wouldExceedSpendLimit = useMemo(() => {
     if (!is1CTEnabled) return false;


### PR DESCRIPTION
## What is the purpose of the change:

1CT add-authenticator message is added to every mobile transaction even though there is no option to enable this on mobile browsers.

### Linear Task

https://linear.app/osmosis/issue/FE-1301/do-not-add-the-authenticator-message-if-the-1ct-swap-tool-is-hidden


## Testing and Verifying

- [ ] 1CT CTA is displayed in desktop
- [ ] 1CT CTA is hidden on desktop and add authenticator message is not added automatically