### PR TITLE
fix(bridge): break deposit quote feedback loop when selecting Max

### DIFF
--- a/packages/web/components/control/__tests__/crypto-fiat-input-max-guard.spec.tsx
+++ b/packages/web/components/control/__tests__/crypto-fiat-input-max-guard.spec.tsx
@@ -409,4 +409,85 @@ describe("CryptoFiatInput gasAppliedToMax guard", () => {
       expect(onChangeCryptoInput).toHaveBeenCalledWith(expectedJuno);
     });
   });
+
+  it("re-applies gas after transferGasCost goes undefined then returns", async () => {
+    const balanceRaw = "2000000";
+    const gasRaw1 = "5000";
+    const gasRaw2 = "5200";
+    const onChangeCryptoInput = jest.fn();
+
+    const balanceDec = makeBalance(balanceRaw).toDec().toString();
+    const balance = makeBalance(balanceRaw);
+
+    const baseProps = {
+      currentUnit: "crypto" as const,
+      setCurrentUnit: jest.fn(),
+      setIsMax: jest.fn(),
+      canSetMax: true,
+      transferGasChain: { prettyName: "Cosmos Hub" },
+      assetPrice: undefined,
+      assetWithBalance: {
+        denom: "ATOM",
+        address: "uatom",
+        decimals: 6,
+        amount: balance,
+      },
+      fiatInput: "",
+      onChangeFiatInput: jest.fn(),
+      isInsufficientBal: false,
+      isInsufficientFee: false,
+    };
+
+    // 1) Gas applied initially
+    const { rerender } = render(
+      <CryptoFiatInput
+        {...baseProps}
+        isMax={true}
+        transferGasCost={makeGasCost(gasRaw1)}
+        cryptoInput={balanceDec}
+        onChangeCryptoInput={onChangeCryptoInput}
+      />
+    );
+
+    const expected1 = expectedMaxAfterGas(balanceRaw, gasRaw1);
+    await waitFor(() => {
+      expect(onChangeCryptoInput).toHaveBeenCalledWith(expected1);
+    });
+
+    onChangeCryptoInput.mockClear();
+
+    // 2) Quotes fail — transferGasCost goes undefined while isMax stays true
+    rerender(
+      <CryptoFiatInput
+        {...baseProps}
+        isMax={true}
+        transferGasCost={undefined}
+        cryptoInput={expected1}
+        onChangeCryptoInput={onChangeCryptoInput}
+      />
+    );
+
+    const fullBalance = trimPlaceholderZeros(balanceDec);
+    await waitFor(() => {
+      expect(onChangeCryptoInput).toHaveBeenCalledWith(fullBalance);
+    });
+
+    onChangeCryptoInput.mockClear();
+
+    // 3) Quotes succeed again — gas should be deducted fresh
+    rerender(
+      <CryptoFiatInput
+        {...baseProps}
+        isMax={true}
+        transferGasCost={makeGasCost(gasRaw2)}
+        cryptoInput={balanceDec}
+        onChangeCryptoInput={onChangeCryptoInput}
+      />
+    );
+
+    const expected2 = expectedMaxAfterGas(balanceRaw, gasRaw2);
+    await waitFor(() => {
+      expect(onChangeCryptoInput).toHaveBeenCalledWith(expected2);
+    });
+  });
 });

