### PR TITLE
fix(e2e): wait for swap UI to settle before checking error state

### DIFF
--- a/packages/e2e/pages/swap-page.ts
+++ b/packages/e2e/pages/swap-page.ts
@@ -177,9 +177,14 @@ export class SwapPage extends BasePage {
     return await issufBalanceBtn.isVisible({ timeout: 2000 })
   }
 
-  async isError() {
+  async isError(settleTimeout = 5_000) {
     const errorBtn = this.page.locator('//button[.="Error"]')
-    return await errorBtn.isVisible({ timeout: 2000 })
+    try {
+      await expect(errorBtn).not.toBeVisible({ timeout: settleTimeout })
+      return false
+    } catch {
+      return true
+    }
   }
 
   async showSwapInfo() {

--- a/packages/e2e/pages/trade-page.ts
+++ b/packages/e2e/pages/trade-page.ts
@@ -307,9 +307,14 @@ export class TradePage extends BasePage {
     ).toBeFalsy();
   }
 
-  async isError() {
+  async isError(settleTimeout = 5_000) {
     const errorBtn = this.page.locator('//button[.="Error"]');
-    return await errorBtn.isVisible({ timeout: 2000 });
+    try {
+      await expect(errorBtn).not.toBeVisible({ timeout: settleTimeout });
+      return false;
+    } catch {
+      return true;
+    }
   }
 
   async showSwapInfo() {


### PR DESCRIPTION
## Summary

Prevents false-positive E2E test failures caused by the swap button briefly showing "Error" during async loading after wallet connection.

### What changed

`isError()` in both `trade-page.ts` and `swap-page.ts` now uses Playwright's auto-retrying `expect().not.toBeVisible()` with a 5-second settling timeout instead of an instant `isVisible()` check. If the "Error" button appears transiently and then disappears as data loads, the assertion passes. If it persists beyond 5 seconds, the test still fails.

### Why this happens

The swap button text is driven by `swapState.error` without checking `isSwapToolLoading` first (`packages/web/components/swap-tool/index.tsx` lines 306-318). When a tRPC quote request fails transiently (network timeout, edge function cold start), the error flows through:

1. `makeRouterErrorFromTrpcError()` in `packages/web/hooks/use-swap.tsx` (line 1570) wraps unrecognized errors as `new Error("Unexpected router error...")`
2. `tError()` in `packages/web/components/localization/translate-error.ts` (line 95) doesn't match any known error subclass, falls through to `return ["errors.generic"]`
3. `errors.generic` in `packages/web/localizations/en.json` (line 286) = `"Error"`

The button shows "Error" while a new quote request is still loading. Once it resolves, the error clears and the button updates. Users may also see this as a brief flash on slow connections.

### Frontend follow-up needed

The button text logic should check `isSwapToolLoading` before rendering `swapState.error`, showing a loading/disabled state instead. This E2E fix is a precautionary measure -- the root cause is in the frontend.

## Files changed

- `packages/e2e/pages/trade-page.ts` -- `isError()` method
- `packages/e2e/pages/swap-page.ts` -- `isError()` method

## Test plan

- All 6 test files that call `isError()` benefit from this change without modification
- Transient "Error" states (< 5s) no longer cause false failures
- Persistent errors (> 5s) still fail the test correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to E2E test helpers and only adjust how transient UI error states are detected, with no production logic impact.
> 
> **Overview**
> Updates E2E `isError()` checks in `swap-page.ts` and `trade-page.ts` to **wait for the UI to settle** before reporting an error.
> 
> Instead of a quick `isVisible()` probe, the helpers now use Playwright’s auto-retrying `expect(errorBtn).not.toBeVisible()` (default `settleTimeout` 5s) and only return `true` when the `Error` state persists, reducing false-positive test failures during brief loading flashes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6fffe95afb8ab09361f4abf26d7b0f5068f550f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->