### PR TITLE
Fix broken link to TradingView Widget methods documentation

### DIFF
--- a/packages/web/public/tradingview/charting_library.d.ts
+++ b/packages/web/public/tradingview/charting_library.d.ts
@@ -10293,7 +10293,7 @@ export interface IChartWidgetApi {
 }
 /**
  * The main interface for interacting with the library, returned by {@link ChartingLibraryWidgetConstructor}.
- * For more information, refer to the [Widget methods](https://www.tradingview.com/charting-library-docs/latest/core_concepts/widget-methods.md) article.
+ * For more information, refer to the [Widget methods](https://www.tradingview.com/charting-library-docs/latest/core_concepts/widget-methods/) article.
  */
 export interface IChartingLibraryWidget {
   /**


### PR DESCRIPTION
Replaced the outdated URL to the TradingView Widget methods documentation in charting_library.d.ts with the current, working link. This ensures that users and developers are directed to the correct resource for up-to-date information on widget methods.