### PR TITLE
fix: Use decimals from quote if present otherwise use parent assets decimals

### DIFF
--- a/packages/web/server/api/routers/bridge-transfer.ts
+++ b/packages/web/server/api/routers/bridge-transfer.ts
@@ -121,6 +121,7 @@ export const bridgeTransferRouter = createTRPCRouter({
             ...quote.transferFee,
             ...input.fromAsset,
             denom: quote.transferFee.denom ?? input.fromAsset.denom,
+            decimals: quote.transferFee.decimals ?? input.fromAsset.decimals,
             chainId: input.fromChain.chainId,
           }
         : quote.transferFee;


### PR DESCRIPTION
For transferFees through bridge use returned decimals if present
Thanks to @deividaspetraitis for helping me figure it out!

## What is the purpose of the change:

Every time a quote for a bridge is requested we use the returned decimals for fees instead of the parent variant one

## Brief Changelog

- Use quote decimals if available for bridges

## Testing and Verifying

Tested on
![image](https://github.com/user-attachments/assets/723b3c3f-8ca4-47e8-bde3-c72eabe2d300)
