### PR TITLE
fix(ci): prevent false Slack balance alerts when check script crashes

### DIFF
--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -66,12 +66,14 @@ jobs:
             echo "summary=${SUMMARY}" >> "$GITHUB_OUTPUT"
             echo "address=${ADDRESS}" >> "$GITHUB_OUTPUT"
             echo "outcome=${OUTCOME}" >> "$GITHUB_OUTPUT"
+            echo "is_balance_issue=true" >> "$GITHUB_OUTPUT"
           else
-            echo "summary=Balance report not available." >> "$GITHUB_OUTPUT"
-            echo "outcome=warn" >> "$GITHUB_OUTPUT"
+            echo "summary=Balance check script crashed (not a balance issue)." >> "$GITHUB_OUTPUT"
+            echo "outcome=error" >> "$GITHUB_OUTPUT"
+            echo "is_balance_issue=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Send low-balance Slack alert
-        if: steps.balance-check.outcome == 'failure'
+        if: steps.balance-check.outcome == 'failure' && steps.balance-details.outputs.is_balance_issue == 'true'
         continue-on-error: true
         uses: slackapi/slack-github-action@v1.26.0
         with:

--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -60,13 +60,13 @@ jobs:
         continue-on-error: true
         run: |
           if [ -f packages/e2e/balance-report.json ]; then
+            echo "is_balance_issue=true" >> "$GITHUB_OUTPUT"
             SUMMARY=$(jq -r '[.details[] | ltrimstr("  ")] | join("\\n")' packages/e2e/balance-report.json)
             ADDRESS=$(jq -r '.address // ""' packages/e2e/balance-report.json)
             OUTCOME=$(jq -r '.outcome // "warn"' packages/e2e/balance-report.json)
             echo "summary=${SUMMARY}" >> "$GITHUB_OUTPUT"
             echo "address=${ADDRESS}" >> "$GITHUB_OUTPUT"
             echo "outcome=${OUTCOME}" >> "$GITHUB_OUTPUT"
-            echo "is_balance_issue=true" >> "$GITHUB_OUTPUT"
           else
             echo "summary=Balance check script crashed (not a balance issue)." >> "$GITHUB_OUTPUT"
             echo "outcome=error" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/monitoring-limit-geo-e2e-tests.yml
+++ b/.github/workflows/monitoring-limit-geo-e2e-tests.yml
@@ -54,12 +54,14 @@ jobs:
             echo "summary=${SUMMARY}" >> "$GITHUB_OUTPUT"
             echo "address=${ADDRESS}" >> "$GITHUB_OUTPUT"
             echo "outcome=${OUTCOME}" >> "$GITHUB_OUTPUT"
+            echo "is_balance_issue=true" >> "$GITHUB_OUTPUT"
           else
-            echo "summary=Balance report not available." >> "$GITHUB_OUTPUT"
-            echo "outcome=warn" >> "$GITHUB_OUTPUT"
+            echo "summary=Balance check script crashed (not a balance issue)." >> "$GITHUB_OUTPUT"
+            echo "outcome=error" >> "$GITHUB_OUTPUT"
+            echo "is_balance_issue=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Send low-balance Slack alert
-        if: steps.balance-check.outcome == 'failure'
+        if: steps.balance-check.outcome == 'failure' && steps.balance-details.outputs.is_balance_issue == 'true'
         continue-on-error: true
         uses: slackapi/slack-github-action@v1.26.0
         with:
@@ -181,12 +183,14 @@ jobs:
             echo "summary=${SUMMARY}" >> "$GITHUB_OUTPUT"
             echo "address=${ADDRESS}" >> "$GITHUB_OUTPUT"
             echo "outcome=${OUTCOME}" >> "$GITHUB_OUTPUT"
+            echo "is_balance_issue=true" >> "$GITHUB_OUTPUT"
           else
