### PR TITLE
Fetch gas assets by `sourceDenom` instead of `coinMinimalDenom`

### DIFF
--- a/packages/bridge/src/utils/gas.ts
+++ b/packages/bridge/src/utils/gas.ts
@@ -24,9 +24,7 @@ export async function getGasAsset({
   // try to get asset list fee asset first, or otherwise the chain fee currency
   const assetListAsset = assetLists
     .flatMap(({ assets }) => assets)
-    .find(
-      (asset) => asset.coinMinimalDenom.toLowerCase() === denom.toLowerCase()
-    );
+    .find((asset) => asset.sourceDenom.toLowerCase() === denom.toLowerCase());
 
   if (assetListAsset) {
     return {


### PR DESCRIPTION
related to recent changes in the asset list, getting the gas token should use `sourceDenom` instead of `coinMinimalDenom`. Essential to deposit/withdraw flow