### PR TITLE
feat(e2e): auto-trigger topup when balance check detects low/critical

### DIFF
--- a/.github/workflows/e2e-topup-accounts.yml
+++ b/.github/workflows/e2e-topup-accounts.yml
@@ -37,7 +37,7 @@ permissions:
 
 jobs:
   topup:
-    name: "${{ inputs.dry_run && 'Dry run' || 'Topup' }} — All accounts"
+    name: "${{ (inputs.dry_run == true || inputs.dry_run == 'true') && 'Dry run' || 'Topup' }} — All accounts"
     timeout-minutes: 10
     runs-on: ubuntu-latest
 
@@ -66,7 +66,7 @@ jobs:
 
       - name: Topup accounts
         env:
-          DRY_RUN: ${{ inputs.dry_run && 'true' || 'false' }}
+          DRY_RUN: ${{ inputs.dry_run == true || inputs.dry_run == 'true' }}
           E2E_PRIVATE_KEY_TOPUP: ${{ secrets.E2E_PRIVATE_KEY_TOPUP }}
           E2E_PRIVATE_KEY_PREVIEW: ${{ secrets.E2E_PRIVATE_KEY_PREVIEW }}
           TEST_PRIVATE_KEY_SG: ${{ secrets.TEST_PRIVATE_KEY_SG }}

--- a/.github/workflows/e2e-topup-accounts.yml
+++ b/.github/workflows/e2e-topup-accounts.yml
@@ -28,6 +28,10 @@ on:
         type: string
         default: "500"
 
+concurrency:
+  group: e2e-topup
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -32,6 +32,9 @@ jobs:
 
   check-balances:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -98,12 +101,22 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh workflow run "E2E: Topup Test Accounts" \
-            --ref stage \
-            -f dry_run=false \
-            -f topup_multiplier=1.5 \
-            -f reserve_osmo=5 \
-            -f reserve_usdc=500
+          if [ -f packages/e2e/balance-report.json ]; then
+            OUTCOME=$(jq -r '.outcome // ""' packages/e2e/balance-report.json)
+            if [ "$OUTCOME" = "warn" ] || [ "$OUTCOME" = "fail" ]; then
+              gh workflow run "E2E: Topup Test Accounts" \
+                --ref stage \
+                -f dry_run=false \
+                -f topup_multiplier=1.5 \
+                -f reserve_osmo=5 \
+                -f reserve_usdc=500
+              echo "Topup workflow dispatched (balance outcome: $OUTCOME)."
+            else
+              echo "Skipping topup — balance outcome: $OUTCOME"
+            fi
+          else
+            echo "Skipping topup — no balance report found."
+          fi
       - name: Fail if balance critically low
         if: always() && steps.balance-check.outcome == 'failure'
         run: |

--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -104,7 +104,7 @@ jobs:
           if [ -f packages/e2e/balance-report.json ]; then
             OUTCOME=$(jq -r '.outcome // ""' packages/e2e/balance-report.json)
             if [ "$OUTCOME" = "warn" ] || [ "$OUTCOME" = "fail" ]; then
-              PENDING=$(gh run list --workflow "E2E: Topup Test Accounts" --status queued --status in_progress --json databaseId --jq 'length')
+              PENDING=$(gh run list --workflow "E2E: Topup Test Accounts" --limit 50 --json status --jq '[.[] | select(.status == "queued" or .status == "in_progress")] | length')
               if [ "$PENDING" -gt 0 ]; then
                 echo "Topup workflow already queued/in-progress — skipping dispatch."
               else

--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -104,13 +104,18 @@ jobs:
           if [ -f packages/e2e/balance-report.json ]; then
             OUTCOME=$(jq -r '.outcome // ""' packages/e2e/balance-report.json)
             if [ "$OUTCOME" = "warn" ] || [ "$OUTCOME" = "fail" ]; then
-              gh workflow run "E2E: Topup Test Accounts" \
-                --ref stage \
-                -f dry_run=false \
-                -f topup_multiplier=1.5 \
-                -f reserve_osmo=5 \
-                -f reserve_usdc=500
-              echo "Topup workflow dispatched (balance outcome: $OUTCOME)."
+              PENDING=$(gh run list --workflow "E2E: Topup Test Accounts" --status queued --status in_progress --json databaseId --jq 'length')
+              if [ "$PENDING" -gt 0 ]; then
+                echo "Topup workflow already queued/in-progress — skipping dispatch."
+              else
+                gh workflow run "E2E: Topup Test Accounts" \
+                  --ref stage \
+                  -f dry_run=false \
+                  -f topup_multiplier=1.5 \
+                  -f reserve_osmo=5 \
+                  -f reserve_usdc=500
+                echo "Topup workflow dispatched (balance outcome: $OUTCOME)."
+              fi
             else
               echo "Skipping topup — balance outcome: $OUTCOME"
             fi

--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -92,6 +92,18 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.E2E_SLACK_WEBHOOK_BALANCE_ALERTS }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      - name: Trigger automatic topup
+        if: steps.balance-check.outcome == 'failure'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run "E2E: Topup Test Accounts" \
+            --ref stage \
+            -f dry_run=false \
+            -f topup_multiplier=1.5 \
+            -f reserve_osmo=5 \
+            -f reserve_usdc=500
       - name: Fail if balance critically low
         if: always() && steps.balance-check.outcome == 'failure'
         run: |

