### PR TITLE
Update use-bridges-supported-assets.ts

### DIFF
--- a/packages/web/components/bridge/use-bridges-supported-assets.ts
+++ b/packages/web/components/bridge/use-bridges-supported-assets.ts
@@ -300,7 +300,6 @@ export const useBridgesSupportedAssets = ({
               if (a.chainId !== "noble-1" && b.chainId === "noble-1") return 1;
             }
 
-
             // For XRP withdrawals, prioritize XPRL EVM first
             if (isXrpWithdrawal) {
               if (

--- a/packages/web/components/bridge/use-bridges-supported-assets.ts
+++ b/packages/web/components/bridge/use-bridges-supported-assets.ts
@@ -255,7 +255,16 @@ export const useBridgesSupportedAssets = ({
           asset.coinGeckoId === "usd-coin"
       );
 
-    // Check if this is a XRP  withdrawal to prioritize Noble
+    // Check if this is a USDC deposit to prioritize Noble
+    const isUsdcDeposit =
+      direction === "deposit" &&
+      assets?.some(
+        (asset) =>
+          asset.coinDenom?.toUpperCase().includes("USDC") ||
+          asset.coinGeckoId === "usd-coin"
+      );
+
+    // Check if this is a XRP withdrawal to prioritize XRPL EVM
     const isXrpWithdrawal =
       direction === "withdraw" &&
       assets?.some(
@@ -264,7 +273,7 @@ export const useBridgesSupportedAssets = ({
           asset.coinGeckoId === "ripple"
       );
 
-    // Check if this is a XRP  withdrawal to prioritize Noble
+    // Check if this is a XRP deposit to prioritize XRPL EVM
     const isXrpDeposit =
       direction === "deposit" &&
       assets?.some(
@@ -284,6 +293,13 @@ export const useBridgesSupportedAssets = ({
               if (a.chainId === "noble-1" && b.chainId !== "noble-1") return -1;
               if (a.chainId !== "noble-1" && b.chainId === "noble-1") return 1;
             }
+
+            // For USDC deposits, prioritize Noble first
+            if (isUsdcDeposit) {
+              if (a.chainId === "noble-1" && b.chainId !== "noble-1") return -1;
+              if (a.chainId !== "noble-1" && b.chainId === "noble-1") return 1;
+            }
+
 
             // For XRP withdrawals, prioritize XPRL EVM first
             if (isXrpWithdrawal) {


### PR DESCRIPTION
## What is the purpose of the change:

To make Osmosis Zone default to using Noble as the first selected network when Depositing (and not just Withdrawing) USDC.

## Brief Changelog

- Update use-bridges-supported-assets.ts to prioritize Noble for USDC Deposits

## Testing and Verifying

This change has not been tested locally. Simple change easy to Verify using Vercel build
