### PR TITLE
fix(e2e): improve Keplr wallet setup reliability with SPA navigation guards

### DIFF
--- a/packages/e2e/pages/keplr-page.ts
+++ b/packages/e2e/pages/keplr-page.ts
@@ -127,12 +127,12 @@ export class WalletPage {
         await allChains.waitFor({ state: 'visible', timeout: 20_000 })
         await allChains.click({ timeout: 5_000 })
         break
-      } catch {
-        const screenshotPath = `keplr-chains-debug-attempt-${attempt}.png`
+      } catch (err) {
+        const screenshotPath = `test-results/keplr-chains-debug-attempt-${attempt}-${Date.now()}.png`
         await this.page.screenshot({ path: screenshotPath, fullPage: true })
         console.error(
           `'All Native Chains' not visible or not clickable (attempt ${attempt + 1}/3). ` +
-          `Screenshot: ${screenshotPath} | URL: ${this.page.url()}`
+          `Screenshot: ${screenshotPath} | URL: ${this.page.url()} | Error: ${err}`
         )
         if (attempt < 2) {
           // Don't reload -- Keplr is a hash-routed SPA so reload resets to the
@@ -140,8 +140,8 @@ export class WalletPage {
           await this.page.waitForTimeout(5_000)
         } else {
           throw new Error(
-            "'All Native Chains' never appeared/clickable after 3 attempts. " +
-            'Check debug screenshots for page state.',
+            `'All Native Chains' never appeared/clickable after 3 attempts. ` +
+            `Last error: ${err}`,
           )
         }
       }

--- a/packages/e2e/pages/keplr-page.ts
+++ b/packages/e2e/pages/keplr-page.ts
@@ -36,18 +36,10 @@ export class WalletPage {
   }
 
   async startImport() {
-    try {
-      await this.page.waitForTimeout(1000)
-      await this.importWalletBtn.click({
-        timeout: 5000,
-      })
-      await this.useRecoveryBtn.click()
-    } catch {
-      expect(
-        this.importWalletBtn,
-        'Import Keplr wallet button is not visible!',
-      ).toBeVisible({ timeout: 2000 })
-    }
+    await this.importWalletBtn.waitFor({ state: 'visible', timeout: 10_000 })
+    await this.importWalletBtn.click({ timeout: 5_000 })
+    await this.useRecoveryBtn.waitFor({ state: 'visible', timeout: 10_000 })
+    await this.useRecoveryBtn.click({ timeout: 5_000 })
   }
 
   /**
@@ -68,7 +60,9 @@ export class WalletPage {
     await this.startImport()
     await this.privateKeyBtn.click()
     await this.privateKeyInput.fill(privateKey)
-    await this.importBtn.click({ timeout: 4000 })
+    await this.importBtn.click({ timeout: 4_000 })
+    // Confirm the SPA navigated to the name/password step before proceeding
+    await this.walletNameInput.waitFor({ state: 'visible', timeout: 10_000 })
     await this.setWalletNameAndPassword('Keplr')
     await this.selectChainsAndSave()
     await this.finish()
@@ -103,6 +97,8 @@ export class WalletPage {
     }
 
     await this.importBtn.click()
+    // Confirm the SPA navigated to the name/password step before proceeding
+    await this.walletNameInput.waitFor({ state: 'visible', timeout: 10_000 })
     await this.setWalletNameAndPassword('Keplr')
     await this.selectChainsAndSave()
     await this.finish()
@@ -117,13 +113,39 @@ export class WalletPage {
     await this.walletPassInput.fill(password)
     await this.walletRePassInput.fill(password)
     await this.nextBtn.click()
+    // Keplr uses hash-based SPA routing so waitForLoadState resolves instantly.
+    // Instead, confirm the name input disappears to verify actual page transition.
+    await this.walletNameInput.waitFor({ state: 'hidden', timeout: 10_000 })
   }
 
   async selectChainsAndSave() {
     console.log('Select all Native chains and save.')
-    await this.page
-      .getByText('All Native Chains')
-      .click({ timeout: 9000, force: true })
+    const allChains = this.page.getByText('All Native Chains')
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        await allChains.waitFor({ state: 'visible', timeout: 20_000 })
+        await allChains.click({ timeout: 5_000 })
+        break
+      } catch {
+        const screenshotPath = `keplr-chains-debug-attempt-${attempt}.png`
+        await this.page.screenshot({ path: screenshotPath, fullPage: true })
+        console.error(
+          `'All Native Chains' not visible or not clickable (attempt ${attempt + 1}/3). ` +
+          `Screenshot: ${screenshotPath} | URL: ${this.page.url()}`
+        )
+        if (attempt < 2) {
+          // Don't reload -- Keplr is a hash-routed SPA so reload resets to the
+          // welcome page, destroying all import progress. Just wait and retry.
+          await this.page.waitForTimeout(5_000)
+        } else {
+          throw new Error(
+            "'All Native Chains' never appeared/clickable after 3 attempts. " +
+            'Check debug screenshots for page state.',
+          )
+        }
+      }
+    }
 
     const accountCreated = this.page.getByText('Account Created!')
 
@@ -144,7 +166,7 @@ export class WalletPage {
     await expect(
       accountCreated,
       'Account is not created!',
-    ).toBeVisible({ timeout: 9000 })
+    ).toBeVisible({ timeout: 20_000 })
   }
 
   async takeScreenshot() {

--- a/packages/e2e/setup-keplr.ts
+++ b/packages/e2e/setup-keplr.ts
@@ -20,9 +20,8 @@ export class SetupKeplr {
       const page =
         existingPages[1] ??
         (await context.waitForEvent("page", { timeout: 15_000 }));
-      await page.waitForTimeout(4000);
       await page.waitForURL("**/register.html#", {
-        timeout: 10_000,
+        timeout: 15_000,
       });
       const walletPage = new WalletPage(page);
       await walletPage.importWallet(secret);

