### PR TITLE
fix(bridge): align Squid CosmWasm transaction path with v2 API format

### DIFF
--- a/packages/bridge/src/squid/__tests__/squid-bridge-provider.spec.ts
+++ b/packages/bridge/src/squid/__tests__/squid-bridge-provider.spec.ts
@@ -418,9 +418,7 @@ describe("SquidBridgeProvider", () => {
     expect(result).toBeDefined();
     expect(result.type).toBe("cosmos");
     expect(result.msgs).toHaveLength(1);
-    expect(result.msgs[0].typeUrl).toBe(
-      "/cosmwasm.wasm.v1.MsgExecuteContract"
-    );
+    expect(result.msgs[0].typeUrl).toBe("/cosmwasm.wasm.v1.MsgExecuteContract");
   });
 
   it("should get chains", async () => {

--- a/packages/bridge/src/squid/__tests__/squid-bridge-provider.spec.ts
+++ b/packages/bridge/src/squid/__tests__/squid-bridge-provider.spec.ts
@@ -419,6 +419,15 @@ describe("SquidBridgeProvider", () => {
     expect(result.type).toBe("cosmos");
     expect(result.msgs).toHaveLength(1);
     expect(result.msgs[0].typeUrl).toBe("/cosmwasm.wasm.v1.MsgExecuteContract");
+
+    const msg = result.msgs[0];
+    expect(msg.value.contract).toBe(
+      "osmo1x0fn7u7qlhxn6cl47hfnsyq0ymga57fz3mn7yccsaywqxpahq2pqs3na3m"
+    );
+    expect(msg.value.sender).toBe(
+      "osmo107vyuer6wzfe7nrrsujppa0pvx35fvplp4t7tx"
+    );
+    expect(msg.value.funds).toEqual([{ denom: "uatom", amount: "1000000" }]);
   });
 
   it("should get chains", async () => {

--- a/packages/bridge/src/squid/__tests__/squid-bridge-provider.spec.ts
+++ b/packages/bridge/src/squid/__tests__/squid-bridge-provider.spec.ts
@@ -396,6 +396,33 @@ describe("SquidBridgeProvider", () => {
     });
   });
 
+  it("should create a Cosmos MsgExecuteContract transaction (v2 format)", async () => {
+    const cosmwasmData = JSON.stringify({
+      typeUrl: "/cosmwasm.wasm.v1.MsgExecuteContract",
+      value: {
+        sender: "osmo107vyuer6wzfe7nrrsujppa0pvx35fvplp4t7tx",
+        contract:
+          "osmo1x0fn7u7qlhxn6cl47hfnsyq0ymga57fz3mn7yccsaywqxpahq2pqs3na3m",
+        msg: { swap: { output_denom: "uosmo" } },
+        funds: [{ denom: "uatom", amount: "1000000" }],
+      },
+    });
+
+    const result = await provider.createCosmosTransaction(
+      cosmwasmData,
+      "osmo107vyuer6wzfe7nrrsujppa0pvx35fvplp4t7tx",
+      { chainId: 1, chainName: "Ethereum", chainType: "evm" },
+      { denom: "uatom", amount: "1000000" }
+    );
+
+    expect(result).toBeDefined();
+    expect(result.type).toBe("cosmos");
+    expect(result.msgs).toHaveLength(1);
+    expect(result.msgs[0].typeUrl).toBe(
+      "/cosmwasm.wasm.v1.MsgExecuteContract"
+    );
+  });
+
   it("should get chains", async () => {
     const chains = await provider.getChains();
     expect(chains).toBeDefined();

--- a/packages/bridge/src/squid/index.ts
+++ b/packages/bridge/src/squid/index.ts
@@ -595,17 +595,17 @@ export class SquidBridgeProvider implements BridgeProvider {
         const cosmwasmData = parsedData as {
           typeUrl: typeof WasmTransferType;
           value: {
-            wasm: {
-              contract: string;
-              value: object;
-            };
+            sender: string;
+            contract: string;
+            msg: object;
+            funds?: { denom: string; amount: string }[];
           };
         };
 
         const { typeUrl, value: msg } = await makeExecuteCosmwasmContractMsg({
           sender: fromAddress,
-          contract: cosmwasmData.value.wasm.contract,
-          msg: cosmwasmData.value.wasm.value,
+          contract: cosmwasmData.value.contract,
+          msg: cosmwasmData.value.msg,
           funds: [fromCoin],
         });
 


### PR DESCRIPTION
## What is the purpose of the change

Fixes Squid bridge Cosmos CosmWasm transactions (`MsgExecuteContract`) crashing with `CreateCosmosTxError: Cannot read properties of undefined (reading 'contract')`. The `createCosmosTransaction` method still used the v1 Squid API data shape (`value.wasm.contract`) instead of the v2 protobuf-JSON format (`value.contract`), causing any Squid route that uses a CosmWasm execute message to fail at runtime.

### Linear Task

[MER-179: fix: Squid bridge CosmWasm transactions crash with "Cannot read properties of undefined (reading 'contract')"](https://linear.app/osmosis/issue/MER-179/fix-squid-bridge-cosmwasm-transactions-crash-with-cannot-read)

## Brief Changelog

- Updated `createCosmosTransaction` in `packages/bridge/src/squid/index.ts` to read `MsgExecuteContract` fields from `value.contract` and `value.msg` (v2 protobuf-JSON format) instead of the legacy `value.wasm.contract` / `value.wasm.value` nesting from the v1 API
- Also fixed the field name: the old code used `wasm.value` for the message body, but even the v1 SDK type `WasmHookMsg` calls it `msg`
- Added a unit test for the `MsgExecuteContract` (CosmWasm execute) path with assertions on `typeUrl`, `contract`, `sender`, and `funds`

### Root cause

PR #4269 (commit `ec1a4dca9`) fixed the **EVM transaction path** to align with the Squid v2 API (`targetAddress` -> `target`, removing `routeType`), but left the **Cosmos CosmWasm path** untouched. The v1 API returned CosmWasm data in a custom nested format (`{ msgTypeUrl, msg: { wasm: { contract, msg } } }`), while the v2 API returns standard protobuf-JSON (`{ typeUrl, value: { sender, contract, msg, funds } }`). The code was accessing `cosmwasmData.value.wasm.contract`, but in the v2 format `value.wasm` is `undefined`.

### Why this wasn't caught before

The existing test suite only covered the **IBC transfer** path (`MsgTransfer`), not the **CosmWasm execute** path (`MsgExecuteContract`). The mock route response used an IBC transfer as the source-side Cosmos message, so the CosmWasm branch had zero test coverage.

## Testing and Verifying

- [x] New unit test `should create a Cosmos MsgExecuteContract transaction (v2 format)` passes with assertions on `typeUrl`, `contract`, `sender`, and `funds`
- [x] All 16 existing Squid bridge tests continue to pass
- [x] ESLint and Prettier checks pass
- [x] Verify on Vercel preview that Squid Cosmos->EVM CosmWasm routes no longer return the `CreateCosmosTxError`