### PR TITLE
(Token Info) Add Realtime flag to assetHistoricalPrice

### DIFF
--- a/packages/server/src/queries/data-services/token-historical-chart.ts
+++ b/packages/server/src/queries/data-services/token-historical-chart.ts
@@ -41,6 +41,7 @@ export interface TokenHistoricalPrice {
 export async function queryTokenHistoricalChart({
   coinMinimalDenom,
   timeFrameMinutes,
+  realtime = false,
 }: {
   /**
    * Major (symbol) denom to fetch historical price data for.
@@ -50,14 +51,16 @@ export async function queryTokenHistoricalChart({
   coinMinimalDenom: string;
   /** Number of minutes per bar. So 60 refers to price every 60 minutes. */
   timeFrameMinutes: TimeFrame;
+  /** Whether to fetch real-time data */
+  realtime?: boolean;
 }): Promise<TokenHistoricalPrice[]> {
-  // collect params
   const url = new URL(
-    `/tokens/v2/historical/${encodeURIComponent(
-      coinMinimalDenom
-    )}/chart?tf=${timeFrameMinutes}`,
+    `/tokens/v2/historical/${encodeURIComponent(coinMinimalDenom)}/chart`,
     HISTORICAL_DATA_URL
   );
+  url.searchParams.set("tf", timeFrameMinutes.toString());
+  url.searchParams.set("realtime", realtime.toString());
+
   try {
     const response = await apiClient<
       TokenHistoricalPrice[] | { message: string }

--- a/packages/trpc/src/assets.ts
+++ b/packages/trpc/src/assets.ts
@@ -473,19 +473,25 @@ export const assetsRouter = createTRPCRouter({
           }),
           z.enum(["1H", "1D", "1W", "1M"]),
         ]),
+        realtime: z.boolean().optional(),
       })
     )
-    .query(({ input: { coinMinimalDenom, timeFrame } }) =>
-      getAssetHistoricalPrice({
-        coinMinimalDenom,
-        ...(typeof timeFrame === "string"
-          ? { timeFrame }
-          : (timeFrame.custom as {
-              timeFrame: TimeFrame;
-              numRecentFrames?: number;
-            })),
-      }).catch((e) => captureErrorAndReturn(e, []))
-    ),
+    .query(({ input: { coinMinimalDenom, timeFrame, realtime } }) => {
+      if (typeof timeFrame === "string") {
+        return getAssetHistoricalPrice({
+          coinMinimalDenom,
+          timeFrame,
+          realtime,
+        }).catch((e) => captureErrorAndReturn(e, []));
+      } else {
+        return getAssetHistoricalPrice({
+          coinMinimalDenom,
+          timeFrame: timeFrame.custom.timeFrame as TimeFrame,
+          numRecentFrames: timeFrame.custom.numRecentFrames,
+          realtime,
+        }).catch((e) => captureErrorAndReturn(e, []));
+      }
+    }),
   getCoingeckoAssetHistoricalPrice: publicProcedure
     .input(
       z.object({

--- a/packages/web/hooks/ui-config/use-asset-info-config.ts
+++ b/packages/web/hooks/ui-config/use-asset-info-config.ts
@@ -14,7 +14,8 @@ import { api } from "~/utils/trpc";
 export const useAssetInfoConfig = (
   denom: string,
   coinMinimalDenom?: string,
-  coingeckoId?: string
+  coingeckoId?: string,
+  realtime?: boolean
 ) => {
   const config = useMemo(
     () => new ObservableAssetInfoConfig(denom, coinMinimalDenom),
@@ -76,11 +77,12 @@ export const useAssetInfoConfig = (
       timeFrame: {
         custom: customTimeFrame,
       },
+      realtime,
     },
     {
       enabled: Boolean(coinMinimalDenom ?? denom),
-      staleTime: 1000 * 60 * 3, // 3 minutes
-      cacheTime: 1000 * 60 * 6, // 6 minutes
+      staleTime: realtime ? 3000 : 1000 * 60 * 3,
+      cacheTime: realtime ? 3000 : 1000 * 60 * 6,
       trpc: {
         context: {
           skipBatch: true,

--- a/packages/web/pages/assets/[denom].tsx
+++ b/packages/web/pages/assets/[denom].tsx
@@ -86,7 +86,8 @@ const AssetInfoView: FunctionComponent<AssetInfoPageStaticProps> = observer(
     const assetInfoConfig = useAssetInfoConfig(
       asset.coinDenom,
       asset.coinMinimalDenom,
-      coinGeckoId
+      coinGeckoId,
+      true
     );
 
     const swapToolProps: SwapToolProps = useMemo(

--- a/packages/web/utils/trading-view.ts
+++ b/packages/web/utils/trading-view.ts
@@ -133,6 +133,7 @@ export const historicalDatafeed: ({
         timeFrame: {
           custom: customTimeFrame,
         },
+        realtime: true,
       });
 
       if (bars.length === 0 || bars.length < countBack) {


### PR DESCRIPTION
## What is the purpose of the change:

Numia has been making good progress on real-time asset price charts, but now that caching has been removed for real-time charts, this could create significant overhead on their infrastructure and potentially introduce latency without adding real value.

To mitigate this, we need to differentiate traffic sources by adding a `realtime=true` flag to the main chart requests on the asset details page. This will allow us to keep the main chart realtime while caching the smaller charts for a short period, similar to the previous behavior. This approach ensures that our services remain performant and scalable while maintaining real-time updates where necessary.

### Linear Task

https://linear.app/osmosis/issue/FE-1333/add-realtime-search-parameter-to-asset-chart-on-the-token-details-page

## Brief Changelog

- Add `realtime` flag to getAssetHistoricalPrices

## Testing and Verifying

- [ ] Can see more up-to-date chart data in token info pages
- [ ] Other charts work as expected