### PR TITLE
fix: send Slack alerts only on first test failure attempt

### DIFF
--- a/.github/workflows/monitoring-e2e-tests.yml
+++ b/.github/workflows/monitoring-e2e-tests.yml
@@ -55,7 +55,7 @@ jobs:
       # Send Slack alert if 'server-e2e-tests' job fails
       - name: Send Slack alert if test fails
         id: slack
-        if: failure()
+        if: failure() && github.run_attempt == 1
         uses: slackapi/slack-github-action@v1.26.0
         with:
           payload: |

--- a/.github/workflows/monitoring-limit-geo-e2e-tests.yml
+++ b/.github/workflows/monitoring-limit-geo-e2e-tests.yml
@@ -392,7 +392,7 @@ jobs:
         fe-limit-us,
         fe-limit-eu,
       ]
-    if: failure() && (needs.fe-trade-eu.outputs.unexpected > 1 || needs.fe-trade-us.outputs.unexpected > 1 || needs.fe-trade-sg.outputs.unexpected > 1 || needs.fe-limit-eu.outputs.unexpected > 1 || needs.fe-limit-us.outputs.unexpected > 1)
+    if: failure() && github.run_attempt == 1 && (needs.fe-trade-eu.outputs.unexpected > 1 || needs.fe-trade-us.outputs.unexpected > 1 || needs.fe-trade-sg.outputs.unexpected > 1 || needs.fe-limit-eu.outputs.unexpected > 1 || needs.fe-limit-us.outputs.unexpected > 1)
     # Send alert only if something failed and unexpected failures are more than 1
     steps:
       - name: Send Slack alert if test fails

--- a/.github/workflows/monitoring-quote-geo-e2e-tests.yml
+++ b/.github/workflows/monitoring-quote-geo-e2e-tests.yml
@@ -66,7 +66,7 @@ jobs:
   fe-bot-alert:
     runs-on: ubuntu-latest
     needs: [fe-quote-tests]
-    if: failure()
+    if: failure() && github.run_attempt == 1
     steps:
       - name: Send Slack alert if test fails
         id: slack

--- a/.github/workflows/prod-frontend-e2e-tests.yml
+++ b/.github/workflows/prod-frontend-e2e-tests.yml
@@ -72,7 +72,7 @@ jobs:
           path: packages/e2e/playwright-report
       - name: Send Slack alert if test fails
         id: slack
-        if: failure()
+        if: failure() && github.run_attempt == 1
         uses: slackapi/slack-github-action@v1.26.0
         with:
           payload: |


### PR DESCRIPTION
## What is the purpose of the change:

- send Slack alerts only on first test failure attempt

No need to send an alert if someone is re-running failed jobs.