### PR TITLE
fix: Initia Deposits

### DIFF
--- a/packages/server/src/queries/complex/assets/price/index.ts
+++ b/packages/server/src/queries/complex/assets/price/index.ts
@@ -33,6 +33,7 @@ export async function getAssetPrice({
     | { coinMinimalDenom: string }
     | { chainId: number | string; address: string }
     | { coinGeckoId: string }
+    | { sourceDenom: string }
   );
   currency?: CoingeckoVsCurrencies;
   priceProvider?: PriceProvider;
@@ -44,7 +45,7 @@ export async function getAssetPrice({
       ? asset
       : { chainId: undefined, address: undefined };
   const coinGeckoId = "coinGeckoId" in asset ? asset.coinGeckoId : undefined;
-
+  const sourceDenom = "sourceDenom" in asset ? asset.sourceDenom : undefined;
   const foundAsset = assetLists
     .map((assets) => assets.assets)
     .flat()
@@ -59,7 +60,8 @@ export async function getAssetPrice({
               "address" in counterparty &&
               counterparty.chainId === chainId &&
               counterparty.address.toLowerCase() === address.toLowerCase()
-          ))
+          )) ||
+        (sourceDenom && asset.sourceDenom === sourceDenom)
     );
 
   // Fall back to CoinGecko if asset list does not provide

--- a/packages/stores/src/account/utils.ts
+++ b/packages/stores/src/account/utils.ts
@@ -100,6 +100,7 @@ export function getPublicKeyTypeUrl({
   const chainIsInjective = chainId.startsWith("injective");
   const chainIsStratos = chainId.startsWith("stratos");
   const useEthereumSign = chainFeatures.includes("eth-key-sign");
+  const chainIsInitia = chainId.startsWith("interwoven-1");
 
   if (!useEthereumSign) {
     return "/cosmos.crypto.secp256k1.PubKey";
@@ -111,6 +112,10 @@ export function getPublicKeyTypeUrl({
 
   if (chainIsStratos) {
     return "/stratos.crypto.v1.ethsecp256k1.PubKey";
+  }
+
+  if (chainIsInitia) {
+    return "/initia.crypto.v1beta1.ethsecp256k1.PubKey";
   }
 
   return "/ethermint.crypto.v1.ethsecp256k1.PubKey";

--- a/packages/web/server/api/routers/bridge-transfer.ts
+++ b/packages/web/server/api/routers/bridge-transfer.ts
@@ -201,6 +201,7 @@ export const bridgeTransferRouter = createTRPCRouter({
           ? getAssetPrice({
               ...ctx,
               asset: {
+                sourceDenom: quote.estimatedGasFee.address,
                 coinMinimalDenom: quote.estimatedGasFee.address,
                 chainId: quote.fromChain.chainId,
                 address: quote.estimatedGasFee.address,
@@ -247,6 +248,8 @@ export const bridgeTransferRouter = createTRPCRouter({
           ? priceFromBridgeCoin(feeCoin, feeAssetPrice)
           : undefined,
       };
+
+      console.log(quote.estimatedGasFee);
 
       const estimatedGasFee = quote.estimatedGasFee
         ? {


### PR DESCRIPTION
## What is the purpose of the change:

Fix the following error when depositing Initita:
Broadcasting transaction failed with code 8 (codespace: ). Log: pubKey does not match signer address init1... with signer index: 0: invalid pubkey.

### Linear Task

https://linear.app/osmosis/issue/FE-1355/pubkey-does-not-match-signer-address-error-on-ibc-transfers-for-initia
