### PR TITLE
Update wormhole bridge redirect path

### DIFF
--- a/packages/bridge/src/int3face/index.ts
+++ b/packages/bridge/src/int3face/index.ts
@@ -51,7 +51,14 @@ export class Int3faceBridgeProvider implements BridgeProvider {
   }
 
   async getQuote(params: GetBridgeQuoteParams): Promise<BridgeQuote> {
-    const { fromAddress, fromChain, toChain, toAddress, fromAsset, fromAmount } = params;
+    const {
+      fromAddress,
+      fromChain,
+      toChain,
+      toAddress,
+      fromAsset,
+      fromAmount,
+    } = params;
 
     if (toChain.chainId !== "dogecoin") {
       throw new BridgeQuoteError({
@@ -63,17 +70,18 @@ export class Int3faceBridgeProvider implements BridgeProvider {
 
     // Check if transfer is available on Int3face side
     const canTransfer = await checkCanTransfer(
-        fromChain.chainId,
-        toChain.chainId,
-        fromAsset.denom,
-        this.ctx.env
+      fromChain.chainId,
+      toChain.chainId,
+      fromAsset.denom,
+      this.ctx.env
     );
 
     if (!canTransfer?.can_transfer) {
       throw new BridgeQuoteError({
         bridgeId: Int3faceProviderId,
         errorType: "UnsupportedQuoteError",
-        message: canTransfer?.reason || "Transfer is not available at this time",
+        message:
+          canTransfer?.reason || "Transfer is not available at this time",
       });
     }
 

--- a/packages/bridge/src/int3face/queries.ts
+++ b/packages/bridge/src/int3face/queries.ts
@@ -48,28 +48,32 @@ interface CanTransferResponse {
 }
 
 const denomOfInt3face: Record<string, string> = {
-  DOGE: 'dogecoin-doge'
-}
+  DOGE: "dogecoin-doge",
+};
 
 export async function checkCanTransfer(
-    srcChainId: string | number,
-    destChainId: string,
-    assetId: string,
-    env: "testnet" | "mainnet"
+  srcChainId: string | number,
+  destChainId: string,
+  assetId: string,
+  env: "testnet" | "mainnet"
 ): Promise<CanTransferResponse> {
   let srcChainIdConverted;
 
   if (typeof srcChainId === "string" && srcChainId.startsWith("osmosis")) {
-    srcChainIdConverted = "osmosis"
+    srcChainIdConverted = "osmosis";
   } else {
     srcChainIdConverted = srcChainId.toString();
   }
 
-  const origin = env === "mainnet"
+  const origin =
+    env === "mainnet"
       ? "https://api.mainnet.int3face.zone/int3face"
       : "https://api.testnet.int3face.zone/int3face";
 
-  const url = new URL(`/bridge/v1beta1/can-transfer/${srcChainIdConverted}/${destChainId}/${denomOfInt3face[assetId]}`, origin);
+  const url = new URL(
+    `/bridge/v1beta1/can-transfer/${srcChainIdConverted}/${destChainId}/${denomOfInt3face[assetId]}`,
+    origin
+  );
 
   return apiClient<CanTransferResponse>(url.toString());
 }

--- a/packages/bridge/src/wormhole/index.ts
+++ b/packages/bridge/src/wormhole/index.ts
@@ -66,35 +66,37 @@ export class WormholeBridgeProvider implements BridgeProvider {
     fromAsset,
     toAsset,
   }: GetBridgeExternalUrlParams): Promise<BridgeExternalUrl | undefined> {
-    // For now we use Portal Bridge
-    const url = new URL("https://portalbridge.com/");
-
-    if (fromChain?.chainType === "cosmos" || toChain?.chainType === "cosmos") {
-      url.pathname = "/cosmos/";
-    }
+    // Use local Wormhole Connect instead of Portal Bridge
+    let urlPath = "/wormhole";
+    const params = new URLSearchParams();
 
     if (fromChain) {
-      url.searchParams.set(
-        "sourceChain",
+      params.set(
+        "from",
         fromChain.chainName?.toLowerCase() ?? fromChain.chainId.toString()
       );
-      if (fromChain.chainType === "solana" && fromAsset) {
-        url.searchParams.set("asset", fromAsset.address);
-      }
     }
 
     if (toChain) {
-      url.searchParams.set(
-        "targetChain",
+      params.set(
+        "to",
         toChain.chainName?.toLowerCase() ?? toChain.chainId.toString()
       );
-      if (fromChain?.chainType !== "solana" && toAsset) {
-        url.searchParams.set("asset", toAsset.address);
-      }
     }
 
+    // Use token symbol for the token parameter
+    const tokenSymbol = fromAsset?.denom || toAsset?.denom;
+    if (tokenSymbol) {
+      params.set("token", tokenSymbol);
+    }
+
+    // Construct the final URL with query parameters
+    const queryString = params.toString();
+    const fullPath = queryString ? `${urlPath}?${queryString}` : urlPath;
+    const url = new URL(fullPath, "http://localhost");
+
     return {
-      urlProviderName: "Portal",
+      urlProviderName: "Wormhole Connect",
       url,
     };
   }

--- a/packages/bridge/src/wormhole/index.ts
+++ b/packages/bridge/src/wormhole/index.ts
@@ -67,7 +67,7 @@ export class WormholeBridgeProvider implements BridgeProvider {
     toAsset,
   }: GetBridgeExternalUrlParams): Promise<BridgeExternalUrl | undefined> {
     // Use local Wormhole Connect instead of Portal Bridge
-    let urlPath = "/wormhole";
+    const urlPath = "/wormhole";
     const params = new URLSearchParams();
 
     if (fromChain) {
@@ -93,7 +93,12 @@ export class WormholeBridgeProvider implements BridgeProvider {
     // Construct the final URL with query parameters
     const queryString = params.toString();
     const fullPath = queryString ? `${urlPath}?${queryString}` : urlPath;
-    const url = new URL(fullPath, "http://localhost");
+
+    // Create URL with proper relative path handling
+    const baseUrl = typeof window !== "undefined" 
+      ? window.location.origin 
+      : "https://app.osmosis.zone";
+    const url = new URL(fullPath, baseUrl);
 
     return {
       urlProviderName: "Wormhole Connect",

--- a/packages/bridge/src/wormhole/index.ts
+++ b/packages/bridge/src/wormhole/index.ts
@@ -95,10 +95,7 @@ export class WormholeBridgeProvider implements BridgeProvider {
     const fullPath = queryString ? `${urlPath}?${queryString}` : urlPath;
 
     // Create URL with proper relative path handling
-    const baseUrl = typeof window !== "undefined" 
-      ? window.location.origin 
-      : "https://app.osmosis.zone";
-    const url = new URL(fullPath, baseUrl);
+    const url = new URL(fullPath, "https://app.osmosis.zone");
 
     return {
       urlProviderName: "Wormhole Connect",

--- a/packages/web/utils/bridge.ts
+++ b/packages/web/utils/bridge.ts
@@ -19,7 +19,7 @@ export const ExternalBridgeLogoUrls: Record<Bridge | "Generic", string> = {
   Axelar: "/external-bridges/satellite.svg",
   IBC: "/external-bridges/tfm.svg",
   Nomic: "/bridges/nomic.svg",
-  Wormhole: "/external-bridges/portalbridge.svg",
+  Wormhole: "/bridges/wormhole.svg",
   Generic: "/external-bridges/generic.svg",
   Nitro: "/bridges/nitro.svg",
   Picasso: "/bridges/picasso.svg",


### PR DESCRIPTION
## Change

Solana-based tokens without supported bridge providers now redirect to our portal widget in /wormhole.