--- a/packages/web/components/control/__tests__/crypto-fiat-input-max-guard.spec.tsx
+++ b/packages/web/components/control/__tests__/crypto-fiat-input-max-guard.spec.tsx
@@ -1,0 +1,415 @@
+import { CoinPretty, Dec } from "@osmosis-labs/unit";
+import { render, waitFor } from "@testing-library/react";
+import React from "react";
+
+import { trimPlaceholderZeros } from "~/utils/number";
+
+import { CryptoFiatInput } from "../crypto-fiat-input";
+
+jest.mock("~/hooks", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+  useWindowSize: () => ({ isMobile: false }),
+}));
+
+const ATOM_CURRENCY = {
+  coinDecimals: 6,
+  coinDenom: "ATOM",
+  coinMinimalDenom: "uatom",
+};
+
+function makeBalance(amount: string) {
+  return new CoinPretty(ATOM_CURRENCY, amount);
+}
+
+function makeGasCost(amount: string) {
+  return new CoinPretty(ATOM_CURRENCY, amount);
+}
+
+const MUL_GAS_SLIPPAGE = new Dec("1.1");
+
+function expectedMaxAfterGas(balanceRaw: string, gasRaw: string) {
+  const balance = new CoinPretty(ATOM_CURRENCY, balanceRaw);
+  const gas = new CoinPretty(ATOM_CURRENCY, gasRaw);
+  const max = balance.toDec().sub(gas.toDec().mul(MUL_GAS_SLIPPAGE));
+  return trimPlaceholderZeros(max.toString());
+}
+
+interface Props {
+  isMax: boolean;
+  cryptoInput: string;
+  transferGasCost: CoinPretty | undefined;
+  balanceRaw: string;
+  onChangeCryptoInput: jest.Mock;
+  canSetMax?: boolean;
+  address?: string;
+}
+
+function renderInput({
+  isMax,
+  cryptoInput,
+  transferGasCost,
+  balanceRaw,
+  onChangeCryptoInput,
+  canSetMax = true,
+  address = "uatom",
+}: Props) {
+  const balance = makeBalance(balanceRaw);
+  return render(
+    <CryptoFiatInput
+      currentUnit="crypto"
+      setCurrentUnit={jest.fn()}
+      isMax={isMax}
+      setIsMax={jest.fn()}
+      canSetMax={canSetMax}
+      transferGasCost={transferGasCost}
+      transferGasChain={{ prettyName: "Cosmos Hub" }}
+      assetPrice={undefined}
+      assetWithBalance={{
+        denom: "ATOM",
+        address,
+        decimals: 6,
+        amount: balance,
+      }}
+      cryptoInput={cryptoInput}
+      onChangeCryptoInput={onChangeCryptoInput}
+      fiatInput=""
+      onChangeFiatInput={jest.fn()}
+      isInsufficientBal={false}
+      isInsufficientFee={false}
+    />
+  );
+}
+
+describe("CryptoFiatInput gasAppliedToMax guard", () => {
+  it("subtracts gas on first render with isMax and transferGasCost", async () => {
+    const balanceRaw = "2000000";
+    const gasRaw = "5000";
+    const onChangeCryptoInput = jest.fn();
+
+    renderInput({
+      isMax: true,
+      cryptoInput: makeBalance(balanceRaw).toDec().toString(),
+      transferGasCost: makeGasCost(gasRaw),
+      balanceRaw,
+      onChangeCryptoInput,
+    });
+
+    const expected = expectedMaxAfterGas(balanceRaw, gasRaw);
+
+    await waitFor(() => {
+      expect(onChangeCryptoInput).toHaveBeenCalledWith(expected);
+    });
+  });
+
+  it("does NOT re-apply gas when transferGasCost changes slightly (feedback loop prevention)", async () => {
+    const balanceRaw = "2000000";
+    const gasRaw1 = "5000";
+    const gasRaw2 = "5050";
+    const onChangeCryptoInput = jest.fn();
+
+    const balanceDec = makeBalance(balanceRaw).toDec().toString();
+
+    const { rerender } = renderInput({
+      isMax: true,
+      cryptoInput: balanceDec,
+      transferGasCost: makeGasCost(gasRaw1),
+      balanceRaw,
+      onChangeCryptoInput,
+    });
+
+    const expected1 = expectedMaxAfterGas(balanceRaw, gasRaw1);
+    await waitFor(() => {
+      expect(onChangeCryptoInput).toHaveBeenCalledWith(expected1);
+    });
+
+    onChangeCryptoInput.mockClear();
+
+    const balance = makeBalance(balanceRaw);
+    rerender(
+      <CryptoFiatInput
+        currentUnit="crypto"
+        setCurrentUnit={jest.fn()}
+        isMax={true}
+        setIsMax={jest.fn()}
+        canSetMax={true}
+        transferGasCost={makeGasCost(gasRaw2)}
+        transferGasChain={{ prettyName: "Cosmos Hub" }}
+        assetPrice={undefined}
+        assetWithBalance={{
+          denom: "ATOM",
+          address: "uatom",
+          decimals: 6,
+          amount: balance,
+        }}
+        cryptoInput={expected1}
+        onChangeCryptoInput={onChangeCryptoInput}
+        fiatInput=""
+        onChangeFiatInput={jest.fn()}
+        isInsufficientBal={false}
+        isInsufficientFee={false}
+      />
+    );
+
+    // Give effects time to settle — gas should NOT be re-applied
+    await new Promise((r) => setTimeout(r, 100));
+    expect(onChangeCryptoInput).not.toHaveBeenCalled();
+  });
+
+  it("resets guard when isMax is toggled off, allowing gas to apply on next Max", async () => {
+    const balanceRaw = "2000000";
+    const gasRaw1 = "5000";
+    const gasRaw2 = "6000";
+    const onChangeCryptoInput = jest.fn();
+
+    const balanceDec = makeBalance(balanceRaw).toDec().toString();
+    const balance = makeBalance(balanceRaw);
+
+    const baseProps = {
+      currentUnit: "crypto" as const,
+      setCurrentUnit: jest.fn(),
+      setIsMax: jest.fn(),
+      canSetMax: true,
+      transferGasChain: { prettyName: "Cosmos Hub" },
+      assetPrice: undefined,
+      assetWithBalance: {
+        denom: "ATOM",
+        address: "uatom",
+        decimals: 6,
+        amount: balance,
+      },
+      fiatInput: "",
+      onChangeFiatInput: jest.fn(),
+      isInsufficientBal: false,
+      isInsufficientFee: false,
+    };
+
+    // 1) isMax=true with first gas cost
+    const { rerender } = render(
+      <CryptoFiatInput
+        {...baseProps}
+        isMax={true}
+        transferGasCost={makeGasCost(gasRaw1)}
+        cryptoInput={balanceDec}
+        onChangeCryptoInput={onChangeCryptoInput}
+      />
+    );
+
+    const expected1 = expectedMaxAfterGas(balanceRaw, gasRaw1);
+    await waitFor(() => {
+      expect(onChangeCryptoInput).toHaveBeenCalledWith(expected1);
+    });
+
+    onChangeCryptoInput.mockClear();
+
+    // 2) Toggle isMax off
+    rerender(
+      <CryptoFiatInput
+        {...baseProps}
+        isMax={false}
+        transferGasCost={makeGasCost(gasRaw1)}
+        cryptoInput="0"
+        onChangeCryptoInput={onChangeCryptoInput}
+      />
+    );
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    // 3) Toggle isMax back on with a different gas cost
+    rerender(
+      <CryptoFiatInput
+        {...baseProps}
+        isMax={true}
+        transferGasCost={makeGasCost(gasRaw2)}
+        cryptoInput={balanceDec}
+        onChangeCryptoInput={onChangeCryptoInput}
+      />
+    );
+
+    const expected2 = expectedMaxAfterGas(balanceRaw, gasRaw2);
+    await waitFor(() => {
+      expect(onChangeCryptoInput).toHaveBeenCalledWith(expected2);
+    });
+  });
+
+  it("sets full balance when transferGasCost is undefined", async () => {
+    const balanceRaw = "2000000";
+    const onChangeCryptoInput = jest.fn();
+    const balanceDec = makeBalance(balanceRaw).toDec().toString();
+    const expected = trimPlaceholderZeros(balanceDec);
+
+    renderInput({
+      isMax: true,
+      cryptoInput: "",
+      transferGasCost: undefined,
+      balanceRaw,
+      onChangeCryptoInput,
+    });
+
+    await waitFor(() => {
+      expect(onChangeCryptoInput).toHaveBeenCalledWith(expected);
+    });
+  });
+
+  it("applies gas when transferGasCost arrives after initial undefined", async () => {
+    const balanceRaw = "2000000";
+    const gasRaw = "5000";
+    const onChangeCryptoInput = jest.fn();
+    const balanceDec = makeBalance(balanceRaw).toDec().toString();
+    const balance = makeBalance(balanceRaw);
+
+    const baseProps = {
+      currentUnit: "crypto" as const,
+      setCurrentUnit: jest.fn(),
+      setIsMax: jest.fn(),
+      canSetMax: true,
+      transferGasChain: { prettyName: "Cosmos Hub" },
+      assetPrice: undefined,
+      assetWithBalance: {
+        denom: "ATOM",
+        address: "uatom",
+        decimals: 6,
+        amount: balance,
+      },
+      fiatInput: "",
+      onChangeFiatInput: jest.fn(),
+      isInsufficientBal: false,
+      isInsufficientFee: false,
+    };
+
+    // 1) Initial render: isMax=true, no gas cost yet
+    const { rerender } = render(
+      <CryptoFiatInput
+        {...baseProps}
+        isMax={true}
+        transferGasCost={undefined}
+        cryptoInput=""
+        onChangeCryptoInput={onChangeCryptoInput}
+      />
+    );
+
+    const fullBalance = trimPlaceholderZeros(balanceDec);
+    await waitFor(() => {
+      expect(onChangeCryptoInput).toHaveBeenCalledWith(fullBalance);
+    });
+
+    onChangeCryptoInput.mockClear();
+
+    // 2) Gas cost arrives — should deduct gas from balance
+    rerender(
+      <CryptoFiatInput
+        {...baseProps}
+        isMax={true}
+        transferGasCost={makeGasCost(gasRaw)}
+        cryptoInput={balanceDec}
+        onChangeCryptoInput={onChangeCryptoInput}
+      />
+    );
+
+    const expectedAfterGas = expectedMaxAfterGas(balanceRaw, gasRaw);
+    await waitFor(() => {
+      expect(onChangeCryptoInput).toHaveBeenCalledWith(expectedAfterGas);
+    });
+  });
+
+  it("does not adjust input when it is already below gas-adjusted max", async () => {
+    const balanceRaw = "2000000";
+    const gasRaw = "5000";
+    const onChangeCryptoInput = jest.fn();
+
+    const alreadyReducedInput = "1.0";
+
+    renderInput({
+      isMax: true,
+      cryptoInput: alreadyReducedInput,
+      transferGasCost: makeGasCost(gasRaw),
+      balanceRaw,
+      onChangeCryptoInput,
+    });
+
+    await new Promise((r) => setTimeout(r, 100));
+    expect(onChangeCryptoInput).not.toHaveBeenCalled();
+  });
+
+  it("re-applies gas when asset changes while Max stays enabled", async () => {
+    const balanceRaw = "2000000";
+    const gasRaw = "5000";
+    const onChangeCryptoInput = jest.fn();
+
+    const balanceDec = makeBalance(balanceRaw).toDec().toString();
+    const balance = makeBalance(balanceRaw);
+
+    const baseProps = {
+      currentUnit: "crypto" as const,
+      setCurrentUnit: jest.fn(),
+      setIsMax: jest.fn(),
+      canSetMax: true,
+      transferGasChain: { prettyName: "Cosmos Hub" },
+      assetPrice: undefined,
+      fiatInput: "",
+      onChangeFiatInput: jest.fn(),
+      isInsufficientBal: false,
+      isInsufficientFee: false,
+    };
+
+    // 1) First asset (ATOM)
+    const { rerender } = render(
+      <CryptoFiatInput
+        {...baseProps}
+        isMax={true}
+        transferGasCost={makeGasCost(gasRaw)}
+        assetWithBalance={{
+          denom: "ATOM",
+          address: "uatom",
+          decimals: 6,
+          amount: balance,
+        }}
+        cryptoInput={balanceDec}
+        onChangeCryptoInput={onChangeCryptoInput}
+      />
+    );
+
+    const expectedAtom = expectedMaxAfterGas(balanceRaw, gasRaw);
+    await waitFor(() => {
+      expect(onChangeCryptoInput).toHaveBeenCalledWith(expectedAtom);
+    });
+
+    onChangeCryptoInput.mockClear();
+
+    const junoBalance = new CoinPretty(
+      { coinDecimals: 6, coinDenom: "JUNO", coinMinimalDenom: "ujuno" },
+      "3000000"
+    );
+    const junoGas = new CoinPretty(
+      { coinDecimals: 6, coinDenom: "JUNO", coinMinimalDenom: "ujuno" },
+      "4200"
+    );
+
+    // 2) Switch to JUNO while Max is still enabled
+    rerender(
+      <CryptoFiatInput
+        {...baseProps}
+        isMax={true}
+        transferGasCost={junoGas}
+        assetWithBalance={{
+          denom: "JUNO",
+          address: "ujuno",
+          decimals: 6,
+          amount: junoBalance,
+        }}
+        cryptoInput={junoBalance.toDec().toString()}
+        onChangeCryptoInput={onChangeCryptoInput}
+      />
+    );
+
+    const expectedJuno = trimPlaceholderZeros(
+      junoBalance
+        .toDec()
+        .sub(junoGas.toDec().mul(MUL_GAS_SLIPPAGE))
+        .toString()
+    );
+
+    await waitFor(() => {
+      expect(onChangeCryptoInput).toHaveBeenCalledWith(expectedJuno);
+    });
+  });
+});

