### PR TITLE
fix: round up gas fees instead of truncating to match Keplr calculation

### DIFF
--- a/packages/tx/src/__tests__/gas.spec.ts
+++ b/packages/tx/src/__tests__/gas.spec.ts
@@ -327,7 +327,7 @@ describe("getGasFeeAmount", () => {
       .quo(new Dec(spotPrice))
       .mul(new Dec(1.01))
       .mul(new Dec(gasLimit))
-      .truncate()
+      .roundUp()
       .toString();
 
     expect(queryBalances).toBeCalledWith({
@@ -424,7 +424,7 @@ describe("getGasFeeAmount", () => {
       .quo(new Dec(spotPrice))
       .mul(new Dec(1.01))
       .mul(new Dec(gasLimit))
-      .truncate()
+      .roundUp()
       .toString();
 
     expect(queryBalances).toBeCalledWith({
@@ -511,7 +511,7 @@ describe("getGasFeeAmount", () => {
       .quo(new Dec(spotPrice))
       .mul(new Dec(1.01))
       .mul(new Dec(gasLimit))
-      .truncate()
+      .roundUp()
       .toString();
 
     expect(queryBalances).toBeCalledWith({
@@ -597,7 +597,7 @@ describe("getGasFeeAmount", () => {
       .quo(new Dec(spotPrice))
       .mul(new Dec(1.01))
       .mul(new Dec(gasLimit))
-      .truncate()
+      .roundUp()
       .toString();
 
     expect(queryBalances).toBeCalledWith({
@@ -684,7 +684,7 @@ describe("getGasFeeAmount", () => {
       .quo(new Dec(spotPrice))
       .mul(new Dec(1.01))
       .mul(new Dec(gasLimit))
-      .truncate()
+      .roundUp()
       .toString();
 
     expect(queryBalances).toBeCalledWith({

--- a/packages/tx/src/gas.ts
+++ b/packages/tx/src/gas.ts
@@ -420,7 +420,7 @@ export async function getGasFeeAmount({
     });
 
     // Calculate the raw fee amount first before applying Math.max
-    const rawFeeAmount = feeDenomGasPrice.mul(new Dec(gasLimit)).truncate();
+    const rawFeeAmount = feeDenomGasPrice.mul(new Dec(gasLimit)).roundUp();
 
     // Only skip if the fee amount is greater than balance
     if (new Int(rawFeeAmount.toString()).gt(new Int(amount))) {


### PR DESCRIPTION
## What is the purpose of the change:

Bug fix: Gas fees are being truncated instead of rounded up, resulting in insufficient gas fees suggested to Keplr wallet.
Also note that Keplr's has already implemented this change in their own code.

### Linear Task

[QAS-81: Fix gas fee rounding error for AKT deposits in Osmosis FE](https://linear.app/osmosis/issue/QAS-81/fix-gas-fee-rounding-error-for-akt-deposits-in-osmosis-fe)

## Brief Changelog

- replaced truncate with round up for gas fees.

## Testing and Verifying

I was able to deploy to vercel and test there.
