### PR TITLE
fix(e2e): dismiss lingering modals before logout and trade retries

### DIFF
--- a/packages/e2e/pages/base-page.ts
+++ b/packages/e2e/pages/base-page.ts
@@ -91,7 +91,14 @@ export class BasePage {
   }
 
   async logOut() {
-    // open the wallet menu
+    // Dismiss any lingering modal overlays that might intercept clicks
+    // (e.g., undismissed "Review trade" confirmation from a failed sell flow)
+    await this.page.keyboard.press('Escape')
+    await this.page
+      .locator('.ReactModal__Overlay')
+      .waitFor({ state: 'hidden', timeout: 2000 })
+      .catch(() => {})
+
     await expect(
       this.connectedWalletBtn,
       'Wallet should be connected.',

--- a/packages/e2e/pages/trade-page.ts
+++ b/packages/e2e/pages/trade-page.ts
@@ -502,7 +502,12 @@ export class TradePage extends BasePage {
           }. ` + `Error: ${error.message ?? "Unknown error"}. Retrying...`
         );
 
-        // Wait before retry to let things settle
+        // Dismiss any lingering "Review trade" modal so the next attempt starts clean
+        await this.page.keyboard.press("Escape");
+        await this.page
+          .locator(".ReactModal__Overlay")
+          .waitFor({ state: "hidden", timeout: 2000 })
+          .catch(() => {});
         await this.page.waitForTimeout(2000);
       }
     }
@@ -664,7 +669,12 @@ export class TradePage extends BasePage {
           }. ` + `Error: ${error.message ?? "Unknown error"}. Retrying...`
         );
 
-        // Wait before retry to let things settle
+        // Dismiss any lingering "Review trade" modal so the next attempt starts clean
+        await this.page.keyboard.press("Escape");
+        await this.page
+          .locator(".ReactModal__Overlay")
+          .waitFor({ state: "hidden", timeout: 2000 })
+          .catch(() => {});
         await this.page.waitForTimeout(2000);
       }
     }


### PR DESCRIPTION
## Summary

- Presses Escape before `logOut()` and in buy/sell retry `catch` blocks to dismiss any leftover `ReactModal__Overlay` (z-9999) that intercepts pointer events
- Waits up to 2s for the overlay to disappear, with a no-op catch so it's safe when no modal is present
- Fixes cascading `TimeoutError` in `connectedWalletBtn.click()` caused by an undismissed 'Review trade' confirmation modal from a prior failed swap

## Test plan

- [ ] CI swap tests (`swap.usdc.wallet.spec.ts`) pass without the `ReactModal__Overlay intercepts pointer events` error
- [ ] Existing trade/portfolio E2E tests unaffected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk test-only change that adds defensive modal dismissal to reduce flaky Playwright interactions; main risk is masking unexpected UI states if an overlay should be asserted instead of dismissed.
> 
> **Overview**
> Improves E2E stability by proactively clearing leftover modal overlays that can intercept clicks.
> 
> `BasePage.logOut()` now presses `Escape` and waits (best-effort) for `.ReactModal__Overlay` to disappear before opening the wallet menu. The buy/sell retry paths in `TradePage` do the same cleanup before delaying and re-attempting the trade, preventing cascading timeouts after a failed attempt leaves the “Review trade” modal open.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 753beed93e186b2c2171c5c4140bfa428c562c82. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->