--- a/.github/workflows/monitoring-limit-geo-e2e-tests.yml
+++ b/.github/workflows/monitoring-limit-geo-e2e-tests.yml
@@ -92,7 +92,7 @@ jobs:
           if [ -f packages/e2e/balance-report.json ]; then
             OUTCOME=$(jq -r '.outcome // ""' packages/e2e/balance-report.json)
             if [ "$OUTCOME" = "warn" ] || [ "$OUTCOME" = "fail" ]; then
-              PENDING=$(gh run list --workflow "E2E: Topup Test Accounts" --status queued --status in_progress --json databaseId --jq 'length')
+              PENDING=$(gh run list --workflow "E2E: Topup Test Accounts" --limit 50 --json status --jq '[.[] | select(.status == "queued" or .status == "in_progress")] | length')
               if [ "$PENDING" -gt 0 ]; then
                 echo "Topup workflow already queued/in-progress — skipping dispatch."
               else
@@ -219,7 +219,7 @@ jobs:
           if [ -f packages/e2e/balance-report.json ]; then
             OUTCOME=$(jq -r '.outcome // ""' packages/e2e/balance-report.json)
             if [ "$OUTCOME" = "warn" ] || [ "$OUTCOME" = "fail" ]; then
-              PENDING=$(gh run list --workflow "E2E: Topup Test Accounts" --status queued --status in_progress --json databaseId --jq 'length')
+              PENDING=$(gh run list --workflow "E2E: Topup Test Accounts" --limit 50 --json status --jq '[.[] | select(.status == "queued" or .status == "in_progress")] | length')
               if [ "$PENDING" -gt 0 ]; then
                 echo "Topup workflow already queued/in-progress — skipping dispatch."
               else
@@ -352,7 +352,7 @@ jobs:
           if [ -f packages/e2e/balance-report.json ]; then
             OUTCOME=$(jq -r '.outcome // ""' packages/e2e/balance-report.json)
             if [ "$OUTCOME" = "warn" ] || [ "$OUTCOME" = "fail" ]; then
-              PENDING=$(gh run list --workflow "E2E: Topup Test Accounts" --status queued --status in_progress --json databaseId --jq 'length')
+              PENDING=$(gh run list --workflow "E2E: Topup Test Accounts" --limit 50 --json status --jq '[.[] | select(.status == "queued" or .status == "in_progress")] | length')
               if [ "$PENDING" -gt 0 ]; then
                 echo "Topup workflow already queued/in-progress — skipping dispatch."
               else
@@ -486,7 +486,7 @@ jobs:
           if [ -f packages/e2e/balance-report.json ]; then
             OUTCOME=$(jq -r '.outcome // ""' packages/e2e/balance-report.json)
             if [ "$OUTCOME" = "warn" ] || [ "$OUTCOME" = "fail" ]; then
-              PENDING=$(gh run list --workflow "E2E: Topup Test Accounts" --status queued --status in_progress --json databaseId --jq 'length')
+              PENDING=$(gh run list --workflow "E2E: Topup Test Accounts" --limit 50 --json status --jq '[.[] | select(.status == "queued" or .status == "in_progress")] | length')
               if [ "$PENDING" -gt 0 ]; then
                 echo "Topup workflow already queued/in-progress — skipping dispatch."
               else
@@ -625,7 +625,7 @@ jobs:
           if [ -f packages/e2e/balance-report.json ]; then
             OUTCOME=$(jq -r '.outcome // ""' packages/e2e/balance-report.json)
             if [ "$OUTCOME" = "warn" ] || [ "$OUTCOME" = "fail" ]; then
-              PENDING=$(gh run list --workflow "E2E: Topup Test Accounts" --status queued --status in_progress --json databaseId --jq 'length')
+              PENDING=$(gh run list --workflow "E2E: Topup Test Accounts" --limit 50 --json status --jq '[.[] | select(.status == "queued" or .status == "in_progress")] | length')
               if [ "$PENDING" -gt 0 ]; then
                 echo "Topup workflow already queued/in-progress — skipping dispatch."
               else
@@ -769,7 +769,7 @@ jobs:
           if [ -f packages/e2e/balance-report.json ]; then
             OUTCOME=$(jq -r '.outcome // ""' packages/e2e/balance-report.json)
             if [ "$OUTCOME" = "warn" ] || [ "$OUTCOME" = "fail" ]; then
-              PENDING=$(gh run list --workflow "E2E: Topup Test Accounts" --status queued --status in_progress --json databaseId --jq 'length')
+              PENDING=$(gh run list --workflow "E2E: Topup Test Accounts" --limit 50 --json status --jq '[.[] | select(.status == "queued" or .status == "in_progress")] | length')
               if [ "$PENDING" -gt 0 ]; then
                 echo "Topup workflow already queued/in-progress — skipping dispatch."
               else
@@ -907,7 +907,7 @@ jobs:
           if [ -f packages/e2e/balance-report.json ]; then
             OUTCOME=$(jq -r '.outcome // ""' packages/e2e/balance-report.json)
             if [ "$OUTCOME" = "warn" ] || [ "$OUTCOME" = "fail" ]; then
