### PR TITLE
fix: Fix Asset Detail link to Pools Search Parameter

### DIFF
--- a/packages/web/components/pages/asset-info-page/pools.tsx
+++ b/packages/web/components/pages/asset-info-page/pools.tsx
@@ -50,7 +50,7 @@ export const AssetPools: FunctionComponent<AssetPoolsProps> = (props) => {
           className=" text-wosmongton-200"
           asChild
         >
-          <Link href={`/pools?searchQuery=${encodeURIComponent(`=${denom}`)}`}>
+          <Link href={`/pools?searchQuery=${encodeURIComponent(`${denom}`)}`}>
             {t("assets.seeAll")}
           </Link>
         </Button>


### PR DESCRIPTION
## What is the purpose of the change:

Fix Asset Detail link to Pools Search Parameter
It added an equals sign that broke the search
![image](https://github.com/user-attachments/assets/947de6ad-32c8-4050-a2b4-a8b501244fcf)
![image](https://github.com/user-attachments/assets/c969aa59-2cf3-4030-9a03-da82cbb6d5e8)


## Linear

https://linear.app/osmosis/issue/FE-1330/see-all-pools-link-on-assets-page-error

## Brief Changelog

- Removed the equals sign from the search parameter in the See Pools link in the Asset Detail Page

## Testing and Verifying

This change has not been tested locally, but it was tested just in this preview Vercel deployment because it was a 1-line change.
And it works!
![image](https://github.com/user-attachments/assets/a8ff88ed-f137-4611-8f20-095e2b44241e)
