### PR TITLE
fix: prevent DOM clobbering in EntityImage causing swap failure on pool 3277

### DIFF
--- a/packages/web/components/ui/entity-image.tsx
+++ b/packages/web/components/ui/entity-image.tsx
@@ -7,19 +7,17 @@ import { useEffect, useState } from "react";
  * Component to display an image for an entity, either a chain or a token, and a fallback for it.
  */
 export function EntityImage({
-  ...props
+  logoURIs,
+  width = 24,
+  height = 24,
+  name,
+  symbol,
+  denom,
+  isChain = false,
+  ...imageProps
 }: Omit<ImageProps, "src" | "alt"> &
   Pick<Asset, "logoURIs" | "name"> &
   Partial<Pick<Asset, "symbol">> & { isChain?: boolean; denom?: string }) {
-  const {
-    logoURIs,
-    width = 24,
-    height = 24,
-    name,
-    symbol,
-    denom,
-    isChain = false,
-  } = props;
   const [imgSrc, setImgSrc] = useState<string | undefined>(
     logoURIs?.svg || logoURIs?.png
   );
@@ -49,7 +47,7 @@ export function EntityImage({
           {
             "rounded-lg": isChain,
           },
-          props.className
+          imageProps.className
         )}
         style={{
           width,
@@ -69,11 +67,13 @@ export function EntityImage({
 
   return (
     <Image
-      {...props}
+      {...imageProps}
+      width={width}
+      height={height}
       src={imgSrc}
       alt={name}
       onError={handleError}
-      className={classNames("object-contain", props.className)}
+      className={classNames("object-contain", imageProps.className)}
     />
   );
 }


### PR DESCRIPTION
## Summary

- Fixes a DOM clobbering bug where `<img name="cookie">` elements overwrite `document.cookie`, causing all swaps on pool 3277 (cookie/OSMO) to fail with `TypeError: document.cookie.match is not a function`
- Destructures non-HTML props (`name`, `logoURIs`, `symbol`, `denom`, `isChain`) out of the spread in `EntityImage`, so only valid `ImageProps` reach the underlying `<img>` element
- Also prevents the same class of bug for any future token whose name collides with a native `document` property (e.g. `"title"`, `"domain"`, `"referrer"`, `"location"`)

## Linear
[MER-166: Fix: Transaction fails with `document.cookie.match is not a function` in mobile wallet browsers](https://linear.app/osmosis/issue/MER-166/fix-transaction-fails-with-documentcookiematch-is-not-a-function-in)

## Problem

The `EntityImage` component spread **all** its props into Next.js's `<Image>` via `{...props}`, including the `name` prop (set to the token's `coinDenom`). For pool 3277, this rendered:

```html
<img name="cookie" src="..." alt="cookie" class="object-contain" />
```

Browsers provide [named access on the `document` object](https://html.spec.whatwg.org/multipage/dom.html#dom-document-namedItem) -- elements with a `name` attribute are accessible as `document[name]`. With multiple `<img name="cookie">` elements on the pool page, `document.cookie` returned an `HTMLCollection` of `<img>` elements instead of the native cookie string.

When Axios broadcasts the swap transaction, its XHR adapter reads XSRF cookies via `document.cookie.match(...)`. With `document.cookie` clobbered, `.match()` doesn't exist on an `HTMLCollection`, throwing the `TypeError` and failing the transaction.

## Steps to reproduce

1. Go to https://app.osmosis.zone/pool/3277
2. Connect a wallet with OSMO balance
3. Click **Trade Pair**, flip to **OSMO -> cookie**, enter any amount
4. Click **Swap** -> **Confirm** -> **Approve** in Keplr
5. **Result:** `Transaction Failed -- document.cookie.match is not a function`

## Fix

Destructure non-HTML props before spreading so they don't leak to `<img>`:

```diff
- export function EntityImage({ ...props }: ...) {
-   const { logoURIs, name, symbol, denom, isChain, ... } = props;
+ export function EntityImage({ logoURIs, name, symbol, denom, isChain, ...imageProps }: ...) {
    ...
-   <Image {...props} src={imgSrc} alt={name} ... />
+   <Image {...imageProps} width={width} height={height} src={imgSrc} alt={name} ... />
```

The `name` value is still used for `alt` text and fallback display -- its only intended purposes.

## Impact of removing `name` from `<img>`

- The `name` attribute on `<img>` is **obsolete** (deprecated in HTML4, removed in HTML5). No semantic, visual, or accessibility effect.
- Nothing in the codebase queries images by `name` attribute.
- Alt text and fallback rendering are completely unaffected.

## Test plan

- [x] Reproduced the bug via Playwright e2e test on staging (swap fails with `document.cookie.match is not a function`)
- [x] Applied the fix at runtime via `MutationObserver` stripping `name` attrs -- swap succeeds
- [x] Verified no code in the codebase queries `<img>` elements by `name`
- [x] Verified `alt` text still renders correctly (uses `name` prop, not HTML `name` attribute)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `EntityImage` forwards props to Next.js `Image`, which can affect rendered attributes across many call sites. Low implementation complexity, but it directly addresses a DOM clobbering issue that can break swap flows if regressed.
> 
> **Overview**
> Prevents `EntityImage` from forwarding asset fields like `name`, `logoURIs`, `symbol`, `denom`, and `isChain` into Next.js `Image` via `{...props}`, so they no longer become DOM attributes (e.g., `name="cookie"`) that can clobber `document` properties.
> 
> Keeps visual behavior the same by explicitly passing `width`/`height`, preserving `alt={name}`, and consistently using `imageProps.className` for both the fallback and `Image` rendering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dede033375a7231072b346c2837b45ea625133e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->