-            echo "summary=Balance report not available." >> "$GITHUB_OUTPUT"
-            echo "outcome=warn" >> "$GITHUB_OUTPUT"
+            echo "summary=Balance check script crashed (not a balance issue)." >> "$GITHUB_OUTPUT"
+            echo "outcome=error" >> "$GITHUB_OUTPUT"
+            echo "is_balance_issue=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Send low-balance Slack alert
-        if: steps.balance-check.outcome == 'failure'
+        if: steps.balance-check.outcome == 'failure' && steps.balance-details.outputs.is_balance_issue == 'true'
         continue-on-error: true
         uses: slackapi/slack-github-action@v1.26.0
         with:
@@ -314,12 +318,14 @@ jobs:
             echo "summary=${SUMMARY}" >> "$GITHUB_OUTPUT"
             echo "address=${ADDRESS}" >> "$GITHUB_OUTPUT"
             echo "outcome=${OUTCOME}" >> "$GITHUB_OUTPUT"
+            echo "is_balance_issue=true" >> "$GITHUB_OUTPUT"
           else
-            echo "summary=Balance report not available." >> "$GITHUB_OUTPUT"
-            echo "outcome=warn" >> "$GITHUB_OUTPUT"
+            echo "summary=Balance check script crashed (not a balance issue)." >> "$GITHUB_OUTPUT"
+            echo "outcome=error" >> "$GITHUB_OUTPUT"
+            echo "is_balance_issue=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Send low-balance Slack alert
-        if: steps.balance-check.outcome == 'failure'
+        if: steps.balance-check.outcome == 'failure' && steps.balance-details.outputs.is_balance_issue == 'true'
         continue-on-error: true
         uses: slackapi/slack-github-action@v1.26.0
         with:
@@ -448,12 +454,14 @@ jobs:
             echo "summary=${SUMMARY}" >> "$GITHUB_OUTPUT"
             echo "address=${ADDRESS}" >> "$GITHUB_OUTPUT"
             echo "outcome=${OUTCOME}" >> "$GITHUB_OUTPUT"
+            echo "is_balance_issue=true" >> "$GITHUB_OUTPUT"
           else
-            echo "summary=Balance report not available." >> "$GITHUB_OUTPUT"
-            echo "outcome=warn" >> "$GITHUB_OUTPUT"
+            echo "summary=Balance check script crashed (not a balance issue)." >> "$GITHUB_OUTPUT"
+            echo "outcome=error" >> "$GITHUB_OUTPUT"
+            echo "is_balance_issue=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Send low-balance Slack alert
-        if: steps.balance-check.outcome == 'failure'
+        if: steps.balance-check.outcome == 'failure' && steps.balance-details.outputs.is_balance_issue == 'true'
         continue-on-error: true
         uses: slackapi/slack-github-action@v1.26.0
         with:
@@ -587,12 +595,14 @@ jobs:
             echo "summary=${SUMMARY}" >> "$GITHUB_OUTPUT"
             echo "address=${ADDRESS}" >> "$GITHUB_OUTPUT"
             echo "outcome=${OUTCOME}" >> "$GITHUB_OUTPUT"
+            echo "is_balance_issue=true" >> "$GITHUB_OUTPUT"
           else
-            echo "summary=Balance report not available." >> "$GITHUB_OUTPUT"
-            echo "outcome=warn" >> "$GITHUB_OUTPUT"
+            echo "summary=Balance check script crashed (not a balance issue)." >> "$GITHUB_OUTPUT"
+            echo "outcome=error" >> "$GITHUB_OUTPUT"
+            echo "is_balance_issue=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Send low-balance Slack alert
-        if: steps.balance-check.outcome == 'failure'
+        if: steps.balance-check.outcome == 'failure' && steps.balance-details.outputs.is_balance_issue == 'true'
         continue-on-error: true
         uses: slackapi/slack-github-action@v1.26.0
         with:
@@ -731,12 +741,14 @@ jobs:
             echo "summary=${SUMMARY}" >> "$GITHUB_OUTPUT"
             echo "address=${ADDRESS}" >> "$GITHUB_OUTPUT"
             echo "outcome=${OUTCOME}" >> "$GITHUB_OUTPUT"
+            echo "is_balance_issue=true" >> "$GITHUB_OUTPUT"
           else
-            echo "summary=Balance report not available." >> "$GITHUB_OUTPUT"
-            echo "outcome=warn" >> "$GITHUB_OUTPUT"
+            echo "summary=Balance check script crashed (not a balance issue)." >> "$GITHUB_OUTPUT"
+            echo "outcome=error" >> "$GITHUB_OUTPUT"
+            echo "is_balance_issue=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Send low-balance Slack alert
-        if: steps.balance-check.outcome == 'failure'
+        if: steps.balance-check.outcome == 'failure' && steps.balance-details.outputs.is_balance_issue == 'true'
         continue-on-error: true
         uses: slackapi/slack-github-action@v1.26.0
         with:
@@ -869,12 +881,14 @@ jobs:
             echo "summary=${SUMMARY}" >> "$GITHUB_OUTPUT"
             echo "address=${ADDRESS}" >> "$GITHUB_OUTPUT"
             echo "outcome=${OUTCOME}" >> "$GITHUB_OUTPUT"
+            echo "is_balance_issue=true" >> "$GITHUB_OUTPUT"
           else
-            echo "summary=Balance report not available." >> "$GITHUB_OUTPUT"
-            echo "outcome=warn" >> "$GITHUB_OUTPUT"
+            echo "summary=Balance check script crashed (not a balance issue)." >> "$GITHUB_OUTPUT"
+            echo "outcome=error" >> "$GITHUB_OUTPUT"
+            echo "is_balance_issue=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Send low-balance Slack alert
-        if: steps.balance-check.outcome == 'failure'
+        if: steps.balance-check.outcome == 'failure' && steps.balance-details.outputs.is_balance_issue == 'true'
         continue-on-error: true
         uses: slackapi/slack-github-action@v1.26.0
         with:
@@ -1005,12 +1019,14 @@ jobs:
             echo "summary=${SUMMARY}" >> "$GITHUB_OUTPUT"
             echo "address=${ADDRESS}" >> "$GITHUB_OUTPUT"
             echo "outcome=${OUTCOME}" >> "$GITHUB_OUTPUT"
+            echo "is_balance_issue=true" >> "$GITHUB_OUTPUT"
           else
-            echo "summary=Balance report not available." >> "$GITHUB_OUTPUT"
-            echo "outcome=warn" >> "$GITHUB_OUTPUT"
+            echo "summary=Balance check script crashed (not a balance issue)." >> "$GITHUB_OUTPUT"
+            echo "outcome=error" >> "$GITHUB_OUTPUT"
+            echo "is_balance_issue=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Send low-balance Slack alert
-        if: steps.balance-check.outcome == 'failure'
+        if: steps.balance-check.outcome == 'failure' && steps.balance-details.outputs.is_balance_issue == 'true'
         continue-on-error: true
         uses: slackapi/slack-github-action@v1.26.0
         with:

--- a/.github/workflows/monitoring-limit-geo-e2e-tests.yml
+++ b/.github/workflows/monitoring-limit-geo-e2e-tests.yml
@@ -48,13 +48,13 @@ jobs:
         continue-on-error: true
         run: |
           if [ -f packages/e2e/balance-report.json ]; then
+            echo "is_balance_issue=true" >> "$GITHUB_OUTPUT"
             SUMMARY=$(jq -r '[.details[] | ltrimstr("  ")] | join("\\n")' packages/e2e/balance-report.json)
             ADDRESS=$(jq -r '.address // ""' packages/e2e/balance-report.json)
             OUTCOME=$(jq -r '.outcome // "warn"' packages/e2e/balance-report.json)
             echo "summary=${SUMMARY}" >> "$GITHUB_OUTPUT"
             echo "address=${ADDRESS}" >> "$GITHUB_OUTPUT"
             echo "outcome=${OUTCOME}" >> "$GITHUB_OUTPUT"