-              PENDING=$(gh run list --workflow "E2E: Topup Test Accounts" --status queued --status in_progress --json databaseId --jq 'length')
+              PENDING=$(gh run list --workflow "E2E: Topup Test Accounts" --limit 50 --json status --jq '[.[] | select(.status == "queued" or .status == "in_progress")] | length')
               if [ "$PENDING" -gt 0 ]; then
                 echo "Topup workflow already queued/in-progress — skipping dispatch."
               else
@@ -1043,7 +1043,7 @@ jobs:
           if [ -f packages/e2e/balance-report.json ]; then
             OUTCOME=$(jq -r '.outcome // ""' packages/e2e/balance-report.json)
             if [ "$OUTCOME" = "warn" ] || [ "$OUTCOME" = "fail" ]; then
-              PENDING=$(gh run list --workflow "E2E: Topup Test Accounts" --status queued --status in_progress --json databaseId --jq 'length')
+              PENDING=$(gh run list --workflow "E2E: Topup Test Accounts" --limit 50 --json status --jq '[.[] | select(.status == "queued" or .status == "in_progress")] | length')
               if [ "$PENDING" -gt 0 ]; then
                 echo "Topup workflow already queued/in-progress — skipping dispatch."
               else

--- a/.github/workflows/monitoring-limit-geo-e2e-tests.yml
+++ b/.github/workflows/monitoring-limit-geo-e2e-tests.yml
@@ -5,6 +5,11 @@ on:
   schedule:
     - cron: "1 * * * *"
 
+permissions:
+  actions: write
+  contents: read
+  deployments: write
+
 jobs:
   fe-swap-us:
     timeout-minutes: 10
@@ -84,12 +89,22 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh workflow run "E2E: Topup Test Accounts" \
-            --ref stage \
-            -f dry_run=false \
-            -f topup_multiplier=1.5 \
-            -f reserve_osmo=5 \
-            -f reserve_usdc=500
+          if [ -f packages/e2e/balance-report.json ]; then
+            OUTCOME=$(jq -r '.outcome // ""' packages/e2e/balance-report.json)
+            if [ "$OUTCOME" = "warn" ] || [ "$OUTCOME" = "fail" ]; then
+              gh workflow run "E2E: Topup Test Accounts" \
+                --ref stage \
+                -f dry_run=false \
+                -f topup_multiplier=1.5 \
+                -f reserve_osmo=5 \
+                -f reserve_usdc=500
+              echo "Topup workflow dispatched (balance outcome: $OUTCOME)."
+            else
+              echo "Skipping topup — balance outcome: $OUTCOME"
+            fi
+          else
+            echo "Skipping topup — no balance report found."
+          fi
       - name: Fail if balance critically low
         if: always() && steps.balance-check.outcome == 'failure'
         run: |
@@ -196,12 +211,22 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh workflow run "E2E: Topup Test Accounts" \
-            --ref stage \
-            -f dry_run=false \
-            -f topup_multiplier=1.5 \
-            -f reserve_osmo=5 \
-            -f reserve_usdc=500
+          if [ -f packages/e2e/balance-report.json ]; then
+            OUTCOME=$(jq -r '.outcome // ""' packages/e2e/balance-report.json)
+            if [ "$OUTCOME" = "warn" ] || [ "$OUTCOME" = "fail" ]; then
+              gh workflow run "E2E: Topup Test Accounts" \
+                --ref stage \
+                -f dry_run=false \
+                -f topup_multiplier=1.5 \
+                -f reserve_osmo=5 \
+                -f reserve_usdc=500
+              echo "Topup workflow dispatched (balance outcome: $OUTCOME)."
+            else
+              echo "Skipping topup — balance outcome: $OUTCOME"
+            fi
+          else
+            echo "Skipping topup — no balance report found."
+          fi
       - name: Fail if balance critically low
         if: always() && steps.balance-check.outcome == 'failure'
         run: |
@@ -314,12 +339,22 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh workflow run "E2E: Topup Test Accounts" \
-            --ref stage \
-            -f dry_run=false \
-            -f topup_multiplier=1.5 \
-            -f reserve_osmo=5 \
-            -f reserve_usdc=500
+          if [ -f packages/e2e/balance-report.json ]; then
+            OUTCOME=$(jq -r '.outcome // ""' packages/e2e/balance-report.json)
+            if [ "$OUTCOME" = "warn" ] || [ "$OUTCOME" = "fail" ]; then
+              gh workflow run "E2E: Topup Test Accounts" \
+                --ref stage \
+                -f dry_run=false \
+                -f topup_multiplier=1.5 \
+                -f reserve_osmo=5 \
+                -f reserve_usdc=500
+              echo "Topup workflow dispatched (balance outcome: $OUTCOME)."
+            else
+              echo "Skipping topup — balance outcome: $OUTCOME"
+            fi
+          else
+            echo "Skipping topup — no balance report found."
+          fi
       - name: Fail if balance critically low
         if: always() && steps.balance-check.outcome == 'failure'
         run: |
