### PR TITLE
fix(e2e): harden 1CT handling to prevent flaky swap, trade, and transaction tests

### DIFF
--- a/packages/e2e/pages/base-page.ts
+++ b/packages/e2e/pages/base-page.ts
@@ -1,5 +1,14 @@
 import { type Locator, type Page, expect } from '@playwright/test'
 
+/**
+ * Base page object shared by all E2E page classes.
+ * Provides wallet connection/disconnection, navigation, and common UI helpers.
+ *
+ * Wallet interaction pattern:
+ *   Keplr opens a popup window for approval. When 1-Click Trading (1CT) is
+ *   enabled the popup may never appear, so all popup waits use timeouts and
+ *   treat TimeoutError as "auto-approved / 1CT active".
+ */
 export class BasePage {
   readonly page: Page
   readonly connectWalletBtn: Locator
@@ -21,8 +30,15 @@ export class BasePage {
     this.connectedWalletBtn = page.locator('//button/div/span[@title]')
   }
 
+  /**
+   * Connects the Keplr wallet via the browser extension popup.
+   * If the Keplr approval popup doesn't appear within 15s (e.g. auto-approved
+   * or 1CT enabled), we continue without error.
+   */
   async connectWallet() {
     await this.connectWalletBtn.click()
+    // Start listening for the Keplr popup BEFORE clicking the wallet button
+    // to avoid a race where the popup opens faster than the listener attaches.
     const pagePromise = this.page
       .context()
       .waitForEvent('page', { timeout: 15000 })
@@ -79,6 +95,7 @@ export class BasePage {
     return balance
   }
 
+  /** Dismisses the "Variants Detected" modal that may appear on staging deploys. */
   async dismissVariantsPopupIfPresent() {
     try {
       const dismissBtn = this.page.getByRole('button', { name: 'Dismiss' })

--- a/packages/e2e/pages/base-page.ts
+++ b/packages/e2e/pages/base-page.ts
@@ -91,14 +91,6 @@ export class BasePage {
   }
 
   async logOut() {
-    // Dismiss any lingering modal overlays that might intercept clicks
-    // (e.g., undismissed "Review trade" confirmation from a failed sell flow)
-    await this.page.keyboard.press('Escape')
-    await this.page
-      .locator('.ReactModal__Overlay')
-      .waitFor({ state: 'hidden', timeout: 2000 })
-      .catch(() => {})
-
     await expect(
       this.connectedWalletBtn,
       'Wallet should be connected.',

--- a/packages/e2e/pages/base-page.ts
+++ b/packages/e2e/pages/base-page.ts
@@ -91,7 +91,14 @@ export class BasePage {
   }
 
   async logOut() {
-    // open the wallet menu
+    // Dismiss any lingering modal overlays that might intercept clicks
+    // (e.g., undismissed "Review trade" confirmation from a failed sell flow)
+    await this.page.keyboard.press('Escape')
+    await this.page
+      .locator('.ReactModal__Overlay')
+      .waitFor({ state: 'hidden', timeout: 2000 })
+      .catch(() => {})
+
     await expect(
       this.connectedWalletBtn,
       'Wallet should be connected.',

--- a/packages/e2e/pages/portfolio-page.ts
+++ b/packages/e2e/pages/portfolio-page.ts
@@ -39,11 +39,14 @@ export class PortfolioPage extends BasePage {
     name: string
     minimalDenom: string
   }) {
-    await this.page.evaluate(() => window.scrollBy(0, 250))
-    const bal = this.page
-      .locator(`//tbody/tr//a[contains(@href, "/assets/${minimalDenom}")]`)
-      .nth(1)
-    await bal.waitFor({ state: 'visible', timeout: 20000 })
+    const row = this.page
+      .locator(
+        `//tbody/tr[.//a[contains(@href, "/assets/${minimalDenom}")]]`,
+      )
+      .first()
+    await row.waitFor({ state: 'visible', timeout: 20000 })
+    const bal = row.locator('td').nth(1).locator('a')
+    await bal.scrollIntoViewIfNeeded()
     const tokenBalance: string = await bal.innerText()
     console.log(`Balance for ${name}: ${tokenBalance}`)
     return tokenBalance
@@ -72,8 +75,9 @@ export class PortfolioPage extends BasePage {
   }
 
   async searchForToken(tokenName: string) {
+    await this.searchInput.clear()
+    await this.page.waitForTimeout(1000)
     await this.searchInput.fill(tokenName)
-    // we expect that after 2 seconds tokens are loaded and any failure after this point should be considered a bug.
     await this.page.waitForTimeout(2000)
   }
 }

--- a/packages/e2e/pages/portfolio-page.ts
+++ b/packages/e2e/pages/portfolio-page.ts
@@ -43,6 +43,7 @@ export class PortfolioPage extends BasePage {
     const bal = this.page
       .locator(`//tbody/tr//a[contains(@href, "/assets/${minimalDenom}")]`)
       .nth(1)
+    await bal.waitFor({ state: 'visible', timeout: 20000 })
     const tokenBalance: string = await bal.innerText()
     console.log(`Balance for ${name}: ${tokenBalance}`)
     return tokenBalance

--- a/packages/e2e/pages/portfolio-page.ts
+++ b/packages/e2e/pages/portfolio-page.ts
@@ -4,6 +4,7 @@ import type { Locator, Page } from '@playwright/test'
 import { BasePage } from './base-page'
 import { TransactionsPage } from './transactions-page'
 
+/** Page object for the /portfolio view -- token balances, search, and navigation to transactions. */
 export class PortfolioPage extends BasePage {
   readonly hideZeros: Locator
   readonly viewMore: Locator

--- a/packages/e2e/pages/swap-page.ts
+++ b/packages/e2e/pages/swap-page.ts
@@ -62,16 +62,26 @@ export class SwapPage extends BasePage {
   }
 
   async swapAndGetWalletMsg(context: BrowserContext) {
-    // Make sure to have sufficient balance and swap button is enabled
     expect(
       await this.isInsufficientBalance(),
       'Insufficient balance for the swap!',
     ).toBeFalsy()
     await expect(this.swapBtn).toBeEnabled({ timeout: 7000 })
-    // Handle Pop-up page ->
-    const pageApprove = context.waitForEvent('page')
+    const pageApprove = context.waitForEvent('page', { timeout: 10000 })
     await this.swapBtn.click()
-    const approvePage = await pageApprove
+    let approvePage: Page | null = null
+    try {
+      approvePage = await pageApprove
+    } catch (error: unknown) {
+      const err = error as { name?: string; message?: string }
+      if (err.name === 'TimeoutError' || /timeout/i.test(err.message ?? '')) {
+        console.log(
+          'Keplr popup did not appear within 10s; assuming 1-click trading.',
+        )
+        return { msgContentAmount: undefined }
+      }
+      throw error
+    }
     await approvePage.waitForLoadState()
     const approvePageTitle = approvePage.url()
     console.log(`Approve page is opened at: ${approvePageTitle}`)
@@ -83,12 +93,8 @@ export class SwapPage extends BasePage {
       .getByText('type: osmosis/poolmanager/')
       .textContent()
     console.log(`Wallet is approving this msg: \n${msgContentAmount}`)
-    // Approve trx
     await approveBtn.click()
-    // wait for trx confirmation
     await this.page.waitForTimeout(4000)
-    //await approvePage.close();
-    // Handle Pop-up page <-
     return { msgContentAmount }
   }
 

--- a/packages/e2e/pages/swap-page.ts
+++ b/packages/e2e/pages/swap-page.ts
@@ -8,6 +8,11 @@ import {
 
 import { BasePage } from './base-page'
 
+/**
+ * Page object for the legacy /swap view (pre-trade-page UI).
+ * Uses the simpler Keplr popup flow (no Promise.race) -- if the popup doesn't
+ * appear within 10s the method returns undefined, assuming 1-Click Trading.
+ */
 export class SwapPage extends BasePage {
   readonly page: Page
   readonly swapBtn: Locator
@@ -98,8 +103,14 @@ export class SwapPage extends BasePage {
     return { msgContentAmount }
   }
 
+  /**
+   * Selects a trading pair, optimising for the common cases:
+   *   1. Pair already matches -> no-op
+   *   2. Pair is the reverse  -> single flip
+   *   3. One token overlaps   -> flip first to avoid the token-picker hiding
+   *      already-selected tokens, then search/select the remaining one(s).
+   */
   async selectPair(from: string, to: string) {
-    // Filter does not show already selected tokens
     console.log(`Select pair ${from} to ${to}`)
     const tokenLocator =
       '//img[@alt="token icon"]/../..//h5 | //img[@alt="token icon"]/../..//span[@class="subtitle1"]'
@@ -123,6 +134,8 @@ export class SwapPage extends BasePage {
       return
     }
 
+    // Flip first when one of the desired tokens sits on the wrong side,
+    // because the token picker hides the already-selected counterpart.
     if (from === toTokenText || to === fromTokenText) {
       await this.flipTokenPair()
     }

--- a/packages/e2e/pages/trade-page.ts
+++ b/packages/e2e/pages/trade-page.ts
@@ -151,6 +151,15 @@ export class TradePage extends BasePage {
     console.log("Second page was not opened in 5 seconds.");
   }
 
+  async disable1CTIfNeeded() {
+    const oneClickToggle =
+      '//div[@role="dialog"]//button[@data-state="checked"]';
+    if (await this.page.locator(oneClickToggle).isVisible({ timeout: 500 })) {
+      await this.page.locator(oneClickToggle).click({ timeout: 3000 });
+      console.log("Disabled 1-Click Trading toggle.");
+    }
+  }
+
   async justApproveIfNeeded(context: BrowserContext) {
     let approvePage: import("@playwright/test").Page | null =
       context
@@ -194,11 +203,7 @@ export class TradePage extends BasePage {
       timeout: 15000,
     });
     await this.swapBtn.click({ timeout: 4000 });
-    // Handle 1-click by default
-    const oneClick = '//div[@role="dialog"]//button[@data-state="checked"]';
-    if (await this.page.locator(oneClick).isVisible({ timeout: 2000 })) {
-      await this.page.locator(oneClick).click({ timeout: 3000 });
-    }
+    await this.disable1CTIfNeeded();
     await this.confirmSwapBtn.click({ timeout: 5000 });
     return await this.approveInKeplrAndGetMsg(context);
   }
@@ -274,7 +279,7 @@ export class TradePage extends BasePage {
   }
 
   async getTransactionUrl() {
-    const trxUrl = await this.trxLink.getAttribute("href");
+    const trxUrl = await this.trxLink.getAttribute("href", { timeout: 10000 });
     console.log(`Trx url: ${trxUrl}`);
     await this.page.reload();
     return trxUrl;
@@ -413,10 +418,9 @@ export class TradePage extends BasePage {
           timeout: 20000,
         });
         await this.buyBtn.click();
-        // Small wait to let UI settle before triggering popup
         await this.page.waitForTimeout(500);
+        await this.disable1CTIfNeeded();
 
-        // Set slippage tolerance if specified (after buy clicked, before confirm)
         if (slippagePercent) {
           await this.setSlippageTolerance(slippagePercent);
         }
@@ -440,13 +444,8 @@ export class TradePage extends BasePage {
             (await approvePage.getByText(msgTextLocator).textContent()) ??
             undefined;
           console.log(`Wallet is approving this msg: \n${msgContentAmount}`);
-          // Approve trx
           await approveBtn.click();
-          // Handle Pop-up page <-
         } catch (error: any) {
-          // IMPORTANT: Gracefully handle timeout errors for 1-click trading scenarios
-          // When 1-click trading is enabled, no Keplr popup appears and waitForEvent times out
-          // This is expected behavior, not an error - transaction is still submitted on-chain
           if (
             error.name === "TimeoutError" ||
             (error instanceof Error && /timeout/i.test(error.message))
@@ -456,12 +455,11 @@ export class TradePage extends BasePage {
             );
             msgContentAmount = undefined;
           } else {
-            // Other errors (button not found, page closed, etc.) should be retried
             console.error(
               "Failed to get Keplr approval popup:",
               error.message ?? "Unknown error"
             );
-            throw error; // Re-throw to be caught by outer try-catch
+            throw error;
           }
         }
 
@@ -580,10 +578,9 @@ export class TradePage extends BasePage {
           timeout: 20000,
         });
         await this.sellBtn.click();
-        // Small wait to let UI settle before triggering popup
         await this.page.waitForTimeout(500);
+        await this.disable1CTIfNeeded();
 
-        // Set slippage tolerance if specified (after sell clicked, before confirm)
         if (slippagePercent) {
           await this.setSlippageTolerance(slippagePercent);
         }
@@ -607,13 +604,8 @@ export class TradePage extends BasePage {
             (await approvePage.getByText(msgTextLocator).textContent()) ??
             undefined;
           console.log(`Wallet is approving this msg: \n${msgContentAmount}`);
-          // Approve trx
           await approveBtn.click();
-          // Handle Pop-up page <-
         } catch (error: any) {
-          // IMPORTANT: Gracefully handle timeout errors for 1-click trading scenarios
-          // When 1-click trading is enabled, no Keplr popup appears and waitForEvent times out
-          // This is expected behavior, not an error - transaction is still submitted on-chain
           if (
             error.name === "TimeoutError" ||
             (error instanceof Error && /timeout/i.test(error.message))
@@ -623,12 +615,11 @@ export class TradePage extends BasePage {
             );
             msgContentAmount = undefined;
           } else {
-            // Other errors (button not found, page closed, etc.) should be retried
             console.error(
               "Failed to get Keplr approval popup:",
               error.message ?? "Unknown error"
             );
-            throw error; // Re-throw to be caught by outer try-catch
+            throw error;
           }
         }
 
@@ -710,6 +701,8 @@ export class TradePage extends BasePage {
 
     await this.sellBtn.click();
 
+    await this.disable1CTIfNeeded();
+
     if (slippagePercent) {
       await this.setSlippageTolerance(slippagePercent);
     }
@@ -748,6 +741,8 @@ export class TradePage extends BasePage {
     });
 
     await this.buyBtn.click();
+
+    await this.disable1CTIfNeeded();
 
     if (slippagePercent) {
       await this.setSlippageTolerance(slippagePercent);
@@ -827,6 +822,8 @@ export class TradePage extends BasePage {
         });
 
         await this.swapBtn.click({ timeout: 4000 });
+
+        await this.disable1CTIfNeeded();
 
         if (slippagePercent) {
           await this.setSlippageTolerance(slippagePercent);

--- a/packages/e2e/pages/trade-page.ts
+++ b/packages/e2e/pages/trade-page.ts
@@ -502,7 +502,12 @@ export class TradePage extends BasePage {
           }. ` + `Error: ${error.message ?? "Unknown error"}. Retrying...`
         );
 
-        // Wait before retry to let things settle
+        // Dismiss any lingering "Review trade" modal so the next attempt starts clean
+        await this.page.keyboard.press("Escape");
+        await this.page
+          .locator(".ReactModal__Overlay")
+          .waitFor({ state: "hidden", timeout: 2000 })
+          .catch(() => {});
         await this.page.waitForTimeout(2000);
       }
     }
@@ -664,7 +669,12 @@ export class TradePage extends BasePage {
           }. ` + `Error: ${error.message ?? "Unknown error"}. Retrying...`
         );
 
-        // Wait before retry to let things settle
+        // Dismiss any lingering "Review trade" modal so the next attempt starts clean
+        await this.page.keyboard.press("Escape");
+        await this.page
+          .locator(".ReactModal__Overlay")
+          .waitFor({ state: "hidden", timeout: 2000 })
+          .catch(() => {});
         await this.page.waitForTimeout(2000);
       }
     }

--- a/packages/e2e/pages/trade-page.ts
+++ b/packages/e2e/pages/trade-page.ts
@@ -203,6 +203,7 @@ export class TradePage extends BasePage {
       timeout: 15000,
     });
     await this.swapBtn.click({ timeout: 4000 });
+    await this.page.waitForTimeout(500);
     await this.disable1CTIfNeeded();
     await this.confirmSwapBtn.click({ timeout: 5000 });
     return await this.approveInKeplrAndGetMsg(context);
@@ -700,7 +701,7 @@ export class TradePage extends BasePage {
     });
 
     await this.sellBtn.click();
-
+    await this.page.waitForTimeout(500);
     await this.disable1CTIfNeeded();
 
     if (slippagePercent) {
@@ -741,7 +742,7 @@ export class TradePage extends BasePage {
     });
 
     await this.buyBtn.click();
-
+    await this.page.waitForTimeout(500);
     await this.disable1CTIfNeeded();
 
     if (slippagePercent) {
@@ -822,7 +823,7 @@ export class TradePage extends BasePage {
         });
 
         await this.swapBtn.click({ timeout: 4000 });
-
+        await this.page.waitForTimeout(500);
         await this.disable1CTIfNeeded();
 
         if (slippagePercent) {

--- a/packages/e2e/pages/trade-page.ts
+++ b/packages/e2e/pages/trade-page.ts
@@ -7,6 +7,19 @@ import {
 
 import { BasePage } from "./base-page";
 
+/**
+ * Page object for the /trade view (swap, buy, sell, limit orders).
+ *
+ * Transaction methods come in two flavours:
+ *   - *AndGetWalletMsg  (e.g. buyAndGetWalletMsg) -- full flow with retry logic,
+ *     returns the raw Keplr message content for test assertions.
+ *   - *AndApprove       (e.g. buyAndApprove) -- simplified fire-and-forget flow
+ *     with no retries; use when you only need to confirm the tx succeeded.
+ *
+ * All methods handle the Keplr / 1-Click Trading duality: if no popup appears
+ * within the timeout, the code assumes 1CT processed the transaction and
+ * continues to wait for the on-chain success toast.
+ */
 export class TradePage extends BasePage {
   readonly page: Page;
   readonly swapBtn: Locator;
@@ -130,8 +143,12 @@ export class TradePage extends BasePage {
     console.log(`Swap ${amount} with rate: ${exchangeRate}`);
   }
 
+  /**
+   * Awaits a pre-registered Keplr popup promise, approves the transaction, and
+   * returns the raw message content. If the popup times out (1CT active), returns
+   * undefined instead of throwing.
+   */
   private async approveInKeplrAndGetMsg(
-    context: BrowserContext,
     pageApprovePromise: Promise<import("@playwright/test").Page>
   ) {
     let msgContentAmount: string | undefined;
@@ -164,6 +181,12 @@ export class TradePage extends BasePage {
     return msgContentAmount;
   }
 
+  /**
+   * If the review-trade dialog shows a 1-Click Trading toggle in the "checked"
+   * state, disable it so the test exercises the full Keplr approval flow.
+   * Uses a short 500ms visibility check -- call sites add a 500ms waitForTimeout
+   * before invoking this, giving ~1s total for the dialog to render.
+   */
   async disable1CTIfNeeded() {
     const oneClickToggle =
       '//div[@role="dialog"]//button[@data-state="checked"]';
@@ -173,6 +196,12 @@ export class TradePage extends BasePage {
     }
   }
 
+  /**
+   * Lightweight Keplr approval helper used by the *AndApprove methods.
+   * Two-phase lookup: first checks if a popup tab already exists (may have opened
+   * before this call), then falls back to waitForEvent with a 10s timeout.
+   * Does nothing if no popup appears (1CT / pre-approved scenario).
+   */
   async justApproveIfNeeded(context: BrowserContext) {
     let approvePage: import("@playwright/test").Page | null =
       context
@@ -224,7 +253,6 @@ export class TradePage extends BasePage {
     await this.confirmSwapBtn.click({ timeout: 5000 });
 
     const msgContentAmount = await this.approveInKeplrAndGetMsg(
-      context,
       pageApprovePromise
     );
     return msgContentAmount;

--- a/packages/e2e/pages/trade-page.ts
+++ b/packages/e2e/pages/trade-page.ts
@@ -130,25 +130,38 @@ export class TradePage extends BasePage {
     console.log(`Swap ${amount} with rate: ${exchangeRate}`);
   }
 
-  private async approveInKeplrAndGetMsg(context: BrowserContext) {
-    console.log("Wait for 5 seconds for any popup");
-    await this.page.waitForTimeout(5_000);
-    const pages = context.pages();
-    console.log(`Number of Open Pages: ${pages.length}`);
-    if (pages.length === 2) {
-      const approvePage = pages[1];
-      const approvePageTitle = approvePage.url();
-      console.log(`Approve page is opened at: ${approvePageTitle}`);
-      const msgContent = await approvePage
-        .getByText("type: osmosis/poolmanager/")
-        .textContent();
-      console.log(`Wallet is approving this msg: \n${msgContent}`);
-      await approvePage
-        .getByRole("button", { name: "Approve" })
-        .click({ timeout: 4000 });
-      return msgContent;
+  private async approveInKeplrAndGetMsg(
+    context: BrowserContext,
+    pageApprovePromise: Promise<import("@playwright/test").Page>
+  ) {
+    let msgContentAmount: string | undefined;
+
+    try {
+      const approvePage = await pageApprovePromise;
+      await approvePage.waitForLoadState();
+      const approveBtn = approvePage.getByRole("button", { name: "Approve" });
+      await expect(approveBtn).toBeEnabled();
+      msgContentAmount =
+        (await approvePage
+          .getByText("type: osmosis/poolmanager/")
+          .textContent()) ?? undefined;
+      console.log(`Wallet is approving this msg: \n${msgContentAmount}`);
+      await approveBtn.click();
+    } catch (error: any) {
+      if (
+        error.name === "TimeoutError" ||
+        (error instanceof Error && /timeout/i.test(error.message))
+      ) {
+        console.log(
+          "Keplr approval popup did not appear within 20s; assuming 1-click trading is enabled or transaction was pre-approved."
+        );
+        msgContentAmount = undefined;
+      } else {
+        throw error;
+      }
     }
-    console.log("Second page was not opened in 5 seconds.");
+
+    return msgContentAmount;
   }
 
   async disable1CTIfNeeded() {
@@ -193,7 +206,6 @@ export class TradePage extends BasePage {
   }
 
   async swapAndGetWalletMsg(context: BrowserContext) {
-    // Make sure to have sufficient balance and swap button is enabled
     expect(
       await this.isInsufficientBalanceForSwap(),
       "Insufficient balance for the swap!"
@@ -202,11 +214,20 @@ export class TradePage extends BasePage {
     await expect(this.swapBtn, "Swap button is disabled!").toBeEnabled({
       timeout: 15000,
     });
+
+    const pageApprovePromise = context.waitForEvent("page", {
+      timeout: 20000,
+    });
     await this.swapBtn.click({ timeout: 4000 });
     await this.page.waitForTimeout(500);
     await this.disable1CTIfNeeded();
     await this.confirmSwapBtn.click({ timeout: 5000 });
-    return await this.approveInKeplrAndGetMsg(context);
+
+    const msgContentAmount = await this.approveInKeplrAndGetMsg(
+      context,
+      pageApprovePromise
+    );
+    return msgContentAmount;
   }
 
   async selectAsset(token: string) {

--- a/packages/e2e/pages/transactions-page.ts
+++ b/packages/e2e/pages/transactions-page.ts
@@ -135,9 +135,14 @@ export class TransactionsPage extends BasePage {
       await approveBtn.click();
       expect(msgContentAmount).toContain("cancel_limit");
       await successPromise;
+    } else if (result.type === "success") {
+      console.log(
+        "Success toast appeared before Keplr popup (cancel limit order)."
+      );
+      await successPromise;
     } else {
       console.log(
-        "Transaction succeeded via 1-click trading (cancel limit order)."
+        "No Keplr popup observed; waiting for success confirmation (cancel limit order)."
       );
       await successPromise;
     }
@@ -197,9 +202,14 @@ export class TransactionsPage extends BasePage {
       expect(msgContentAmount1).toContain("claim_limit");
       expect(msgContentAmount2).toContain("cancel_limit");
       await successPromise;
+    } else if (result.type === "success") {
+      console.log(
+        "Success toast appeared before Keplr popup (claim and close)."
+      );
+      await successPromise;
     } else {
       console.log(
-        "Transaction succeeded via 1-click trading (claim and close)."
+        "No Keplr popup observed; waiting for success confirmation (claim and close)."
       );
       await successPromise;
     }
@@ -229,8 +239,13 @@ export class TransactionsPage extends BasePage {
       await expect(approveBtn).toBeEnabled();
       await approveBtn.click();
       await successPromise;
+    } else if (result.type === "success") {
+      console.log("Success toast appeared before Keplr popup (claim all).");
+      await successPromise;
     } else {
-      console.log("Transaction succeeded via 1-click trading (claim all).");
+      console.log(
+        "No Keplr popup observed; waiting for success confirmation (claim all)."
+      );
       await successPromise;
     }
   }

--- a/packages/e2e/pages/transactions-page.ts
+++ b/packages/e2e/pages/transactions-page.ts
@@ -6,8 +6,24 @@ import {
 } from "@playwright/test";
 
 import { BasePage } from "./base-page";
-const TRANSACTION_CONFIRMATION_TIMEOUT = 2000;
 
+/**
+ * Page object for the /transactions view and limit-order actions (cancel, claim).
+ *
+ * Keplr popup handling pattern (used by cancelLimitOrder, claimAndCloseAny, claimAll):
+ *   Each method uses Promise.race between the Keplr popup and a "Transaction
+ *   Successful" toast. This handles three scenarios:
+ *     1. Keplr popup appears  -> approve manually, then wait for success toast
+ *     2. Success toast first  -> 1-Click Trading handled it automatically
+ *     3. Popup resolves null  -> no popup observed; still waits for success toast
+ *        (prevents false positives -- the test will fail if the tx truly didn't succeed)
+ *
+ *   Two defensive guards are applied before each action click:
+ *     - Stale toast dismissal: waits for any lingering success toast to hide so the
+ *       Promise.race doesn't short-circuit on DOM state from a previous transaction.
+ *     - Early listener registration: context.waitForEvent("page") is started BEFORE
+ *       the click so fast-opening Keplr popups are never missed.
+ */
 export class TransactionsPage extends BasePage {
   readonly transactionRow: Locator;
   readonly viewExplorerLink: Locator;
@@ -42,8 +58,11 @@ export class TransactionsPage extends BasePage {
     await this.page.waitForTimeout(1000);
   }
 
+  /**
+   * Locates and clicks a transaction row by its swap amount.
+   * Waits up to ~60s with a mid-point reload because on-chain indexing can lag.
+   */
   async viewBySwapAmount(amount: string | number) {
-    // Transactions need some time to get loaded, wait for 30 seconds.
     await this.page.waitForTimeout(30000);
     await this.page.reload();
     const loc = `//div/div[@class="subtitle1 text-osmoverse-100" and contains(text(), "${amount}")]`;
@@ -107,15 +126,24 @@ export class TransactionsPage extends BasePage {
       timeout: 30000,
     });
 
+    // Dismiss any lingering success toast from a previous transaction so
+    // the upcoming Promise.race doesn't short-circuit on stale DOM state.
+    await this.page
+      .getByText("Transaction Successful")
+      .waitFor({ state: "hidden", timeout: 3000 })
+      .catch(() => {});
+
+    // Register the popup listener BEFORE the click so we never miss a
+    // fast-opening Keplr approval window.
+    const keplrPopup = context
+      .waitForEvent("page", { timeout: 40000 })
+      .catch(() => null);
+
     await cancelBtnLocator.click();
 
     const successPromise = expect(
       this.page.getByText("Transaction Successful")
     ).toBeVisible({ timeout: 40000 });
-
-    const keplrPopup = context
-      .waitForEvent("page", { timeout: 40000 })
-      .catch(() => null);
 
     const result = await Promise.race([
       keplrPopup.then((p) => ({ type: "popup" as const, page: p })),
@@ -166,15 +194,24 @@ export class TransactionsPage extends BasePage {
       return;
     }
 
+    // Dismiss any lingering success toast from a previous transaction so
+    // the upcoming Promise.race doesn't short-circuit on stale DOM state.
+    await this.page
+      .getByText("Transaction Successful")
+      .waitFor({ state: "hidden", timeout: 3000 })
+      .catch(() => {});
+
+    // Register the popup listener BEFORE the click so we never miss a
+    // fast-opening Keplr approval window.
+    const keplrPopup = context
+      .waitForEvent("page", { timeout: 40000 })
+      .catch(() => null);
+
     await this.claimAndClose.first().click();
 
     const successPromise = expect(
       this.page.getByText("Transaction Successful")
     ).toBeVisible({ timeout: 40000 });
-
-    const keplrPopup = context
-      .waitForEvent("page", { timeout: 40000 })
-      .catch(() => null);
 
     const result = await Promise.race([
       keplrPopup.then((p) => ({ type: "popup" as const, page: p })),
@@ -216,15 +253,24 @@ export class TransactionsPage extends BasePage {
   }
 
   async claimAll(context: BrowserContext) {
+    // Dismiss any lingering success toast from a previous transaction so
+    // the upcoming Promise.race doesn't short-circuit on stale DOM state.
+    await this.page
+      .getByText("Transaction Successful")
+      .waitFor({ state: "hidden", timeout: 3000 })
+      .catch(() => {});
+
+    // Register the popup listener BEFORE the click so we never miss a
+    // fast-opening Keplr approval window.
+    const keplrPopup = context
+      .waitForEvent("page", { timeout: 40000 })
+      .catch(() => null);
+
     await this.claimAllBtn.click();
 
     const successPromise = expect(
       this.page.getByText("Transaction Successful")
     ).toBeVisible({ timeout: 40000 });
-
-    const keplrPopup = context
-      .waitForEvent("page", { timeout: 40000 })
-      .catch(() => null);
 
     const result = await Promise.race([
       keplrPopup.then((p) => ({ type: "popup" as const, page: p })),

--- a/packages/e2e/pages/transactions-page.ts
+++ b/packages/e2e/pages/transactions-page.ts
@@ -113,41 +113,33 @@ export class TransactionsPage extends BasePage {
       this.page.getByText("Transaction Successful")
     ).toBeVisible({ timeout: 40000 });
 
-    let approvePage: Page | null =
-      context.pages().find((p) => p !== this.page && !p.isClosed()) ?? null;
+    const keplrPopup = context
+      .waitForEvent("page", { timeout: 40000 })
+      .catch(() => null);
 
-    if (!approvePage) {
-      try {
-        approvePage = await context.waitForEvent("page", { timeout: 10000 });
-      } catch (error: any) {
-        if (
-          error.name === "TimeoutError" ||
-          /timeout/i.test(error.message ?? "")
-        ) {
-          console.log(
-            "Keplr popup did not appear within 10s for cancel; assuming 1-click trading."
-          );
-        } else {
-          throw error;
-        }
-      }
-    }
+    const result = await Promise.race([
+      keplrPopup.then((p) => ({ type: "popup" as const, page: p })),
+      successPromise.then(() => ({ type: "success" as const, page: null })),
+    ]);
 
-    if (approvePage) {
-      await approvePage.waitForLoadState();
-      const approveBtn = approvePage.getByRole("button", {
+    if (result.type === "popup" && result.page) {
+      await result.page.waitForLoadState();
+      const approveBtn = result.page.getByRole("button", {
         name: "Approve",
       });
       await expect(approveBtn).toBeEnabled();
-      const msgContentAmount = await approvePage
+      const msgContentAmount = await result.page
         .getByText("Execute contract")
         .textContent();
       console.log(`Wallet is approving this msg: \n${msgContentAmount}`);
       await approveBtn.click();
       expect(msgContentAmount).toContain("cancel_limit");
+      await successPromise;
+    } else {
+      console.log(
+        "Transaction succeeded via 1-click trading (cancel limit order)."
+      );
     }
-
-    await successPromise;
   }
 
   async isFilledByLimitPrice(price: string | number) {
@@ -174,37 +166,26 @@ export class TransactionsPage extends BasePage {
       this.page.getByText("Transaction Successful")
     ).toBeVisible({ timeout: 40000 });
 
-    let approvePage: Page | null =
-      context.pages().find((p) => p !== this.page && !p.isClosed()) ?? null;
+    const keplrPopup = context
+      .waitForEvent("page", { timeout: 40000 })
+      .catch(() => null);
 
-    if (!approvePage) {
-      try {
-        approvePage = await context.waitForEvent("page", { timeout: 10000 });
-      } catch (error: any) {
-        if (
-          error.name === "TimeoutError" ||
-          /timeout/i.test(error.message ?? "")
-        ) {
-          console.log(
-            "Keplr popup did not appear within 10s for claim and close; assuming 1-click trading."
-          );
-        } else {
-          throw error;
-        }
-      }
-    }
+    const result = await Promise.race([
+      keplrPopup.then((p) => ({ type: "popup" as const, page: p })),
+      successPromise.then(() => ({ type: "success" as const, page: null })),
+    ]);
 
-    if (approvePage) {
-      await approvePage.waitForLoadState();
-      const approveBtn = approvePage.getByRole("button", {
+    if (result.type === "popup" && result.page) {
+      await result.page.waitForLoadState();
+      const approveBtn = result.page.getByRole("button", {
         name: "Approve",
       });
       await expect(approveBtn).toBeEnabled();
-      const msgContentAmount1 = await approvePage
+      const msgContentAmount1 = await result.page
         .getByText("Execute contract")
         .first()
         .textContent();
-      const msgContentAmount2 = await approvePage
+      const msgContentAmount2 = await result.page
         .getByText("Execute contract")
         .last()
         .textContent();
@@ -214,9 +195,12 @@ export class TransactionsPage extends BasePage {
       await approveBtn.click();
       expect(msgContentAmount1).toContain("claim_limit");
       expect(msgContentAmount2).toContain("cancel_limit");
+      await successPromise;
+    } else {
+      console.log(
+        "Transaction succeeded via 1-click trading (claim and close)."
+      );
     }
-
-    await successPromise;
   }
 
   async claimAll(context: BrowserContext) {
@@ -226,36 +210,26 @@ export class TransactionsPage extends BasePage {
       this.page.getByText("Transaction Successful")
     ).toBeVisible({ timeout: 40000 });
 
-    let approvePage: Page | null =
-      context.pages().find((p) => p !== this.page && !p.isClosed()) ?? null;
+    const keplrPopup = context
+      .waitForEvent("page", { timeout: 40000 })
+      .catch(() => null);
 
-    if (!approvePage) {
-      try {
-        approvePage = await context.waitForEvent("page", { timeout: 10000 });
-      } catch (error: any) {
-        if (
-          error.name === "TimeoutError" ||
-          /timeout/i.test(error.message ?? "")
-        ) {
-          console.log(
-            "Keplr popup did not appear within 10s for claim all; assuming 1-click trading."
-          );
-        } else {
-          throw error;
-        }
-      }
-    }
+    const result = await Promise.race([
+      keplrPopup.then((p) => ({ type: "popup" as const, page: p })),
+      successPromise.then(() => ({ type: "success" as const, page: null })),
+    ]);
 
-    if (approvePage) {
-      await approvePage.waitForLoadState();
-      const approveBtn = approvePage.getByRole("button", {
+    if (result.type === "popup" && result.page) {
+      await result.page.waitForLoadState();
+      const approveBtn = result.page.getByRole("button", {
         name: "Approve",
       });
       await expect(approveBtn).toBeEnabled();
       await approveBtn.click();
+      await successPromise;
+    } else {
+      console.log("Transaction succeeded via 1-click trading (claim all).");
     }
-
-    await successPromise;
   }
 
   async claimAllIfPresent(context: BrowserContext) {

--- a/packages/e2e/pages/transactions-page.ts
+++ b/packages/e2e/pages/transactions-page.ts
@@ -104,7 +104,7 @@ export class TransactionsPage extends BasePage {
 
     const cancelBtnLocator = this.page.locator(cancelBtn).first();
     await expect(cancelBtnLocator, "Cancel button not found!").toBeVisible({
-      timeout: 5000,
+      timeout: 30000,
     });
 
     await cancelBtnLocator.click();

--- a/packages/e2e/pages/transactions-page.ts
+++ b/packages/e2e/pages/transactions-page.ts
@@ -139,6 +139,7 @@ export class TransactionsPage extends BasePage {
       console.log(
         "Transaction succeeded via 1-click trading (cancel limit order)."
       );
+      await successPromise;
     }
   }
 
@@ -200,6 +201,7 @@ export class TransactionsPage extends BasePage {
       console.log(
         "Transaction succeeded via 1-click trading (claim and close)."
       );
+      await successPromise;
     }
   }
 
@@ -229,6 +231,7 @@ export class TransactionsPage extends BasePage {
       await successPromise;
     } else {
       console.log("Transaction succeeded via 1-click trading (claim all).");
+      await successPromise;
     }
   }
 


### PR DESCRIPTION
## What is the purpose of the change

Fixes flaky e2e tests caused by 1CT (one-click trading) session activation during swap flows. When 1CT is enabled mid-session, subsequent transactions bypass Keplr approval, causing the test to waste 10s waiting for a popup that never appears while the 7s auto-dismissing "Transaction Successful" toast vanishes. This makes `getTransactionUrl()` unable to find the "View explorer" link, failing the test even though the transaction succeeded on-chain.

Also fixes the flaky "cancel limit sell OSMO" test where the newly placed order may not appear in the orders table within the original 5s timeout due to SQS indexing delay and multiple caching layers.

Also fixes the portfolio/transactions job exceeding its 10-minute limit due to `getBalanceFor()` hanging for 90s (the full test timeout) when search results haven't loaded yet, causing cascading retries.

### Linear Tasks

- [MER-176: E2E: Fix 1CT-induced flaky swap, trade, and transaction tests](https://linear.app/osmosis/issue/MER-176/e2e-fix-1ct-induced-flaky-swap-trade-and-transaction-tests)
- [MER-177: E2E: Fix flaky "cancel limit sell OSMO" test — order not visible within 5s timeout](https://linear.app/osmosis/issue/MER-177/e2e-fix-flaky-cancel-limit-sell-osmo-test-order-not-visible-within-5s)

## Brief Changelog

- Extract shared `disable1CTIfNeeded()` helper in `trade-page.ts` with 500ms visibility check to disable the 1CT toggle in the swap review dialog, forcing Keplr approval for deterministic test behavior
- Apply `disable1CTIfNeeded()` to all 6 TradePage methods: `swapAndApprove`, `buyAndApprove`, `sellAndApprove`, `swapAndGetWalletMsg`, `buyAndGetWalletMsg`, `sellAndGetWalletMsg`
- Add explicit 10s timeout to `getTransactionUrl()` `getAttribute` call
- Refactor `transactions-page.ts` methods (`cancelLimitOrder`, `claimAndCloseAny`, `claimAll`) to use `Promise.race` between Keplr popup and success toast, handling both 1CT and non-1CT flows without wasted timeouts
- Increase `cancelLimitOrder` visibility timeout from 5s to 30s to survive SQS indexing delay (5s cache TTL + 10s TRPC cache + 10s client refetch)
- Add 10s timeout to `swap-page.ts` `swapAndGetWalletMsg` `waitForEvent('page')` with graceful 1CT fallback to fix latent indefinite-hang bug
- Add explicit 20s `waitFor` in `portfolio-page.ts` `getBalanceFor()` before `innerText()` to prevent 90s hangs when search results are still loading, keeping portfolio job within its 10-minute limit

## Testing and Verifying

- [ ] CI swap monitoring tests (`monitoring.swap.wallet.spec.ts`) pass without retries
- [ ] Trade tests (`trade.wallet.spec.ts`) pass with buy/sell/cancel limit order flows
- [ ] Claim tests (`claim.spec.ts`) pass with claim and close / claim all flows
- [ ] Portfolio/transactions tests (`portfolio.wallet.spec.ts`, `transactions.wallet.spec.ts`) complete within 10-minute job limit
- [ ] No regressions in other e2e wallet tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since changes are confined to Playwright E2E page objects, but they touch timing/popup-handling logic that could mask genuine UI regressions if timeouts or races are mis-tuned.
> 
> **Overview**
> Improves E2E stability around Keplr vs 1-Click Trading (1CT) by adding time-bounded popup waits, registering popup listeners *before* clicks, and gracefully treating popup timeouts as auto-approved flows across `BasePage`, `SwapPage`, `TradePage`, and `TransactionsPage`.
> 
> `TradePage` adds `disable1CTIfNeeded()` and uses it across swap/buy/sell flows, refactors Keplr approval to use a pre-registered popup promise, adds a timeout to `getTransactionUrl()`, and cleans up retry attempts by dismissing the lingering review modal.
> 
> `TransactionsPage` refactors cancel/claim actions to `Promise.race` the Keplr popup against the success toast (with stale-toast dismissal), and increases limit-order cancel visibility timeout; `PortfolioPage` tightens balance lookup by waiting for the row to be visible and clearing search input before fills.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5b99b948aa8b006009e004ba151f3cc7bc5e657. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->