### PR TITLE
Show 0 liquidity pools in the pools page

### DIFF
--- a/packages/web/components/complex/pools-table.tsx
+++ b/packages/web/components/complex/pools-table.tsx
@@ -153,7 +153,7 @@ export const PoolsTable = (props: PropsWithChildren<PoolsTableProps>) => {
             direction: sortParams.allPoolsSortDir,
           }
         : undefined,
-      minLiquidityUsd: 1_000,
+      minLiquidityUsd: 0,
     },
     {
       getNextPageParam: (lastPage) => lastPage.nextCursor,


### PR DESCRIPTION
## What is the purpose of the change:

This PR enables including 0 liquidity pools in the pools page.
### Linear Task

[FE-1308](https://linear.app/osmosis/issue/FE-1308/display-0-liquidity-pools-on-frontend-for-user-visibility)

## Brief Changelog

- Updates `minLiquidityUsd` param from `1_000` to `0` to be sent to SQS.

## Testing and Verifying

This change has been tested locally by rebuilding the website and verified content and links are expected