@@ -433,12 +468,22 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh workflow run "E2E: Topup Test Accounts" \
-            --ref stage \
-            -f dry_run=false \
-            -f topup_multiplier=1.5 \
-            -f reserve_osmo=5 \
-            -f reserve_usdc=500
+          if [ -f packages/e2e/balance-report.json ]; then
+            OUTCOME=$(jq -r '.outcome // ""' packages/e2e/balance-report.json)
+            if [ "$OUTCOME" = "warn" ] || [ "$OUTCOME" = "fail" ]; then
+              gh workflow run "E2E: Topup Test Accounts" \
+                --ref stage \
+                -f dry_run=false \
+                -f topup_multiplier=1.5 \
+                -f reserve_osmo=5 \
+                -f reserve_usdc=500
+              echo "Topup workflow dispatched (balance outcome: $OUTCOME)."
+            else
+              echo "Skipping topup — balance outcome: $OUTCOME"
+            fi
+          else
+            echo "Skipping topup — no balance report found."
+          fi
       - name: Fail if balance critically low
         if: always() && steps.balance-check.outcome == 'failure'
         run: |
@@ -557,12 +602,22 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh workflow run "E2E: Topup Test Accounts" \
-            --ref stage \
-            -f dry_run=false \
-            -f topup_multiplier=1.5 \
-            -f reserve_osmo=5 \
-            -f reserve_usdc=500
+          if [ -f packages/e2e/balance-report.json ]; then
+            OUTCOME=$(jq -r '.outcome // ""' packages/e2e/balance-report.json)
+            if [ "$OUTCOME" = "warn" ] || [ "$OUTCOME" = "fail" ]; then
+              gh workflow run "E2E: Topup Test Accounts" \
+                --ref stage \
+                -f dry_run=false \
+                -f topup_multiplier=1.5 \
+                -f reserve_osmo=5 \
+                -f reserve_usdc=500
+              echo "Topup workflow dispatched (balance outcome: $OUTCOME)."
+            else
+              echo "Skipping topup — balance outcome: $OUTCOME"
+            fi
+          else
+            echo "Skipping topup — no balance report found."
+          fi
       - name: Fail if balance critically low
         if: always() && steps.balance-check.outcome == 'failure'
         run: |
@@ -686,12 +741,22 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh workflow run "E2E: Topup Test Accounts" \
-            --ref stage \
-            -f dry_run=false \
-            -f topup_multiplier=1.5 \
-            -f reserve_osmo=5 \
-            -f reserve_usdc=500
+          if [ -f packages/e2e/balance-report.json ]; then
+            OUTCOME=$(jq -r '.outcome // ""' packages/e2e/balance-report.json)
+            if [ "$OUTCOME" = "warn" ] || [ "$OUTCOME" = "fail" ]; then
+              gh workflow run "E2E: Topup Test Accounts" \
+                --ref stage \
+                -f dry_run=false \
+                -f topup_multiplier=1.5 \
+                -f reserve_osmo=5 \
+                -f reserve_usdc=500
+              echo "Topup workflow dispatched (balance outcome: $OUTCOME)."
+            else
+              echo "Skipping topup — balance outcome: $OUTCOME"
+            fi
+          else
+            echo "Skipping topup — no balance report found."
+          fi
       - name: Fail if balance critically low
         if: always() && steps.balance-check.outcome == 'failure'
         run: |
@@ -809,12 +874,22 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh workflow run "E2E: Topup Test Accounts" \
-            --ref stage \
-            -f dry_run=false \
-            -f topup_multiplier=1.5 \
-            -f reserve_osmo=5 \
-            -f reserve_usdc=500
+          if [ -f packages/e2e/balance-report.json ]; then
+            OUTCOME=$(jq -r '.outcome // ""' packages/e2e/balance-report.json)
+            if [ "$OUTCOME" = "warn" ] || [ "$OUTCOME" = "fail" ]; then
+              gh workflow run "E2E: Topup Test Accounts" \
+                --ref stage \
+                -f dry_run=false \
+                -f topup_multiplier=1.5 \
+                -f reserve_osmo=5 \
+                -f reserve_usdc=500
+              echo "Topup workflow dispatched (balance outcome: $OUTCOME)."
+            else
+              echo "Skipping topup — balance outcome: $OUTCOME"
+            fi
+          else
+            echo "Skipping topup — no balance report found."
+          fi
       - name: Fail if balance critically low
         if: always() && steps.balance-check.outcome == 'failure'
         run: |
@@ -930,12 +1005,22 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh workflow run "E2E: Topup Test Accounts" \
-            --ref stage \
-            -f dry_run=false \
-            -f topup_multiplier=1.5 \
-            -f reserve_osmo=5 \
-            -f reserve_usdc=500
+          if [ -f packages/e2e/balance-report.json ]; then
+            OUTCOME=$(jq -r '.outcome // ""' packages/e2e/balance-report.json)
+            if [ "$OUTCOME" = "warn" ] || [ "$OUTCOME" = "fail" ]; then
+              gh workflow run "E2E: Topup Test Accounts" \
+                --ref stage \
+                -f dry_run=false \
+                -f topup_multiplier=1.5 \
+                -f reserve_osmo=5 \
+                -f reserve_usdc=500
+              echo "Topup workflow dispatched (balance outcome: $OUTCOME)."
+            else
+              echo "Skipping topup — balance outcome: $OUTCOME"
+            fi
+          else
+            echo "Skipping topup — no balance report found."
+          fi
       - name: Fail if balance critically low
         if: always() && steps.balance-check.outcome == 'failure'
         run: |

