### PR TITLE
fix(e2e): add timeout to connectWallet() to prevent indefinite hang

### DIFF
--- a/packages/e2e/pages/base-page.ts
+++ b/packages/e2e/pages/base-page.ts
@@ -28,11 +28,9 @@ export class BasePage {
       .waitForEvent('page', { timeout: 15000 })
     await this.kepltWalletBtn.click()
     await this.page.waitForTimeout(1000)
+    let newPage: Page | null = null
     try {
-      const newPage = await pagePromise
-      await newPage.waitForLoadState('load', { timeout: 10000 })
-      console.log(`Title of the new page: ${await newPage.title()}`)
-      await newPage.getByRole('button', { name: 'Approve' }).click()
+      newPage = await pagePromise
     } catch (error: any) {
       if (
         error.name === 'TimeoutError' ||
@@ -44,6 +42,12 @@ export class BasePage {
       } else {
         throw error
       }
+    }
+
+    if (newPage) {
+      await newPage.waitForLoadState('load', { timeout: 10000 })
+      console.log(`Title of the new page: ${await newPage.title()}`)
+      await newPage.getByRole('button', { name: 'Approve' }).click()
     }
     await this.getWalletBalance()
     await this.dismissVariantsPopupIfPresent()

--- a/packages/e2e/pages/base-page.ts
+++ b/packages/e2e/pages/base-page.ts
@@ -23,18 +23,28 @@ export class BasePage {
 
   async connectWallet() {
     await this.connectWalletBtn.click()
-    // This is needed to handle a wallet popup
-    const pagePromise = this.page.context().waitForEvent('page')
+    const pagePromise = this.page
+      .context()
+      .waitForEvent('page', { timeout: 15000 })
     await this.kepltWalletBtn.click()
     await this.page.waitForTimeout(1000)
-    // Handle Pop-up page ->
-    const newPage = await pagePromise
-    await newPage.waitForLoadState('load', { timeout: 10000 })
-    const pageTitle = await newPage.title()
-    console.log(`Title of the new page: ${pageTitle}`)
-    await newPage.getByRole('button', { name: 'Approve' }).click()
-    // PopUp page is auto-closed
-    // Handle Pop-up page <-
+    try {
+      const newPage = await pagePromise
+      await newPage.waitForLoadState('load', { timeout: 10000 })
+      console.log(`Title of the new page: ${await newPage.title()}`)
+      await newPage.getByRole('button', { name: 'Approve' }).click()
+    } catch (error: any) {
+      if (
+        error.name === 'TimeoutError' ||
+        /timeout/i.test(error.message ?? '')
+      ) {
+        console.log(
+          'Keplr popup did not appear within 15s; assuming auto-approved.',
+        )
+      } else {
+        throw error
+      }
+    }
     await this.getWalletBalance()
     await this.dismissVariantsPopupIfPresent()
   }


### PR DESCRIPTION
## TLDR
`connectWallet()` hangs indefinitely on wallet reconnection because `waitForEvent('page')` has no timeout. This causes EU/SG geo-monitoring trade and limit test runs to exceed their 12-minute job timeout. Fixed by adding a 15s timeout with graceful fallback.

## Context
The market and limit geo-monitoring tests have been timing out since ~November 2025. The EU and SG proxy jobs (`prod-fe-trade-eu`, `prod-fe-trade-sg`) hit their 12-minute job limit because `connectWallet()` hangs when Keplr auto-approves without opening a popup.

Example failing run: https://github.com/osmosis-labs/osmosis-frontend/actions/runs/23026284167/job/66875273870

## Root cause analysis

Checked 7 consecutive runs of `monitoring-limit-geo-e2e-tests.yml`. The pattern is 100% consistent:

| Job | Proxy? | Connect pattern | Result |
|---|---|---|---|
| `prod-fe-swap-us` | No | once in `beforeAll` | always passes |
| `prod-fe-swap-eu` | Yes | once in `beforeAll` | always passes |
| `prod-fe-swap-sg` | Yes | once in `beforeAll` | always passes |
| `prod-fe-trade-us` | No | per-test `beforeEach`/`afterEach` | always passes |
| `prod-fe-trade-eu` | Yes | per-test `beforeEach`/`afterEach` | **always fails** |
| `prod-fe-trade-sg` | Yes | per-test `beforeEach`/`afterEach` | **always fails** |
| `prod-fe-limit-us` | No | per-test `beforeEach`/`afterEach` | always passes |
| `prod-fe-limit-eu` | Yes | skipped (blocked by trade-eu timeout) | skipped |
| quote-geo (all regions) | Yes | no wallet connection | always passes |

**Both conditions are required for the failure:**
1. Proxy is enabled (EU/SG) — adds network latency
2. Multiple connect/disconnect cycles (`beforeEach`/`afterEach`) — triggers reconnection

Swap tests use proxies but connect once → pass. US tests reconnect per-test but have no proxy → pass. Quote tests use proxies but don't connect a wallet → pass.

The proxy latency likely shifts the timing of Keplr's reconnection flow, causing `waitForEvent('page')` to miss the popup (it may open and auto-close too fast, or Keplr may skip it entirely).

## Summary
- `connectWallet()` calls `context.waitForEvent('page')` to catch the Keplr approval popup
- On first connection, Keplr opens a popup — works fine
- On reconnection (after `logOut()` + `connectWallet()`), Keplr may auto-approve without a popup — `waitForEvent` hangs indefinitely
- Added a 15s timeout to `waitForEvent('page')` with a graceful fallback
- Narrowed the try/catch to only the popup acquisition step (not the popup interaction)

### How the fix works

```
Before (broken):
  try {
    1. Wait for popup       ← might not appear (hangs forever)
    2. Wait for it to load  ← should work if popup appeared
    3. Click "Approve"      ← should work if popup appeared
  } catch (timeout) {
    "no popup, assume auto-approved"  ← hides real failures from steps 2 & 3!
  }

After (fixed):
  try {
    1. Wait for popup       ← 15s timeout, graceful fallback
  } catch (timeout) {
    "no popup, assume auto-approved"  ← only catches step 1
  }
  if (popup appeared) {
    2. Wait for it to load  ← errors propagate (good!)
    3. Click "Approve"      ← errors propagate (good!)
  }
```

## Test plan
- [x] Local connect/disconnect cycle test (3 cycles, no transactions) against stage.osmosis.zone
  - Cycle 1: Keplr popup appeared and was approved (happy path)
  - Cycles 2-3: No popup, 15s timeout fired, `getWalletBalance()` confirmed wallet connected
  - All 3 tests passed in 2.1 minutes
- [x] Without the fix, Cycles 2-3 hung for full test timeout, confirming root cause
- [ ] After merge: verify `prod-fe-trade-eu` and `prod-fe-trade-sg` no longer timeout
