### PR TITLE
fix: remove trailing decimal point from round-number price display

### DIFF
--- a/packages/web/components/chart/price-historical.tsx
+++ b/packages/web/components/chart/price-historical.tsx
@@ -330,7 +330,8 @@ export const PriceChartHeader: FunctionComponent<{
                 {fiatSymbol}
                 {compactZeros ? (
                   <>
-                    {significantDigits}.
+                    {significantDigits}
+                    {(decimalDigits || Boolean(zeros)) && "."}
                     {Boolean(zeros) && (
                       <>
                         0<sub title={`${getFormattedPrice()}USD`}>{zeros}</sub>
@@ -471,7 +472,8 @@ export const SubscriptDecimal: FunctionComponent<{
 
   return (
     <>
-      {significantDigits}.
+      {significantDigits}
+      {(decimalDigits || Boolean(zeros)) && "."}
       {Boolean(zeros) && (
         <>
           0<sub title={getFormattedPrice()}>{zeros}</sub>


### PR DESCRIPTION
## What is the purpose of the change:

The asset detail page (and chart headers) display a trailing decimal point for round-number prices — e.g. USDC shows as **`$1.`** instead of **`$1`**. This is a cosmetic rendering bug in the `SubscriptDecimal` component and the `PriceChartHeader` compact-zeros branch.

### Linear Task

[MER-180: FE: Fix trailing decimal point on round-number price display](https://linear.app/osmosis/issue/MER-180/fe-fix-trailing-decimal-point-on-round-number-price-display)

## Brief Changelog

- Conditionally render the decimal point in `PriceChartHeader` and `SubscriptDecimal` only when there are actual decimal digits or compressed zeros to display after it
- Previously, a hardcoded `.` was always appended after `significantDigits`, even when `compressZeros` returned no fractional portion (no `decimalDigits` or `zeros`)

## Testing and Verifying

- Navigate to the USDC asset page (`/assets/USDC`) — price should display as `$1` not `$1.`
- Verify other assets with fractional prices (e.g. OSMO, ATOM) still display decimals correctly
- Verify very small prices (e.g. memecoins with compressed subscript zeros) still render the subscript notation correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cosmetic change that only affects price string rendering in `PriceChartHeader` and `SubscriptDecimal`. Main risk is minor formatting regressions for edge cases (very small prices with compressed zeros).
> 
> **Overview**
> Fixes a UI formatting bug where round-number prices rendered as `1.` in compact/subscript mode.
> 
> The chart header (`PriceChartHeader` compact-zeros branch) and `SubscriptDecimal` now only render the decimal point when there are actual fractional digits or compressed subscript zeros to display.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef9c5682838162257f9354d12812f7f684b7060b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->