--- a/.github/workflows/monitoring-limit-geo-e2e-tests.yml
+++ b/.github/workflows/monitoring-limit-geo-e2e-tests.yml
@@ -78,6 +78,18 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.E2E_SLACK_WEBHOOK_BALANCE_ALERTS }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      - name: Trigger automatic topup
+        if: steps.balance-check.outcome == 'failure'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run "E2E: Topup Test Accounts" \
+            --ref stage \
+            -f dry_run=false \
+            -f topup_multiplier=1.5 \
+            -f reserve_osmo=5 \
+            -f reserve_usdc=500
       - name: Fail if balance critically low
         if: always() && steps.balance-check.outcome == 'failure'
         run: |
@@ -178,6 +190,18 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.E2E_SLACK_WEBHOOK_BALANCE_ALERTS }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      - name: Trigger automatic topup
+        if: steps.balance-check.outcome == 'failure'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run "E2E: Topup Test Accounts" \
+            --ref stage \
+            -f dry_run=false \
+            -f topup_multiplier=1.5 \
+            -f reserve_osmo=5 \
+            -f reserve_usdc=500
       - name: Fail if balance critically low
         if: always() && steps.balance-check.outcome == 'failure'
         run: |
@@ -284,6 +308,18 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.E2E_SLACK_WEBHOOK_BALANCE_ALERTS }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      - name: Trigger automatic topup
+        if: steps.balance-check.outcome == 'failure'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run "E2E: Topup Test Accounts" \
+            --ref stage \
+            -f dry_run=false \
+            -f topup_multiplier=1.5 \
+            -f reserve_osmo=5 \
+            -f reserve_usdc=500
       - name: Fail if balance critically low
         if: always() && steps.balance-check.outcome == 'failure'
         run: |
@@ -391,6 +427,18 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.E2E_SLACK_WEBHOOK_BALANCE_ALERTS }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      - name: Trigger automatic topup
+        if: steps.balance-check.outcome == 'failure'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run "E2E: Topup Test Accounts" \
+            --ref stage \
+            -f dry_run=false \
+            -f topup_multiplier=1.5 \
+            -f reserve_osmo=5 \
+            -f reserve_usdc=500
       - name: Fail if balance critically low
         if: always() && steps.balance-check.outcome == 'failure'
         run: |
@@ -503,6 +551,18 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.E2E_SLACK_WEBHOOK_BALANCE_ALERTS }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      - name: Trigger automatic topup
+        if: steps.balance-check.outcome == 'failure'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run "E2E: Topup Test Accounts" \
+            --ref stage \
+            -f dry_run=false \
+            -f topup_multiplier=1.5 \
+            -f reserve_osmo=5 \
+            -f reserve_usdc=500
       - name: Fail if balance critically low
         if: always() && steps.balance-check.outcome == 'failure'
         run: |
@@ -620,6 +680,18 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.E2E_SLACK_WEBHOOK_BALANCE_ALERTS }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      - name: Trigger automatic topup
+        if: steps.balance-check.outcome == 'failure'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run "E2E: Topup Test Accounts" \
+            --ref stage \
+            -f dry_run=false \
+            -f topup_multiplier=1.5 \
+            -f reserve_osmo=5 \
+            -f reserve_usdc=500
       - name: Fail if balance critically low
         if: always() && steps.balance-check.outcome == 'failure'
         run: |
@@ -731,6 +803,18 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.E2E_SLACK_WEBHOOK_BALANCE_ALERTS }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      - name: Trigger automatic topup
+        if: steps.balance-check.outcome == 'failure'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run "E2E: Topup Test Accounts" \
+            --ref stage \
+            -f dry_run=false \
+            -f topup_multiplier=1.5 \
+            -f reserve_osmo=5 \
+            -f reserve_usdc=500
       - name: Fail if balance critically low
         if: always() && steps.balance-check.outcome == 'failure'
         run: |
@@ -840,6 +924,18 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.E2E_SLACK_WEBHOOK_BALANCE_ALERTS }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      - name: Trigger automatic topup
+        if: steps.balance-check.outcome == 'failure'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run "E2E: Topup Test Accounts" \
+            --ref stage \
+            -f dry_run=false \
+            -f topup_multiplier=1.5 \
+            -f reserve_osmo=5 \
+            -f reserve_usdc=500
       - name: Fail if balance critically low
         if: always() && steps.balance-check.outcome == 'failure'
         run: |

--- a/.github/workflows/monitoring-limit-geo-e2e-tests.yml
+++ b/.github/workflows/monitoring-limit-geo-e2e-tests.yml
@@ -92,13 +92,18 @@ jobs:
           if [ -f packages/e2e/balance-report.json ]; then
             OUTCOME=$(jq -r '.outcome // ""' packages/e2e/balance-report.json)
             if [ "$OUTCOME" = "warn" ] || [ "$OUTCOME" = "fail" ]; then
-              gh workflow run "E2E: Topup Test Accounts" \
-                --ref stage \
-                -f dry_run=false \
-                -f topup_multiplier=1.5 \
-                -f reserve_osmo=5 \
-                -f reserve_usdc=500
-              echo "Topup workflow dispatched (balance outcome: $OUTCOME)."
+              PENDING=$(gh run list --workflow "E2E: Topup Test Accounts" --status queued --status in_progress --json databaseId --jq 'length')
+              if [ "$PENDING" -gt 0 ]; then
+                echo "Topup workflow already queued/in-progress — skipping dispatch."
+              else
+                gh workflow run "E2E: Topup Test Accounts" \
+                  --ref stage \
+                  -f dry_run=false \
+                  -f topup_multiplier=1.5 \
+                  -f reserve_osmo=5 \
+                  -f reserve_usdc=500
+                echo "Topup workflow dispatched (balance outcome: $OUTCOME)."
+              fi
             else
               echo "Skipping topup — balance outcome: $OUTCOME"
             fi
