### PR TITLE
fix(e2e): optimize stablecoin swap amounts to reduce USDC.eth.axl drain

### DIFF
--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -177,7 +177,7 @@ All three monitoring accounts (SG, EU, US) share the same thresholds:
 | USDC | 7 | 8.4 | token | market buy + limit buy + swap stables |
 | OSMO | $2 | $5 | USD | market sell + limit sell OSMO |
 | BTC | $1.60 | $5 | USD | market sell BTC |
-| USDC.eth.axl | 1 | 1.2 | token | swap stables |
+| USDC.eth.axl | 1 | 2 | token | swap stables |
 | USDT | 1 | 1.2 | token | swap stables |
 
 ---

--- a/packages/e2e/tests/monitoring.swap.wallet.spec.ts
+++ b/packages/e2e/tests/monitoring.swap.wallet.spec.ts
@@ -9,16 +9,15 @@ test.describe("Test Swap Stables feature", () => {
   let context: BrowserContext;
   const privateKey = process.env.PRIVATE_KEY ?? "private_key";
   let tradePage: TradePage;
-  const swapAmount = "0.55";
 
   test.beforeAll(async () => {
     context = await new SetupKeplr().setupWallet(privateKey);
 
     const { address } = await deriveAddress(privateKey);
     await ensureBalances(address, [
-      { token: "USDC", amount: 1.2 }, // Total for USDC swaps
-      { token: "USDC.eth.axl", amount: 0.6 }, // For USDC.eth.axl swap
-      { token: "USDT", amount: 0.6 }, // For USDT swap
+      { token: "USDC", amount: 1.15 }, // Total for USDC forward legs (0.55 x2)
+      { token: "USDC.eth.axl", amount: 0.59 }, // For USDC.eth.axl return leg
+      { token: "USDT", amount: 0.59 }, // For USDT return leg
     ]);
 
     tradePage = new TradePage(context.pages()[0]);
@@ -42,15 +41,15 @@ test.describe("Test Swap Stables feature", () => {
 
   // biome-ignore lint/complexity/noForEach: <explanation>
   [
-    { from: "USDC", to: "USDC.eth.axl" },
-    { from: "USDC.eth.axl", to: "USDC" },
-    { from: "USDC", to: "USDT" },
-    { from: "USDT", to: "USDC" },
-  ].forEach(({ from, to }) => {
+    { from: "USDC", to: "USDC.eth.axl", amount: "0.55" },
+    { from: "USDC.eth.axl", to: "USDC", amount: "0.54" },
+    { from: "USDC", to: "USDT", amount: "0.55" },
+    { from: "USDT", to: "USDC", amount: "0.54" },
+  ].forEach(({ from, to, amount }) => {
     test(`User should be able to swap ${from} to ${to}`, async () => {
       await tradePage.goto();
       await tradePage.selectPair(from, to);
-      await tradePage.enterAmount(swapAmount);
+      await tradePage.enterAmount(amount);
       await tradePage.showSwapInfo();
       // Slippage tolerance set to 1% for stablecoin swaps.
       // Stablecoin pairs typically have tighter spreads and more predictable pricing,

--- a/packages/e2e/utils/balance-config.ts
+++ b/packages/e2e/utils/balance-config.ts
@@ -87,7 +87,7 @@ export const ACCOUNT_REQUIREMENTS: Record<
     {
       token: "USDC.eth.axl",
       minAmount: 1,
-      warnAmount: 1.2,
+      warnAmount: 2,
       note: "swap stables",
     },
     { token: "USDT", minAmount: 1, warnAmount: 1.2, note: "swap stables" },
@@ -118,7 +118,7 @@ export const ACCOUNT_REQUIREMENTS: Record<
     {
       token: "USDC.eth.axl",
       minAmount: 1,
-      warnAmount: 1.2,
+      warnAmount: 2,
       note: "swap stables",
     },
     { token: "USDT", minAmount: 1, warnAmount: 1.2, note: "swap stables" },
@@ -149,7 +149,7 @@ export const ACCOUNT_REQUIREMENTS: Record<
     {
       token: "USDC.eth.axl",
       minAmount: 1,
-      warnAmount: 1.2,
+      warnAmount: 2,
       note: "swap stables",
     },
     { token: "USDT", minAmount: 1, warnAmount: 1.2, note: "swap stables" },


### PR DESCRIPTION
**TL;DR:** Monitoring accounts drain USDC.eth.axl because the swap test spends 0.55 on both legs of a round-trip, but receives less due to fees. Fix: reduce return-leg to 0.54 so each run is net-positive, and bump topup target from 1.8 to 3.

## Linear
[MER-171: fix(e2e): optimize stablecoin swap amounts to reduce USDC.eth.axl drain](https://linear.app/osmosis/issue/MER-171/fixe2e-optimize-stablecoin-swap-amounts-to-reduce-usdcethaxl-drain)

## Summary

- **Asymmetric swap amounts**: Forward legs (USDC->X) stay at 0.55, return legs (X->USDC) reduced to 0.54. On-chain analysis shows the SQS router sometimes picks multi-hop routes through OSMO that lose ~0.4% per swap vs ~0.01% on direct routes. The 0.01 difference ensures each round-trip leaves a small surplus instead of draining scarce tokens.
- **Bump USDC.eth.axl warnAmount**: 1.2 -> 2 across all monitoring accounts (SG/EU/US), so topups fill to 3 instead of 1.8 for more runway.

## On-chain data

Analyzed recent swaps from the US monitoring account (osmo10tv5djyyj0492ulgq2kv66n90mhfyakwupy9tv):

| Route | Loss per swap |
|-------|---------------|
| Direct pool 1223 (USDC/USDC.eth.axl) | ~0.01% |
| Multi-hop via OSMO (pools 1464->1133) | ~0.4% |

With 0.55/0.54 asymmetry, even the worst-case OSMO route leaves a +0.006 surplus per run.

## Test plan

- [ ] Verify monitoring swap tests still pass with the new amounts
- [ ] Confirm topup script respects the updated warnAmount (dry run)