### PR TITLE
XRPL EVM as the default network for XRP

### DIFF
--- a/packages/web/components/bridge/use-bridges-supported-assets.ts
+++ b/packages/web/components/bridge/use-bridges-supported-assets.ts
@@ -287,14 +287,30 @@ export const useBridgesSupportedAssets = ({
 
             // For XRP withdrawals, prioritize XPRL EVM first
             if (isXrpWithdrawal) {
-              if (a.chainId === "xrplevm_1440000-1" && b.chainId !== "xrplevm_1440000-1") return -1;
-              if (a.chainId !== "xrplevm_1440000-1" && b.chainId === "xrplevm_1440000-1") return 1;
+              if (
+                a.chainId === "xrplevm_1440000-1" &&
+                b.chainId !== "xrplevm_1440000-1"
+              )
+                return -1;
+              if (
+                a.chainId !== "xrplevm_1440000-1" &&
+                b.chainId === "xrplevm_1440000-1"
+              )
+                return 1;
             }
-            
+
             // For XRP deposits, prioritize XPRL EVM first
             if (isXrpDeposit) {
-              if (a.chainId === "xrplevm_1440000-1" && b.chainId !== "xrplevm_1440000-1") return -1;
-              if (a.chainId !== "xrplevm_1440000-1" && b.chainId === "xrplevm_1440000-1") return 1;
+              if (
+                a.chainId === "xrplevm_1440000-1" &&
+                b.chainId !== "xrplevm_1440000-1"
+              )
+                return -1;
+              if (
+                a.chainId !== "xrplevm_1440000-1" &&
+                b.chainId === "xrplevm_1440000-1"
+              )
+                return 1;
             }
 
             // prioritize bitcoin and doge chains first, then evm

--- a/packages/web/components/bridge/use-bridges-supported-assets.ts
+++ b/packages/web/components/bridge/use-bridges-supported-assets.ts
@@ -255,6 +255,24 @@ export const useBridgesSupportedAssets = ({
           asset.coinGeckoId === "usd-coin"
       );
 
+    // Check if this is a XRP  withdrawal to prioritize Noble
+    const isXrpWithdrawal =
+      direction === "withdraw" &&
+      assets?.some(
+        (asset) =>
+          asset.coinDenom?.toUpperCase().includes("XRP") ||
+          asset.coinGeckoId === "ripple"
+      );
+
+    // Check if this is a XRP  withdrawal to prioritize Noble
+    const isXrpDeposit =
+      direction === "deposit" &&
+      assets?.some(
+        (asset) =>
+          asset.coinDenom?.toUpperCase().includes("XRP") ||
+          asset.coinGeckoId === "ripple"
+      );
+
     return Array.from(
       // Remove duplicate chains
       new Map(
@@ -265,6 +283,18 @@ export const useBridgesSupportedAssets = ({
             if (isUsdcWithdrawal) {
               if (a.chainId === "noble-1" && b.chainId !== "noble-1") return -1;
               if (a.chainId !== "noble-1" && b.chainId === "noble-1") return 1;
+            }
+
+            // For XRP withdrawals, prioritize XPRL EVM first
+            if (isXrpWithdrawal) {
+              if (a.chainId === "xrplevm_1440000-1" && b.chainId !== "xrplevm_1440000-1") return -1;
+              if (a.chainId !== "xrplevm_1440000-1" && b.chainId === "xrplevm_1440000-1") return 1;
+            }
+            
+            // For XRP withdrawals, prioritize XPRL EVM first
+            if (isXrpDeposit) {
+              if (a.chainId === "xrplevm_1440000-1" && b.chainId !== "xrplevm_1440000-1") return 1;
+              if (a.chainId !== "xrplevm_1440000-1" && b.chainId === "xrplevm_1440000-1") return -1;
             }
 
             // prioritize bitcoin and doge chains first, then evm

--- a/packages/web/components/bridge/use-bridges-supported-assets.ts
+++ b/packages/web/components/bridge/use-bridges-supported-assets.ts
@@ -291,10 +291,10 @@ export const useBridgesSupportedAssets = ({
               if (a.chainId !== "xrplevm_1440000-1" && b.chainId === "xrplevm_1440000-1") return 1;
             }
             
-            // For XRP withdrawals, prioritize XPRL EVM first
+            // For XRP deposits, prioritize XPRL EVM first
             if (isXrpDeposit) {
-              if (a.chainId === "xrplevm_1440000-1" && b.chainId !== "xrplevm_1440000-1") return 1;
-              if (a.chainId !== "xrplevm_1440000-1" && b.chainId === "xrplevm_1440000-1") return -1;
+              if (a.chainId === "xrplevm_1440000-1" && b.chainId !== "xrplevm_1440000-1") return -1;
+              if (a.chainId !== "xrplevm_1440000-1" && b.chainId === "xrplevm_1440000-1") return 1;
             }
 
             // prioritize bitcoin and doge chains first, then evm


### PR DESCRIPTION
## What is the purpose of the change:

 Specify XRPL EVM as the default network for XRP transfers.

## Brief Changelog
 - Update use-bridges-supported-assets.ts to specify a default network for XRP transfers.

## Testing and Verifying

This change has been tested using the Vercel build

Alternatively, I could remove the check for transfer direction, since it should apply to both withdraw and deposit