@@ -214,13 +219,18 @@ jobs:
           if [ -f packages/e2e/balance-report.json ]; then
             OUTCOME=$(jq -r '.outcome // ""' packages/e2e/balance-report.json)
             if [ "$OUTCOME" = "warn" ] || [ "$OUTCOME" = "fail" ]; then
-              gh workflow run "E2E: Topup Test Accounts" \
-                --ref stage \
-                -f dry_run=false \
-                -f topup_multiplier=1.5 \
-                -f reserve_osmo=5 \
-                -f reserve_usdc=500
-              echo "Topup workflow dispatched (balance outcome: $OUTCOME)."
+              PENDING=$(gh run list --workflow "E2E: Topup Test Accounts" --status queued --status in_progress --json databaseId --jq 'length')
+              if [ "$PENDING" -gt 0 ]; then
+                echo "Topup workflow already queued/in-progress — skipping dispatch."
+              else
+                gh workflow run "E2E: Topup Test Accounts" \
+                  --ref stage \
+                  -f dry_run=false \
+                  -f topup_multiplier=1.5 \
+                  -f reserve_osmo=5 \
+                  -f reserve_usdc=500
+                echo "Topup workflow dispatched (balance outcome: $OUTCOME)."
+              fi
             else
               echo "Skipping topup — balance outcome: $OUTCOME"
             fi
@@ -342,13 +352,18 @@ jobs:
           if [ -f packages/e2e/balance-report.json ]; then
             OUTCOME=$(jq -r '.outcome // ""' packages/e2e/balance-report.json)
             if [ "$OUTCOME" = "warn" ] || [ "$OUTCOME" = "fail" ]; then
-              gh workflow run "E2E: Topup Test Accounts" \
-                --ref stage \
-                -f dry_run=false \
-                -f topup_multiplier=1.5 \
-                -f reserve_osmo=5 \
-                -f reserve_usdc=500
-              echo "Topup workflow dispatched (balance outcome: $OUTCOME)."
+              PENDING=$(gh run list --workflow "E2E: Topup Test Accounts" --status queued --status in_progress --json databaseId --jq 'length')
+              if [ "$PENDING" -gt 0 ]; then
+                echo "Topup workflow already queued/in-progress — skipping dispatch."
+              else
+                gh workflow run "E2E: Topup Test Accounts" \
+                  --ref stage \
+                  -f dry_run=false \
+                  -f topup_multiplier=1.5 \
+                  -f reserve_osmo=5 \
+                  -f reserve_usdc=500
+                echo "Topup workflow dispatched (balance outcome: $OUTCOME)."
+              fi
             else
               echo "Skipping topup — balance outcome: $OUTCOME"
             fi
@@ -471,13 +486,18 @@ jobs:
           if [ -f packages/e2e/balance-report.json ]; then
             OUTCOME=$(jq -r '.outcome // ""' packages/e2e/balance-report.json)
             if [ "$OUTCOME" = "warn" ] || [ "$OUTCOME" = "fail" ]; then
-              gh workflow run "E2E: Topup Test Accounts" \
-                --ref stage \
-                -f dry_run=false \
-                -f topup_multiplier=1.5 \
-                -f reserve_osmo=5 \
-                -f reserve_usdc=500
-              echo "Topup workflow dispatched (balance outcome: $OUTCOME)."
+              PENDING=$(gh run list --workflow "E2E: Topup Test Accounts" --status queued --status in_progress --json databaseId --jq 'length')
+              if [ "$PENDING" -gt 0 ]; then
+                echo "Topup workflow already queued/in-progress — skipping dispatch."
+              else
+                gh workflow run "E2E: Topup Test Accounts" \
+                  --ref stage \
+                  -f dry_run=false \
+                  -f topup_multiplier=1.5 \
+                  -f reserve_osmo=5 \
+                  -f reserve_usdc=500
+                echo "Topup workflow dispatched (balance outcome: $OUTCOME)."
+              fi
             else
               echo "Skipping topup — balance outcome: $OUTCOME"
             fi
@@ -605,13 +625,18 @@ jobs:
           if [ -f packages/e2e/balance-report.json ]; then
             OUTCOME=$(jq -r '.outcome // ""' packages/e2e/balance-report.json)
             if [ "$OUTCOME" = "warn" ] || [ "$OUTCOME" = "fail" ]; then
-              gh workflow run "E2E: Topup Test Accounts" \
-                --ref stage \
-                -f dry_run=false \
-                -f topup_multiplier=1.5 \
-                -f reserve_osmo=5 \
-                -f reserve_usdc=500
-              echo "Topup workflow dispatched (balance outcome: $OUTCOME)."
+              PENDING=$(gh run list --workflow "E2E: Topup Test Accounts" --status queued --status in_progress --json databaseId --jq 'length')
+              if [ "$PENDING" -gt 0 ]; then
+                echo "Topup workflow already queued/in-progress — skipping dispatch."
+              else
+                gh workflow run "E2E: Topup Test Accounts" \
+                  --ref stage \
+                  -f dry_run=false \
+                  -f topup_multiplier=1.5 \
+                  -f reserve_osmo=5 \
+                  -f reserve_usdc=500
+                echo "Topup workflow dispatched (balance outcome: $OUTCOME)."
+              fi
             else
               echo "Skipping topup — balance outcome: $OUTCOME"
             fi
