### PR TITLE
Get total balance from last datapoint in numia chart

### DIFF
--- a/packages/web/stores/index.tsx
+++ b/packages/web/stores/index.tsx
@@ -30,6 +30,7 @@ export function refetchUserQueries(apiUtils: ReturnType<typeof api.useUtils>) {
   apiUtils.edge.assets.getImmersiveBridgeAssets.invalidate();
   apiUtils.local.orderbooks.getAllOrdersSQS.invalidate();
   apiUtils.local.portfolio.getPortfolioAssets.invalidate();
+  apiUtils.local.portfolio.getPortfolioOverTime.invalidate();
   // Add delay before invalidating transactions since it can take a few seconds
   // for transactions to be indexed in the backend after broadcast
   setTimeout(() => {


### PR DESCRIPTION
## What is the purpose of the change:

This PR resolves an issue with the portfolio balance display in the Numia chart. Previously, an incorrect total balance calculation caused discrepancies between the displayed and actual portfolio values. To ensure accuracy, we now append the SQS total value to the last data point, keeping the portfolio data up to date after transactions.

### Linear Task

https://linear.app/osmosis/issue/NUMIA-120/get-total-balance-from-last-datapoint-in-numia-chart

## Testing and Verifying

- [ ] Displays up to date portfolio balance 