### PR TITLE
fix: add condition to run jobs on success or failure in monitoring workflow

### DIFF
--- a/.github/workflows/monitoring-limit-geo-e2e-tests.yml
+++ b/.github/workflows/monitoring-limit-geo-e2e-tests.yml
@@ -185,6 +185,7 @@ jobs:
 
   fe-limit-eu:
     timeout-minutes: 15
+    if: failure() || success()
     name: prod-fe-limit-eu
     needs: fe-trade-eu
     runs-on: macos-latest
@@ -332,6 +333,7 @@ jobs:
 
   fe-limit-us:
     timeout-minutes: 15
+    if: failure() || success()
     needs: fe-trade-us
     name: prod-fe-limit-us
     runs-on: macos-latest


### PR DESCRIPTION
## What is the purpose of the change:

- add condition to run jobs on success or failure in monitoring workflow