### PR TITLE
fix: single-sided liquidity max button uses stale balance

### DIFF
--- a/packages/stores/src/ui-config/manage-liquidity/add-liquidity.ts
+++ b/packages/stores/src/ui-config/manage-liquidity/add-liquidity.ts
@@ -431,8 +431,15 @@ export class ObservableAddLiquidityConfig extends ManageLiquidityConfigBase {
   setMax() {
     if (this.isSingleAmountIn && this.singleAmountInConfig) {
       const config = this.singleAmountInConfig;
+      // Query fresh balance instead of reading potentially stale config.amount
+      const balance = this._queryBalances
+        .getQueryBech32Address(this.sender)
+        .getBalanceFromCurrency(config.sendCurrency);
       config.setIsMax(true);
-      this.setAmountAt(this._singleAmountInConfigIndex, config.amount);
+      this.setAmountAt(
+        this._singleAmountInConfigIndex,
+        balance.toDec().toString()
+      );
       config.setIsMax(false);
       return;
     }

--- a/packages/stores/src/ui-config/manage-liquidity/add-liquidity.ts
+++ b/packages/stores/src/ui-config/manage-liquidity/add-liquidity.ts
@@ -438,7 +438,8 @@ export class ObservableAddLiquidityConfig extends ManageLiquidityConfigBase {
       config.setIsMax(true);
       this.setAmountAt(
         this._singleAmountInConfigIndex,
-        balance.toDec().toString()
+		balance.toDec().toString(), 
+		true
       );
       config.setIsMax(false);
       return;


### PR DESCRIPTION
## What is the purpose of the change:

Fixed issue where clicking max button in single-sided liquidity mode would use stale balance value instead of querying fresh balance.

### Linear Task

<!-- > Add a link to the linear task that this PR is addressing. TIP: go to the linear task and use Ctrl/⌘ + C to copy a link. -->
https://linear.app/osmosis/issue/FE-1554/max-button-for-single-sided-add-liquidity-not-displaying-correct-value

## Brief Changelog

- Query current balance from _queryBalances instead of reading config.amount
- Ensures max button always uses latest balance matching the displayed value

## Testing and Verifying

This change has been tested locally by rebuilding the website and verified content and links are expected
