### PR TITLE
fix(ui): standardise EntityImage circular masking across all components

### DIFF
--- a/packages/types/src/asset-types.ts
+++ b/packages/types/src/asset-types.ts
@@ -189,13 +189,6 @@ export interface Asset {
 
   pegMechanism?: "algorithmic" | "collateralized" | "hybrid";
 
-  /**
-   * When true, the logo image uses its full bounding box — content extends near
-   * the edges and should not be clipped to a circle. Set in osmosis-labs/assetlists
-   * and flows through codegen automatically.
-   */
-  logoUsesFullBounds?: boolean;
-
   /** Add to asset at build time. */
   relative_image_url: string;
 

--- a/packages/types/src/asset-types.ts
+++ b/packages/types/src/asset-types.ts
@@ -189,6 +189,13 @@ export interface Asset {
 
   pegMechanism?: "algorithmic" | "collateralized" | "hybrid";
 
+  /**
+   * When true, the logo image uses its full bounding box — content extends near
+   * the edges and should not be clipped to a circle. Set in osmosis-labs/assetlists
+   * and flows through codegen automatically.
+   */
+  logoUsesFullBounds?: boolean;
+
   /** Add to asset at build time. */
   relative_image_url: string;
 

--- a/packages/web/components/alloyed-assets.tsx
+++ b/packages/web/components/alloyed-assets.tsx
@@ -97,8 +97,9 @@ export const AlloyedAssetsSection = (props: AlloyedAssetsSectionProps) => {
             className="flex"
           >
             {alloyedAsset.asset.coinImageUrl ? (
-              <div className="h-12 w-12 min-w-[48px] shrink-0 overflow-hidden rounded-full">
+              <div className="min-w-[48px] shrink-0">
                 <EntityImage
+                  circular
                   logoURIs={getLogoURIs(alloyedAsset.asset.coinImageUrl)}
                   symbol={alloyedAsset.asset.coinDenom}
                   name={alloyedAsset.asset.coinName}

--- a/packages/web/components/alloyed-assets.tsx
+++ b/packages/web/components/alloyed-assets.tsx
@@ -97,14 +97,15 @@ export const AlloyedAssetsSection = (props: AlloyedAssetsSectionProps) => {
             className="flex"
           >
             {alloyedAsset.asset.coinImageUrl ? (
-              <EntityImage
-                logoURIs={getLogoURIs(alloyedAsset.asset.coinImageUrl)}
-                symbol={alloyedAsset.asset.coinDenom}
-                name={alloyedAsset.asset.coinName}
-                width={48}
-                height={48}
-                className="h-12 w-12 min-w-[48px]"
-              />
+              <div className="h-12 w-12 min-w-[48px] shrink-0 overflow-hidden rounded-full">
+                <EntityImage
+                  logoURIs={getLogoURIs(alloyedAsset.asset.coinImageUrl)}
+                  symbol={alloyedAsset.asset.coinDenom}
+                  name={alloyedAsset.asset.coinName}
+                  width={48}
+                  height={48}
+                />
+              </div>
             ) : (
               false
             )}

--- a/packages/web/components/alloyed-assets.tsx
+++ b/packages/web/components/alloyed-assets.tsx
@@ -97,9 +97,8 @@ export const AlloyedAssetsSection = (props: AlloyedAssetsSectionProps) => {
             className="flex"
           >
             {alloyedAsset.asset.coinImageUrl ? (
-              <div className="min-w-[48px] shrink-0">
+              <div className="h-12 w-12 min-w-[48px] shrink-0 overflow-hidden rounded-full">
                 <EntityImage
-                  circular
                   logoURIs={getLogoURIs(alloyedAsset.asset.coinImageUrl)}
                   symbol={alloyedAsset.asset.coinDenom}
                   name={alloyedAsset.asset.coinName}

--- a/packages/web/components/assets/highlights-categories.tsx
+++ b/packages/web/components/assets/highlights-categories.tsx
@@ -317,13 +317,15 @@ const AssetHighlightRow: FunctionComponent<{
   const AssetContent = (
     <>
       <div className="flex items-center gap-2">
-        <EntityImage
-          symbol={coinDenom}
-          name={coinName}
-          logoURIs={logoURIs}
-          width={32}
-          height={32}
-        />
+        <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full">
+          <EntityImage
+            symbol={coinDenom}
+            name={coinName}
+            logoURIs={logoURIs}
+            width={32}
+            height={32}
+          />
+        </div>
         <span className="body2 max-w-[7rem] overflow-clip text-ellipsis whitespace-nowrap">
           {coinName}
         </span>

--- a/packages/web/components/assets/highlights-categories.tsx
+++ b/packages/web/components/assets/highlights-categories.tsx
@@ -317,9 +317,8 @@ const AssetHighlightRow: FunctionComponent<{
   const AssetContent = (
     <>
       <div className="flex items-center gap-2">
-        <div className="shrink-0">
+        <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full">
           <EntityImage
-            circular
             symbol={coinDenom}
             name={coinName}
             logoURIs={logoURIs}

--- a/packages/web/components/assets/highlights-categories.tsx
+++ b/packages/web/components/assets/highlights-categories.tsx
@@ -317,8 +317,9 @@ const AssetHighlightRow: FunctionComponent<{
   const AssetContent = (
     <>
       <div className="flex items-center gap-2">
-        <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full">
+        <div className="shrink-0">
           <EntityImage
+            circular
             symbol={coinDenom}
             name={coinName}
             logoURIs={logoURIs}

--- a/packages/web/components/bridge/amount-screen.tsx
+++ b/packages/web/components/bridge/amount-screen.tsx
@@ -992,9 +992,8 @@ export const AmountScreen = observer(
                 className="flex items-center gap-3"
                 onClick={() => setCurrentScreen(BridgeScreen.Asset)}
               >
-                <div className="shrink-0">
+                <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full">
                   <EntityImage
-                    circular
                     logoURIs={getLogoURIs(canonicalAsset.coinImageUrl)}
                     name={canonicalAsset.coinName}
                     symbol={canonicalAsset.coinDenom}

--- a/packages/web/components/bridge/amount-screen.tsx
+++ b/packages/web/components/bridge/amount-screen.tsx
@@ -992,13 +992,15 @@ export const AmountScreen = observer(
                 className="flex items-center gap-3"
                 onClick={() => setCurrentScreen(BridgeScreen.Asset)}
               >
-                <EntityImage
-                  logoURIs={getLogoURIs(canonicalAsset.coinImageUrl)}
-                  name={canonicalAsset.coinName}
-                  symbol={canonicalAsset.coinDenom}
-                  width={32}
-                  height={32}
-                />
+                <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full">
+                  <EntityImage
+                    logoURIs={getLogoURIs(canonicalAsset.coinImageUrl)}
+                    name={canonicalAsset.coinName}
+                    symbol={canonicalAsset.coinDenom}
+                    width={32}
+                    height={32}
+                  />
+                </div>
                 <span>{canonicalAsset.coinDenom}</span>
               </button>
             </>

--- a/packages/web/components/bridge/amount-screen.tsx
+++ b/packages/web/components/bridge/amount-screen.tsx
@@ -992,8 +992,9 @@ export const AmountScreen = observer(
                 className="flex items-center gap-3"
                 onClick={() => setCurrentScreen(BridgeScreen.Asset)}
               >
-                <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full">
+                <div className="shrink-0">
                   <EntityImage
+                    circular
                     logoURIs={getLogoURIs(canonicalAsset.coinImageUrl)}
                     name={canonicalAsset.coinName}
                     symbol={canonicalAsset.coinDenom}

--- a/packages/web/components/bridge/asset-select-screen.tsx
+++ b/packages/web/components/bridge/asset-select-screen.tsx
@@ -206,13 +206,15 @@ export const AssetSelectScreen: FunctionComponent<AssetSelectScreenProps> =
                         !shouldShowUnverifiedAssets && !asset.isVerified,
                     })}
                   >
-                    <EntityImage
-                      logoURIs={getLogoURIs(asset.coinImageUrl)}
-                      width={isMobile ? 32 : 48}
-                      height={isMobile ? 32 : 48}
-                      name={asset.coinName}
-                      symbol={asset.coinDenom}
-                    />
+                    <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full md:h-12 md:w-12">
+                      <EntityImage
+                        logoURIs={getLogoURIs(asset.coinImageUrl)}
+                        width={isMobile ? 32 : 48}
+                        height={isMobile ? 32 : 48}
+                        name={asset.coinName}
+                        symbol={asset.coinDenom}
+                      />
+                    </div>
                     <span className="flex flex-col text-left">
                       <div className="flex items-center gap-1">
                         <span className="subtitle1 md:body2">

--- a/packages/web/components/bridge/asset-select-screen.tsx
+++ b/packages/web/components/bridge/asset-select-screen.tsx
@@ -206,9 +206,8 @@ export const AssetSelectScreen: FunctionComponent<AssetSelectScreenProps> =
                         !shouldShowUnverifiedAssets && !asset.isVerified,
                     })}
                   >
-                    <div className="shrink-0">
+                    <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full md:h-12 md:w-12">
                       <EntityImage
-                        circular
                         logoURIs={getLogoURIs(asset.coinImageUrl)}
                         width={isMobile ? 32 : 48}
                         height={isMobile ? 32 : 48}

--- a/packages/web/components/bridge/asset-select-screen.tsx
+++ b/packages/web/components/bridge/asset-select-screen.tsx
@@ -206,8 +206,9 @@ export const AssetSelectScreen: FunctionComponent<AssetSelectScreenProps> =
                         !shouldShowUnverifiedAssets && !asset.isVerified,
                     })}
                   >
-                    <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full md:h-12 md:w-12">
+                    <div className="shrink-0">
                       <EntityImage
+                        circular
                         logoURIs={getLogoURIs(asset.coinImageUrl)}
                         width={isMobile ? 32 : 48}
                         height={isMobile ? 32 : 48}

--- a/packages/web/components/bridge/bridge-receive-asset-dropdown.tsx
+++ b/packages/web/components/bridge/bridge-receive-asset-dropdown.tsx
@@ -140,9 +140,8 @@ export const BridgeReceiveAssetDropdown: FunctionComponent<BridgeReceiveAssetDro
                               )}
                               onClick={onClick}
                             >
-                              <div className="shrink-0">
+                              <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full">
                                 <EntityImage
-                                  circular
                                   logoURIs={getLogoURIs(asset.coinImageUrl)}
                                   name={asset.coinName}
                                   symbol={asset.coinDenom}
@@ -198,9 +197,8 @@ export const BridgeReceiveAssetDropdown: FunctionComponent<BridgeReceiveAssetDro
                               )}
                               onClick={onClick}
                             >
-                              <div className="shrink-0">
+                              <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full">
                                 <EntityImage
-                                  circular
                                   logoURIs={getLogoURIs(
                                     representativeAsset.coinImageUrl
                                   )}

--- a/packages/web/components/bridge/bridge-receive-asset-dropdown.tsx
+++ b/packages/web/components/bridge/bridge-receive-asset-dropdown.tsx
@@ -140,13 +140,15 @@ export const BridgeReceiveAssetDropdown: FunctionComponent<BridgeReceiveAssetDro
                               )}
                               onClick={onClick}
                             >
-                              <EntityImage
-                                logoURIs={getLogoURIs(asset.coinImageUrl)}
-                                name={asset.coinName}
-                                symbol={asset.coinDenom}
-                                width={32}
-                                height={32}
-                              />
+                              <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full">
+                                <EntityImage
+                                  logoURIs={getLogoURIs(asset.coinImageUrl)}
+                                  name={asset.coinName}
+                                  symbol={asset.coinDenom}
+                                  width={32}
+                                  height={32}
+                                />
+                              </div>
                               <div className="flex flex-col">
                                 <p className="body1 md:body2">
                                   {isConvert
@@ -195,15 +197,17 @@ export const BridgeReceiveAssetDropdown: FunctionComponent<BridgeReceiveAssetDro
                               )}
                               onClick={onClick}
                             >
-                              <EntityImage
-                                logoURIs={getLogoURIs(
-                                  representativeAsset.coinImageUrl
-                                )}
-                                name={asset.denom}
-                                symbol={asset.denom}
-                                width={32}
-                                height={32}
-                              />
+                              <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full">
+                                <EntityImage
+                                  logoURIs={getLogoURIs(
+                                    representativeAsset.coinImageUrl
+                                  )}
+                                  name={asset.denom}
+                                  symbol={asset.denom}
+                                  width={32}
+                                  height={32}
+                                />
+                              </div>
                               <div className="flex flex-col">
                                 <p className="body1 md:body2">
                                   {t("transfer.withdrawAs")} {asset.denom}

--- a/packages/web/components/bridge/bridge-receive-asset-dropdown.tsx
+++ b/packages/web/components/bridge/bridge-receive-asset-dropdown.tsx
@@ -140,8 +140,9 @@ export const BridgeReceiveAssetDropdown: FunctionComponent<BridgeReceiveAssetDro
                               )}
                               onClick={onClick}
                             >
-                              <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full">
+                              <div className="shrink-0">
                                 <EntityImage
+                                  circular
                                   logoURIs={getLogoURIs(asset.coinImageUrl)}
                                   name={asset.coinName}
                                   symbol={asset.coinDenom}
@@ -197,8 +198,9 @@ export const BridgeReceiveAssetDropdown: FunctionComponent<BridgeReceiveAssetDro
                               )}
                               onClick={onClick}
                             >
-                              <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full">
+                              <div className="shrink-0">
                                 <EntityImage
+                                  circular
                                   logoURIs={getLogoURIs(
                                     representativeAsset.coinImageUrl
                                   )}