@@ -744,13 +769,18 @@ jobs:
           if [ -f packages/e2e/balance-report.json ]; then
             OUTCOME=$(jq -r '.outcome // ""' packages/e2e/balance-report.json)
             if [ "$OUTCOME" = "warn" ] || [ "$OUTCOME" = "fail" ]; then
-              gh workflow run "E2E: Topup Test Accounts" \
-                --ref stage \
-                -f dry_run=false \
-                -f topup_multiplier=1.5 \
-                -f reserve_osmo=5 \
-                -f reserve_usdc=500
-              echo "Topup workflow dispatched (balance outcome: $OUTCOME)."
+              PENDING=$(gh run list --workflow "E2E: Topup Test Accounts" --status queued --status in_progress --json databaseId --jq 'length')
+              if [ "$PENDING" -gt 0 ]; then
+                echo "Topup workflow already queued/in-progress — skipping dispatch."
+              else
+                gh workflow run "E2E: Topup Test Accounts" \
+                  --ref stage \
+                  -f dry_run=false \
+                  -f topup_multiplier=1.5 \
+                  -f reserve_osmo=5 \
+                  -f reserve_usdc=500
+                echo "Topup workflow dispatched (balance outcome: $OUTCOME)."
+              fi
             else
               echo "Skipping topup — balance outcome: $OUTCOME"
             fi
@@ -877,13 +907,18 @@ jobs:
           if [ -f packages/e2e/balance-report.json ]; then
             OUTCOME=$(jq -r '.outcome // ""' packages/e2e/balance-report.json)
             if [ "$OUTCOME" = "warn" ] || [ "$OUTCOME" = "fail" ]; then
-              gh workflow run "E2E: Topup Test Accounts" \
-                --ref stage \
-                -f dry_run=false \
-                -f topup_multiplier=1.5 \
-                -f reserve_osmo=5 \
-                -f reserve_usdc=500
-              echo "Topup workflow dispatched (balance outcome: $OUTCOME)."
+              PENDING=$(gh run list --workflow "E2E: Topup Test Accounts" --status queued --status in_progress --json databaseId --jq 'length')
+              if [ "$PENDING" -gt 0 ]; then
+                echo "Topup workflow already queued/in-progress — skipping dispatch."
+              else
+                gh workflow run "E2E: Topup Test Accounts" \
+                  --ref stage \
+                  -f dry_run=false \
+                  -f topup_multiplier=1.5 \
+                  -f reserve_osmo=5 \
+                  -f reserve_usdc=500
+                echo "Topup workflow dispatched (balance outcome: $OUTCOME)."
+              fi
             else
               echo "Skipping topup — balance outcome: $OUTCOME"
             fi
@@ -1008,13 +1043,18 @@ jobs:
           if [ -f packages/e2e/balance-report.json ]; then
             OUTCOME=$(jq -r '.outcome // ""' packages/e2e/balance-report.json)
             if [ "$OUTCOME" = "warn" ] || [ "$OUTCOME" = "fail" ]; then
-              gh workflow run "E2E: Topup Test Accounts" \
-                --ref stage \
-                -f dry_run=false \
-                -f topup_multiplier=1.5 \
-                -f reserve_osmo=5 \
-                -f reserve_usdc=500
-              echo "Topup workflow dispatched (balance outcome: $OUTCOME)."
+              PENDING=$(gh run list --workflow "E2E: Topup Test Accounts" --status queued --status in_progress --json databaseId --jq 'length')
+              if [ "$PENDING" -gt 0 ]; then
+                echo "Topup workflow already queued/in-progress — skipping dispatch."
+              else
+                gh workflow run "E2E: Topup Test Accounts" \
+                  --ref stage \
+                  -f dry_run=false \
+                  -f topup_multiplier=1.5 \
+                  -f reserve_osmo=5 \
+                  -f reserve_usdc=500
+                echo "Topup workflow dispatched (balance outcome: $OUTCOME)."
+              fi
             else
               echo "Skipping topup — balance outcome: $OUTCOME"
             fi

--- a/.github/workflows/prod-frontend-e2e-tests.yml
+++ b/.github/workflows/prod-frontend-e2e-tests.yml
@@ -103,7 +103,7 @@ jobs:
           if [ -f packages/e2e/balance-report.json ]; then
             OUTCOME=$(jq -r '.outcome // ""' packages/e2e/balance-report.json)
             if [ "$OUTCOME" = "warn" ] || [ "$OUTCOME" = "fail" ]; then
-              PENDING=$(gh run list --workflow "E2E: Topup Test Accounts" --status queued --status in_progress --json databaseId --jq 'length')
+              PENDING=$(gh run list --workflow "E2E: Topup Test Accounts" --limit 50 --json status --jq '[.[] | select(.status == "queued" or .status == "in_progress")] | length')
               if [ "$PENDING" -gt 0 ]; then
                 echo "Topup workflow already queued/in-progress — skipping dispatch."
               else

