### PR TITLE
Added a condition of number of failed test for monitoring

### DIFF
--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -5,6 +5,10 @@ on:
     branches-ignore:
       - master
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   wait-for-deployment:
     runs-on: ubuntu-latest
@@ -83,6 +87,7 @@ jobs:
   test-output:
     runs-on: ubuntu-latest
     needs: preview-swap-osmo-tests
+    if: contains(fromJson('["1", "0"]'), needs.preview-swap-osmo-tests.outputs.unexpected)
     steps:
       - name: print unexpected
         run: echo ${{ needs.preview-swap-osmo-tests.outputs.unexpected }}

--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -84,14 +84,6 @@ jobs:
           name: osmo-swap-test-results
           path: packages/e2e/playwright-report
 
-  test-output:
-    runs-on: ubuntu-latest
-    needs: preview-swap-osmo-tests
-    if: needs.preview-swap-osmo-tests.outputs.unexpected >= 0
-    steps:
-      - name: print unexpected
-        run: echo ${{ needs.preview-swap-osmo-tests.outputs.unexpected }}
-
   preview-swap-usdc-tests:
     timeout-minutes: 15
     runs-on: macos-latest

--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -87,7 +87,7 @@ jobs:
   test-output:
     runs-on: ubuntu-latest
     needs: preview-swap-osmo-tests
-    if: contains(fromJson('["1", "0"]'), needs.preview-swap-osmo-tests.outputs.unexpected)
+    if: needs.preview-swap-osmo-tests.outputs.unexpected >= 0
     steps:
       - name: print unexpected
         run: echo ${{ needs.preview-swap-osmo-tests.outputs.unexpected }}

--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -69,8 +69,9 @@ jobs:
           cd packages/e2e
           npx playwright test swap.osmo.wallet
       - name: set-output
+        if: failure() || success()
         id: set-output
-        run: echo "::set-output name=unexpected::$(jq -r '.stats.unexpected' packages/e2e/playwright-report/test-results.json)"
+        run: echo "unexpected=$(jq -r '.stats.unexpected' packages/e2e/playwright-report/test-results.json)" >> $GITHUB_OUTPUT
       - name: upload Swap test results
         if: failure() || success()
         id: swap-test-results

--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -30,6 +30,8 @@ jobs:
     timeout-minutes: 15
     runs-on: macos-latest
     needs: wait-for-deployment
