### PR TITLE
Fix Incorrect Amount When Swapping Exact Amount Out

### DIFF
--- a/packages/server/src/queries/sidecar/router.ts
+++ b/packages/server/src/queries/sidecar/router.ts
@@ -138,8 +138,8 @@ class OsmosisSidecarRemoteRouter {
         swapFee,
         priceImpactTokenOut: priceImpact,
         tokenInFeeAmount: new Dec(amount_in).mul(swapFee).truncate(),
-        split: routes.map(({ pools, in_amount }) => ({
-          initialAmount: new Int(in_amount),
+        split: routes.map(({ pools, out_amount }) => ({
+          initialAmount: new Int(out_amount),
           pools: pools
             .map(({ id, spread_factor, type, code_id }) => ({
               id: id.toString(),


### PR DESCRIPTION
## What is the purpose of the change:

When doing a swap exact amount out (specifying the exact token amount to receive), the router was incorrectly using `in_amount` instead of `out_amount` for the initialAmount property in the split response. This caused incorrect calculations, resulting in small amounts received.

### Linear Task

https://linear.app/osmosis/issue/BE-733/frontend-issue-with-incorrect-amounts-when-swapping-to-alldym