--- a/.github/workflows/prod-frontend-e2e-tests.yml
+++ b/.github/workflows/prod-frontend-e2e-tests.yml
@@ -103,13 +103,18 @@ jobs:
           if [ -f packages/e2e/balance-report.json ]; then
             OUTCOME=$(jq -r '.outcome // ""' packages/e2e/balance-report.json)
             if [ "$OUTCOME" = "warn" ] || [ "$OUTCOME" = "fail" ]; then
-              gh workflow run "E2E: Topup Test Accounts" \
-                --ref stage \
-                -f dry_run=false \
-                -f topup_multiplier=1.5 \
-                -f reserve_osmo=5 \
-                -f reserve_usdc=500
-              echo "Topup workflow dispatched (balance outcome: $OUTCOME)."
+              PENDING=$(gh run list --workflow "E2E: Topup Test Accounts" --status queued --status in_progress --json databaseId --jq 'length')
+              if [ "$PENDING" -gt 0 ]; then
+                echo "Topup workflow already queued/in-progress — skipping dispatch."
+              else
+                gh workflow run "E2E: Topup Test Accounts" \
+                  --ref stage \
+                  -f dry_run=false \
+                  -f topup_multiplier=1.5 \
+                  -f reserve_osmo=5 \
+                  -f reserve_usdc=500
+                echo "Topup workflow dispatched (balance outcome: $OUTCOME)."
+              fi
             else
               echo "Skipping topup — balance outcome: $OUTCOME"
             fi

--- a/.github/workflows/prod-frontend-e2e-tests.yml
+++ b/.github/workflows/prod-frontend-e2e-tests.yml
@@ -91,6 +91,18 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.E2E_SLACK_WEBHOOK_BALANCE_ALERTS }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      - name: Trigger automatic topup
+        if: steps.balance-check.outcome == 'failure'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run "E2E: Topup Test Accounts" \
+            --ref stage \
+            -f dry_run=false \
+            -f topup_multiplier=1.5 \
+            -f reserve_osmo=5 \
+            -f reserve_usdc=500
       - name: Fail if balance critically low
         if: always() && steps.balance-check.outcome == 'failure'
         run: |

--- a/.github/workflows/prod-frontend-e2e-tests.yml
+++ b/.github/workflows/prod-frontend-e2e-tests.yml
@@ -30,6 +30,9 @@ jobs:
 
   check-balances:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -97,12 +100,22 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh workflow run "E2E: Topup Test Accounts" \
-            --ref stage \
-            -f dry_run=false \
-            -f topup_multiplier=1.5 \
-            -f reserve_osmo=5 \
-            -f reserve_usdc=500
+          if [ -f packages/e2e/balance-report.json ]; then
+            OUTCOME=$(jq -r '.outcome // ""' packages/e2e/balance-report.json)
+            if [ "$OUTCOME" = "warn" ] || [ "$OUTCOME" = "fail" ]; then
+              gh workflow run "E2E: Topup Test Accounts" \
+                --ref stage \
+                -f dry_run=false \
+                -f topup_multiplier=1.5 \
+                -f reserve_osmo=5 \
+                -f reserve_usdc=500
+              echo "Topup workflow dispatched (balance outcome: $OUTCOME)."
+            else
+              echo "Skipping topup — balance outcome: $OUTCOME"
+            fi
+          else
+            echo "Skipping topup — no balance report found."
+          fi
       - name: Fail if balance critically low
         if: always() && steps.balance-check.outcome == 'failure'
         run: |

--- a/packages/e2e/scripts/topup-accounts.ts
+++ b/packages/e2e/scripts/topup-accounts.ts
@@ -159,6 +159,15 @@ async function sendSlackSummary(
 
   lines.push("```");
 
+  const serverUrl = process.env.GITHUB_SERVER_URL;
+  const repo = process.env.GITHUB_REPOSITORY;
+  const runId = process.env.GITHUB_RUN_ID;
+  if (serverUrl && repo && runId) {
+    lines.push(
+      `*Details:* <${serverUrl}/${repo}/actions/runs/${runId}|View run logs>`
+    );
+  }
+
   const payload = {
     text: headerText,
     blocks: [


### PR DESCRIPTION
## Summary

Auto-trigger the topup workflow when any balance-check job detects low/critical funds, so E2E accounts are replenished without manual intervention.

## Linear
[MER-170](https://linear.app/osmosis/issue/MER-170/feate2e-auto-trigger-topup-when-balance-check-detects-lowcritical)

## Changes

- Balance-check jobs now dispatch `E2E: Topup Test Accounts` (with `dry_run=false`, `--ref stage`) when outcome is `warn` or `fail`
- Dedup check skips dispatch if a topup is already queued/in-progress
- Concurrency group on topup workflow prevents parallel runs
- Topup Slack summary includes a link to the GitHub Actions run
- Fixed `dry_run` input handling for string coercion edge case

## Files

- **frontend-e2e-tests.yml** / **prod-frontend-e2e-tests.yml** -- trigger step + `actions: write`
- **monitoring-limit-geo-e2e-tests.yml** -- trigger step across all 8 balance-check sections
- **e2e-topup-accounts.yml** -- concurrency group + `dry_run` fix
- **topup-accounts.ts** -- workflow run link in Slack summary

## Test plan

- [ ] Balance-check Slack alerts still fire as before
- [ ] Topup dispatches on warn/fail, skips if one is already pending
- [ ] Concurrency group prevents parallel topup runs

Made with [Cursor](https://cursor.com)