-            echo "is_balance_issue=true" >> "$GITHUB_OUTPUT"
           else
             echo "summary=Balance check script crashed (not a balance issue)." >> "$GITHUB_OUTPUT"
             echo "outcome=error" >> "$GITHUB_OUTPUT"
@@ -177,13 +177,13 @@ jobs:
         continue-on-error: true
         run: |
           if [ -f packages/e2e/balance-report.json ]; then
+            echo "is_balance_issue=true" >> "$GITHUB_OUTPUT"
             SUMMARY=$(jq -r '[.details[] | ltrimstr("  ")] | join("\\n")' packages/e2e/balance-report.json)
             ADDRESS=$(jq -r '.address // ""' packages/e2e/balance-report.json)
             OUTCOME=$(jq -r '.outcome // "warn"' packages/e2e/balance-report.json)
             echo "summary=${SUMMARY}" >> "$GITHUB_OUTPUT"
             echo "address=${ADDRESS}" >> "$GITHUB_OUTPUT"
             echo "outcome=${OUTCOME}" >> "$GITHUB_OUTPUT"
-            echo "is_balance_issue=true" >> "$GITHUB_OUTPUT"
           else
             echo "summary=Balance check script crashed (not a balance issue)." >> "$GITHUB_OUTPUT"
             echo "outcome=error" >> "$GITHUB_OUTPUT"
@@ -312,13 +312,13 @@ jobs:
         continue-on-error: true
         run: |
           if [ -f packages/e2e/balance-report.json ]; then
+            echo "is_balance_issue=true" >> "$GITHUB_OUTPUT"
             SUMMARY=$(jq -r '[.details[] | ltrimstr("  ")] | join("\\n")' packages/e2e/balance-report.json)
             ADDRESS=$(jq -r '.address // ""' packages/e2e/balance-report.json)
             OUTCOME=$(jq -r '.outcome // "warn"' packages/e2e/balance-report.json)
             echo "summary=${SUMMARY}" >> "$GITHUB_OUTPUT"
             echo "address=${ADDRESS}" >> "$GITHUB_OUTPUT"
             echo "outcome=${OUTCOME}" >> "$GITHUB_OUTPUT"
-            echo "is_balance_issue=true" >> "$GITHUB_OUTPUT"
           else
             echo "summary=Balance check script crashed (not a balance issue)." >> "$GITHUB_OUTPUT"
             echo "outcome=error" >> "$GITHUB_OUTPUT"
@@ -448,13 +448,13 @@ jobs:
         continue-on-error: true
         run: |
           if [ -f packages/e2e/balance-report.json ]; then
+            echo "is_balance_issue=true" >> "$GITHUB_OUTPUT"
             SUMMARY=$(jq -r '[.details[] | ltrimstr("  ")] | join("\\n")' packages/e2e/balance-report.json)
             ADDRESS=$(jq -r '.address // ""' packages/e2e/balance-report.json)
             OUTCOME=$(jq -r '.outcome // "warn"' packages/e2e/balance-report.json)
             echo "summary=${SUMMARY}" >> "$GITHUB_OUTPUT"
             echo "address=${ADDRESS}" >> "$GITHUB_OUTPUT"
             echo "outcome=${OUTCOME}" >> "$GITHUB_OUTPUT"
-            echo "is_balance_issue=true" >> "$GITHUB_OUTPUT"
           else
             echo "summary=Balance check script crashed (not a balance issue)." >> "$GITHUB_OUTPUT"
             echo "outcome=error" >> "$GITHUB_OUTPUT"
@@ -589,13 +589,13 @@ jobs:
         continue-on-error: true
         run: |
           if [ -f packages/e2e/balance-report.json ]; then
