### PR TITLE
fix(e2e): optimize transaction timeout budgets and approval detection

### DIFF
--- a/packages/e2e/pages/trade-page.ts
+++ b/packages/e2e/pages/trade-page.ts
@@ -152,13 +152,26 @@ export class TradePage extends BasePage {
   }
 
   async justApproveIfNeeded(context: BrowserContext) {
-    let approvePage: import("@playwright/test").Page | null = null;
-    try {
-      approvePage = await context.waitForEvent("page", { timeout: 10000 });
-    } catch {
-      console.log(
-        "Keplr approval popup did not appear within 10s; assuming 1-click trading or pre-approved."
-      );
+    let approvePage: import("@playwright/test").Page | null =
+      context
+        .pages()
+        .find((p) => p !== this.page && !p.isClosed()) ?? null;
+
+    if (!approvePage) {
+      try {
+        approvePage = await context.waitForEvent("page", { timeout: 10000 });
+      } catch (error: any) {
+        if (
+          error.name === "TimeoutError" ||
+          /timeout/i.test(error.message ?? "")
+        ) {
+          console.log(
+            "Keplr approval popup did not appear within 10s; assuming 1-click trading or pre-approved."
+          );
+        } else {
+          throw error;
+        }
+      }
     }
 
     if (approvePage) {

--- a/packages/e2e/pages/trade-page.ts
+++ b/packages/e2e/pages/trade-page.ts
@@ -152,19 +152,22 @@ export class TradePage extends BasePage {
   }
 
   async justApproveIfNeeded(context: BrowserContext) {
-    console.log("Wait for 7 seconds for any popup");
-    await this.page.waitForTimeout(7_000);
-    const pages = context.pages();
-    console.log(`Number of Open Pages: ${pages.length}`);
-    if (pages.length === 2) {
-      const approvePage = pages[1];
-      const approvePageTitle = approvePage.url();
-      console.log(`Approve page is opened at: ${approvePageTitle}`);
+    let approvePage: import("@playwright/test").Page | null = null;
+    try {
+      approvePage = await context.waitForEvent("page", { timeout: 10000 });
+    } catch {
+      console.log(
+        "Keplr approval popup did not appear within 10s; assuming 1-click trading or pre-approved."
+      );
+    }
+
+    if (approvePage) {
+      await approvePage.waitForLoadState("load", { timeout: 10000 });
+      console.log(`Approve page is opened at: ${approvePage.url()}`);
       await approvePage
         .getByRole("button", { name: "Approve" })
         .click({ timeout: 4000 });
     }
-    console.log("Second page was not opened in 7 seconds.");
   }
 
   async swapAndGetWalletMsg(context: BrowserContext) {
@@ -299,9 +302,9 @@ export class TradePage extends BasePage {
   async showSwapInfo() {
     const swapInfo = this.page.locator("//button//span[.='Show details']");
     await expect(swapInfo, "Show Swap Info button not visible!").toBeVisible({
-      timeout: 4000,
+      timeout: 10000,
     });
-    await swapInfo.click({ timeout: 2000 });
+    await swapInfo.click({ timeout: 5000 });
   }
 
   async getPriceInpact() {
@@ -662,9 +665,9 @@ export class TradePage extends BasePage {
    *
    * @remarks
    * - Waits for sell button to be enabled before proceeding
-   * - Automatically approves transaction in Keplr if popup appears (7s timeout)
+   * - Automatically approves transaction in Keplr if popup appears (10s event-driven timeout)
    * - Gracefully handles 1-click trading (no popup scenario)
-   * - Waits for blockchain confirmation before returning (40s timeout)
+   * - Waits for blockchain confirmation (40s timeout, starts after confirm click, parallel with approval)
    * - No retry logic - for retry support, use sellAndGetWalletMsg()
    */
   async sellAndApprove(
@@ -673,31 +676,21 @@ export class TradePage extends BasePage {
   ) {
     const slippagePercent = options?.slippagePercent;
 
-    // Make sure Sell button is enabled
     await expect(this.sellBtn, "Sell button is disabled!").toBeEnabled({
       timeout: this.buySellTimeout,
     });
 
-    // IMPORTANT: Start listening for transaction success BEFORE any UI interactions
-    // This ensures we don't miss immediate confirmations (1-click trading can be very fast)
-    // The promise runs in parallel with subsequent operations to minimize total wait time
-    const successPromise = expect(this.trxSuccessful).toBeVisible({
-      timeout: 40000,
-    });
-
     await this.sellBtn.click();
 
-    // Set slippage tolerance if specified (after sell clicked, before confirm)
     if (slippagePercent) {
       await this.setSlippageTolerance(slippagePercent);
     }
 
     await this.confirmSwapBtn.click();
+    const successPromise = expect(this.trxSuccessful).toBeVisible({
+      timeout: 40000,
+    });
     await this.justApproveIfNeeded(context);
-    await this.page.waitForTimeout(1000);
-
-    // IMPORTANT: Wait for actual blockchain confirmation instead of arbitrary timeout
-    // This ensures transaction is actually confirmed on-chain (or fails) before proceeding
     await successPromise;
   }
 
@@ -711,9 +704,9 @@ export class TradePage extends BasePage {
    *
    * @remarks
    * - Waits for buy button to be enabled before proceeding
-   * - Automatically approves transaction in Keplr if popup appears (7s timeout)
+   * - Automatically approves transaction in Keplr if popup appears (10s event-driven timeout)
    * - Gracefully handles 1-click trading (no popup scenario)
-   * - Waits for blockchain confirmation before returning (40s timeout)
+   * - Waits for blockchain confirmation (40s timeout, starts after confirm click, parallel with approval)
    * - No retry logic - for retry support, use buyAndGetWalletMsg()
    */
   async buyAndApprove(
@@ -726,26 +719,17 @@ export class TradePage extends BasePage {
       timeout: this.buySellTimeout,
     });
 
-    // IMPORTANT: Start listening for transaction success BEFORE any UI interactions
-    // This ensures we don't miss immediate confirmations (1-click trading can be very fast)
-    // The promise runs in parallel with subsequent operations to minimize total wait time
-    const successPromise = expect(this.trxSuccessful).toBeVisible({
-      timeout: 40000,
-    });
-
     await this.buyBtn.click();
 
-    // Set slippage tolerance if specified (after buy clicked, before confirm)
     if (slippagePercent) {
       await this.setSlippageTolerance(slippagePercent);
     }
 
     await this.confirmSwapBtn.click();
+    const successPromise = expect(this.trxSuccessful).toBeVisible({
+      timeout: 40000,
+    });
     await this.justApproveIfNeeded(context);
-    await this.page.waitForTimeout(1000);
-
-    // IMPORTANT: Wait for actual blockchain confirmation instead of arbitrary timeout
-    // This ensures transaction is actually confirmed on-chain (or fails) before proceeding
     await successPromise;
   }
 
@@ -791,9 +775,9 @@ export class TradePage extends BasePage {
    * @remarks
    * - Checks for sufficient balance before attempting swap
    * - Implements automatic retry logic with 1.5s delay for quote refresh race conditions
-   * - Automatically approves transaction in Keplr if popup appears (7s timeout)
+   * - Automatically approves transaction in Keplr if popup appears (10s event-driven timeout)
    * - Gracefully handles 1-click trading (no popup scenario)
-   * - Waits for blockchain confirmation before returning (40s timeout)
+   * - Waits for blockchain confirmation (40s timeout, starts after confirm click, parallel with approval)
    * - Retries only on swap button disabled errors; other errors fail immediately
    */
   async swapAndApprove(
@@ -803,10 +787,8 @@ export class TradePage extends BasePage {
     const maxRetries = options?.maxRetries ?? 3;
     const slippagePercent = options?.slippagePercent;
 
-    // Retry logic to handle race conditions where quote refreshes and temporarily disables swap button
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
       try {
-        // Make sure to have sufficient balance and swap button is enabled
         expect(
           await this.isInsufficientBalanceForSwap(),
           "Insufficient balance for the swap!"
@@ -816,33 +798,24 @@ export class TradePage extends BasePage {
           timeout: this.buySellTimeout,
         });
 
-        // IMPORTANT: Start listening for transaction success BEFORE any UI interactions
-        // This ensures we don't miss immediate confirmations (1-click trading can be very fast)
-        // The promise runs in parallel with subsequent operations to minimize total wait time
-        const successPromise = expect(this.trxSuccessful).toBeVisible({
-          timeout: 40000,
-        });
-
         await this.swapBtn.click({ timeout: 4000 });
 
-        // Set slippage tolerance if specified (after swap clicked, before confirm)
         if (slippagePercent) {
           await this.setSlippageTolerance(slippagePercent);
         }
 
         await this.confirmSwapBtn.click({ timeout: 5000 });
+        const successPromise = expect(this.trxSuccessful).toBeVisible({
+          timeout: 40000,
+        });
         await this.justApproveIfNeeded(context);
 
-        // Successfully submitted! Now wait for transaction success
         if (attempt > 0) {
           console.log(
             `✓ Swap transaction submitted after ${attempt} retry(ies)`
           );
         }
 
-        // IMPORTANT: Wait for actual blockchain confirmation instead of arbitrary timeout
-        // This ensures transaction is actually confirmed on-chain (or fails) before proceeding
-        // Each retry gets a fresh 40s timeout to avoid timeout exhaustion
         await successPromise;
 
         return;
@@ -858,17 +831,14 @@ export class TradePage extends BasePage {
               `Waiting for quote to stabilize and retrying...`
           );
 
-          // Wait for quote/route to finish refreshing
           await this.page.waitForTimeout(1500);
 
-          // Log exchange rate to see if it changed
           const rate = await this.getExchangeRate().catch(() => "N/A");
           console.log(`Exchange rate after wait: ${rate}`);
 
-          continue; // Retry
+          continue;
         }
 
-        // Final attempt failed or different error - throw it
         throw error;
       }
     }

--- a/packages/e2e/pages/transactions-page.ts
+++ b/packages/e2e/pages/transactions-page.ts
@@ -89,11 +89,10 @@ export class TransactionsPage extends BasePage {
    *
    * @remarks
    * - Locates cancel button using xpath with amount and price selectors
-   * - Checks button visibility first to fail fast if not found (avoids hanging promises)
-   * - Starts success listener BEFORE clicking to catch immediate confirmations (1-click trading)
-   * - Waits for Keplr approval popup with 20s timeout (gracefully handles 1-click scenarios)
+   * - Checks button visibility first to fail fast if not found
+   * - Waits for Keplr approval popup with 10s event-driven timeout (gracefully handles 1-click scenarios)
    * - Validates that the transaction message contains 'cancel_limit'
-   * - Waits for actual blockchain confirmation (40s timeout) instead of arbitrary delays
+   * - Waits for blockchain confirmation (40s timeout, starts after action click, parallel with approval)
    */
   async cancelLimitOrder(
     amount: string,
@@ -103,28 +102,19 @@ export class TransactionsPage extends BasePage {
     const cancelBtn = `//td//span[.='${amount}']/../../../../..//td//p[.='$${price}']/../../..//button`;
     console.log(`Use locator for a cancel btn: ${cancelBtn}`);
 
-    // IMPORTANT: Check button exists first before starting success listener
-    // This prevents hanging promises if button is not found (fail-fast pattern)
     const cancelBtnLocator = this.page.locator(cancelBtn).first();
     await expect(cancelBtnLocator, "Cancel button not found!").toBeVisible({
       timeout: 5000,
     });
 
-    // IMPORTANT: Start listening for transaction success BEFORE clicking cancel button
-    // This ensures we don't miss immediate confirmations (1-click trading can be very fast)
-    // The promise runs in parallel with subsequent operations to minimize total wait time
-    const successPromise = expect(
-      this.page.getByText("Transaction Successful")
-    ).toBeVisible({
-      timeout: 40000,
-    });
-
     await cancelBtnLocator.click();
 
-    // IMPORTANT: waitForEvent MUST have a timeout to prevent hanging indefinitely
-    // If Keplr popup doesn't appear (1-click trading enabled), this will timeout gracefully
+    const successPromise = expect(
+      this.page.getByText("Transaction Successful")
+    ).toBeVisible({ timeout: 40000 });
+
     const pageApprovePromise = context.waitForEvent("page", {
-      timeout: 20000,
+      timeout: 10000,
     });
 
     try {
@@ -138,35 +128,22 @@ export class TransactionsPage extends BasePage {
         .getByText("Execute contract")
         .textContent();
       console.log(`Wallet is approving this msg: \n${msgContentAmount}`);
-      // Approve trx
       await approveBtn.click();
-      // Expect that this is a cancel limit call
       expect(msgContentAmount).toContain("cancel_limit");
     } catch (error: any) {
-      // IMPORTANT: Gracefully handle timeout errors for 1-click trading scenarios
-      // When 1-click trading is enabled, no Keplr popup appears and waitForEvent times out
-      // This is expected behavior, not an error - transaction is still submitted on-chain
       if (
         error.name === "TimeoutError" ||
         error.message?.includes("Timeout") ||
         error.message?.includes("timeout")
       ) {
         console.log(
-          "✓ Keplr approval popup did not appear within 20s for cancel operation; assuming 1-click trading is enabled or transaction was pre-approved."
+          "Keplr popup did not appear within 10s for cancel; assuming 1-click trading."
         );
       } else {
-        // Other errors (button not found, page closed, etc.) should fail the test
-        console.error(
-          "Failed to get Keplr approval popup for cancel:",
-          error.message ?? "Unknown error"
-        );
         throw error;
       }
     }
 
-    // IMPORTANT: Wait for actual blockchain confirmation instead of arbitrary timeout
-    // This ensures transaction is actually confirmed on-chain (or fails) before proceeding
-    // Replaces old pattern: await this.page.waitForTimeout(2000)
     await successPromise;
   }
 
@@ -188,21 +165,14 @@ export class TransactionsPage extends BasePage {
       return;
     }
 
-    // IMPORTANT: Start listening for transaction success BEFORE clicking button
-    // This ensures we don't miss immediate confirmations (1-click trading can be very fast)
-    // The promise runs in parallel with subsequent operations to minimize total wait time
-    const successPromise = expect(
-      this.page.getByText("Transaction Successful")
-    ).toBeVisible({
-      timeout: 40000,
-    });
-
     await this.claimAndClose.first().click();
 
-    // IMPORTANT: waitForEvent MUST have a timeout to prevent hanging indefinitely
-    // If Keplr popup doesn't appear (1-click trading enabled), this will timeout gracefully
+    const successPromise = expect(
+      this.page.getByText("Transaction Successful")
+    ).toBeVisible({ timeout: 40000 });
+
     const pageApprovePromise = context.waitForEvent("page", {
-      timeout: 20000,
+      timeout: 10000,
     });
 
     try {
@@ -223,54 +193,35 @@ export class TransactionsPage extends BasePage {
       console.log(
         `Wallet is approving this msg: \n${msgContentAmount1}---- \n${msgContentAmount2}`
       );
-      // Approve trx
       await approveBtn.click();
       expect(msgContentAmount1).toContain("claim_limit");
       expect(msgContentAmount2).toContain("cancel_limit");
     } catch (error: any) {
-      // IMPORTANT: Gracefully handle timeout errors for 1-click trading scenarios
-      // When 1-click trading is enabled, no Keplr popup appears and waitForEvent times out
-      // This is expected behavior, not an error - transaction is still submitted on-chain
       if (
         error.name === "TimeoutError" ||
         error.message?.includes("Timeout") ||
         error.message?.includes("timeout")
       ) {
         console.log(
-          "✓ Keplr approval popup did not appear within 20s for claim and close; assuming 1-click trading is enabled or transaction was pre-approved."
+          "Keplr popup did not appear within 10s for claim and close; assuming 1-click trading."
         );
       } else {
-        // Other errors (button not found, page closed, etc.) should fail the test
-        console.error(
-          "Failed to get Keplr approval popup for claim and close:",
-          error.message ?? "Unknown error"
-        );
         throw error;
       }
     }
 
-    // IMPORTANT: Wait for actual blockchain confirmation instead of arbitrary timeout
-    // This ensures transaction is actually confirmed on-chain (or fails) before proceeding
-    // Replaces old pattern: await this.page.waitForTimeout(TRANSACTION_CONFIRMATION_TIMEOUT)
     await successPromise;
   }
 
   async claimAll(context: BrowserContext) {
-    // IMPORTANT: Start listening for transaction success BEFORE clicking button
-    // This ensures we don't miss immediate confirmations (1-click trading can be very fast)
-    // The promise runs in parallel with subsequent operations to minimize total wait time
-    const successPromise = expect(
-      this.page.getByText("Transaction Successful")
-    ).toBeVisible({
-      timeout: 40000,
-    });
-
     await this.claimAllBtn.click();
 
-    // IMPORTANT: waitForEvent MUST have a timeout to prevent hanging indefinitely
-    // If Keplr popup doesn't appear (1-click trading enabled), this will timeout gracefully
+    const successPromise = expect(
+      this.page.getByText("Transaction Successful")
+    ).toBeVisible({ timeout: 40000 });
+
     const pageApprovePromise = context.waitForEvent("page", {
-      timeout: 20000,
+      timeout: 10000,
     });
 
     try {
@@ -280,33 +231,21 @@ export class TransactionsPage extends BasePage {
         name: "Approve",
       });
       await expect(approveBtn).toBeEnabled();
-      // Approve trx
       await approveBtn.click();
     } catch (error: any) {
-      // IMPORTANT: Gracefully handle timeout errors for 1-click trading scenarios
-      // When 1-click trading is enabled, no Keplr popup appears and waitForEvent times out
-      // This is expected behavior, not an error - transaction is still submitted on-chain
       if (
         error.name === "TimeoutError" ||
         error.message?.includes("Timeout") ||
         error.message?.includes("timeout")
       ) {
         console.log(
-          "✓ Keplr approval popup did not appear within 20s for claim all; assuming 1-click trading is enabled or transaction was pre-approved."
+          "Keplr popup did not appear within 10s for claim all; assuming 1-click trading."
         );
       } else {
-        // Other errors (button not found, page closed, etc.) should fail the test
-        console.error(
-          "Failed to get Keplr approval popup for claim all:",
-          error.message ?? "Unknown error"
-        );
         throw error;
       }
     }
 
-    // IMPORTANT: Wait for actual blockchain confirmation instead of arbitrary timeout
-    // This ensures transaction is actually confirmed on-chain (or fails) before proceeding
-    // Replaces old pattern: await this.page.waitForTimeout(TRANSACTION_CONFIRMATION_TIMEOUT)
     await successPromise;
   }
 

--- a/packages/e2e/pages/transactions-page.ts
+++ b/packages/e2e/pages/transactions-page.ts
@@ -113,12 +113,27 @@ export class TransactionsPage extends BasePage {
       this.page.getByText("Transaction Successful")
     ).toBeVisible({ timeout: 40000 });
 
-    const pageApprovePromise = context.waitForEvent("page", {
-      timeout: 10000,
-    });
+    let approvePage: Page | null =
+      context.pages().find((p) => p !== this.page && !p.isClosed()) ?? null;
 
-    try {
-      const approvePage = await pageApprovePromise;
+    if (!approvePage) {
+      try {
+        approvePage = await context.waitForEvent("page", { timeout: 10000 });
+      } catch (error: any) {
+        if (
+          error.name === "TimeoutError" ||
+          /timeout/i.test(error.message ?? "")
+        ) {
+          console.log(
+            "Keplr popup did not appear within 10s for cancel; assuming 1-click trading."
+          );
+        } else {
+          throw error;
+        }
+      }
+    }
+
+    if (approvePage) {
       await approvePage.waitForLoadState();
       const approveBtn = approvePage.getByRole("button", {
         name: "Approve",
@@ -130,18 +145,6 @@ export class TransactionsPage extends BasePage {
       console.log(`Wallet is approving this msg: \n${msgContentAmount}`);
       await approveBtn.click();
       expect(msgContentAmount).toContain("cancel_limit");
-    } catch (error: any) {
-      if (
-        error.name === "TimeoutError" ||
-        error.message?.includes("Timeout") ||
-        error.message?.includes("timeout")
-      ) {
-        console.log(
-          "Keplr popup did not appear within 10s for cancel; assuming 1-click trading."
-        );
-      } else {
-        throw error;
-      }
     }
 
     await successPromise;
@@ -171,12 +174,27 @@ export class TransactionsPage extends BasePage {
       this.page.getByText("Transaction Successful")
     ).toBeVisible({ timeout: 40000 });
 
-    const pageApprovePromise = context.waitForEvent("page", {
-      timeout: 10000,
-    });
+    let approvePage: Page | null =
+      context.pages().find((p) => p !== this.page && !p.isClosed()) ?? null;
 
-    try {
-      const approvePage = await pageApprovePromise;
+    if (!approvePage) {
+      try {
+        approvePage = await context.waitForEvent("page", { timeout: 10000 });
+      } catch (error: any) {
+        if (
+          error.name === "TimeoutError" ||
+          /timeout/i.test(error.message ?? "")
+        ) {
+          console.log(
+            "Keplr popup did not appear within 10s for claim and close; assuming 1-click trading."
+          );
+        } else {
+          throw error;
+        }
+      }
+    }
+
+    if (approvePage) {
       await approvePage.waitForLoadState();
       const approveBtn = approvePage.getByRole("button", {
         name: "Approve",
@@ -196,18 +214,6 @@ export class TransactionsPage extends BasePage {
       await approveBtn.click();
       expect(msgContentAmount1).toContain("claim_limit");
       expect(msgContentAmount2).toContain("cancel_limit");
-    } catch (error: any) {
-      if (
-        error.name === "TimeoutError" ||
-        error.message?.includes("Timeout") ||
-        error.message?.includes("timeout")
-      ) {
-        console.log(
-          "Keplr popup did not appear within 10s for claim and close; assuming 1-click trading."
-        );
-      } else {
-        throw error;
-      }
     }
 
     await successPromise;
@@ -220,30 +226,33 @@ export class TransactionsPage extends BasePage {
       this.page.getByText("Transaction Successful")
     ).toBeVisible({ timeout: 40000 });
 
-    const pageApprovePromise = context.waitForEvent("page", {
-      timeout: 10000,
-    });
+    let approvePage: Page | null =
+      context.pages().find((p) => p !== this.page && !p.isClosed()) ?? null;
 
-    try {
-      const approvePage = await pageApprovePromise;
+    if (!approvePage) {
+      try {
+        approvePage = await context.waitForEvent("page", { timeout: 10000 });
+      } catch (error: any) {
+        if (
+          error.name === "TimeoutError" ||
+          /timeout/i.test(error.message ?? "")
+        ) {
+          console.log(
+            "Keplr popup did not appear within 10s for claim all; assuming 1-click trading."
+          );
+        } else {
+          throw error;
+        }
+      }
+    }
+
+    if (approvePage) {
       await approvePage.waitForLoadState();
       const approveBtn = approvePage.getByRole("button", {
         name: "Approve",
       });
       await expect(approveBtn).toBeEnabled();
       await approveBtn.click();
-    } catch (error: any) {
-      if (
-        error.name === "TimeoutError" ||
-        error.message?.includes("Timeout") ||
-        error.message?.includes("timeout")
-      ) {
-        console.log(
-          "Keplr popup did not appear within 10s for claim all; assuming 1-click trading."
-        );
-      } else {
-        throw error;
-      }
     }
 
     await successPromise;


### PR DESCRIPTION
## Summary

Optimizes E2E test timeout budgets so the full 40s blockchain confirmation window is actually available for on-chain confirmation, and replaces blind waits with event-driven popup detection.

### Problem

Three issues were causing test timeouts:

1. **`justApproveIfNeeded` used a blind 7s `waitForTimeout`** -- always waited 7 seconds regardless of whether a Keplr popup appeared or not. In the 1-click trading case (no popup), this was pure waste.

2. **`successPromise` started too early** -- the 40s "Transaction Successful" watcher was created before UI interactions (clicking buy/sell, setting slippage, clicking confirm). By the time the transaction was actually submitted, 10-20s of the 40s budget was already consumed by pre-transaction steps.

3. **`showSwapInfo` timeouts too tight** -- 4s visibility + 2s click timeouts weren't enough when route calculations took longer under network latency.

### Changes

**`trade-page.ts`**

| Method | Change | Effect |
|---|---|---|
| `justApproveIfNeeded` | 7s blind `waitForTimeout` replaced with event-driven `waitForEvent('page', { timeout: 10000 })` | Resolves instantly when popup appears; times out at 10s if no popup (1-click trading) |
| `showSwapInfo` | `toBeVisible` timeout: 4s to 10s, `click` timeout: 2s to 5s | Accommodates slower route calculations |
| `buyAndApprove` | `successPromise` moved to right after `confirmSwapBtn.click()`, runs in parallel with `justApproveIfNeeded` | Full 40s for blockchain confirmation; catches early toasts during popup wait |
| `sellAndApprove` | Same as `buyAndApprove` | Same |
| `swapAndApprove` | Same as `buyAndApprove` | Same |

**`transactions-page.ts`**

| Method | Change | Effect |
|---|---|---|
| `cancelLimitOrder` | `successPromise` moved to right after action click; popup timeout reduced from 20s to 10s | Full 40s for confirmation; faster popup detection |
| `claimAndCloseAny` | Same pattern | Same |
| `claimAll` | Same pattern | Same |

### How it works

Before (sequential, budget wasted):
```
confirmSwapBtn.click()
  -> waitForTimeout(7000)        // 7s blind wait (always)
    -> check for popup            // might not exist
      -> successPromise waited    // only ~20-25s left of 40s budget
```

After (event-driven, parallel):
```
confirmSwapBtn.click()
  -> successPromise starts        // 40s timer begins here
  -> waitForEvent('page', 10s)    // resolves instantly on popup, or 10s timeout
    -> successPromise awaited     // still has ~30-40s of budget remaining
```

### Testing

- Verified locally with Playwright tests using real transactions through VPN (simulating network latency)
- Both market sell cycles passed (2.0 min total, both transactions confirmed on-chain)
- Event-driven popup detection correctly identified the no-popup scenario on reconnection

### Post-merge verification

Monitor the next few runs of the geo E2E workflows to confirm:
- [Synthetic Geo Monitoring Limit E2E Tests](https://github.com/osmosis-labs/osmosis-frontend/actions/workflows/monitoring-limit-geo-e2e-tests.yml)
- [Synthetic Geo Monitoring Quote E2E Tests](https://github.com/osmosis-labs/osmosis-frontend/actions/workflows/monitoring-quote-geo-e2e-tests.yml)

### Example failing run (before fix)

- https://github.com/osmosis-labs/osmosis-frontend/actions/runs/23049566387/job/66949136307

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since changes are confined to Playwright E2E helpers, but they may alter test timing/ordering and could affect flakiness if Keplr popup behavior differs in CI.
> 
> **Overview**
> **E2E transaction flows now use event-driven Keplr popup detection** instead of blind sleeps, first reusing an already-open popup page and otherwise waiting up to 10s before assuming 1-click/pre-approved behavior.
> 
> **Timeout budgets were rebalanced** so the 40s `Transaction Successful` watcher starts after the confirm/action click (running in parallel with approval), and `showSwapInfo` timeouts were increased to better tolerate slow route calculations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df9eb9edf599e4d45d00d419ac7de364d29cc8a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->