--- a/packages/e2e/setup-keplr.ts
+++ b/packages/e2e/setup-keplr.ts
@@ -16,13 +16,13 @@ export class SetupKeplr {
     try {
       const context = await chromium.launchPersistentContext("", testConfig);
       context.setDefaultNavigationTimeout(30_000);
-      const pagePromise = context.waitForEvent("page", { timeout: 10_000 });
-      const emptyPage = await pagePromise;
-      // Playwright is too fast to decide that page is not opened.
-      await emptyPage.waitForTimeout(4000);
-      const page = context.pages()[1];
+      const existingPages = context.pages();
+      const page =
+        existingPages[1] ??
+        (await context.waitForEvent("page", { timeout: 15_000 }));
+      await page.waitForTimeout(4000);
       await page.waitForURL("**/register.html#", {
-        timeout: 5000,
+        timeout: 10_000,
       });
       const walletPage = new WalletPage(page);
       await walletPage.importWallet(secret);


### PR DESCRIPTION
## Summary

Fixes persistent CI flakiness in Keplr wallet setup during E2E tests.
- Makes setup more reliable
- Makes failures fail fast and loud
- Adds extra screenshots for failure context

## Linear Task
[MER-169: E2E: improve Keplr wallet setup reliability with SPA navigation guards](https://linear.app/osmosis/issue/MER-169/e2e-improve-keplr-wallet-setup-reliability-with-spa-navigation-guards)

### Root cause

`startImport()` had a try/catch that silently swallowed failures. When `useRecoveryBtn.click()` failed (Keplr SPA hadn't navigated yet), the catch block asserted `importWalletBtn` was visible -- which passed because we were still on the welcome page. The method returned "successfully" without completing the import, and all downstream steps ran on the wrong page. This eventually surfaced as a "Wallet should be connected" timeout, making it look like a wallet connection issue rather than a setup issue.

### Why USDC tests appeared uniquely flaky

The USDC job depends on OSMO passing first (`needs: [preview-swap-osmo-tests, ...]`). When OSMO's Keplr setup failed, OSMO failed and USDC was skipped -- so you only ever saw USDC fail when OSMO got lucky. Same underlying bug, selection bias in observation.

### Fixes

- **Removed error-swallowing catch** in `startImport()` -- replaced with explicit `waitFor` visibility guards before each click. Failures now propagate and fail fast in `beforeAll`.
- **SPA navigation guards** -- after each Keplr step (Import, Next), waits for expected UI elements to appear/disappear before proceeding, preventing the automation from racing ahead of the Keplr SPA.
- **Fixed page event race** in `setup-keplr.ts` -- checks for an already-opened Keplr page before waiting for a new page event.
- **Removed vestigial 4s sleep** -- the old `waitForTimeout(4000)` was needed because the original code grabbed the page from `waitForEvent`, then re-indexed `context.pages()[1]`. The sleep gave the extension time to populate the pages array. Now that we use a single page reference (`existingPages[1] ?? waitForEvent`), the sleep no longer serves a purpose. `waitForURL` with a 15s timeout handles it deterministically.
- **Retry with debug screenshots** for chain selection, writing to `test-results/` with unique filenames so CI artifact upload picks them up.
- **Increased timeouts** for slow CI runners.

## Files changed

- `packages/e2e/pages/keplr-page.ts` -- all setup flow methods
- `packages/e2e/setup-keplr.ts` -- page event handling and timeouts

## Test plan

- Verified locally: Keplr setup completes successfully (import seed, set name/password, select chains, finish)
- OSMO-to-ATOM swap test passes end-to-end locally

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to Playwright E2E setup helpers, mainly adding deterministic waits/retries and better diagnostics for CI flakiness.
> 
> **Overview**
> Improves Keplr extension onboarding reliability in E2E tests by replacing the `startImport()` try/catch with explicit visibility waits and click timeouts so failures surface immediately instead of silently continuing on the wrong SPA step.
> 
> Adds SPA navigation guards after `Import`/`Next` (wait for `walletNameInput` to appear, then disappear) to prevent racing the hash-routed UI, and introduces a 3-attempt retry loop for selecting **All Native Chains** that captures debug screenshots to `test-results/`.
> 
> Fixes a page-event race in `setup-keplr.ts` by using an already-open extension page when present (otherwise waiting for a new page) and increases `waitForURL`/page creation timeouts while removing the vestigial sleep.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d26d9a1c3c69bd757d55ad7de1cf2b215af6db40. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->