### PR TITLE
feat: :sparkles: add amplitude domain proxy

### DIFF
--- a/packages/web/hooks/use-amplitude-analytics.ts
+++ b/packages/web/hooks/use-amplitude-analytics.ts
@@ -60,7 +60,7 @@ export function useAmplitudeAnalytics({
     if (init) {
       if (process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY !== undefined) {
         amplitudeInit(process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY, undefined, {
-          serverUrl: "https://amplitude.osmosis.zone/2/httpapi",
+          serverUrl: process.env.NEXT_PUBLIC_AMPLITUDE_SERVER_URL,
         });
       }
     }

--- a/packages/web/hooks/use-amplitude-analytics.ts
+++ b/packages/web/hooks/use-amplitude-analytics.ts
@@ -59,7 +59,9 @@ export function useAmplitudeAnalytics({
   useEffect(() => {
     if (init) {
       if (process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY !== undefined) {
-        amplitudeInit(process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY);
+        amplitudeInit(process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY, undefined, {
+          serverUrl: "https://amplitude.osmosis.zone/2/httpapi",
+        });
       }
     }
 


### PR DESCRIPTION
## What is the purpose of the change:

Right now due to uBlock or stuffs like that, our request to amplitude are blocked for some users, this create a lot of missing data in our metrics. This PR should address this issue by using a domain proxy!

### Linear Task

https://linear.app/osmosis/issue/FE-1233/amplitude-or-using-proxy-to-redirect-event-logs-to-amplitude

## Brief Changelog

-

## Testing and Verifying

-
