### PR TITLE
BE-747 | Omit leading tilde symbol from the price impact

### DIFF
--- a/packages/web/components/swap-tool/trade-details.tsx
+++ b/packages/web/components/swap-tool/trade-details.tsx
@@ -201,7 +201,6 @@ export const TradeDetails = observer(
                                 "text-bullish-400": !isPriceImpactHigh,
                               })}
                             >
-                              {!priceImpact?.toDec().isZero()}
                               {formatPretty(priceImpact ?? new Dec(0))}
                             </span>
                           </div>

--- a/packages/web/components/swap-tool/trade-details.tsx
+++ b/packages/web/components/swap-tool/trade-details.tsx
@@ -201,7 +201,7 @@ export const TradeDetails = observer(
                                 "text-bullish-400": !isPriceImpactHigh,
                               })}
                             >
-                              {!priceImpact?.toDec().isZero() && "~"}
+                              {!priceImpact?.toDec().isZero()}
                               {formatPretty(priceImpact ?? new Dec(0))}
                             </span>
                           </div>


### PR DESCRIPTION
Omits tilde symbol from the price impact since it makes the number harder to read and understand when it's negative.

## What is the purpose of the change:

Omits leading tilde symbol from the price impact since it makes the number harder to read and understand when it's negative.

### Linear Task

[BE-747](https://linear.app/osmosis/issue/BE-747/verify-if-price-impact-field-sign-was-changed-in-frontend)

## Brief Changelog

Updates packages/web/components/swap-tool/trade-details.tsx to omit leading tilde symbol near the price impact.

![image](https://github.com/user-attachments/assets/32c29df6-1444-49dd-b141-259330d891d4)

## Testing and Verifying

<!-- _(Please pick either of the following options)_ --!>

This change has been tested locally by rebuilding the website and verified content and links are expected
