### PR TITLE
fix: disable axios XSRF cookie read in broadcast to prevent crash in mobile wallet browsers

### DIFF
--- a/packages/stores/src/account/base.ts
+++ b/packages/stores/src/account/base.ts
@@ -647,11 +647,20 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
           timestamp: string;
           events: unknown[];
         };
-      }>(this.options?.broadcastUrl ?? "/api/broadcast-transaction", {
-        restEndpoint: removeLastSlash(restEndpoint),
-        tx_bytes: Buffer.from(encodedTx).toString("base64"),
-        mode: "BROADCAST_MODE_SYNC",
-      });
+      }>(
+        this.options?.broadcastUrl ?? "/api/broadcast-transaction",
+        {
+          restEndpoint: removeLastSlash(restEndpoint),
+          tx_bytes: Buffer.from(encodedTx).toString("base64"),
+          mode: "BROADCAST_MODE_SYNC",
+        },
+        {
+          // Disable XSRF cookie reading — the broadcast endpoint doesn't use
+          // XSRF tokens, and some mobile wallet WebViews restrict
+          // document.cookie access, causing axios to crash.
+          xsrfCookieName: "",
+        }
+      );
 
       const broadcasted = res.data.tx_response;
 


### PR DESCRIPTION
## Summary

- Disables the unnecessary XSRF cookie read on the `axios.post` call in `signAndBroadcast()` by setting `xsrfCookieName: ""`
- Fixes a crash in mobile wallet in-app browsers (iOS WKWebView) where `document.cookie` is undefined, causing `document.cookie.match()` to throw
- The `/api/broadcast-transaction` endpoint does not use XSRF tokens, so this cookie read was always a no-op

## Linear

[MER-166: Fix: Transaction fails with document.cookie.match is not a function in mobile wallet browsers](https://linear.app/osmosis/issue/MER-166/fix-transaction-fails-with-documentcookiematch-is-not-a-function-in)

## Test plan

- [x] Verify transactions (add/remove liquidity, swap) still work on desktop browsers
- [x] Verify transactions work on mobile wallet in-app browsers (Keplr mobile, Leap, etc.)
- [x] Test on Vercel preview deployment

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts axios request options for the tx broadcast call to avoid WebView cookie access crashes, without changing signing or broadcast payload semantics.
> 
> **Overview**
> Prevents mobile in-app browser (WKWebView) crashes during `signAndBroadcast()` by disabling axios’s XSRF cookie lookup on the `/api/broadcast-transaction` POST.
> 
> The broadcast request now passes `{ xsrfCookieName: "" }`, ensuring axios won’t try to read `document.cookie` in environments where cookie access is restricted.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2057789f66bb082e5f2fd3b4ba5fac5fc301e34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->