### PR TITLE
fix: split in-given-out amounts

### DIFF
--- a/packages/server/src/queries/sidecar/router.ts
+++ b/packages/server/src/queries/sidecar/router.ts
@@ -138,8 +138,8 @@ class OsmosisSidecarRemoteRouter {
         swapFee,
         priceImpactTokenOut: priceImpact,
         tokenInFeeAmount: new Dec(amount_in).mul(swapFee).truncate(),
-        split: routes.map(({ pools, in_amount }) => ({
-          initialAmount: new Int(in_amount),
+        split: routes.map(({ pools, out_amount }) => ({
+          initialAmount: new Int(out_amount),
           pools: pools
             .map(({ id, spread_factor, type, code_id }) => ({
               id: id.toString(),


### PR DESCRIPTION
## What is the purpose of the change:

These changes fix an issue with split routes for in-given-out message generation.

### Linear Task

[FE-1287](https://linear.app/osmosis/issue/FE-1287/erroneous-parameters-passed-to-split-amount-out-on-trade-widget#comment-c9f56a0c)

## Brief Changelog

- Initial amount for splits uses `out_amount` instead of `in_amount`

## Testing and Verifying

Tested a split route for UM to JUNO

```
Custom
type: osmosis/poolmanager/split-amount-out
value:
  routes:
    - pools:
        - pool_id: '2281'
          token_in_denom: ibc/0FA9232B262B89E77D1335D54FB1E1F506A92A7E4B51524B400DC69C68D28372
        - pool_id: '497'
          token_in_denom: uosmo
      token_out_amount: '135000000'
    - pools:
        - pool_id: '1964'
          token_in_denom: ibc/0FA9232B262B89E77D1335D54FB1E1F506A92A7E4B51524B400DC69C68D28372
        - pool_id: '1464'
          token_in_denom: ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4
        - pool_id: '1097'
          token_in_denom: uosmo
      token_out_amount: '15000000'
  sender:*
  token_in_max_amount: '33856457'
  token_out_denom: ibc/46B44899322F3CD854D2D46DEEF881958467CDD4B3B10086DA49296BBED94BED
  ```
  
  
<img width="473" alt="image" src="https://github.com/user-attachments/assets/6426f6d1-5830-4f65-b0ec-6af447575375" />

  
