### PR TITLE
(Deposit/Withdraw) Resolve initial layout race condition

### DIFF
--- a/packages/web/components/bridge/amount-and-review-screen.tsx
+++ b/packages/web/components/bridge/amount-and-review-screen.tsx
@@ -139,9 +139,8 @@ export const AmountAndReviewScreen = observer(
     const { supportedAssetsByChainId: counterpartySupportedAssetsByChainId } =
       supportedAssets;
 
-    const hasNoSupportedChains =
-      !supportedAssets.isLoading &&
-      supportedAssets.supportedChains.length === 0;
+    const hasSupportedChains =
+      !supportedAssets.isLoading && supportedAssets.supportedChains.length > 0;
 
     /** Filter for bridges for the current to/from chain/asset selection. */
     const supportedBridgeInfo = useMemo<SupportedBridgeInfo>(() => {
@@ -287,7 +286,7 @@ export const AmountAndReviewScreen = observer(
               isLoadingAssetsInOsmosis={isLoadingAssetsInOsmosis}
               bridgesSupportedAssets={supportedAssets}
               supportedBridgeInfo={supportedBridgeInfo}
-              hasNoSupportedChains={hasNoSupportedChains}
+              hasSupportedChains={hasSupportedChains}
               fromChain={fromChain}
               setFromChain={setFromChain}
               toChain={toChain}


### PR DESCRIPTION
## What is the purpose of the change:

After #4017, there is a brief period where external URLs are displayed, even though the asset supports quotes. This PR ensures the quote layout is displayed first, as intended.

### Linear Task

https://linear.app/osmosis/issue/FE-1298/need-to-be-able-to-transfer-assets-with-non-cosmos-counterparties