+    outputs:
+      unexpected: ${{ steps.set-output.outputs.unexpected }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -66,13 +68,23 @@ jobs:
         run: |
           cd packages/e2e
           npx playwright test swap.osmo.wallet
+      - name: set-output
+        id: set-output
+        run: echo "::set-output name=unexpected::$(jq -r '.stats.unexpected' packages/e2e/playwright-report/test-results.json)"
       - name: upload Swap test results
-        if: failure()
+        if: failure() || success()
         id: swap-test-results
         uses: actions/upload-artifact@v4
         with:
           name: osmo-swap-test-results
           path: packages/e2e/playwright-report
+
+  test-output:
+    runs-on: ubuntu-latest
+    needs: preview-swap-osmo-tests
+    steps:
+      - name: print unexpected
+        run: echo ${{ needs.preview-swap-osmo-tests.outputs.unexpected }}
 
   preview-swap-usdc-tests:
     timeout-minutes: 15

--- a/.github/workflows/monitoring-limit-geo-e2e-tests.yml
+++ b/.github/workflows/monitoring-limit-geo-e2e-tests.yml
@@ -335,6 +335,8 @@ jobs:
     needs: fe-trade-us
     name: prod-fe-limit-us
     runs-on: macos-latest
+    outputs:
+      unexpected: ${{ steps.set-output.outputs.unexpected }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -363,6 +365,10 @@ jobs:
         run: |
           cd packages/e2e
           npx playwright test monitoring.limit --timeout 180000
+      - name: set-output
+        if: failure() || success()
+        id: set-output
+        run: echo "unexpected=$(jq -r '.stats.unexpected' packages/e2e/playwright-report/test-results.json)" >> $GITHUB_OUTPUT
       - name: upload monitoring test results
         if: failure()
         id: monitoring-test-results
@@ -382,7 +388,7 @@ jobs:
         fe-limit-us,
         fe-limit-eu,
       ]
-    if: failure()
+    if: failure() && needs.fe-trade-eu.outputs.unexpected > 1 && needs.fe-trade-us.outputs.unexpected > 1 && needs.fe-trade-sg.outputs.unexpected > 1 && needs.fe-limit-eu.outputs.unexpected > 1 && needs.fe-limit-us.outputs.unexpected > 1
     steps:
       - name: Send Slack alert if test fails
         id: slack

--- a/.github/workflows/monitoring-limit-geo-e2e-tests.yml
+++ b/.github/workflows/monitoring-limit-geo-e2e-tests.yml
@@ -172,8 +172,9 @@ jobs:
           cd packages/e2e
           npx playwright test monitoring.market --timeout 180000
       - name: set-output
+        if: failure() || success()
         id: set-output
-        run: echo "::set-output name=unexpected::$(jq -r '.stats.unexpected' packages/e2e/playwright-report/test-results.json)"
+        run: echo "unexpected=$(jq -r '.stats.unexpected' packages/e2e/playwright-report/test-results.json)" >> $GITHUB_OUTPUT
       - name: upload monitoring test results
         if: failure()
         id: monitoring-test-results
@@ -187,6 +188,8 @@ jobs:
     name: prod-fe-limit-eu
     needs: fe-trade-eu
     runs-on: macos-latest
+    outputs:
+      unexpected: ${{ steps.set-output.outputs.unexpected }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -218,6 +221,10 @@ jobs:
         run: |
           cd packages/e2e
           npx playwright test monitoring.limit --timeout 180000
+      - name: set-output
+        if: failure() || success()
+        id: set-output
+        run: echo "unexpected=$(jq -r '.stats.unexpected' packages/e2e/playwright-report/test-results.json)" >> $GITHUB_OUTPUT
       - name: upload monitoring test results
         if: failure()
         id: monitoring-test-results
@@ -231,6 +238,8 @@ jobs:
     needs: fe-swap-sg
     name: prod-fe-trade-sg
     runs-on: macos-latest
+    outputs:
+      unexpected: ${{ steps.set-output.outputs.unexpected }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -262,6 +271,10 @@ jobs:
         run: |
           cd packages/e2e
           npx playwright test monitoring.market --timeout 90000
+      - name: set-output
+        if: failure() || success()
+        id: set-output
+        run: echo "unexpected=$(jq -r '.stats.unexpected' packages/e2e/playwright-report/test-results.json)" >> $GITHUB_OUTPUT
       - name: upload monitoring test results
         if: failure()
         id: monitoring-test-results
@@ -275,6 +288,8 @@ jobs:
     needs: fe-swap-us
     name: prod-fe-trade-us
     runs-on: macos-latest
+    outputs:
+      unexpected: ${{ steps.set-output.outputs.unexpected }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -303,6 +318,10 @@ jobs:
         run: |
           cd packages/e2e
           npx playwright test monitoring.market --timeout 90000
+      - name: set-output
+        if: failure() || success()
+        id: set-output
+        run: echo "unexpected=$(jq -r '.stats.unexpected' packages/e2e/playwright-report/test-results.json)" >> $GITHUB_OUTPUT
       - name: upload monitoring test results
         if: failure()
         id: monitoring-test-results

--- a/.github/workflows/monitoring-limit-geo-e2e-tests.yml
+++ b/.github/workflows/monitoring-limit-geo-e2e-tests.yml
@@ -138,6 +138,8 @@ jobs:
     needs: fe-swap-eu
     name: prod-fe-trade-eu
     runs-on: macos-latest
+    outputs:
+      unexpected: ${{ steps.set-output.outputs.unexpected }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -169,6 +171,9 @@ jobs:
         run: |
           cd packages/e2e
           npx playwright test monitoring.market --timeout 180000
+      - name: set-output
+        id: set-output
+        run: echo "::set-output name=unexpected::$(jq -r '.stats.unexpected' packages/e2e/playwright-report/test-results.json)"
       - name: upload monitoring test results
         if: failure()
         id: monitoring-test-results


### PR DESCRIPTION
Currently tests produce a false negative results 30% of the time due to a known issue. 
Not to spam a slack, this change will allow 1 failed test. Workflow will fails anyway but no alert will be issued. 