--- a/packages/web/components/control/__tests__/crypto-fiat-input-max-guard.spec.tsx
+++ b/packages/web/components/control/__tests__/crypto-fiat-input-max-guard.spec.tsx
@@ -402,10 +402,7 @@ describe("CryptoFiatInput gasAppliedToMax guard", () => {
     );
 
     const expectedJuno = trimPlaceholderZeros(
-      junoBalance
-        .toDec()
-        .sub(junoGas.toDec().mul(MUL_GAS_SLIPPAGE))
-        .toString()
+      junoBalance.toDec().sub(junoGas.toDec().mul(MUL_GAS_SLIPPAGE)).toString()
     );
 
     await waitFor(() => {

--- a/packages/web/components/control/crypto-fiat-input.tsx
+++ b/packages/web/components/control/crypto-fiat-input.tsx
@@ -107,6 +107,7 @@ export const CryptoFiatInput: FunctionComponent<{
   });
 
   const gasAppliedToMax = useRef(false);
+  const gasAppliedForAsset = useRef<string | undefined>(undefined);
 
   // Check if price is available for fiat input
   const isPriceAvailable = Boolean(assetPrice?.fiatCurrency);
@@ -259,6 +260,10 @@ export const CryptoFiatInput: FunctionComponent<{
 
     if (!canSetMax || !assetWithBalance?.amount || !inputCoin) return;
 
+    if (assetWithBalance.address !== gasAppliedForAsset.current) {
+      gasAppliedToMax.current = false;
+    }
+
     if (transferGasCost) {
       if (gasAppliedToMax.current) return;
 
@@ -285,7 +290,10 @@ export const CryptoFiatInput: FunctionComponent<{
       }
 
       gasAppliedToMax.current = true;
+      gasAppliedForAsset.current = assetWithBalance.address;
     } else {
+      // Don't set gasAppliedToMax here — allow gas deduction to run
+      // once transferGasCost arrives from the first quote response.
       onInput("crypto")(
         trimPlaceholderZeros(assetWithBalance.amount.toDec().toString())
       );

--- a/packages/web/components/control/crypto-fiat-input.tsx
+++ b/packages/web/components/control/crypto-fiat-input.tsx
@@ -106,6 +106,8 @@ export const CryptoFiatInput: FunctionComponent<{
     onChange: setIsMaxProp,
   });
 
+  const gasAppliedToMax = useRef(false);
+
   // Check if price is available for fiat input
   const isPriceAvailable = Boolean(assetPrice?.fiatCurrency);
 
@@ -245,36 +247,48 @@ export const CryptoFiatInput: FunctionComponent<{
     pendingRatioUpdate,
   ]);
 
-  // Subtract gas cost and adjust input when selecting max amount
+  // Subtract gas cost and adjust input when selecting max amount.
+  // Uses gasAppliedToMax ref to prevent a feedback loop: without it,
+  // each quote response returns a slightly different gas estimate which
+  // re-triggers this effect, adjusts the input, fires a new quote, etc.
   useEffect(() => {
-    if (isMax && canSetMax && assetWithBalance?.amount && inputCoin) {
-      if (transferGasCost) {
-        let maxTransferAmount = new Dec(0);
+    if (!isMax) {
+      gasAppliedToMax.current = false;
+      return;
+    }
 
-        const gasFeeMatchesInputDenom = isSameCoinDenom(
-          transferGasCost,
-          assetWithBalance.amount
-        );
+    if (!canSetMax || !assetWithBalance?.amount || !inputCoin) return;
 
-        if (gasFeeMatchesInputDenom) {
-          maxTransferAmount = assetWithBalance.amount
-            .toDec()
-            .sub(transferGasCost.toDec().mul(mulGasSlippage));
-        } else {
-          maxTransferAmount = assetWithBalance.amount.toDec();
-        }
+    if (transferGasCost) {
+      if (gasAppliedToMax.current) return;
 
-        if (
-          maxTransferAmount.isPositive() &&
-          inputCoin.toDec().gt(maxTransferAmount)
-        ) {
-          onInput("crypto")(trimPlaceholderZeros(maxTransferAmount.toString()));
-        }
+      let maxTransferAmount = new Dec(0);
+
+      const gasFeeMatchesInputDenom = isSameCoinDenom(
+        transferGasCost,
+        assetWithBalance.amount
+      );
+
+      if (gasFeeMatchesInputDenom) {
+        maxTransferAmount = assetWithBalance.amount
+          .toDec()
+          .sub(transferGasCost.toDec().mul(mulGasSlippage));
       } else {
-        onInput("crypto")(
-          trimPlaceholderZeros(assetWithBalance.amount.toDec().toString())
-        );
+        maxTransferAmount = assetWithBalance.amount.toDec();
       }
+
+      if (
+        maxTransferAmount.isPositive() &&
+        inputCoin.toDec().gt(maxTransferAmount)
+      ) {
+        onInput("crypto")(trimPlaceholderZeros(maxTransferAmount.toString()));
+      }
+
+      gasAppliedToMax.current = true;
+    } else {
+      onInput("crypto")(
+        trimPlaceholderZeros(assetWithBalance.amount.toDec().toString())
+      );
     }
   }, [
     assetWithBalance?.amount,

--- a/packages/web/components/control/crypto-fiat-input.tsx
+++ b/packages/web/components/control/crypto-fiat-input.tsx
@@ -292,8 +292,10 @@ export const CryptoFiatInput: FunctionComponent<{
       gasAppliedToMax.current = true;
       gasAppliedForAsset.current = assetWithBalance.address;
     } else {
-      // Don't set gasAppliedToMax here — allow gas deduction to run
-      // once transferGasCost arrives from the first quote response.
+      // Reset the guard so gas deduction runs when transferGasCost arrives.
+      // This covers both the initial render (ref starts false) and the case
+      // where quotes temporarily fail after gas was previously applied.
+      gasAppliedToMax.current = false;
       onInput("crypto")(
         trimPlaceholderZeros(assetWithBalance.amount.toDec().toString())
       );

--- a/packages/web/components/control/crypto-fiat-input.tsx
+++ b/packages/web/components/control/crypto-fiat-input.tsx
@@ -299,6 +299,7 @@ export const CryptoFiatInput: FunctionComponent<{
       );
     }
   }, [
+    assetWithBalance?.address,
     assetWithBalance?.amount,
     canSetMax,
     inputCoin,


### PR DESCRIPTION
## What is the purpose of the change:

When selecting **Max** on an empty deposit/withdrawal input, the gas-adjustment `useEffect` in `CryptoFiatInput` fires on every quote response because each gas estimate differs slightly. This re-sets the input amount, triggers a new debounced quote fetch, and repeats 2-3 times until values converge — causing unnecessary network requests and UI flicker.

The fix adds a `gasAppliedToMax` ref that gates the gas deduction to run only once per Max activation. The ref resets whenever `isMax` becomes `false` (button toggle or keyboard edit), so subsequent Max presses still apply gas correctly.

**Affected flows:** Both deposits and withdrawals (same `CryptoFiatInput` component). Swaps are unaffected (different input flow).

**Affected assets:** Any asset where the gas fee denom matches the transfer denom — confirmed on Firmachain, Photon, AKT. ATOM was unaffected because its gas estimates are more stable.

### Linear Task

[MER-183: Fix: Deposit quote feedback loop when selecting Max on empty input](https://linear.app/osmosis/issue/MER-183/fix-deposit-quote-feedback-loop-when-selecting-max-on-empty-input)

## Brief Changelog

- Add `gasAppliedToMax` ref to `CryptoFiatInput` to prevent repeated gas-adjustment cycles
- Restructure the max-amount `useEffect` to early-return when gas has already been applied
- Reset the ref when `isMax` goes `false` (Max button toggle or keyboard input)

## Testing and Verifying

- **Deposit** Firmachain: select Max on empty input — quote should fire once (not 3x)
- **Withdrawal** Firmachain: same test
- **Deposit** AKT: same test
- **Deposit** ATOM: confirm no regression (was already unaffected)
- Select Max, then keyboard-edit the amount, then select Max again — gas should be re-applied fresh
- Select Max on a pre-filled input — gas should still be deducted correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `Max` amount calculation behavior in `CryptoFiatInput`, which can affect how much a user attempts to transfer when gas estimates change or disappear. While scoped and covered by new tests, it touches user-facing amount-setting logic in deposit/withdraw flows.
> 
> **Overview**
> Fixes a quote feedback loop when selecting **Max** by guarding the gas-deduction logic in `CryptoFiatInput` so it only applies once per Max activation, rather than re-adjusting on every slightly-changed `transferGasCost`.
> 
> The guard resets when **Max** is turned off, when the selected asset changes, and when `transferGasCost` becomes `undefined` (setting full balance and allowing gas to be deducted again once quotes return). Adds a focused test suite covering these Max/gas edge cases and regression scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98b09d836d8b256dee629b0abd385fc09af888c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->