### PR TITLE
fix: :bug: fix EarnPage.pageViewed event logs

### DIFF
--- a/packages/web/pages/earn/index.tsx
+++ b/packages/web/pages/earn/index.tsx
@@ -70,7 +70,9 @@ function Earn() {
     unclaimedRewards,
   } = useGetEarnStrategies(userOsmoAddress, isWalletConnected);
 
-  const { logEvent } = useAmplitudeAnalytics();
+  useAmplitudeAnalytics({
+    onLoadEvent: [EventName.EarnPage.pageViewed],
+  });
 
   const defaultFilters: Filters = useMemo(
     () => ({
@@ -99,8 +101,7 @@ function Earn() {
     if (!earnPage && _isInitialized) {
       router.push("/");
     }
-    logEvent([EventName.EarnPage.pageViewed]);
-  }, [earnPage, router, _isInitialized, logEvent]);
+  }, [earnPage, router, _isInitialized]);
 
   return (
     <div className="relative mx-auto flex max-w-[1508px] flex-col gap-10 py-10 pl-8 pr-9">


### PR DESCRIPTION
## What is the purpose of the change:

due to `useEffect` we invoke the event for visiting the earnPage too many times, this PR fixes this error

### Linear Task

https://linear.app/osmosis/issue/FE-1302/amplitude-or-issue-with-emission-of-earn-and-assets-pages-page-viewed

## Brief Changelog

- Replace `useEffect` with `onLoadEvent` using `useAmplitudeAnalytics` hook

## Testing and Verifying

This change has been tested locally by rebuilding the website and verified content and links are expected