--- a/packages/web/components/bridge/deposit-address-screen.tsx
+++ b/packages/web/components/bridge/deposit-address-screen.tsx
@@ -127,13 +127,15 @@ export const DepositAddressScreen = observer(
                   className="flex items-center gap-3"
                   onClick={() => setCurrentScreen(BridgeScreen.Asset)}
                 >
-                  <EntityImage
-                    logoURIs={getLogoURIs(canonicalAsset.coinImageUrl)}
-                    name={canonicalAsset.coinName}
-                    symbol={canonicalAsset.coinDenom}
-                    width={32}
-                    height={32}
-                  />
+                  <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full">
+                    <EntityImage
+                      logoURIs={getLogoURIs(canonicalAsset.coinImageUrl)}
+                      name={canonicalAsset.coinName}
+                      symbol={canonicalAsset.coinDenom}
+                      width={32}
+                      height={32}
+                    />
+                  </div>
                   <span>
                     {canonicalAsset.coinName} ({canonicalAsset.coinDenom})
                   </span>

--- a/packages/web/components/bridge/deposit-address-screen.tsx
+++ b/packages/web/components/bridge/deposit-address-screen.tsx
@@ -127,9 +127,8 @@ export const DepositAddressScreen = observer(
                   className="flex items-center gap-3"
                   onClick={() => setCurrentScreen(BridgeScreen.Asset)}
                 >
-                  <div className="shrink-0">
+                  <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full">
                     <EntityImage
-                      circular
                       logoURIs={getLogoURIs(canonicalAsset.coinImageUrl)}
                       name={canonicalAsset.coinName}
                       symbol={canonicalAsset.coinDenom}

--- a/packages/web/components/bridge/deposit-address-screen.tsx
+++ b/packages/web/components/bridge/deposit-address-screen.tsx
@@ -127,8 +127,9 @@ export const DepositAddressScreen = observer(
                   className="flex items-center gap-3"
                   onClick={() => setCurrentScreen(BridgeScreen.Asset)}
                 >
-                  <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full">
+                  <div className="shrink-0">
                     <EntityImage
+                      circular
                       logoURIs={getLogoURIs(canonicalAsset.coinImageUrl)}
                       name={canonicalAsset.coinName}
                       symbol={canonicalAsset.coinDenom}

--- a/packages/web/components/bridge/review-screen.tsx
+++ b/packages/web/components/bridge/review-screen.tsx
@@ -297,15 +297,17 @@ const AssetBox: FunctionComponent<{
     <div className="flex w-full flex-col rounded-2xl border border-osmoverse-700">
       <div className="flex place-content-between items-center p-6 md:p-3">
         <div className="flex items-center gap-4 md:gap-2">
-          <EntityImage
-            logoURIs={{
-              png: assetImageUrl,
-            }}
-            name={coin.denom}
-            symbol={coin.denom}
-            width={isMobile ? 32 : 48}
-            height={isMobile ? 32 : 48}
-          />
+          <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full md:h-12 md:w-12">
+            <EntityImage
+              logoURIs={{
+                png: assetImageUrl,
+              }}
+              name={coin.denom}
+              symbol={coin.denom}
+              width={isMobile ? 32 : 48}
+              height={isMobile ? 32 : 48}
+            />
+          </div>
           <div className="md:flex md:flex-col md:gap-1">
             <div className="md:body2 text-h6 font-h6">
               {t(type === "from" ? "transfer.transfer" : "transfer.receive", {

--- a/packages/web/components/bridge/review-screen.tsx
+++ b/packages/web/components/bridge/review-screen.tsx
@@ -297,8 +297,9 @@ const AssetBox: FunctionComponent<{
     <div className="flex w-full flex-col rounded-2xl border border-osmoverse-700">
       <div className="flex place-content-between items-center p-6 md:p-3">
         <div className="flex items-center gap-4 md:gap-2">
-          <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full md:h-12 md:w-12">
+          <div className="shrink-0">
             <EntityImage
+              circular
               logoURIs={{
                 png: assetImageUrl,
               }}

--- a/packages/web/components/bridge/review-screen.tsx
+++ b/packages/web/components/bridge/review-screen.tsx
@@ -297,9 +297,8 @@ const AssetBox: FunctionComponent<{
     <div className="flex w-full flex-col rounded-2xl border border-osmoverse-700">
       <div className="flex place-content-between items-center p-6 md:p-3">
         <div className="flex items-center gap-4 md:gap-2">
-          <div className="shrink-0">
+          <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full md:h-12 md:w-12">
             <EntityImage
-              circular
               logoURIs={{
                 png: assetImageUrl,
               }}

--- a/packages/web/components/cards/my-position/expanded.tsx
+++ b/packages/web/components/cards/my-position/expanded.tsx
@@ -469,8 +469,9 @@ export const AssetsInfo: FunctionComponent<
             <div className="flex flex-wrap gap-x-5 gap-y-3">
               {assets.map((asset) => (
                 <div key={asset.denom} className="flex items-center gap-2">
-                  <div className="h-[24px] w-[24px] flex-shrink-0 overflow-hidden rounded-full">
+                  <div className="flex-shrink-0">
                     <EntityImage
+                      circular
                       logoURIs={getLogoURIs(asset.currency.coinImageUrl)}
                       name={asset.currency.coinDenom}
                       symbol={asset.currency.coinDenom}

--- a/packages/web/components/cards/my-position/expanded.tsx
+++ b/packages/web/components/cards/my-position/expanded.tsx
@@ -469,9 +469,8 @@ export const AssetsInfo: FunctionComponent<
             <div className="flex flex-wrap gap-x-5 gap-y-3">
               {assets.map((asset) => (
                 <div key={asset.denom} className="flex items-center gap-2">
-                  <div className="flex-shrink-0">
+                  <div className="h-[24px] w-[24px] flex-shrink-0 overflow-hidden rounded-full">
                     <EntityImage
-                      circular
                       logoURIs={getLogoURIs(asset.currency.coinImageUrl)}
                       name={asset.currency.coinDenom}
                       symbol={asset.currency.coinDenom}

--- a/packages/web/components/cards/my-position/expanded.tsx
+++ b/packages/web/components/cards/my-position/expanded.tsx
@@ -469,7 +469,7 @@ export const AssetsInfo: FunctionComponent<
             <div className="flex flex-wrap gap-x-5 gap-y-3">
               {assets.map((asset) => (
                 <div key={asset.denom} className="flex items-center gap-2">
-                  <div className="h-[24px] w-[24px] flex-shrink-0">
+                  <div className="h-[24px] w-[24px] flex-shrink-0 overflow-hidden rounded-full">
                     <EntityImage
                       logoURIs={getLogoURIs(asset.currency.coinImageUrl)}
                       name={asset.currency.coinDenom}

--- a/packages/web/components/chart/pool-composition.tsx
+++ b/packages/web/components/chart/pool-composition.tsx
@@ -12,7 +12,7 @@ export const PoolComposition: FunctionComponent<{
       {assets.map((asset) => (
         <li key={asset.denom} className="flex items-center tracking-wide">
           {asset.currency.coinImageUrl && (
-            <div className="mr-2 h-[20px] w-[20px]">
+            <div className="mr-2 h-[20px] w-[20px] overflow-hidden rounded-full">
               <EntityImage
                 logoURIs={getLogoURIs(asset.currency.coinImageUrl)}
                 name={asset.currency.coinDenom}

--- a/packages/web/components/chart/pool-composition.tsx
+++ b/packages/web/components/chart/pool-composition.tsx
@@ -12,8 +12,9 @@ export const PoolComposition: FunctionComponent<{
       {assets.map((asset) => (
         <li key={asset.denom} className="flex items-center tracking-wide">
           {asset.currency.coinImageUrl && (
-            <div className="mr-2 h-[20px] w-[20px] overflow-hidden rounded-full">
+            <div className="mr-2">
               <EntityImage
+                circular
                 logoURIs={getLogoURIs(asset.currency.coinImageUrl)}
                 name={asset.currency.coinDenom}
                 symbol={asset.currency.coinDenom}

--- a/packages/web/components/chart/pool-composition.tsx
+++ b/packages/web/components/chart/pool-composition.tsx
@@ -12,9 +12,8 @@ export const PoolComposition: FunctionComponent<{
       {assets.map((asset) => (
         <li key={asset.denom} className="flex items-center tracking-wide">
           {asset.currency.coinImageUrl && (
-            <div className="mr-2">
+            <div className="mr-2 h-[20px] w-[20px] overflow-hidden rounded-full">
               <EntityImage
-                circular
                 logoURIs={getLogoURIs(asset.currency.coinImageUrl)}
                 name={asset.currency.coinDenom}
                 symbol={asset.currency.coinDenom}

--- a/packages/web/components/complex/asset-fieldset.tsx
+++ b/packages/web/components/complex/asset-fieldset.tsx
@@ -267,7 +267,7 @@ const AssetFieldsetTokenSelector = ({
           symbol={selectedCoinDenom ?? ""}
           width={isMobile ? 24 : 40}
           height={isMobile ? 24 : 40}
-          className="h-10 w-10 rounded-full sm:h-6 sm:w-6"
+          className="h-10 w-10 overflow-hidden rounded-full sm:h-6 sm:w-6"
         />
         <span className="ml-2 truncate text-h5 font-h5 sm:ml-1 sm:text-h6 sm:font-h6">
           {selectedCoinDenom}

--- a/packages/web/components/complex/asset-fieldset.tsx
+++ b/packages/web/components/complex/asset-fieldset.tsx
@@ -267,7 +267,7 @@ const AssetFieldsetTokenSelector = ({
           symbol={selectedCoinDenom ?? ""}
           width={isMobile ? 24 : 40}
           height={isMobile ? 24 : 40}
-          className="h-10 w-10 overflow-hidden rounded-full sm:h-6 sm:w-6"
+          circular
         />
         <span className="ml-2 truncate text-h5 font-h5 sm:ml-1 sm:text-h6 sm:font-h6">
           {selectedCoinDenom}

--- a/packages/web/components/complex/asset-fieldset.tsx
+++ b/packages/web/components/complex/asset-fieldset.tsx
@@ -267,7 +267,7 @@ const AssetFieldsetTokenSelector = ({
           symbol={selectedCoinDenom ?? ""}
           width={isMobile ? 24 : 40}
           height={isMobile ? 24 : 40}
-          circular
+          className="h-10 w-10 overflow-hidden rounded-full sm:h-6 sm:w-6"
         />
         <span className="ml-2 truncate text-h5 font-h5 sm:ml-1 sm:text-h6 sm:font-h6">
           {selectedCoinDenom}

--- a/packages/web/components/complex/orders-history/index.tsx
+++ b/packages/web/components/complex/orders-history/index.tsx
@@ -551,8 +551,9 @@ const TableOrderRow = memo(
                   )}{" "}
                   {t("limitOrders.of")}
                 </span>
-                <div className="h-5 w-5 shrink-0 overflow-hidden rounded-full">
+                <div className="shrink-0">
                   <EntityImage
+                    circular
                     width={20}
                     height={20}
                     logoURIs={

--- a/packages/web/components/complex/orders-history/index.tsx
+++ b/packages/web/components/complex/orders-history/index.tsx
@@ -551,14 +551,15 @@ const TableOrderRow = memo(
                   )}{" "}
                   {t("limitOrders.of")}
                 </span>
-                <EntityImage
-                  width={20}
-                  height={20}
-                  logoURIs={baseAsset?.rawAsset.logoURIs ?? { png: undefined }}
-                  name={baseAsset?.rawAsset.name ?? ""}
-                  symbol={baseAsset?.rawAsset.symbol ?? ""}
-                  className="h-5 w-5"
-                />
+                <div className="h-5 w-5 shrink-0 overflow-hidden rounded-full">
+                  <EntityImage
+                    width={20}
+                    height={20}
+                    logoURIs={baseAsset?.rawAsset.logoURIs ?? { png: undefined }}
+                    name={baseAsset?.rawAsset.name ?? ""}
+                    symbol={baseAsset?.rawAsset.symbol ?? ""}
+                  />
+                </div>
                 <span>{baseAsset?.symbol}</span>
               </div>
             </div>

--- a/packages/web/components/complex/orders-history/index.tsx
+++ b/packages/web/components/complex/orders-history/index.tsx
@@ -551,14 +551,17 @@ const TableOrderRow = memo(
                   )}{" "}
                   {t("limitOrders.of")}
                 </span>
-                <EntityImage
-                  width={20}
-                  height={20}
-                  logoURIs={baseAsset?.rawAsset.logoURIs ?? { png: undefined }}
-                  name={baseAsset?.rawAsset.name ?? ""}
-                  symbol={baseAsset?.rawAsset.symbol ?? ""}
-                  className="h-5 w-5"
-                />
+                <div className="h-5 w-5 shrink-0 overflow-hidden rounded-full">
+                  <EntityImage
+                    width={20}
+                    height={20}
+                    logoURIs={
+                      baseAsset?.rawAsset.logoURIs ?? { png: undefined }
+                    }
+                    name={baseAsset?.rawAsset.name ?? ""}
+                    symbol={baseAsset?.rawAsset.symbol ?? ""}
+                  />
+                </div>
                 <span>{baseAsset?.symbol}</span>
               </div>
             </div>

--- a/packages/web/components/complex/orders-history/index.tsx
+++ b/packages/web/components/complex/orders-history/index.tsx
@@ -551,9 +551,8 @@ const TableOrderRow = memo(
                   )}{" "}
                   {t("limitOrders.of")}
                 </span>
-                <div className="shrink-0">
+                <div className="h-5 w-5 shrink-0 overflow-hidden rounded-full">
                   <EntityImage
-                    circular
                     width={20}
                     height={20}
                     logoURIs={

--- a/packages/web/components/complex/orders-history/order-modal.tsx
+++ b/packages/web/components/complex/orders-history/order-modal.tsx
@@ -252,15 +252,14 @@ const OrderDetails = observer(
         <div className="flex flex-col rounded-2xl border border-osmoverse-700 p-2">
           <div className="flex justify-between p-2">
             <div className="flex items-center gap-4">
-              <div className="h-10 w-10 overflow-hidden rounded-full">
-                <EntityImage
-                  logoURIs={getLogoURIs(tokenIn?.currency.coinImageUrl)}
-                  name={tokenIn?.sourceDenom ?? ""}
-                  symbol={tokenIn?.sourceDenom ?? ""}
-                  height={40}
-                  width={40}
-                />
-              </div>
+              <EntityImage
+                circular
+                logoURIs={getLogoURIs(tokenIn?.currency.coinImageUrl)}
+                name={tokenIn?.sourceDenom ?? ""}
+                symbol={tokenIn?.sourceDenom ?? ""}
+                height={40}
+                width={40}
+              />
               <div className="flex flex-col">
                 <div className="subtitle1 sm:body2">{topText}</div>
                 <div className="body1 sm:body2 text-osmoverse-300">
@@ -297,15 +296,14 @@ const OrderDetails = observer(
           </div>
           <div className="flex justify-between p-2">
             <div className="flex items-center gap-4">
-              <div className="h-10 w-10 overflow-hidden rounded-full">
-                <EntityImage
-                  logoURIs={getLogoURIs(tokenOut?.currency.coinImageUrl)}
-                  name={tokenOut?.sourceDenom ?? ""}
-                  symbol={tokenOut?.sourceDenom ?? ""}
-                  height={40}
-                  width={40}
-                />
-              </div>
+              <EntityImage
+                circular
+                logoURIs={getLogoURIs(tokenOut?.currency.coinImageUrl)}
+                name={tokenOut?.sourceDenom ?? ""}
+                symbol={tokenOut?.sourceDenom ?? ""}
+                height={40}
+                width={40}
+              />
               <div className="flex flex-col">
                 <div className="subtitle1 sm:body2">{bottomText}</div>
                 <div className="body1 sm:body2 text-osmoverse-300">

--- a/packages/web/components/complex/orders-history/order-modal.tsx
+++ b/packages/web/components/complex/orders-history/order-modal.tsx
@@ -252,7 +252,7 @@ const OrderDetails = observer(
         <div className="flex flex-col rounded-2xl border border-osmoverse-700 p-2">
           <div className="flex justify-between p-2">
             <div className="flex items-center gap-4">
-              <div className="h-10 w-10">
+              <div className="h-10 w-10 overflow-hidden rounded-full">
                 <EntityImage
                   logoURIs={getLogoURIs(tokenIn?.currency.coinImageUrl)}
                   name={tokenIn?.sourceDenom ?? ""}
@@ -297,7 +297,7 @@ const OrderDetails = observer(
           </div>
           <div className="flex justify-between p-2">
             <div className="flex items-center gap-4">
-              <div className="h-10 w-10">
+              <div className="h-10 w-10 overflow-hidden rounded-full">
                 <EntityImage
                   logoURIs={getLogoURIs(tokenOut?.currency.coinImageUrl)}
                   name={tokenOut?.sourceDenom ?? ""}

--- a/packages/web/components/complex/orders-history/order-modal.tsx
+++ b/packages/web/components/complex/orders-history/order-modal.tsx
@@ -252,14 +252,15 @@ const OrderDetails = observer(
         <div className="flex flex-col rounded-2xl border border-osmoverse-700 p-2">
           <div className="flex justify-between p-2">
             <div className="flex items-center gap-4">
-              <EntityImage
-                circular
-                logoURIs={getLogoURIs(tokenIn?.currency.coinImageUrl)}
-                name={tokenIn?.sourceDenom ?? ""}
-                symbol={tokenIn?.sourceDenom ?? ""}
-                height={40}
-                width={40}
-              />
+              <div className="h-10 w-10 overflow-hidden rounded-full">
+                <EntityImage
+                  logoURIs={getLogoURIs(tokenIn?.currency.coinImageUrl)}
+                  name={tokenIn?.sourceDenom ?? ""}
+                  symbol={tokenIn?.sourceDenom ?? ""}
+                  height={40}
+                  width={40}
+                />
+              </div>
               <div className="flex flex-col">
                 <div className="subtitle1 sm:body2">{topText}</div>
                 <div className="body1 sm:body2 text-osmoverse-300">
@@ -296,14 +297,15 @@ const OrderDetails = observer(
           </div>
           <div className="flex justify-between p-2">
             <div className="flex items-center gap-4">
-              <EntityImage
-                circular
-                logoURIs={getLogoURIs(tokenOut?.currency.coinImageUrl)}
-                name={tokenOut?.sourceDenom ?? ""}
-                symbol={tokenOut?.sourceDenom ?? ""}
-                height={40}
-                width={40}
-              />
+              <div className="h-10 w-10 overflow-hidden rounded-full">
+                <EntityImage
+                  logoURIs={getLogoURIs(tokenOut?.currency.coinImageUrl)}
+                  name={tokenOut?.sourceDenom ?? ""}
+                  symbol={tokenOut?.sourceDenom ?? ""}
+                  height={40}
+                  width={40}
+                />
+              </div>
               <div className="flex flex-col">
                 <div className="subtitle1 sm:body2">{bottomText}</div>
                 <div className="body1 sm:body2 text-osmoverse-300">

--- a/packages/web/components/complex/pool/create/cl/add-initial-liquidity.tsx
+++ b/packages/web/components/complex/pool/create/cl/add-initial-liquidity.tsx
@@ -229,7 +229,7 @@ const TokenLiquiditySelector = observer(
             symbol={selectedAsset.token.coinDenom}
             width={52}
             height={52}
-            className="overflow-hidden rounded-full"
+            circular
           />
           <h5 className="max-w-[90px] truncate">
             {selectedAsset.token.coinDenom}

--- a/packages/web/components/complex/pool/create/cl/add-initial-liquidity.tsx
+++ b/packages/web/components/complex/pool/create/cl/add-initial-liquidity.tsx
@@ -229,7 +229,7 @@ const TokenLiquiditySelector = observer(
             symbol={selectedAsset.token.coinDenom}
             width={52}
             height={52}
-            circular
+            className="overflow-hidden rounded-full"
           />
           <h5 className="max-w-[90px] truncate">
             {selectedAsset.token.coinDenom}

--- a/packages/web/components/complex/pool/create/cl/add-initial-liquidity.tsx
+++ b/packages/web/components/complex/pool/create/cl/add-initial-liquidity.tsx
@@ -229,7 +229,7 @@ const TokenLiquiditySelector = observer(
             symbol={selectedAsset.token.coinDenom}
             width={52}
             height={52}
-            className="rounded-full"
+            className="overflow-hidden rounded-full"
           />
           <h5 className="max-w-[90px] truncate">
             {selectedAsset.token.coinDenom}

--- a/packages/web/components/complex/pool/create/cl/set-base-info.tsx
+++ b/packages/web/components/complex/pool/create/cl/set-base-info.tsx
@@ -238,7 +238,7 @@ const TokenSelector = observer(
                   symbol={selectedAsset.token.coinDenom}
                   width={52}
                   height={52}
-                  className="rounded-full"
+                  className="overflow-hidden rounded-full"
                 />
                 <h5 className="max-w-[130px] truncate">
                   {selectedAsset.token.coinDenom}

--- a/packages/web/components/complex/pool/create/cl/set-base-info.tsx
+++ b/packages/web/components/complex/pool/create/cl/set-base-info.tsx
@@ -238,7 +238,7 @@ const TokenSelector = observer(
                   symbol={selectedAsset.token.coinDenom}
                   width={52}
                   height={52}
-                  className="overflow-hidden rounded-full"
+                  circular
                 />
                 <h5 className="max-w-[130px] truncate">
                   {selectedAsset.token.coinDenom}

--- a/packages/web/components/complex/pool/create/cl/set-base-info.tsx
+++ b/packages/web/components/complex/pool/create/cl/set-base-info.tsx
@@ -238,7 +238,7 @@ const TokenSelector = observer(
                   symbol={selectedAsset.token.coinDenom}
                   width={52}
                   height={52}
-                  circular
+                  className="overflow-hidden rounded-full"
                 />
                 <h5 className="max-w-[130px] truncate">
                   {selectedAsset.token.coinDenom}

--- a/packages/web/components/complex/pool/create/step2-add-liquidity.tsx
+++ b/packages/web/components/complex/pool/create/step2-add-liquidity.tsx
@@ -30,9 +30,8 @@ export const Step2AddLiquidity: FunctionComponent<StepProps> = observer(
                 className="flex h-24 place-content-between items-center rounded-2xl border border-white-faint px-7 md:h-fit md:p-2"
               >
                 <div className="flex items-center">
-                  <div className="flex items-center">
+                  <div className="flex h-14 w-14 items-center overflow-hidden rounded-full md:h-7 md:w-7">
                     <EntityImage
-                      circular
                       logoURIs={getLogoURIs(currency.coinImageUrl)}
                       name={currency.coinDenom}
                       symbol={currency.coinDenom}

--- a/packages/web/components/complex/pool/create/step2-add-liquidity.tsx
+++ b/packages/web/components/complex/pool/create/step2-add-liquidity.tsx
@@ -30,8 +30,9 @@ export const Step2AddLiquidity: FunctionComponent<StepProps> = observer(
                 className="flex h-24 place-content-between items-center rounded-2xl border border-white-faint px-7 md:h-fit md:p-2"
               >
                 <div className="flex items-center">
-                  <div className="flex h-14 w-14 items-center overflow-hidden rounded-full md:h-7 md:w-7">
+                  <div className="flex items-center">
                     <EntityImage
+                      circular
                       logoURIs={getLogoURIs(currency.coinImageUrl)}
                       name={currency.coinDenom}
                       symbol={currency.coinDenom}

--- a/packages/web/components/complex/pool/create/step2-add-liquidity.tsx
+++ b/packages/web/components/complex/pool/create/step2-add-liquidity.tsx
@@ -30,7 +30,7 @@ export const Step2AddLiquidity: FunctionComponent<StepProps> = observer(
                 className="flex h-24 place-content-between items-center rounded-2xl border border-white-faint px-7 md:h-fit md:p-2"
               >
                 <div className="flex items-center">
-                  <div className="flex h-14 w-14 items-center overflow-hidden md:h-7 md:w-7">
+                  <div className="flex h-14 w-14 items-center overflow-hidden rounded-full md:h-7 md:w-7">
                     <EntityImage
                       logoURIs={getLogoURIs(currency.coinImageUrl)}
                       name={currency.coinDenom}

--- a/packages/web/components/complex/portfolio/open-orders.tsx
+++ b/packages/web/components/complex/portfolio/open-orders.tsx
@@ -94,8 +94,9 @@ export const OpenOrders: FunctionComponent = () => {
 
             return (
               <div key={index} className="-mx-2 flex justify-between gap-4 p-2">
-                <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full">
+                <div className="shrink-0">
                   <EntityImage
+                    circular
                     width={32}
                     height={32}
                     logoURIs={

--- a/packages/web/components/complex/portfolio/open-orders.tsx
+++ b/packages/web/components/complex/portfolio/open-orders.tsx
@@ -94,14 +94,17 @@ export const OpenOrders: FunctionComponent = () => {
 
             return (
               <div key={index} className="-mx-2 flex justify-between gap-4 p-2">
-                <EntityImage
-                  width={32}
-                  height={32}
-                  logoURIs={baseAsset?.rawAsset.logoURIs ?? { png: undefined }}
-                  name={baseAsset?.rawAsset.name ?? ""}
-                  symbol={baseAsset?.rawAsset.symbol ?? ""}
-                  className="inline-block"
-                />
+                <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full">
+                  <EntityImage
+                    width={32}
+                    height={32}
+                    logoURIs={
+                      baseAsset?.rawAsset.logoURIs ?? { png: undefined }
+                    }
+                    name={baseAsset?.rawAsset.name ?? ""}
+                    symbol={baseAsset?.rawAsset.symbol ?? ""}
+                  />
+                </div>
                 <div className="flex h-full flex-col justify-between overflow-hidden whitespace-nowrap">
                   <span className="body2 overflow-hidden overflow-ellipsis">
                     {buySellText} {baseAsset?.currency?.coinDenom}{" "}

--- a/packages/web/components/complex/portfolio/open-orders.tsx
+++ b/packages/web/components/complex/portfolio/open-orders.tsx
@@ -94,14 +94,15 @@ export const OpenOrders: FunctionComponent = () => {
 
             return (
               <div key={index} className="-mx-2 flex justify-between gap-4 p-2">
-                <EntityImage
-                  width={32}
-                  height={32}
-                  logoURIs={baseAsset?.rawAsset.logoURIs ?? { png: undefined }}
-                  name={baseAsset?.rawAsset.name ?? ""}
-                  symbol={baseAsset?.rawAsset.symbol ?? ""}
-                  className="inline-block"
-                />
+                <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full">
+                  <EntityImage
+                    width={32}
+                    height={32}
+                    logoURIs={baseAsset?.rawAsset.logoURIs ?? { png: undefined }}
+                    name={baseAsset?.rawAsset.name ?? ""}
+                    symbol={baseAsset?.rawAsset.symbol ?? ""}
+                  />
+                </div>
                 <div className="flex h-full flex-col justify-between overflow-hidden whitespace-nowrap">
                   <span className="body2 overflow-hidden overflow-ellipsis">
                     {buySellText} {baseAsset?.currency?.coinDenom}{" "}

--- a/packages/web/components/complex/portfolio/open-orders.tsx
+++ b/packages/web/components/complex/portfolio/open-orders.tsx
@@ -94,9 +94,8 @@ export const OpenOrders: FunctionComponent = () => {
 
             return (
               <div key={index} className="-mx-2 flex justify-between gap-4 p-2">
-                <div className="shrink-0">
+                <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full">
                   <EntityImage
-                    circular
                     width={32}
                     height={32}
                     logoURIs={

--- a/packages/web/components/complex/remove-liquidity.tsx
+++ b/packages/web/components/complex/remove-liquidity.tsx
@@ -67,9 +67,8 @@ export const RemoveLiquidity: FunctionComponent<
                 className="flex items-center gap-2"
                 key={asset.currency.coinDenom}
               >
-                <div className="shrink-0">
+                <div className="h-4 w-4 shrink-0 overflow-hidden rounded-full">
                   <EntityImage
-                    circular
                     logoURIs={{
                       png: asset.currency.coinImageUrl,
                     }}

--- a/packages/web/components/complex/remove-liquidity.tsx
+++ b/packages/web/components/complex/remove-liquidity.tsx
@@ -67,8 +67,9 @@ export const RemoveLiquidity: FunctionComponent<
                 className="flex items-center gap-2"
                 key={asset.currency.coinDenom}
               >
-                <div className="h-4 w-4 shrink-0 overflow-hidden rounded-full">
+                <div className="shrink-0">
                   <EntityImage
+                    circular
                     logoURIs={{
                       png: asset.currency.coinImageUrl,
                     }}

--- a/packages/web/components/complex/remove-liquidity.tsx
+++ b/packages/web/components/complex/remove-liquidity.tsx
@@ -67,15 +67,17 @@ export const RemoveLiquidity: FunctionComponent<
                 className="flex items-center gap-2"
                 key={asset.currency.coinDenom}
               >
-                <EntityImage
-                  logoURIs={{
-                    png: asset.currency.coinImageUrl,
-                  }}
-                  name={asset.currency.coinDenom}
-                  symbol={asset.currency.coinDenom}
-                  height={16}
-                  width={16}
-                />
+                <div className="h-4 w-4 shrink-0 overflow-hidden rounded-full">
+                  <EntityImage
+                    logoURIs={{
+                      png: asset.currency.coinImageUrl,
+                    }}
+                    name={asset.currency.coinDenom}
+                    symbol={asset.currency.coinDenom}
+                    height={16}
+                    width={16}
+                  />
+                </div>
                 <span className="max-w-xs truncate">
                   {asset.mul(percentageMultiplier).trim(true).toString()}
                 </span>

--- a/packages/web/components/control/token-select-with-drawer.tsx
+++ b/packages/web/components/control/token-select-with-drawer.tsx
@@ -87,9 +87,8 @@ export const TokenSelectWithDrawer: FunctionComponent<
               isFromSelect ? "'from'" : "'to'"
             } token. Current token is ${selectedToken.coinDenom}`}
           >
-            <div className="mr-1 shrink-0">
+            <div className="mr-1 h-[50px] w-[50px] shrink-0 overflow-hidden rounded-full md:h-7 md:w-7">
               <EntityImage
-                circular
                 logoURIs={{
                   png: selectedToken.coinImageUrl,
                 }}

--- a/packages/web/components/control/token-select-with-drawer.tsx
+++ b/packages/web/components/control/token-select-with-drawer.tsx
@@ -87,7 +87,7 @@ export const TokenSelectWithDrawer: FunctionComponent<
               isFromSelect ? "'from'" : "'to'"
             } token. Current token is ${selectedToken.coinDenom}`}
           >
-            <div className="mr-1 h-[50px] w-[50px] shrink-0 rounded-full md:h-7 md:w-7">
+            <div className="mr-1 h-[50px] w-[50px] shrink-0 overflow-hidden rounded-full md:h-7 md:w-7">
               <EntityImage
                 logoURIs={{
                   png: selectedToken.coinImageUrl,

--- a/packages/web/components/control/token-select-with-drawer.tsx
+++ b/packages/web/components/control/token-select-with-drawer.tsx
@@ -87,8 +87,9 @@ export const TokenSelectWithDrawer: FunctionComponent<
               isFromSelect ? "'from'" : "'to'"
             } token. Current token is ${selectedToken.coinDenom}`}
           >
-            <div className="mr-1 h-[50px] w-[50px] shrink-0 overflow-hidden rounded-full md:h-7 md:w-7">
+            <div className="mr-1 shrink-0">
               <EntityImage
+                circular
                 logoURIs={{
                   png: selectedToken.coinImageUrl,
                 }}

--- a/packages/web/components/drawers/token-select-drawer.tsx
+++ b/packages/web/components/drawers/token-select-drawer.tsx
@@ -221,7 +221,7 @@ export const TokenSelectDrawer: FunctionComponent<{
                             onClickAsset(coinDenom);
                           }}
                         >
-                          <div className="h-[24px] w-[24px] rounded-full">
+                          <div className="h-[24px] w-[24px] overflow-hidden rounded-full">
                             <EntityImage
                               symbol={coinDenom}
                               name={coinDenom}
@@ -287,16 +287,18 @@ export const TokenSelectDrawer: FunctionComponent<{
                         )}
                       >
                         <div className="flex items-center">
-                          <EntityImage
-                            symbol={coinDenom}
-                            name={coinDenom}
-                            logoURIs={{
-                              png: coinImageUrl,
-                              svg: coinImageUrl,
-                            }}
-                            width={32}
-                            height={32}
-                          />
+                          <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full">
+                            <EntityImage
+                              symbol={coinDenom}
+                              name={coinDenom}
+                              logoURIs={{
+                                png: coinImageUrl,
+                                svg: coinImageUrl,
+                              }}
+                              width={32}
+                              height={32}
+                            />
+                          </div>
                           <div className="mr-4">
                             <h6 className="button font-button text-white-full">
                               {coinDenom}

--- a/packages/web/components/drawers/token-select-drawer.tsx
+++ b/packages/web/components/drawers/token-select-drawer.tsx
@@ -221,17 +221,18 @@ export const TokenSelectDrawer: FunctionComponent<{
                             onClickAsset(coinDenom);
                           }}
                         >
-                          <EntityImage
-                            circular
-                            symbol={coinDenom}
-                            name={coinDenom}
-                            logoURIs={{
-                              png: coinImageUrl,
-                              svg: coinImageUrl,
-                            }}
-                            width={24}
-                            height={24}
-                          />
+                          <div className="h-[24px] w-[24px] overflow-hidden rounded-full">
+                            <EntityImage
+                              symbol={coinDenom}
+                              name={coinDenom}
+                              logoURIs={{
+                                png: coinImageUrl,
+                                svg: coinImageUrl,
+                              }}
+                              width={24}
+                              height={24}
+                            />
+                          </div>
                           <p className="subtitle1">{coinDenom}</p>
                         </button>
                       );
@@ -286,9 +287,8 @@ export const TokenSelectDrawer: FunctionComponent<{
                         )}
                       >
                         <div className="flex items-center">
-                          <div className="shrink-0">
+                          <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full">
                             <EntityImage
-                              circular
                               symbol={coinDenom}
                               name={coinDenom}
                               logoURIs={{

--- a/packages/web/components/drawers/token-select-drawer.tsx
+++ b/packages/web/components/drawers/token-select-drawer.tsx
@@ -221,18 +221,17 @@ export const TokenSelectDrawer: FunctionComponent<{
                             onClickAsset(coinDenom);
                           }}
                         >
-                          <div className="h-[24px] w-[24px] overflow-hidden rounded-full">
-                            <EntityImage
-                              symbol={coinDenom}
-                              name={coinDenom}
-                              logoURIs={{
-                                png: coinImageUrl,
-                                svg: coinImageUrl,
-                              }}
-                              width={24}
-                              height={24}
-                            />
-                          </div>
+                          <EntityImage
+                            circular
+                            symbol={coinDenom}
+                            name={coinDenom}
+                            logoURIs={{
+                              png: coinImageUrl,
+                              svg: coinImageUrl,
+                            }}
+                            width={24}
+                            height={24}
+                          />
                           <p className="subtitle1">{coinDenom}</p>
                         </button>
                       );
@@ -287,8 +286,9 @@ export const TokenSelectDrawer: FunctionComponent<{
                         )}
                       >
                         <div className="flex items-center">
-                          <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full">
+                          <div className="shrink-0">
                             <EntityImage
+                              circular
                               symbol={coinDenom}
                               name={coinDenom}
                               logoURIs={{

--- a/packages/web/components/earn/table/columns.tsx
+++ b/packages/web/components/earn/table/columns.tsx
@@ -91,12 +91,11 @@ export const tableColumns = [
           <div
             key={`${coinDenom} ${i} ${item.cell.id}`}
             className={classNames(
-              "shrink-0",
+              "h-9 w-9 shrink-0 overflow-hidden rounded-full",
               { "-ml-4": i > 0 }
             )}
           >
             <EntityImage
-              circular
               symbol={coinDenom}
               name={coinDenom}
               logoURIs={{
@@ -162,7 +161,7 @@ export const tableColumns = [
           <div
             key={`${coinDenom} ${i} ${item.cell.id}`}
             className={classNames(
-              "shrink-0",
+              "h-6 w-6 shrink-0 overflow-hidden rounded-full",
               {
                 "-ml-2": i > 0,
                 "mr-2": item.getValue().length === 1,
@@ -170,7 +169,6 @@ export const tableColumns = [
             )}
           >
             <EntityImage
-              circular
               symbol={coinDenom}
               name={coinDenom}
               logoURIs={{

--- a/packages/web/components/earn/table/columns.tsx
+++ b/packages/web/components/earn/table/columns.tsx
@@ -88,20 +88,24 @@ export const tableColumns = [
         )}
       >
         {item.getValue().map(({ coinDenom, coinImageUrl }, i) => (
-          <EntityImage
+          <div
             key={`${coinDenom} ${i} ${item.cell.id}`}
-            symbol={coinDenom}
-            name={coinDenom}
-            logoURIs={{
-              png: coinImageUrl,
-              svg: coinImageUrl,
-            }}
-            width={36}
-            height={36}
-            className={classNames("h-9 min-w-[36px] rounded-full", {
-              "-ml-4": i > 0,
-            })}
-          />
+            className={classNames(
+              "h-9 w-9 shrink-0 overflow-hidden rounded-full",
+              { "-ml-4": i > 0 }
+            )}
+          >
+            <EntityImage
+              symbol={coinDenom}
+              name={coinDenom}
+              logoURIs={{
+                png: coinImageUrl,
+                svg: coinImageUrl,
+              }}
+              width={36}
+              height={36}
+            />
+          </div>
         ))}
       </div>
     ),
@@ -154,21 +158,27 @@ export const tableColumns = [
     cell: (item) => (
       <div className="relative flex items-center justify-end">
         {item.getValue().map(({ coinDenom, coinImageUrl }, i) => (
-          <EntityImage
+          <div
             key={`${coinDenom} ${i} ${item.cell.id}`}
-            symbol={coinDenom}
-            name={coinDenom}
-            logoURIs={{
-              png: coinImageUrl,
-              svg: coinImageUrl,
-            }}
-            width={24}
-            height={24}
-            className={classNames("h-6 w-6 rounded-full", {
-              "-ml-2": i > 0,
-              "mr-2": item.getValue().length === 1,
-            })}
-          />
+            className={classNames(
+              "h-6 w-6 shrink-0 overflow-hidden rounded-full",
+              {
+                "-ml-2": i > 0,
+                "mr-2": item.getValue().length === 1,
+              }
+            )}
+          >
+            <EntityImage
+              symbol={coinDenom}
+              name={coinDenom}
+              logoURIs={{
+                png: coinImageUrl,
+                svg: coinImageUrl,
+              }}
+              width={24}
+              height={24}
+            />
+          </div>
         ))}
       </div>
     ),

--- a/packages/web/components/earn/table/columns.tsx
+++ b/packages/web/components/earn/table/columns.tsx
@@ -89,24 +89,7 @@ export const tableColumns = [
       >
         {item.getValue().map(({ coinDenom, coinImageUrl }, i) => (
           <div
-          <div
             key={`${coinDenom} ${i} ${item.cell.id}`}
-            className={classNames(
-              "h-9 w-9 shrink-0 overflow-hidden rounded-full",
-              { "-ml-4": i > 0 }
-            )}
-          >
-            <EntityImage
-              symbol={coinDenom}
-              name={coinDenom}
-              logoURIs={{
-                png: coinImageUrl,
-                svg: coinImageUrl,
-              }}
-              width={36}
-              height={36}
-            />
-          </div>
             className={classNames(
               "h-9 w-9 shrink-0 overflow-hidden rounded-full",
               { "-ml-4": i > 0 }
@@ -177,19 +160,25 @@ export const tableColumns = [
         {item.getValue().map(({ coinDenom, coinImageUrl }, i) => (
           <div
             key={`${coinDenom} ${i} ${item.cell.id}`}
-            symbol={coinDenom}
-            name={coinDenom}
-            logoURIs={{
-              png: coinImageUrl,
-              svg: coinImageUrl,
-            }}
-            width={24}
-            height={24}
-            className={classNames("h-6 w-6 rounded-full", {
-              "-ml-2": i > 0,
-              "mr-2": item.getValue().length === 1,
-            })}
-          />
+            className={classNames(
+              "h-6 w-6 shrink-0 overflow-hidden rounded-full",
+              {
+                "-ml-2": i > 0,
+                "mr-2": item.getValue().length === 1,
+              }
+            )}
+          >
+            <EntityImage
+              symbol={coinDenom}
+              name={coinDenom}
+              logoURIs={{
+                png: coinImageUrl,
+                svg: coinImageUrl,
+              }}
+              width={24}
+              height={24}
+            />
+          </div>
         ))}
       </div>
     ),

--- a/packages/web/components/earn/table/columns.tsx
+++ b/packages/web/components/earn/table/columns.tsx
@@ -88,20 +88,24 @@ export const tableColumns = [
         )}
       >
         {item.getValue().map(({ coinDenom, coinImageUrl }, i) => (
-          <EntityImage
+          <div
             key={`${coinDenom} ${i} ${item.cell.id}`}
-            symbol={coinDenom}
-            name={coinDenom}
-            logoURIs={{
-              png: coinImageUrl,
-              svg: coinImageUrl,
-            }}
-            width={36}
-            height={36}
-            className={classNames("h-9 min-w-[36px] rounded-full", {
-              "-ml-4": i > 0,
-            })}
-          />
+            className={classNames(
+              "h-9 w-9 shrink-0 overflow-hidden rounded-full",
+              { "-ml-4": i > 0 }
+            )}
+          >
+            <EntityImage
+              symbol={coinDenom}
+              name={coinDenom}
+              logoURIs={{
+                png: coinImageUrl,
+                svg: coinImageUrl,
+              }}
+              width={36}
+              height={36}
+            />
+          </div>
         ))}
       </div>
     ),
@@ -154,21 +158,24 @@ export const tableColumns = [
     cell: (item) => (
       <div className="relative flex items-center justify-end">
         {item.getValue().map(({ coinDenom, coinImageUrl }, i) => (
-          <EntityImage
+          <div
             key={`${coinDenom} ${i} ${item.cell.id}`}
-            symbol={coinDenom}
-            name={coinDenom}
-            logoURIs={{
-              png: coinImageUrl,
-              svg: coinImageUrl,
-            }}
-            width={24}
-            height={24}
-            className={classNames("h-6 w-6 rounded-full", {
+            className={classNames("h-6 w-6 shrink-0 overflow-hidden rounded-full", {
               "-ml-2": i > 0,
               "mr-2": item.getValue().length === 1,
             })}
-          />
+          >
+            <EntityImage
+              symbol={coinDenom}
+              name={coinDenom}
+              logoURIs={{
+                png: coinImageUrl,
+                svg: coinImageUrl,
+              }}
+              width={24}
+              height={24}
+            />
+          </div>
         ))}
       </div>
     ),

--- a/packages/web/components/earn/table/columns.tsx
+++ b/packages/web/components/earn/table/columns.tsx
@@ -91,11 +91,12 @@ export const tableColumns = [
           <div
             key={`${coinDenom} ${i} ${item.cell.id}`}
             className={classNames(
-              "h-9 w-9 shrink-0 overflow-hidden rounded-full",
+              "shrink-0",
               { "-ml-4": i > 0 }
             )}
           >
             <EntityImage
+              circular
               symbol={coinDenom}
               name={coinDenom}
               logoURIs={{
@@ -161,7 +162,7 @@ export const tableColumns = [
           <div
             key={`${coinDenom} ${i} ${item.cell.id}`}
             className={classNames(
-              "h-6 w-6 shrink-0 overflow-hidden rounded-full",
+              "shrink-0",
               {
                 "-ml-2": i > 0,
                 "mr-2": item.getValue().length === 1,
@@ -169,6 +170,7 @@ export const tableColumns = [
             )}
           >
             <EntityImage
+              circular
               symbol={coinDenom}
               name={coinDenom}
               logoURIs={{

--- a/packages/web/components/navbar-osmo-price.tsx
+++ b/packages/web/components/navbar-osmo-price.tsx
@@ -37,16 +37,17 @@ export const NavbarOsmoPrice = observer(() => {
           className="min-w-[70px]"
         >
           <div className="flex items-center gap-1">
-            <EntityImage
-              circular
-              name={osmo.coinName}
-              symbol={osmo.coinDenom}
-              logoURIs={{
-                png: osmo.coinImageUrl,
-              }}
-              width={20}
-              height={20}
-            />
+            <div className="h-[20px] w-[20px] overflow-hidden rounded-full">
+              <EntityImage
+                name={osmo.coinName}
+                symbol={osmo.coinDenom}
+                logoURIs={{
+                  png: osmo.coinImageUrl,
+                }}
+                width={20}
+                height={20}
+              />
+            </div>
 
             <p className="mt-[3px]">
               {formatPretty(osmo.currentPrice, {

--- a/packages/web/components/navbar-osmo-price.tsx
+++ b/packages/web/components/navbar-osmo-price.tsx
@@ -37,17 +37,15 @@ export const NavbarOsmoPrice = observer(() => {
           className="min-w-[70px]"
         >
           <div className="flex items-center gap-1">
-            <div className="h-[20px] w-[20px] overflow-hidden rounded-full">
-              <EntityImage
-                name={osmo.coinName}
-                symbol={osmo.coinDenom}
-                logoURIs={{
-                  png: osmo.coinImageUrl,
-                }}
-                width={20}
-                height={20}
-              />
-            </div>
+            <EntityImage
+              name={osmo.coinName}
+              symbol={osmo.coinDenom}
+              logoURIs={{
+                png: osmo.coinImageUrl,
+              }}
+              width={20}
+              height={20}
+            />
 
             <p className="mt-[3px]">
               {formatPretty(osmo.currentPrice, {

--- a/packages/web/components/navbar-osmo-price.tsx
+++ b/packages/web/components/navbar-osmo-price.tsx
@@ -37,17 +37,16 @@ export const NavbarOsmoPrice = observer(() => {
           className="min-w-[70px]"
         >
           <div className="flex items-center gap-1">
-            <div className="h-[20px] w-[20px] overflow-hidden rounded-full">
-              <EntityImage
-                name={osmo.coinName}
-                symbol={osmo.coinDenom}
-                logoURIs={{
-                  png: osmo.coinImageUrl,
-                }}
-                width={20}
-                height={20}
-              />
-            </div>
+            <EntityImage
+              circular
+              name={osmo.coinName}
+              symbol={osmo.coinDenom}
+              logoURIs={{
+                png: osmo.coinImageUrl,
+              }}
+              width={20}
+              height={20}
+            />
 
             <p className="mt-[3px]">
               {formatPretty(osmo.currentPrice, {

--- a/packages/web/components/navbar-osmo-price.tsx
+++ b/packages/web/components/navbar-osmo-price.tsx
@@ -37,7 +37,7 @@ export const NavbarOsmoPrice = observer(() => {
           className="min-w-[70px]"
         >
           <div className="flex items-center gap-1">
-            <div className="h-[20px] w-[20px]">
+            <div className="h-[20px] w-[20px] overflow-hidden rounded-full">
               <EntityImage
                 name={osmo.coinName}
                 symbol={osmo.coinDenom}

--- a/packages/web/components/pages/asset-info-page/navigation.tsx
+++ b/packages/web/components/pages/asset-info-page/navigation.tsx
@@ -17,8 +17,9 @@ export const AssetNavigation: FunctionComponent = observer(() => {
   return (
     <nav className="flex w-full flex-wrap justify-between gap-2">
       <div className="flex flex-wrap items-center gap-4">
-        <div className="h-10 w-10 shrink-0 overflow-hidden rounded-full">
+        <div className="shrink-0">
           <EntityImage
+            circular
             logoURIs={{
               png: token.coinImageUrl,
             }}

--- a/packages/web/components/pages/asset-info-page/navigation.tsx
+++ b/packages/web/components/pages/asset-info-page/navigation.tsx
@@ -17,9 +17,8 @@ export const AssetNavigation: FunctionComponent = observer(() => {
   return (
     <nav className="flex w-full flex-wrap justify-between gap-2">
       <div className="flex flex-wrap items-center gap-4">
-        <div className="shrink-0">
+        <div className="h-10 w-10 shrink-0 overflow-hidden rounded-full">
           <EntityImage
-            circular
             logoURIs={{
               png: token.coinImageUrl,
             }}

--- a/packages/web/components/pages/asset-info-page/navigation.tsx
+++ b/packages/web/components/pages/asset-info-page/navigation.tsx
@@ -17,15 +17,17 @@ export const AssetNavigation: FunctionComponent = observer(() => {
   return (
     <nav className="flex w-full flex-wrap justify-between gap-2">
       <div className="flex flex-wrap items-center gap-4">
-        <EntityImage
-          logoURIs={{
-            png: token.coinImageUrl,
-          }}
-          name={token.coinName}
-          symbol={token.coinDenom}
-          width={40}
-          height={40}
-        />
+        <div className="h-10 w-10 shrink-0 overflow-hidden rounded-full">
+          <EntityImage
+            logoURIs={{
+              png: token.coinImageUrl,
+            }}
+            name={token.coinName}
+            symbol={token.coinDenom}
+            width={40}
+            height={40}
+          />
+        </div>
         <div className="flex flex-wrap gap-2">
           {title ? <h6 className="font-h6">{title}</h6> : null}
           <h6 className="font-h6 text-osmoverse-300">{token.coinDenom}</h6>

--- a/packages/web/components/pool-detail/concentrated.tsx
+++ b/packages/web/components/pool-detail/concentrated.tsx
@@ -498,19 +498,21 @@ const UserAssetsAndExternalIncentives: FunctionComponent<{ poolId: string }> =
                 key={asset.currency.coinMinimalDenom}
               >
                 {asset.currency.coinImageUrl && (
-                  <EntityImage
-                    logoURIs={{
-                      svg: asset.currency.coinImageUrl?.replace(
-                        /\.png$/,
-                        ".svg"
-                      ),
-                      png: asset.currency.coinImageUrl,
-                    }}
-                    width={20}
-                    height={20}
-                    name={asset.currency.coinDenom}
-                    symbol={asset.currency.coinDenom}
-                  />
+                  <div className="h-5 w-5 shrink-0 overflow-hidden rounded-full">
+                    <EntityImage
+                      logoURIs={{
+                        svg: asset.currency.coinImageUrl?.replace(
+                          /\.png$/,
+                          ".svg"
+                        ),
+                        png: asset.currency.coinImageUrl,
+                      }}
+                      width={20}
+                      height={20}
+                      name={asset.currency.coinDenom}
+                      symbol={asset.currency.coinDenom}
+                    />
+                  </div>
                 )}
                 <span className="text-osmoverse-300">
                   {asset.currency.coinDenom}
@@ -549,15 +551,17 @@ const UserAssetsAndExternalIncentives: FunctionComponent<{ poolId: string }> =
                         +{incentive.apr.maxDecimals(0).toString()}
                       </span>
                     )}
-                    <EntityImage
-                      logoURIs={{
-                        png: incentive.coinPerDay.currency.coinImageUrl,
-                      }}
-                      name={incentive.coinPerDay.currency.coinDenom}
-                      symbol={incentive.coinPerDay.currency.coinDenom}
-                      width={20}
-                      height={20}
-                    />
+                    <div className="h-5 w-5 shrink-0 overflow-hidden rounded-full">
+                      <EntityImage
+                        logoURIs={{
+                          png: incentive.coinPerDay.currency.coinImageUrl,
+                        }}
+                        name={incentive.coinPerDay.currency.coinDenom}
+                        symbol={incentive.coinPerDay.currency.coinDenom}
+                        width={20}
+                        height={20}
+                      />
+                    </div>
                   </div>
                   <div className="subtitle1 flex flex-col gap-1 text-osmoverse-300">
                     <span>

--- a/packages/web/components/pool-detail/concentrated.tsx
+++ b/packages/web/components/pool-detail/concentrated.tsx
@@ -498,9 +498,8 @@ const UserAssetsAndExternalIncentives: FunctionComponent<{ poolId: string }> =
                 key={asset.currency.coinMinimalDenom}
               >
                 {asset.currency.coinImageUrl && (
-                  <div className="shrink-0">
+                  <div className="h-5 w-5 shrink-0 overflow-hidden rounded-full">
                     <EntityImage
-                      circular
                       logoURIs={{
                         svg: asset.currency.coinImageUrl?.replace(
                           /\.png$/,
@@ -552,9 +551,8 @@ const UserAssetsAndExternalIncentives: FunctionComponent<{ poolId: string }> =
                         +{incentive.apr.maxDecimals(0).toString()}
                       </span>
                     )}
-                    <div className="shrink-0">
+                    <div className="h-5 w-5 shrink-0 overflow-hidden rounded-full">
                       <EntityImage
-                        circular
                         logoURIs={{
                           png: incentive.coinPerDay.currency.coinImageUrl,
                         }}

--- a/packages/web/components/pool-detail/concentrated.tsx
+++ b/packages/web/components/pool-detail/concentrated.tsx
@@ -498,8 +498,9 @@ const UserAssetsAndExternalIncentives: FunctionComponent<{ poolId: string }> =
                 key={asset.currency.coinMinimalDenom}
               >
                 {asset.currency.coinImageUrl && (
-                  <div className="h-5 w-5 shrink-0 overflow-hidden rounded-full">
+                  <div className="shrink-0">
                     <EntityImage
+                      circular
                       logoURIs={{
                         svg: asset.currency.coinImageUrl?.replace(
                           /\.png$/,
@@ -551,8 +552,9 @@ const UserAssetsAndExternalIncentives: FunctionComponent<{ poolId: string }> =
                         +{incentive.apr.maxDecimals(0).toString()}
                       </span>
                     )}
-                    <div className="h-5 w-5 shrink-0 overflow-hidden rounded-full">
+                    <div className="shrink-0">
                       <EntityImage
+                        circular
                         logoURIs={{
                           png: incentive.coinPerDay.currency.coinImageUrl,
                         }}

--- a/packages/web/components/swap-tool/price-selector.tsx
+++ b/packages/web/components/swap-tool/price-selector.tsx
@@ -247,8 +247,9 @@ export const PriceSelector = memo(
                       </span>
                       <div className="flex items-center gap-2 py-1 pl-1 pr-3 sm:gap-1 sm:py-1.5">
                         {quoteAsset.logoURIs && (
-                          <div className="h-5 w-5 shrink-0 overflow-hidden rounded-full md:h-6 md:w-6">
+                          <div className="shrink-0">
                             <EntityImage
+                              circular
                               width={isMobile ? 20 : 24}
                               height={isMobile ? 20 : 24}
                               logoURIs={quoteAsset.logoURIs}

--- a/packages/web/components/swap-tool/price-selector.tsx
+++ b/packages/web/components/swap-tool/price-selector.tsx
@@ -247,9 +247,8 @@ export const PriceSelector = memo(
                       </span>
                       <div className="flex items-center gap-2 py-1 pl-1 pr-3 sm:gap-1 sm:py-1.5">
                         {quoteAsset.logoURIs && (
-                          <div className="shrink-0">
+                          <div className="h-5 w-5 shrink-0 overflow-hidden rounded-full md:h-6 md:w-6">
                             <EntityImage
-                              circular
                               width={isMobile ? 20 : 24}
                               height={isMobile ? 20 : 24}
                               logoURIs={quoteAsset.logoURIs}

--- a/packages/web/components/swap-tool/price-selector.tsx
+++ b/packages/web/components/swap-tool/price-selector.tsx
@@ -247,13 +247,15 @@ export const PriceSelector = memo(
                       </span>
                       <div className="flex items-center gap-2 py-1 pl-1 pr-3 sm:gap-1 sm:py-1.5">
                         {quoteAsset.logoURIs && (
-                          <EntityImage
-                            width={isMobile ? 20 : 24}
-                            height={isMobile ? 20 : 24}
-                            logoURIs={quoteAsset.logoURIs}
-                            name={quoteAsset.name}
-                            symbol={quoteAsset.symbol}
-                          />
+                          <div className="h-5 w-5 shrink-0 overflow-hidden rounded-full md:h-6 md:w-6">
+                            <EntityImage
+                              width={isMobile ? 20 : 24}
+                              height={isMobile ? 20 : 24}
+                              logoURIs={quoteAsset.logoURIs}
+                              name={quoteAsset.name}
+                              symbol={quoteAsset.symbol}
+                            />
+                          </div>
                         )}
                         <span className="md:caption body2 text-left">
                           {quoteAsset.symbol}

--- a/packages/web/components/swap-tool/split-route.tsx
+++ b/packages/web/components/swap-tool/split-route.tsx
@@ -237,11 +237,9 @@ const DenomImage: FunctionComponent<{
   size?: number;
 }> = ({ currency, size = 20 }) => {
   return (
-    <div
-      className="shrink-0 overflow-hidden rounded-full"
-      style={{ width: size, height: size }}
-    >
+    <div className="shrink-0">
       <EntityImage
+        circular
         logoURIs={getLogoURIs(currency.coinImageUrl)}
         name={currency.coinDenom}
         symbol={currency.coinDenom}

--- a/packages/web/components/swap-tool/split-route.tsx
+++ b/packages/web/components/swap-tool/split-route.tsx
@@ -237,12 +237,17 @@ const DenomImage: FunctionComponent<{
   size?: number;
 }> = ({ currency, size = 20 }) => {
   return (
-    <EntityImage
-      logoURIs={getLogoURIs(currency.coinImageUrl)}
-      name={currency.coinDenom}
-      symbol={currency.coinDenom}
-      width={size}
-      height={size}
-    />
+    <div
+      className="shrink-0 overflow-hidden rounded-full"
+      style={{ width: size, height: size }}
+    >
+      <EntityImage
+        logoURIs={getLogoURIs(currency.coinImageUrl)}
+        name={currency.coinDenom}
+        symbol={currency.coinDenom}
+        width={size}
+        height={size}
+      />
+    </div>
   );
 };

--- a/packages/web/components/swap-tool/split-route.tsx
+++ b/packages/web/components/swap-tool/split-route.tsx
@@ -237,9 +237,11 @@ const DenomImage: FunctionComponent<{
   size?: number;
 }> = ({ currency, size = 20 }) => {
   return (
-    <div className="shrink-0">
+    <div
+      className="shrink-0 overflow-hidden rounded-full"
+      style={{ width: size, height: size }}
+    >
       <EntityImage
-        circular
         logoURIs={getLogoURIs(currency.coinImageUrl)}
         name={currency.coinDenom}
         symbol={currency.coinDenom}

--- a/packages/web/components/table/cells/asset.tsx
+++ b/packages/web/components/table/cells/asset.tsx
@@ -47,9 +47,8 @@ export const AssetCell: FunctionComponent<
           />
         </div>
       )}
-      <div className="flex-shrink-0">
+      <div className="h-10 w-10 flex-shrink-0 overflow-hidden rounded-full">
         <EntityImage
-          circular
           symbol={coinDenom ?? ""}
           name={coinName ?? ""}
           logoURIs={{

--- a/packages/web/components/table/cells/asset.tsx
+++ b/packages/web/components/table/cells/asset.tsx
@@ -47,7 +47,7 @@ export const AssetCell: FunctionComponent<
           />
         </div>
       )}
-      <div className="h-10 w-10 flex-shrink-0">
+      <div className="h-10 w-10 flex-shrink-0 overflow-hidden rounded-full">
         <EntityImage
           symbol={coinDenom ?? ""}
           name={coinName ?? ""}

--- a/packages/web/components/table/cells/asset.tsx
+++ b/packages/web/components/table/cells/asset.tsx
@@ -47,8 +47,9 @@ export const AssetCell: FunctionComponent<
           />
         </div>
       )}
-      <div className="h-10 w-10 flex-shrink-0 overflow-hidden rounded-full">
+      <div className="flex-shrink-0">
         <EntityImage
+          circular
           symbol={coinDenom ?? ""}
           name={coinName ?? ""}
           logoURIs={{

--- a/packages/web/components/trade-tool/polaris-banner.tsx
+++ b/packages/web/components/trade-tool/polaris-banner.tsx
@@ -26,7 +26,7 @@ export const PolarisBanner = ({ onClose }: { onClose: () => void }) => {
               symbol={fromAsset?.coinDenom}
               width={24}
               height={24}
-              circular
+              className="overflow-hidden rounded-full"
             />
           </div>
           <span className="text-[#F8F6F2]">{fromAsset?.coinDenom ?? ""}</span>

--- a/packages/web/components/trade-tool/polaris-banner.tsx
+++ b/packages/web/components/trade-tool/polaris-banner.tsx
@@ -26,7 +26,7 @@ export const PolarisBanner = ({ onClose }: { onClose: () => void }) => {
               symbol={fromAsset?.coinDenom}
               width={24}
               height={24}
-              className="overflow-hidden rounded-full"
+              circular
             />
           </div>
           <span className="text-[#F8F6F2]">{fromAsset?.coinDenom ?? ""}</span>

--- a/packages/web/components/trade-tool/polaris-banner.tsx
+++ b/packages/web/components/trade-tool/polaris-banner.tsx
@@ -26,7 +26,7 @@ export const PolarisBanner = ({ onClose }: { onClose: () => void }) => {
               symbol={fromAsset?.coinDenom}
               width={24}
               height={24}
-              className="rounded-full"
+              className="overflow-hidden rounded-full"
             />
           </div>
           <span className="text-[#F8F6F2]">{fromAsset?.coinDenom ?? ""}</span>

--- a/packages/web/components/transactions/transaction-details/transaction-swap-details.tsx
+++ b/packages/web/components/transactions/transaction-details/transaction-swap-details.tsx
@@ -114,15 +114,14 @@ export const TransactionSwapDetails = ({
         <div className="flex flex-col rounded-2xl border border-osmoverse-700 p-2">
           <div className="flex justify-between p-2">
             <div className="flex items-center gap-4">
-              <div className="h-10 w-10 overflow-hidden rounded-full">
-                <EntityImage
-                  logoURIs={getLogoURIs(tokenIn.token.currency.coinImageUrl)}
-                  name={tokenIn.token.denom}
-                  symbol={tokenIn.token.denom}
-                  height={40}
-                  width={40}
-                />
-              </div>
+              <EntityImage
+                circular
+                logoURIs={getLogoURIs(tokenIn.token.currency.coinImageUrl)}
+                name={tokenIn.token.denom}
+                symbol={tokenIn.token.denom}
+                height={40}
+                width={40}
+              />
               <div className="flex flex-col">
                 <div className="subtitle1">{t("transactions.sold")}</div>
                 <div className="body1 text-osmoverse-300">
@@ -151,15 +150,14 @@ export const TransactionSwapDetails = ({
           </div>
           <div className="flex justify-between p-2">
             <div className="flex items-center gap-4">
-              <div className="h-10 w-10 overflow-hidden rounded-full">
-                <EntityImage
-                  logoURIs={getLogoURIs(tokenOut.token.currency.coinImageUrl)}
-                  name={tokenOut.token.denom}
-                  symbol={tokenOut.token.denom}
-                  height={40}
-                  width={40}
-                />
-              </div>
+              <EntityImage
+                circular
+                logoURIs={getLogoURIs(tokenOut.token.currency.coinImageUrl)}
+                name={tokenOut.token.denom}
+                symbol={tokenOut.token.denom}
+                height={40}
+                width={40}
+              />
               <div className="flex flex-col">
                 <div className="subtitle1">{t("transactions.bought")}</div>
                 <div className="body1 text-osmoverse-300">

--- a/packages/web/components/transactions/transaction-details/transaction-swap-details.tsx
+++ b/packages/web/components/transactions/transaction-details/transaction-swap-details.tsx
@@ -114,7 +114,7 @@ export const TransactionSwapDetails = ({
         <div className="flex flex-col rounded-2xl border border-osmoverse-700 p-2">
           <div className="flex justify-between p-2">
             <div className="flex items-center gap-4">
-              <div className="h-10 w-10">
+              <div className="h-10 w-10 overflow-hidden rounded-full">
                 <EntityImage
                   logoURIs={getLogoURIs(tokenIn.token.currency.coinImageUrl)}
                   name={tokenIn.token.denom}
@@ -151,7 +151,7 @@ export const TransactionSwapDetails = ({
           </div>
           <div className="flex justify-between p-2">
             <div className="flex items-center gap-4">
-              <div className="h-10 w-10">
+              <div className="h-10 w-10 overflow-hidden rounded-full">
                 <EntityImage
                   logoURIs={getLogoURIs(tokenOut.token.currency.coinImageUrl)}
                   name={tokenOut.token.denom}

--- a/packages/web/components/transactions/transaction-details/transaction-swap-details.tsx
+++ b/packages/web/components/transactions/transaction-details/transaction-swap-details.tsx
@@ -114,14 +114,15 @@ export const TransactionSwapDetails = ({
         <div className="flex flex-col rounded-2xl border border-osmoverse-700 p-2">
           <div className="flex justify-between p-2">
             <div className="flex items-center gap-4">
-              <EntityImage
-                circular
-                logoURIs={getLogoURIs(tokenIn.token.currency.coinImageUrl)}
-                name={tokenIn.token.denom}
-                symbol={tokenIn.token.denom}
-                height={40}
-                width={40}
-              />
+              <div className="h-10 w-10 overflow-hidden rounded-full">
+                <EntityImage
+                  logoURIs={getLogoURIs(tokenIn.token.currency.coinImageUrl)}
+                  name={tokenIn.token.denom}
+                  symbol={tokenIn.token.denom}
+                  height={40}
+                  width={40}
+                />
+              </div>
               <div className="flex flex-col">
                 <div className="subtitle1">{t("transactions.sold")}</div>
                 <div className="body1 text-osmoverse-300">
@@ -150,14 +151,15 @@ export const TransactionSwapDetails = ({
           </div>
           <div className="flex justify-between p-2">
             <div className="flex items-center gap-4">
-              <EntityImage
-                circular
-                logoURIs={getLogoURIs(tokenOut.token.currency.coinImageUrl)}
-                name={tokenOut.token.denom}
-                symbol={tokenOut.token.denom}
-                height={40}
-                width={40}
-              />
+              <div className="h-10 w-10 overflow-hidden rounded-full">
+                <EntityImage
+                  logoURIs={getLogoURIs(tokenOut.token.currency.coinImageUrl)}
+                  name={tokenOut.token.denom}
+                  symbol={tokenOut.token.denom}
+                  height={40}
+                  width={40}
+                />
+              </div>
               <div className="flex flex-col">
                 <div className="subtitle1">{t("transactions.bought")}</div>
                 <div className="body1 text-osmoverse-300">

--- a/packages/web/components/transactions/transaction-types/transaction-swap-row.tsx
+++ b/packages/web/components/transactions/transaction-types/transaction-swap-row.tsx
@@ -60,30 +60,34 @@ export const TransactionSwapRow = ({
   const rightComponent =
     size === "sm" ? (
       <div className="flex items-center justify-end">
-        <EntityImage
-          logoURIs={getLogoURIs(
-            transaction.tokenIn.amount.currency.coinImageUrl
-          )}
-          name={transaction.tokenIn.amount.denom}
-          symbol={transaction.tokenIn.amount.denom}
-          height={32}
-          width={32}
-        />
+        <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full">
+          <EntityImage
+            logoURIs={getLogoURIs(
+              transaction.tokenIn.amount.currency.coinImageUrl
+            )}
+            name={transaction.tokenIn.amount.denom}
+            symbol={transaction.tokenIn.amount.denom}
+            height={32}
+            width={32}
+          />
+        </div>
         <Icon
           id="arrows-swap"
           width={16}
           height={16}
           className="my-[8px] mx-[4px] text-osmoverse-500"
         />
-        <EntityImage
-          logoURIs={getLogoURIs(
-            transaction.tokenOut.amount.currency.coinImageUrl
-          )}
-          name={transaction.tokenOut.amount.denom}
-          symbol={transaction.tokenOut.amount.denom}
-          height={32}
-          width={32}
-        />
+        <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full">
+          <EntityImage
+            logoURIs={getLogoURIs(
+              transaction.tokenOut.amount.currency.coinImageUrl
+            )}
+            name={transaction.tokenOut.amount.denom}
+            symbol={transaction.tokenOut.amount.denom}
+            height={32}
+            width={32}
+          />
+        </div>
       </div>
     ) : (
       <div className="flex w-2/3 items-center justify-end gap-4 md:w-1/2">
@@ -104,16 +108,17 @@ export const TransactionSwapRow = ({
                 `- ${formatFiatPrice(transaction.tokenIn.value)}`}
             </div>
           </div>
-          <EntityImage
-            logoURIs={getLogoURIs(
-              transaction.tokenIn.amount.currency.coinImageUrl
-            )}
-            name={transaction.tokenIn.amount.denom}
-            symbol={transaction.tokenIn.amount.denom}
-            height={32}
-            width={32}
-            className="block md:hidden"
-          />
+          <div className="block h-8 w-8 shrink-0 overflow-hidden rounded-full md:hidden">
+            <EntityImage
+              logoURIs={getLogoURIs(
+                transaction.tokenIn.amount.currency.coinImageUrl
+              )}
+              name={transaction.tokenIn.amount.denom}
+              symbol={transaction.tokenIn.amount.denom}
+              height={32}
+              width={32}
+            />
+          </div>
         </div>
         <Icon
           id="arrow-right"
@@ -122,16 +127,17 @@ export const TransactionSwapRow = ({
           className="block text-osmoverse-600 md:hidden"
         />
         <div className="flex w-60 items-center justify-start gap-4 md:justify-end">
-          <EntityImage
-            logoURIs={getLogoURIs(
-              transaction.tokenOut.amount.currency.coinImageUrl
-            )}
-            name={transaction.tokenOut.amount.denom}
-            symbol={transaction.tokenOut.amount.denom}
-            height={32}
-            width={32}
-            className="block md:hidden"
-          />
+          <div className="block h-8 w-8 shrink-0 overflow-hidden rounded-full md:hidden">
+            <EntityImage
+              logoURIs={getLogoURIs(
+                transaction.tokenOut.amount.currency.coinImageUrl
+              )}
+              name={transaction.tokenOut.amount.denom}
+              symbol={transaction.tokenOut.amount.denom}
+              height={32}
+              width={32}
+            />
+          </div>
           <div className="text-left text-osmoverse-400 md:text-right">
             {transaction.tokenOut.value && (
               <div

--- a/packages/web/components/transactions/transaction-types/transaction-swap-row.tsx
+++ b/packages/web/components/transactions/transaction-types/transaction-swap-row.tsx
@@ -60,9 +60,8 @@ export const TransactionSwapRow = ({
   const rightComponent =
     size === "sm" ? (
       <div className="flex items-center justify-end">
-        <div className="shrink-0">
+        <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full">
           <EntityImage
-            circular
             logoURIs={getLogoURIs(
               transaction.tokenIn.amount.currency.coinImageUrl
             )}
@@ -78,9 +77,8 @@ export const TransactionSwapRow = ({
           height={16}
           className="my-[8px] mx-[4px] text-osmoverse-500"
         />
-        <div className="shrink-0">
+        <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full">
           <EntityImage
-            circular
             logoURIs={getLogoURIs(
               transaction.tokenOut.amount.currency.coinImageUrl
             )}
@@ -110,9 +108,8 @@ export const TransactionSwapRow = ({
                 `- ${formatFiatPrice(transaction.tokenIn.value)}`}
             </div>
           </div>
-          <div className="block shrink-0 md:hidden">
+          <div className="block h-8 w-8 shrink-0 overflow-hidden rounded-full md:hidden">
             <EntityImage
-              circular
               logoURIs={getLogoURIs(
                 transaction.tokenIn.amount.currency.coinImageUrl
               )}
@@ -130,9 +127,8 @@ export const TransactionSwapRow = ({
           className="block text-osmoverse-600 md:hidden"
         />
         <div className="flex w-60 items-center justify-start gap-4 md:justify-end">
-          <div className="block shrink-0 md:hidden">
+          <div className="block h-8 w-8 shrink-0 overflow-hidden rounded-full md:hidden">
             <EntityImage
-              circular
               logoURIs={getLogoURIs(
                 transaction.tokenOut.amount.currency.coinImageUrl
               )}

--- a/packages/web/components/transactions/transaction-types/transaction-swap-row.tsx
+++ b/packages/web/components/transactions/transaction-types/transaction-swap-row.tsx
@@ -60,8 +60,9 @@ export const TransactionSwapRow = ({
   const rightComponent =
     size === "sm" ? (
       <div className="flex items-center justify-end">
-        <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full">
+        <div className="shrink-0">
           <EntityImage
+            circular
             logoURIs={getLogoURIs(
               transaction.tokenIn.amount.currency.coinImageUrl
             )}
@@ -77,8 +78,9 @@ export const TransactionSwapRow = ({
           height={16}
           className="my-[8px] mx-[4px] text-osmoverse-500"
         />
-        <div className="h-8 w-8 shrink-0 overflow-hidden rounded-full">
+        <div className="shrink-0">
           <EntityImage
+            circular
             logoURIs={getLogoURIs(
               transaction.tokenOut.amount.currency.coinImageUrl
             )}
@@ -108,8 +110,9 @@ export const TransactionSwapRow = ({
                 `- ${formatFiatPrice(transaction.tokenIn.value)}`}
             </div>
           </div>
-          <div className="block h-8 w-8 shrink-0 overflow-hidden rounded-full md:hidden">
+          <div className="block shrink-0 md:hidden">
             <EntityImage
+              circular
               logoURIs={getLogoURIs(
                 transaction.tokenIn.amount.currency.coinImageUrl
               )}
@@ -127,8 +130,9 @@ export const TransactionSwapRow = ({
           className="block text-osmoverse-600 md:hidden"
         />
         <div className="flex w-60 items-center justify-start gap-4 md:justify-end">
-          <div className="block h-8 w-8 shrink-0 overflow-hidden rounded-full md:hidden">
+          <div className="block shrink-0 md:hidden">
             <EntityImage
+              circular
               logoURIs={getLogoURIs(
                 transaction.tokenOut.amount.currency.coinImageUrl
               )}

--- a/packages/web/components/transactions/transaction-types/transaction-transfer-row.tsx
+++ b/packages/web/components/transactions/transaction-types/transaction-transfer-row.tsx
@@ -94,30 +94,31 @@ export const TransactionTransferRow = ({
         transaction?.direction === "deposit" && (
           <Spinner className="absolute inset-0 !w-full !h-full text-wosmongton-500" />
         )}
-      <EntityImage
-        circular
-        logoURIs={getLogoURIs(fromAsset.currency.coinImageUrl)}
-        name={fromAsset.denom}
-        symbol={fromAsset.denom}
-        height={
-          simplifiedStatus === "pending" &&
-          transaction?.direction === "deposit"
-            ? 24
-            : 32
-        }
-        width={
-          simplifiedStatus === "pending" &&
-          transaction?.direction === "deposit"
-            ? 24
-            : 32
-        }
-        className={
-          simplifiedStatus !== "success" &&
-          transaction?.direction === "deposit"
-            ? "opacity-50"
-            : undefined
-        }
-      />
+      <div className="h-8 w-8 overflow-hidden rounded-full">
+        <EntityImage
+          logoURIs={getLogoURIs(fromAsset.currency.coinImageUrl)}
+          name={fromAsset.denom}
+          symbol={fromAsset.denom}
+          height={
+            simplifiedStatus === "pending" &&
+            transaction?.direction === "deposit"
+              ? 24
+              : 32
+          }
+          width={
+            simplifiedStatus === "pending" &&
+            transaction?.direction === "deposit"
+              ? 24
+              : 32
+          }
+          className={
+            simplifiedStatus !== "success" &&
+            transaction?.direction === "deposit"
+              ? "opacity-50"
+              : undefined
+          }
+        />
+      </div>
     </div>,
     <Icon
       key="icon-arrow-right"
@@ -176,30 +177,31 @@ export const TransactionTransferRow = ({
           transaction?.direction === "deposit" && (
             <Spinner className="absolute inset-0 !w-full !h-full text-wosmongton-500" />
           )}
-        <EntityImage
-          circular
-          logoURIs={getLogoURIs(fromAsset.currency.coinImageUrl)}
-          name={fromAsset.denom}
-          symbol={fromAsset.denom}
-          height={
-            simplifiedStatus === "pending" &&
-            transaction?.direction === "deposit"
-              ? 24
-              : 32
-          }
-          width={
-            simplifiedStatus === "pending" &&
-            transaction?.direction === "deposit"
-              ? 24
-              : 32
-          }
-          className={
-            simplifiedStatus !== "success" &&
-            transaction?.direction === "deposit"
-              ? "opacity-50"
-              : undefined
-          }
-        />
+        <div className="h-8 w-8 overflow-hidden rounded-full">
+          <EntityImage
+            logoURIs={getLogoURIs(fromAsset.currency.coinImageUrl)}
+            name={fromAsset.denom}
+            symbol={fromAsset.denom}
+            height={
+              simplifiedStatus === "pending" &&
+              transaction?.direction === "deposit"
+                ? 24
+                : 32
+            }
+            width={
+              simplifiedStatus === "pending" &&
+              transaction?.direction === "deposit"
+                ? 24
+                : 32
+            }
+            className={
+              simplifiedStatus !== "success" &&
+              transaction?.direction === "deposit"
+                ? "opacity-50"
+                : undefined
+            }
+          />
+        </div>
       </div>
       {transaction.direction === "deposit" && (
         <div className="flex flex-col">

--- a/packages/web/components/transactions/transaction-types/transaction-transfer-row.tsx
+++ b/packages/web/components/transactions/transaction-types/transaction-transfer-row.tsx
@@ -94,26 +94,31 @@ export const TransactionTransferRow = ({
         transaction?.direction === "deposit" && (
           <Spinner className="absolute inset-0 !w-full !h-full text-wosmongton-500" />
         )}
-      <EntityImage
-        logoURIs={getLogoURIs(fromAsset.currency.coinImageUrl)}
-        name={fromAsset.denom}
-        symbol={fromAsset.denom}
-        height={
-          simplifiedStatus === "pending" && transaction?.direction === "deposit"
-            ? 24
-            : 32
-        }
-        width={
-          simplifiedStatus === "pending" && transaction?.direction === "deposit"
-            ? 24
-            : 32
-        }
-        className={
-          simplifiedStatus !== "success" && transaction?.direction === "deposit"
-            ? "opacity-50"
-            : undefined
-        }
-      />
+      <div className="h-8 w-8 overflow-hidden rounded-full">
+        <EntityImage
+          logoURIs={getLogoURIs(fromAsset.currency.coinImageUrl)}
+          name={fromAsset.denom}
+          symbol={fromAsset.denom}
+          height={
+            simplifiedStatus === "pending" &&
+            transaction?.direction === "deposit"
+              ? 24
+              : 32
+          }
+          width={
+            simplifiedStatus === "pending" &&
+            transaction?.direction === "deposit"
+              ? 24
+              : 32
+          }
+          className={
+            simplifiedStatus !== "success" &&
+            transaction?.direction === "deposit"
+              ? "opacity-50"
+              : undefined
+          }
+        />
+      </div>
     </div>,
     <Icon
       key="icon-arrow-right"
@@ -172,29 +177,31 @@ export const TransactionTransferRow = ({
           transaction?.direction === "deposit" && (
             <Spinner className="absolute inset-0 !w-full !h-full text-wosmongton-500" />
           )}
-        <EntityImage
-          logoURIs={getLogoURIs(fromAsset.currency.coinImageUrl)}
-          name={fromAsset.denom}
-          symbol={fromAsset.denom}
-          height={
-            simplifiedStatus === "pending" &&
-            transaction?.direction === "deposit"
-              ? 24
-              : 32
-          }
-          width={
-            simplifiedStatus === "pending" &&
-            transaction?.direction === "deposit"
-              ? 24
-              : 32
-          }
-          className={
-            simplifiedStatus !== "success" &&
-            transaction?.direction === "deposit"
-              ? "opacity-50"
-              : undefined
-          }
-        />
+        <div className="h-8 w-8 overflow-hidden rounded-full">
+          <EntityImage
+            logoURIs={getLogoURIs(fromAsset.currency.coinImageUrl)}
+            name={fromAsset.denom}
+            symbol={fromAsset.denom}
+            height={
+              simplifiedStatus === "pending" &&
+              transaction?.direction === "deposit"
+                ? 24
+                : 32
+            }
+            width={
+              simplifiedStatus === "pending" &&
+              transaction?.direction === "deposit"
+                ? 24
+                : 32
+            }
+            className={
+              simplifiedStatus !== "success" &&
+              transaction?.direction === "deposit"
+                ? "opacity-50"
+                : undefined
+            }
+          />
+        </div>
       </div>
       {transaction.direction === "deposit" && (
         <div className="flex flex-col">

--- a/packages/web/components/transactions/transaction-types/transaction-transfer-row.tsx
+++ b/packages/web/components/transactions/transaction-types/transaction-transfer-row.tsx
@@ -94,31 +94,30 @@ export const TransactionTransferRow = ({
         transaction?.direction === "deposit" && (
           <Spinner className="absolute inset-0 !w-full !h-full text-wosmongton-500" />
         )}
-      <div className="h-8 w-8 overflow-hidden rounded-full">
-        <EntityImage
-          logoURIs={getLogoURIs(fromAsset.currency.coinImageUrl)}
-          name={fromAsset.denom}
-          symbol={fromAsset.denom}
-          height={
-            simplifiedStatus === "pending" &&
-            transaction?.direction === "deposit"
-              ? 24
-              : 32
-          }
-          width={
-            simplifiedStatus === "pending" &&
-            transaction?.direction === "deposit"
-              ? 24
-              : 32
-          }
-          className={
-            simplifiedStatus !== "success" &&
-            transaction?.direction === "deposit"
-              ? "opacity-50"
-              : undefined
-          }
-        />
-      </div>
+      <EntityImage
+        circular
+        logoURIs={getLogoURIs(fromAsset.currency.coinImageUrl)}
+        name={fromAsset.denom}
+        symbol={fromAsset.denom}
+        height={
+          simplifiedStatus === "pending" &&
+          transaction?.direction === "deposit"
+            ? 24
+            : 32
+        }
+        width={
+          simplifiedStatus === "pending" &&
+          transaction?.direction === "deposit"
+            ? 24
+            : 32
+        }
+        className={
+          simplifiedStatus !== "success" &&
+          transaction?.direction === "deposit"
+            ? "opacity-50"
+            : undefined
+        }
+      />
     </div>,
     <Icon
       key="icon-arrow-right"
@@ -177,31 +176,30 @@ export const TransactionTransferRow = ({
           transaction?.direction === "deposit" && (
             <Spinner className="absolute inset-0 !w-full !h-full text-wosmongton-500" />
           )}
-        <div className="h-8 w-8 overflow-hidden rounded-full">
-          <EntityImage
-            logoURIs={getLogoURIs(fromAsset.currency.coinImageUrl)}
-            name={fromAsset.denom}
-            symbol={fromAsset.denom}
-            height={
-              simplifiedStatus === "pending" &&
-              transaction?.direction === "deposit"
-                ? 24
-                : 32
-            }
-            width={
-              simplifiedStatus === "pending" &&
-              transaction?.direction === "deposit"
-                ? 24
-                : 32
-            }
-            className={
-              simplifiedStatus !== "success" &&
-              transaction?.direction === "deposit"
-                ? "opacity-50"
-                : undefined
-            }
-          />
-        </div>
+        <EntityImage
+          circular
+          logoURIs={getLogoURIs(fromAsset.currency.coinImageUrl)}
+          name={fromAsset.denom}
+          symbol={fromAsset.denom}
+          height={
+            simplifiedStatus === "pending" &&
+            transaction?.direction === "deposit"
+              ? 24
+              : 32
+          }
+          width={
+            simplifiedStatus === "pending" &&
+            transaction?.direction === "deposit"
+              ? 24
+              : 32
+          }
+          className={
+            simplifiedStatus !== "success" &&
+            transaction?.direction === "deposit"
+              ? "opacity-50"
+              : undefined
+          }
+        />
       </div>
       {transaction.direction === "deposit" && (
         <div className="flex flex-col">

--- a/packages/web/components/ui/entity-image.tsx
+++ b/packages/web/components/ui/entity-image.tsx
@@ -14,26 +14,10 @@ export function EntityImage({
   symbol,
   denom,
   isChain = false,
-  circular = false,
-  logoUsesFullBounds = false,
   ...imageProps
 }: Omit<ImageProps, "src" | "alt"> &
   Pick<Asset, "logoURIs" | "name"> &
-  Partial<Pick<Asset, "symbol">> & {
-    isChain?: boolean;
-    denom?: string;
-    /**
-     * When true, wraps the image in a circle. For logos whose content extends to
-     * the edges of the image (logoUsesFullBounds), the clip is omitted so corner
-     * content is not cut off.
-     */
-    circular?: boolean;
-    /**
-     * When true, skips the overflow-hidden circular clip even in circular mode.
-     * Sourced from the asset's logoUsesFullBounds field in osmosis-labs/assetlists.
-     */
-    logoUsesFullBounds?: boolean;
-  }) {
+  Partial<Pick<Asset, "symbol">> & { isChain?: boolean; denom?: string }) {
   const [imgSrc, setImgSrc] = useState<string | undefined>(
     logoURIs?.svg || logoURIs?.png
   );
@@ -54,38 +38,6 @@ export function EntityImage({
       setErr(true);
     }
   };
-
-  if (circular) {
-    return (
-      <div
-        className={classNames(
-          "flex items-center justify-center rounded-full bg-osmoverse-alpha-700",
-          !logoUsesFullBounds && "overflow-hidden"
-        )}
-        style={{ width, height }}
-      >
-        {!imgSrc || err ? (
-          <span
-            className={classNames("text-sm text-osmoverse-400", {
-              "text-xxs": +width <= 20,
-            })}
-          >
-            {isChain ? name[0] : (symbol ?? denom)?.slice(0, 3) ?? "???"}
-          </span>
-        ) : (
-          <Image
-            {...imageProps}
-            width={width}
-            height={height}
-            src={imgSrc}
-            alt={name}
-            onError={handleError}
-            className="object-contain"
-          />
-        )}
-      </div>
-    );
-  }
 
   if (!imgSrc || err) {
     return (

--- a/packages/web/components/ui/entity-image.tsx
+++ b/packages/web/components/ui/entity-image.tsx
@@ -14,10 +14,26 @@ export function EntityImage({
   symbol,
   denom,
   isChain = false,
+  circular = false,
+  logoUsesFullBounds = false,
   ...imageProps
 }: Omit<ImageProps, "src" | "alt"> &
   Pick<Asset, "logoURIs" | "name"> &
-  Partial<Pick<Asset, "symbol">> & { isChain?: boolean; denom?: string }) {
+  Partial<Pick<Asset, "symbol">> & {
+    isChain?: boolean;
+    denom?: string;
+    /**
+     * When true, wraps the image in a circle. For logos whose content extends to
+     * the edges of the image (logoUsesFullBounds), the clip is omitted so corner
+     * content is not cut off.
+     */
+    circular?: boolean;
+    /**
+     * When true, skips the overflow-hidden circular clip even in circular mode.
+     * Sourced from the asset's logoUsesFullBounds field in osmosis-labs/assetlists.
+     */
+    logoUsesFullBounds?: boolean;
+  }) {
   const [imgSrc, setImgSrc] = useState<string | undefined>(
     logoURIs?.svg || logoURIs?.png
   );
@@ -38,6 +54,38 @@ export function EntityImage({
       setErr(true);
     }
   };
+
+  if (circular) {
+    return (
+      <div
+        className={classNames(
+          "flex items-center justify-center rounded-full bg-osmoverse-alpha-700",
+          !logoUsesFullBounds && "overflow-hidden"
+        )}
+        style={{ width, height }}
+      >
+        {!imgSrc || err ? (
+          <span
+            className={classNames("text-sm text-osmoverse-400", {
+              "text-xxs": +width <= 20,
+            })}
+          >
+            {isChain ? name[0] : (symbol ?? denom)?.slice(0, 3) ?? "???"}
+          </span>
+        ) : (
+          <Image
+            {...imageProps}
+            width={width}
+            height={height}
+            src={imgSrc}
+            alt={name}
+            onError={handleError}
+            className="object-contain"
+          />
+        )}
+      </div>
+    );
+  }
 
   if (!imgSrc || err) {
     return (

--- a/packages/web/components/ui/entity-image.tsx
+++ b/packages/web/components/ui/entity-image.tsx
@@ -80,7 +80,7 @@ export function EntityImage({
             src={imgSrc}
             alt={name}
             onError={handleError}
-            className="object-contain"
+            className={classNames("object-contain", imageProps.className)}
           />
         )}
       </div>

--- a/packages/web/components/ui/entity-image.tsx
+++ b/packages/web/components/ui/entity-image.tsx
@@ -80,7 +80,7 @@ export function EntityImage({
             src={imgSrc}
             alt={name}
             onError={handleError}
-            className={classNames("object-contain", imageProps.className)}
+            className="object-contain"
           />
         )}
       </div>

--- a/packages/web/modals/activate-unverified-token-confirmation.tsx
+++ b/packages/web/modals/activate-unverified-token-confirmation.tsx
@@ -25,9 +25,8 @@ export const ActivateUnverifiedTokenConfirmation: FunctionComponent<
     >
       <div className="mx-auto flex max-w-sm flex-col items-center gap-8 pt-8">
         <div className="flex flex-col items-center gap-5">
-          <div className="mr-4">
+          <div className="mr-4 h-16 w-16 overflow-hidden rounded-full">
             <EntityImage
-              circular
               symbol={coinDenom}
               name={coinDenom}
               logoURIs={{

--- a/packages/web/modals/activate-unverified-token-confirmation.tsx
+++ b/packages/web/modals/activate-unverified-token-confirmation.tsx
@@ -25,7 +25,7 @@ export const ActivateUnverifiedTokenConfirmation: FunctionComponent<
     >
       <div className="mx-auto flex max-w-sm flex-col items-center gap-8 pt-8">
         <div className="flex flex-col items-center gap-5">
-          <div className="mr-4 h-16 w-16 rounded-full">
+          <div className="mr-4 h-16 w-16 overflow-hidden rounded-full">
             <EntityImage
               symbol={coinDenom}
               name={coinDenom}

--- a/packages/web/modals/activate-unverified-token-confirmation.tsx
+++ b/packages/web/modals/activate-unverified-token-confirmation.tsx
@@ -25,8 +25,9 @@ export const ActivateUnverifiedTokenConfirmation: FunctionComponent<
     >
       <div className="mx-auto flex max-w-sm flex-col items-center gap-8 pt-8">
         <div className="flex flex-col items-center gap-5">
-          <div className="mr-4 h-16 w-16 overflow-hidden rounded-full">
+          <div className="mr-4">
             <EntityImage
+              circular
               symbol={coinDenom}
               name={coinDenom}
               logoURIs={{

--- a/packages/web/modals/add-funds.tsx
+++ b/packages/web/modals/add-funds.tsx
@@ -212,9 +212,8 @@ export function AddFundsModal({
               }}
               className="flex items-center gap-4 rounded-2xl p-4 text-left transition-colors hover:bg-osmoverse-900"
             >
-              <div className="shrink-0">
+              <div className="h-12 w-12 shrink-0 overflow-hidden rounded-full">
                 <EntityImage
-                  circular
                   logoURIs={{
                     png: fromAsset?.coinImageUrl,
                   }}

--- a/packages/web/modals/add-funds.tsx
+++ b/packages/web/modals/add-funds.tsx
@@ -212,15 +212,17 @@ export function AddFundsModal({
               }}
               className="flex items-center gap-4 rounded-2xl p-4 text-left transition-colors hover:bg-osmoverse-900"
             >
-              <EntityImage
-                logoURIs={{
-                  png: fromAsset?.coinImageUrl,
-                }}
-                name={fromAsset?.coinName ?? ""}
-                symbol={fromAsset?.coinDenom ?? ""}
-                width={48}
-                height={48}
-              />
+              <div className="h-12 w-12 shrink-0 overflow-hidden rounded-full">
+                <EntityImage
+                  logoURIs={{
+                    png: fromAsset?.coinImageUrl,
+                  }}
+                  name={fromAsset?.coinName ?? ""}
+                  symbol={fromAsset?.coinDenom ?? ""}
+                  width={48}
+                  height={48}
+                />
+              </div>
               <div className="flex w-full flex-col gap-1">
                 <span className="subtitle1">
                   {t("limitOrders.buy")} {fromAsset?.coinDenom}

--- a/packages/web/modals/add-funds.tsx
+++ b/packages/web/modals/add-funds.tsx
@@ -212,8 +212,9 @@ export function AddFundsModal({
               }}
               className="flex items-center gap-4 rounded-2xl p-4 text-left transition-colors hover:bg-osmoverse-900"
             >
-              <div className="h-12 w-12 shrink-0 overflow-hidden rounded-full">
+              <div className="shrink-0">
                 <EntityImage
+                  circular
                   logoURIs={{
                     png: fromAsset?.coinImageUrl,
                   }}

--- a/packages/web/modals/increase-concentrated-liquidity.tsx
+++ b/packages/web/modals/increase-concentrated-liquidity.tsx
@@ -123,8 +123,9 @@ export const IncreaseConcentratedLiquidityModal: FunctionComponent<
         </div>
         <div className="mb-2 flex justify-between rounded-[12px] bg-osmoverse-700 px-5 py-3 text-osmoverse-100 xs:flex-wrap xs:gap-y-2 xs:px-3">
           <div className="flex items-center gap-2 text-subtitle1 font-subtitle1 xs:text-body2">
-            <div className="h-6 w-6 shrink-0 overflow-hidden rounded-full">
+            <div className="shrink-0">
               <EntityImage
+                circular
                 logoURIs={{
                   png: baseCoin.currency.coinImageUrl,
                 }}
@@ -138,8 +139,9 @@ export const IncreaseConcentratedLiquidityModal: FunctionComponent<
           </div>
           <div className="flex items-center gap-2 text-subtitle1 font-subtitle1 xs:text-body2">
             {quoteCoin.currency.coinImageUrl && (
-              <div className="h-6 w-6 shrink-0 overflow-hidden rounded-full">
+              <div className="shrink-0">
                 <EntityImage
+                  circular
                   logoURIs={{
                     png: quoteCoin.currency.coinImageUrl,
                   }}

--- a/packages/web/modals/increase-concentrated-liquidity.tsx
+++ b/packages/web/modals/increase-concentrated-liquidity.tsx
@@ -123,9 +123,8 @@ export const IncreaseConcentratedLiquidityModal: FunctionComponent<
         </div>
         <div className="mb-2 flex justify-between rounded-[12px] bg-osmoverse-700 px-5 py-3 text-osmoverse-100 xs:flex-wrap xs:gap-y-2 xs:px-3">
           <div className="flex items-center gap-2 text-subtitle1 font-subtitle1 xs:text-body2">
-            <div className="shrink-0">
+            <div className="h-6 w-6 shrink-0 overflow-hidden rounded-full">
               <EntityImage
-                circular
                 logoURIs={{
                   png: baseCoin.currency.coinImageUrl,
                 }}
@@ -139,9 +138,8 @@ export const IncreaseConcentratedLiquidityModal: FunctionComponent<
           </div>
           <div className="flex items-center gap-2 text-subtitle1 font-subtitle1 xs:text-body2">
             {quoteCoin.currency.coinImageUrl && (
-              <div className="shrink-0">
+              <div className="h-6 w-6 shrink-0 overflow-hidden rounded-full">
                 <EntityImage
-                  circular
                   logoURIs={{
                     png: quoteCoin.currency.coinImageUrl,
                   }}

--- a/packages/web/modals/increase-concentrated-liquidity.tsx
+++ b/packages/web/modals/increase-concentrated-liquidity.tsx
@@ -123,28 +123,32 @@ export const IncreaseConcentratedLiquidityModal: FunctionComponent<
         </div>
         <div className="mb-2 flex justify-between rounded-[12px] bg-osmoverse-700 px-5 py-3 text-osmoverse-100 xs:flex-wrap xs:gap-y-2 xs:px-3">
           <div className="flex items-center gap-2 text-subtitle1 font-subtitle1 xs:text-body2">
-            <EntityImage
-              logoURIs={{
-                png: baseCoin.currency.coinImageUrl,
-              }}
-              name={baseCoin.currency.coinDenom}
-              symbol={baseCoin.currency.coinDenom}
-              height={24}
-              width={24}
-            />
+            <div className="h-6 w-6 shrink-0 overflow-hidden rounded-full">
+              <EntityImage
+                logoURIs={{
+                  png: baseCoin.currency.coinImageUrl,
+                }}
+                name={baseCoin.currency.coinDenom}
+                symbol={baseCoin.currency.coinDenom}
+                height={24}
+                width={24}
+              />
+            </div>
             <span>{formatPretty(baseCoin, { maxDecimals: 2 })}</span>
           </div>
           <div className="flex items-center gap-2 text-subtitle1 font-subtitle1 xs:text-body2">
             {quoteCoin.currency.coinImageUrl && (
-              <EntityImage
-                logoURIs={{
-                  png: quoteCoin.currency.coinImageUrl,
-                }}
-                name={quoteCoin.currency.coinDenom}
-                symbol={quoteCoin.currency.coinDenom}
-                height={24}
-                width={24}
-              />
+              <div className="h-6 w-6 shrink-0 overflow-hidden rounded-full">
+                <EntityImage
+                  logoURIs={{
+                    png: quoteCoin.currency.coinImageUrl,
+                  }}
+                  name={quoteCoin.currency.coinDenom}
+                  symbol={quoteCoin.currency.coinDenom}
+                  height={24}
+                  width={24}
+                />
+              </div>
             )}
             <span>{formatPretty(quoteCoin, { maxDecimals: 2 })}</span>
           </div>

--- a/packages/web/modals/remove-concentrated-liquidity.tsx
+++ b/packages/web/modals/remove-concentrated-liquidity.tsx
@@ -206,15 +206,17 @@ const AssetAmount: FunctionComponent<{
       className
     )}
   >
-    <EntityImage
-      logoURIs={{
-        png: amount.currency.coinImageUrl,
-      }}
-      name={amount.currency.coinDenom}
-      symbol={amount.currency.coinDenom}
-      height={24}
-      width={24}
-    />
+    <div className="h-6 w-6 shrink-0 overflow-hidden rounded-full">
+      <EntityImage
+        logoURIs={{
+          png: amount.currency.coinImageUrl,
+        }}
+        name={amount.currency.coinDenom}
+        symbol={amount.currency.coinDenom}
+        height={24}
+        width={24}
+      />
+    </div>
     <span>{formatPretty(amount, { maxDecimals: 2 })}</span>
   </div>
 );

--- a/packages/web/modals/remove-concentrated-liquidity.tsx
+++ b/packages/web/modals/remove-concentrated-liquidity.tsx
@@ -206,9 +206,8 @@ const AssetAmount: FunctionComponent<{
       className
     )}
   >
-    <div className="shrink-0">
+    <div className="h-6 w-6 shrink-0 overflow-hidden rounded-full">
       <EntityImage
-        circular
         logoURIs={{
           png: amount.currency.coinImageUrl,
         }}

--- a/packages/web/modals/remove-concentrated-liquidity.tsx
+++ b/packages/web/modals/remove-concentrated-liquidity.tsx
@@ -206,8 +206,9 @@ const AssetAmount: FunctionComponent<{
       className
     )}
   >
-    <div className="h-6 w-6 shrink-0 overflow-hidden rounded-full">
+    <div className="shrink-0">
       <EntityImage
+        circular
         logoURIs={{
           png: amount.currency.coinImageUrl,
         }}

--- a/packages/web/modals/review-order.tsx
+++ b/packages/web/modals/review-order.tsx
@@ -386,9 +386,8 @@ export function ReviewOrder({
             >
               <div className="flex items-end justify-between p-2">
                 <div className="flex items-center gap-4">
-                  <div className="shrink-0">
+                  <div className="h-10 w-10 shrink-0 overflow-hidden rounded-full">
                     <EntityImage
-                      circular
                       logoURIs={{
                         png: fromAsset?.coinImageUrl,
                       }}
@@ -430,9 +429,8 @@ export function ReviewOrder({
               <div className="flex items-end justify-between p-2">
                 <div className="flex items-center gap-4">
                   {toAsset && (
-                    <div className="shrink-0">
+                    <div className="h-10 w-10 shrink-0 overflow-hidden rounded-full">
                       <EntityImage
-                        circular
                         logoURIs={{
                           png: toAsset.coinImageUrl,
                         }}

--- a/packages/web/modals/review-order.tsx
+++ b/packages/web/modals/review-order.tsx
@@ -386,8 +386,9 @@ export function ReviewOrder({
             >
               <div className="flex items-end justify-between p-2">
                 <div className="flex items-center gap-4">
-                  <div className="h-10 w-10 shrink-0 overflow-hidden rounded-full">
+                  <div className="shrink-0">
                     <EntityImage
+                      circular
                       logoURIs={{
                         png: fromAsset?.coinImageUrl,
                       }}
@@ -429,8 +430,9 @@ export function ReviewOrder({
               <div className="flex items-end justify-between p-2">
                 <div className="flex items-center gap-4">
                   {toAsset && (
-                    <div className="h-10 w-10 shrink-0 overflow-hidden rounded-full">
+                    <div className="shrink-0">
                       <EntityImage
+                        circular
                         logoURIs={{
                           png: toAsset.coinImageUrl,
                         }}

--- a/packages/web/modals/review-order.tsx
+++ b/packages/web/modals/review-order.tsx
@@ -386,16 +386,17 @@ export function ReviewOrder({
             >
               <div className="flex items-end justify-between p-2">
                 <div className="flex items-center gap-4">
-                  <EntityImage
-                    logoURIs={{
-                      png: fromAsset?.coinImageUrl,
-                    }}
-                    name={fromAsset?.coinDenom ?? ""}
-                    symbol={fromAsset?.coinDenom ?? ""}
-                    width={40}
-                    height={40}
-                    className="h-10 w-10"
-                  />
+                  <div className="h-10 w-10 shrink-0 overflow-hidden rounded-full">
+                    <EntityImage
+                      logoURIs={{
+                        png: fromAsset?.coinImageUrl,
+                      }}
+                      name={fromAsset?.coinDenom ?? ""}
+                      symbol={fromAsset?.coinDenom ?? ""}
+                      width={40}
+                      height={40}
+                    />
+                  </div>
                   <div className="flex flex-col">
                     <p className="sm:caption text-osmoverse-300">
                       {tab === "buy"
@@ -428,16 +429,17 @@ export function ReviewOrder({
               <div className="flex items-end justify-between p-2">
                 <div className="flex items-center gap-4">
                   {toAsset && (
-                    <EntityImage
-                      logoURIs={{
-                        png: toAsset.coinImageUrl,
-                      }}
-                      name={toAsset.coinName}
-                      symbol={toAsset.coinDenom}
-                      width={40}
-                      height={40}
-                      className="h-10 w-10"
-                    />
+                    <div className="h-10 w-10 shrink-0 overflow-hidden rounded-full">
+                      <EntityImage
+                        logoURIs={{
+                          png: toAsset.coinImageUrl,
+                        }}
+                        name={toAsset.coinName}
+                        symbol={toAsset.coinDenom}
+                        width={40}
+                        height={40}
+                      />
+                    </div>
                   )}
                   <div className="flex flex-col">
                     <p className="sm:caption text-osmoverse-300">

--- a/packages/web/modals/token-select-modal-limit.tsx
+++ b/packages/web/modals/token-select-modal-limit.tsx
@@ -274,18 +274,17 @@ export const TokenSelectModalLimit: FunctionComponent<TokenSelectModalLimitProps
                               onClickAsset(coinMinimalDenom);
                             }}
                           >
-                            <div className="h-6 w-6 overflow-hidden rounded-full">
-                              <EntityImage
-                                symbol={coinDenom}
-                                name={coinDenom}
-                                logoURIs={{
-                                  png: coinImageUrl,
-                                  svg: coinImageUrl,
-                                }}
-                                width={24}
-                                height={24}
-                              />
-                            </div>
+                            <EntityImage
+                              circular
+                              symbol={coinDenom}
+                              name={coinDenom}
+                              logoURIs={{
+                                png: coinImageUrl,
+                                svg: coinImageUrl,
+                              }}
+                              width={24}
+                              height={24}
+                            />
                             <p className="font-semibold">{coinDenom}</p>
                           </button>
                         );
@@ -345,8 +344,9 @@ export const TokenSelectModalLimit: FunctionComponent<TokenSelectModalLimitProps
                               )}
                             >
                               <div className="flex min-w-0 items-center gap-4">
-                                <div className="h-12 w-12 shrink-0 overflow-hidden rounded-full">
+                                <div className="shrink-0">
                                   <EntityImage
+                                    circular
                                     symbol={coinDenom}
                                     name={coinDenom}
                                     logoURIs={{
@@ -355,7 +355,6 @@ export const TokenSelectModalLimit: FunctionComponent<TokenSelectModalLimitProps
                                     }}
                                     width={48}
                                     height={48}
-                                    className="rounded-full"
                                   />
                                 </div>
                                 <div className="flex flex-col gap-1 overflow-hidden">

--- a/packages/web/modals/token-select-modal-limit.tsx
+++ b/packages/web/modals/token-select-modal-limit.tsx
@@ -274,17 +274,18 @@ export const TokenSelectModalLimit: FunctionComponent<TokenSelectModalLimitProps
                               onClickAsset(coinMinimalDenom);
                             }}
                           >
-                            <EntityImage
-                              circular
-                              symbol={coinDenom}
-                              name={coinDenom}
-                              logoURIs={{
-                                png: coinImageUrl,
-                                svg: coinImageUrl,
-                              }}
-                              width={24}
-                              height={24}
-                            />
+                            <div className="h-6 w-6 overflow-hidden rounded-full">
+                              <EntityImage
+                                symbol={coinDenom}
+                                name={coinDenom}
+                                logoURIs={{
+                                  png: coinImageUrl,
+                                  svg: coinImageUrl,
+                                }}
+                                width={24}
+                                height={24}
+                              />
+                            </div>
                             <p className="font-semibold">{coinDenom}</p>
                           </button>
                         );
@@ -344,9 +345,8 @@ export const TokenSelectModalLimit: FunctionComponent<TokenSelectModalLimitProps
                               )}
                             >
                               <div className="flex min-w-0 items-center gap-4">
-                                <div className="shrink-0">
+                                <div className="h-12 w-12 shrink-0 overflow-hidden rounded-full">
                                   <EntityImage
-                                    circular
                                     symbol={coinDenom}
                                     name={coinDenom}
                                     logoURIs={{
@@ -355,6 +355,7 @@ export const TokenSelectModalLimit: FunctionComponent<TokenSelectModalLimitProps
                                     }}
                                     width={48}
                                     height={48}
+                                    className="rounded-full"
                                   />
                                 </div>
                                 <div className="flex flex-col gap-1 overflow-hidden">

--- a/packages/web/modals/token-select-modal-limit.tsx
+++ b/packages/web/modals/token-select-modal-limit.tsx
@@ -274,7 +274,7 @@ export const TokenSelectModalLimit: FunctionComponent<TokenSelectModalLimitProps
                               onClickAsset(coinMinimalDenom);
                             }}
                           >
-                            <div className="h-6 w-6 rounded-full">
+                            <div className="h-6 w-6 overflow-hidden rounded-full">
                               <EntityImage
                                 symbol={coinDenom}
                                 name={coinDenom}
@@ -345,7 +345,7 @@ export const TokenSelectModalLimit: FunctionComponent<TokenSelectModalLimitProps
                               )}
                             >
                               <div className="flex min-w-0 items-center gap-4">
-                                <div className="h-12 w-12 shrink-0 rounded-full">
+                                <div className="h-12 w-12 shrink-0 overflow-hidden rounded-full">
                                   <EntityImage
                                     symbol={coinDenom}
                                     name={coinDenom}

--- a/packages/web/modals/token-select.tsx
+++ b/packages/web/modals/token-select.tsx
@@ -84,14 +84,14 @@ export const TokenSelectModal: FunctionComponent<
             >
               <button className="flex w-full items-center justify-between text-left">
                 <div className="flex items-center">
-                  <div className="mr-4">
+                  <div className="mr-4 h-8 w-8 overflow-hidden rounded-full">
                     <EntityImage
-                      circular
                       symbol={coinDenom}
                       name={coinDenom}
                       logoURIs={getLogoURIs(coinImageUrl)}
                       width={32}
                       height={32}
+                      className="rounded-full"
                     />
                   </div>
                   <div>

--- a/packages/web/modals/token-select.tsx
+++ b/packages/web/modals/token-select.tsx
@@ -84,14 +84,14 @@ export const TokenSelectModal: FunctionComponent<
             >
               <button className="flex w-full items-center justify-between text-left">
                 <div className="flex items-center">
-                  <div className="mr-4 h-8 w-8 overflow-hidden rounded-full">
+                  <div className="mr-4">
                     <EntityImage
+                      circular
                       symbol={coinDenom}
                       name={coinDenom}
                       logoURIs={getLogoURIs(coinImageUrl)}
                       width={32}
                       height={32}
-                      className="rounded-full"
                     />
                   </div>
                   <div>

--- a/packages/web/modals/token-select.tsx
+++ b/packages/web/modals/token-select.tsx
@@ -84,7 +84,7 @@ export const TokenSelectModal: FunctionComponent<
             >
               <button className="flex w-full items-center justify-between text-left">
                 <div className="flex items-center">
-                  <div className="mr-4 h-8 w-8 rounded-full">
+                  <div className="mr-4 h-8 w-8 overflow-hidden rounded-full">
                     <EntityImage
                       symbol={coinDenom}
                       name={coinDenom}

--- a/packages/web/modals/variants-conversion.tsx
+++ b/packages/web/modals/variants-conversion.tsx
@@ -272,9 +272,8 @@ const AssetVariantRow: React.FC<{
       <div className="flex flex-col justify-between gap-3 rounded-2xl py-4">
         <div className="grid w-full grid-cols-[1fr_1.5rem_1fr_1.5rem] items-center gap-3 py-2">
           <div className="flex min-w-0 items-center gap-3">
-            <div className="shrink-0">
+            <div className="h-10 w-10 shrink-0 overflow-hidden rounded-full">
               <EntityImage
-                circular
                 logoURIs={
                   variant.amount.currency.coinImageUrl
                     ? {
@@ -309,9 +308,8 @@ const AssetVariantRow: React.FC<{
             className="text-osmoverse-700"
           />
           <div className="flex grow items-center gap-3 py-2 px-4">
-            <div className="shrink-0">
+            <div className="h-10 w-10 shrink-0 overflow-hidden rounded-full">
               <EntityImage
-                circular
                 logoURIs={
                   variant?.canonicalAsset?.coinImageUrl
                     ? {

--- a/packages/web/modals/variants-conversion.tsx
+++ b/packages/web/modals/variants-conversion.tsx
@@ -272,8 +272,9 @@ const AssetVariantRow: React.FC<{
       <div className="flex flex-col justify-between gap-3 rounded-2xl py-4">
         <div className="grid w-full grid-cols-[1fr_1.5rem_1fr_1.5rem] items-center gap-3 py-2">
           <div className="flex min-w-0 items-center gap-3">
-            <div className="h-10 w-10 shrink-0 overflow-hidden rounded-full">
+            <div className="shrink-0">
               <EntityImage
+                circular
                 logoURIs={
                   variant.amount.currency.coinImageUrl
                     ? {
@@ -308,8 +309,9 @@ const AssetVariantRow: React.FC<{
             className="text-osmoverse-700"
           />
           <div className="flex grow items-center gap-3 py-2 px-4">
-            <div className="h-10 w-10 shrink-0 overflow-hidden rounded-full">
+            <div className="shrink-0">
               <EntityImage
+                circular
                 logoURIs={
                   variant?.canonicalAsset?.coinImageUrl
                     ? {

--- a/packages/web/modals/variants-conversion.tsx
+++ b/packages/web/modals/variants-conversion.tsx
@@ -272,26 +272,28 @@ const AssetVariantRow: React.FC<{
       <div className="flex flex-col justify-between gap-3 rounded-2xl py-4">
         <div className="grid w-full grid-cols-[1fr_1.5rem_1fr_1.5rem] items-center gap-3 py-2">
           <div className="flex min-w-0 items-center gap-3">
-            <EntityImage
-              logoURIs={
-                variant.amount.currency.coinImageUrl
-                  ? {
-                      svg: variant.amount.currency.coinImageUrl.replace(
-                        /\.(png|svg)$/,
-                        ".svg"
-                      ),
-                      png: variant.amount.currency.coinImageUrl.replace(
-                        /\.(png|svg)$/,
-                        ".png"
-                      ),
-                    }
-                  : {}
-              }
-              name={variant.amount.currency.coinDenom ?? ""}
-              symbol={variant.amount.currency.coinDenom ?? ""}
-              height={40}
-              width={40}
-            />
+            <div className="h-10 w-10 shrink-0 overflow-hidden rounded-full">
+              <EntityImage
+                logoURIs={
+                  variant.amount.currency.coinImageUrl
+                    ? {
+                        svg: variant.amount.currency.coinImageUrl.replace(
+                          /\.(png|svg)$/,
+                          ".svg"
+                        ),
+                        png: variant.amount.currency.coinImageUrl.replace(
+                          /\.(png|svg)$/,
+                          ".png"
+                        ),
+                      }
+                    : {}
+                }
+                name={variant.amount.currency.coinDenom ?? ""}
+                symbol={variant.amount.currency.coinDenom ?? ""}
+                height={40}
+                width={40}
+              />
+            </div>
             <div className="flex min-w-0 flex-col gap-1 overflow-hidden">
               <span className="subtitle1 truncate">{variant.name}</span>
               <span className="body2 truncate text-osmoverse-300">
@@ -306,26 +308,28 @@ const AssetVariantRow: React.FC<{
             className="text-osmoverse-700"
           />
           <div className="flex grow items-center gap-3 py-2 px-4">
-            <EntityImage
-              logoURIs={
-                variant?.canonicalAsset?.coinImageUrl
-                  ? {
-                      svg: variant.canonicalAsset.coinImageUrl.replace(
-                        /\.(png|svg)$/,
-                        ".svg"
-                      ),
-                      png: variant.canonicalAsset.coinImageUrl.replace(
-                        /\.(png|svg)$/,
-                        ".png"
-                      ),
-                    }
-                  : {}
-              }
-              name={variant?.canonicalAsset?.coinDenom ?? ""}
-              symbol={variant?.canonicalAsset?.coinDenom ?? ""}
-              height={40}
-              width={40}
-            />
+            <div className="h-10 w-10 shrink-0 overflow-hidden rounded-full">
+              <EntityImage
+                logoURIs={
+                  variant?.canonicalAsset?.coinImageUrl
+                    ? {
+                        svg: variant.canonicalAsset.coinImageUrl.replace(
+                          /\.(png|svg)$/,
+                          ".svg"
+                        ),
+                        png: variant.canonicalAsset.coinImageUrl.replace(
+                          /\.(png|svg)$/,
+                          ".png"
+                        ),
+                      }
+                    : {}
+                }
+                name={variant?.canonicalAsset?.coinDenom ?? ""}
+                symbol={variant?.canonicalAsset?.coinDenom ?? ""}
+                height={40}
+                width={40}
+              />
+            </div>
             <div className="flex flex-col gap-1 overflow-hidden">
               <span className="subtitle1 truncate">
                 {variant.canonicalAsset?.coinName}

--- a/packages/web/stores/transfer-history.tsx
+++ b/packages/web/stores/transfer-history.tsx
@@ -402,15 +402,17 @@ const PendingTransferLoadingIcon: FunctionComponent<{
 
   return (
     <div className="relative flex h-12 w-12 items-center justify-center">
-      <EntityImage
-        logoURIs={{
-          png: assetLogo,
-        }}
-        name="Token"
-        symbol="TOK"
-        width={32}
-        height={32}
-      />
+      <div className="h-8 w-8 overflow-hidden rounded-full">
+        <EntityImage
+          logoURIs={{
+            png: assetLogo,
+          }}
+          name="Token"
+          symbol="TOK"
+          width={32}
+          height={32}
+        />
+      </div>
       <div className="absolute inset-0" ref={progressRef}>
         <RadialProgress progress={100} strokeWidth={2} />
       </div>

--- a/packages/web/stores/transfer-history.tsx
+++ b/packages/web/stores/transfer-history.tsx
@@ -402,16 +402,17 @@ const PendingTransferLoadingIcon: FunctionComponent<{
 
   return (
     <div className="relative flex h-12 w-12 items-center justify-center">
-      <EntityImage
-        circular
-        logoURIs={{
-          png: assetLogo,
-        }}
-        name="Token"
-        symbol="TOK"
-        width={32}
-        height={32}
-      />
+      <div className="h-8 w-8 overflow-hidden rounded-full">
+        <EntityImage
+          logoURIs={{
+            png: assetLogo,
+          }}
+          name="Token"
+          symbol="TOK"
+          width={32}
+          height={32}
+        />
+      </div>
       <div className="absolute inset-0" ref={progressRef}>
         <RadialProgress progress={100} strokeWidth={2} />
       </div>

--- a/packages/web/stores/transfer-history.tsx
+++ b/packages/web/stores/transfer-history.tsx
@@ -402,17 +402,16 @@ const PendingTransferLoadingIcon: FunctionComponent<{
 
   return (
     <div className="relative flex h-12 w-12 items-center justify-center">
-      <div className="h-8 w-8 overflow-hidden rounded-full">
-        <EntityImage
-          logoURIs={{
-            png: assetLogo,
-          }}
-          name="Token"
-          symbol="TOK"
-          width={32}
-          height={32}
-        />
-      </div>
+      <EntityImage
+        circular
+        logoURIs={{
+          png: assetLogo,
+        }}
+        name="Token"
+        symbol="TOK"
+        width={32}
+        height={32}
+      />
       <div className="absolute inset-0" ref={progressRef}>
         <RadialProgress progress={100} strokeWidth={2} />
       </div>


### PR DESCRIPTION
Apply consistent `overflow-hidden rounded-full` wrapper to all EntityImage usages to ensure token logos render as circles throughout the app.

Previously ~75% of usages had no circular masking, relying on the logo file itself to appear circular. The canonical pattern (used in token-select.tsx) wraps EntityImage in a sized div with overflow-hidden and rounded-full, which correctly clips any image regardless of its shape, aspect ratio, or fallback rendering.

Upgraded existing partial implementations (rounded-full without overflow-hidden) and added new wrappers across assets table, bridge screens, transaction history, swap tool, pool detail, orders, portfolio, and navbar components.

Intentionally excluded: pool-assets-icon.tsx and price-selector default quotes row (overlapping stacked icon designs that require square bounds).