+            echo "is_balance_issue=true" >> "$GITHUB_OUTPUT"
             SUMMARY=$(jq -r '[.details[] | ltrimstr("  ")] | join("\\n")' packages/e2e/balance-report.json)
             ADDRESS=$(jq -r '.address // ""' packages/e2e/balance-report.json)
             OUTCOME=$(jq -r '.outcome // "warn"' packages/e2e/balance-report.json)
             echo "summary=${SUMMARY}" >> "$GITHUB_OUTPUT"
             echo "address=${ADDRESS}" >> "$GITHUB_OUTPUT"
             echo "outcome=${OUTCOME}" >> "$GITHUB_OUTPUT"
-            echo "is_balance_issue=true" >> "$GITHUB_OUTPUT"
           else
             echo "summary=Balance check script crashed (not a balance issue)." >> "$GITHUB_OUTPUT"
             echo "outcome=error" >> "$GITHUB_OUTPUT"
@@ -735,13 +735,13 @@ jobs:
         continue-on-error: true
         run: |
           if [ -f packages/e2e/balance-report.json ]; then
+            echo "is_balance_issue=true" >> "$GITHUB_OUTPUT"
             SUMMARY=$(jq -r '[.details[] | ltrimstr("  ")] | join("\\n")' packages/e2e/balance-report.json)
             ADDRESS=$(jq -r '.address // ""' packages/e2e/balance-report.json)
             OUTCOME=$(jq -r '.outcome // "warn"' packages/e2e/balance-report.json)
             echo "summary=${SUMMARY}" >> "$GITHUB_OUTPUT"
             echo "address=${ADDRESS}" >> "$GITHUB_OUTPUT"
             echo "outcome=${OUTCOME}" >> "$GITHUB_OUTPUT"
-            echo "is_balance_issue=true" >> "$GITHUB_OUTPUT"
           else
             echo "summary=Balance check script crashed (not a balance issue)." >> "$GITHUB_OUTPUT"
             echo "outcome=error" >> "$GITHUB_OUTPUT"
@@ -875,13 +875,13 @@ jobs:
         continue-on-error: true
         run: |
           if [ -f packages/e2e/balance-report.json ]; then
+            echo "is_balance_issue=true" >> "$GITHUB_OUTPUT"
             SUMMARY=$(jq -r '[.details[] | ltrimstr("  ")] | join("\\n")' packages/e2e/balance-report.json)
             ADDRESS=$(jq -r '.address // ""' packages/e2e/balance-report.json)
             OUTCOME=$(jq -r '.outcome // "warn"' packages/e2e/balance-report.json)
             echo "summary=${SUMMARY}" >> "$GITHUB_OUTPUT"
             echo "address=${ADDRESS}" >> "$GITHUB_OUTPUT"
             echo "outcome=${OUTCOME}" >> "$GITHUB_OUTPUT"
-            echo "is_balance_issue=true" >> "$GITHUB_OUTPUT"
           else
             echo "summary=Balance check script crashed (not a balance issue)." >> "$GITHUB_OUTPUT"
             echo "outcome=error" >> "$GITHUB_OUTPUT"
@@ -1013,13 +1013,13 @@ jobs:
         continue-on-error: true
         run: |
           if [ -f packages/e2e/balance-report.json ]; then
+            echo "is_balance_issue=true" >> "$GITHUB_OUTPUT"
             SUMMARY=$(jq -r '[.details[] | ltrimstr("  ")] | join("\\n")' packages/e2e/balance-report.json)
             ADDRESS=$(jq -r '.address // ""' packages/e2e/balance-report.json)
             OUTCOME=$(jq -r '.outcome // "warn"' packages/e2e/balance-report.json)
             echo "summary=${SUMMARY}" >> "$GITHUB_OUTPUT"
             echo "address=${ADDRESS}" >> "$GITHUB_OUTPUT"
             echo "outcome=${OUTCOME}" >> "$GITHUB_OUTPUT"
