### PR TITLE
Update homepage link in package.json

### DIFF
--- a/packages/proto-codecs/package.json
+++ b/packages/proto-codecs/package.json
@@ -3,7 +3,7 @@
   "version": "5.1.0",
   "main": "build/index.js",
   "author": "osmosis-labs",
-  "homepage": "https://github.com/osmosis-labs/osmosis-frontend/tree/master/packages/telescope#readme",
+  "homepage": "https://github.com/osmosis-labs/osmosis-frontend/",
   "repository": {
     "type": "git",
     "url": "https://github.com/osmosis-labs/osmosis-frontend"


### PR DESCRIPTION
The current homepage link in package.json points to a path that no longer exists. I recommend replacing or removing it. I'm happy to assist with this update if needed.