-            echo "is_balance_issue=true" >> "$GITHUB_OUTPUT"
           else
             echo "summary=Balance check script crashed (not a balance issue)." >> "$GITHUB_OUTPUT"
             echo "outcome=error" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/prod-frontend-e2e-tests.yml
+++ b/.github/workflows/prod-frontend-e2e-tests.yml
@@ -59,13 +59,13 @@ jobs:
         continue-on-error: true
         run: |
           if [ -f packages/e2e/balance-report.json ]; then
+            echo "is_balance_issue=true" >> "$GITHUB_OUTPUT"
             SUMMARY=$(jq -r '[.details[] | ltrimstr("  ")] | join("\\n")' packages/e2e/balance-report.json)
             ADDRESS=$(jq -r '.address // ""' packages/e2e/balance-report.json)
             OUTCOME=$(jq -r '.outcome // "warn"' packages/e2e/balance-report.json)
             echo "summary=${SUMMARY}" >> "$GITHUB_OUTPUT"
             echo "address=${ADDRESS}" >> "$GITHUB_OUTPUT"
             echo "outcome=${OUTCOME}" >> "$GITHUB_OUTPUT"
-            echo "is_balance_issue=true" >> "$GITHUB_OUTPUT"
           else
             echo "summary=Balance check script crashed (not a balance issue)." >> "$GITHUB_OUTPUT"
             echo "outcome=error" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/prod-frontend-e2e-tests.yml
+++ b/.github/workflows/prod-frontend-e2e-tests.yml
@@ -65,12 +65,14 @@ jobs:
             echo "summary=${SUMMARY}" >> "$GITHUB_OUTPUT"
             echo "address=${ADDRESS}" >> "$GITHUB_OUTPUT"
             echo "outcome=${OUTCOME}" >> "$GITHUB_OUTPUT"
+            echo "is_balance_issue=true" >> "$GITHUB_OUTPUT"
           else
-            echo "summary=Balance report not available." >> "$GITHUB_OUTPUT"
-            echo "outcome=warn" >> "$GITHUB_OUTPUT"
+            echo "summary=Balance check script crashed (not a balance issue)." >> "$GITHUB_OUTPUT"
+            echo "outcome=error" >> "$GITHUB_OUTPUT"
+            echo "is_balance_issue=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Send low-balance Slack alert
-        if: steps.balance-check.outcome == 'failure'
+        if: steps.balance-check.outcome == 'failure' && steps.balance-details.outputs.is_balance_issue == 'true'
         continue-on-error: true
         uses: slackapi/slack-github-action@v1.26.0
         with:


### PR DESCRIPTION
When the check-balances script crashes (network error, dependency issue, etc.) rather than detecting a real low balance, all three e2e workflows fire a false Low Balance Warning to Slack because they only gate on `steps.balance-check.outcome == 'failure'`.

Added an `is_balance_issue` output to the Extract balance details step (`true` when `balance-report.json` exists, `false` on script crash) and gated the Slack alert on it.

**Files:** `frontend-e2e-tests.yml` (1), `prod-frontend-e2e-tests.yml` (1), `monitoring-limit-geo-e2e-tests.yml` (8 instances).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that narrows when Slack alerts fire; main risk is misconfigured outputs/conditions causing missed notifications.
> 
> **Overview**
> Prevents **false low-balance Slack alerts** when `check-balances` fails due to a script crash rather than an actual balance shortage.
> 
> Across the E2E GitHub Actions workflows, the balance-details extraction step now emits an `is_balance_issue` output based on whether `packages/e2e/balance-report.json` exists, and the Slack alert step is additionally gated on `is_balance_issue == 'true'` (with the crash case reported as `outcome=error`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50783d8d9aa7ecfe9e7fe0c458fc5f5f8730330a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->