### PR TITLE
fix(e2e): upload artifacts on job cancellation + optimize market test lifecycle

### DIFF
--- a/.github/workflows/monitoring-limit-geo-e2e-tests.yml
+++ b/.github/workflows/monitoring-limit-geo-e2e-tests.yml
@@ -415,7 +415,7 @@ jobs:
           path: packages/e2e/playwright-report
 
   fe-trade-eu:
-    timeout-minutes: 12
+    timeout-minutes: 20
     needs: fe-swap-eu
     name: prod-fe-trade-eu
     runs-on: ubuntu-latest
@@ -545,11 +545,11 @@ jobs:
           cd packages/e2e
           npx playwright test monitoring.market --timeout 180000
       - name: set-output
-        if: failure() || success()
+        if: always()
         id: set-output
         run: echo "unexpected=$(jq -r '.stats.unexpected' packages/e2e/playwright-report/test-results.json)" >> $GITHUB_OUTPUT
       - name: upload monitoring test results
-        if: failure()
+        if: failure() || cancelled()
         id: monitoring-test-results
         uses: actions/upload-artifact@v4
         with:
@@ -694,11 +694,11 @@ jobs:
           cd packages/e2e
           npx playwright test monitoring.limit --timeout 180000
       - name: set-output
-        if: failure() || success()
+        if: always()
         id: set-output
         run: echo "unexpected=$(jq -r '.stats.unexpected' packages/e2e/playwright-report/test-results.json)" >> $GITHUB_OUTPUT
       - name: upload monitoring test results
-        if: failure()
+        if: failure() || cancelled()
         id: monitoring-test-results
         uses: actions/upload-artifact@v4
         with:
@@ -706,7 +706,7 @@ jobs:
           path: packages/e2e/playwright-report
 
   fe-trade-sg:
-    timeout-minutes: 12
+    timeout-minutes: 15
     needs: fe-swap-sg
     name: prod-fe-trade-sg
     runs-on: ubuntu-latest
@@ -836,11 +836,11 @@ jobs:
           cd packages/e2e
           npx playwright test monitoring.market --timeout 90000
       - name: set-output
-        if: failure() || success()
+        if: always()
         id: set-output
         run: echo "unexpected=$(jq -r '.stats.unexpected' packages/e2e/playwright-report/test-results.json)" >> $GITHUB_OUTPUT
       - name: upload monitoring test results
-        if: failure()
+        if: failure() || cancelled()
         id: monitoring-test-results
         uses: actions/upload-artifact@v4
         with:
@@ -975,11 +975,11 @@ jobs:
           cd packages/e2e
           npx playwright test monitoring.market --timeout 90000
       - name: set-output
-        if: failure() || success()
+        if: always()
         id: set-output
         run: echo "unexpected=$(jq -r '.stats.unexpected' packages/e2e/playwright-report/test-results.json)" >> $GITHUB_OUTPUT
       - name: upload monitoring test results
-        if: failure()
+        if: failure() || cancelled()
         id: monitoring-test-results
         uses: actions/upload-artifact@v4
         with:
@@ -1121,13 +1121,13 @@ jobs:
           cd packages/e2e
           npx playwright test monitoring.limit --timeout 180000
       - name: set-output
-        if: failure() || success()
+        if: always()
         id: set-output
         run: |
           echo "unexpected=$(jq -r '.stats.unexpected' packages/e2e/playwright-report/test-results.json)"
           echo "unexpected=$(jq -r '.stats.unexpected' packages/e2e/playwright-report/test-results.json)" >> $GITHUB_OUTPUT
       - name: upload monitoring test results
-        if: failure()
+        if: failure() || cancelled()
         id: monitoring-test-results
         uses: actions/upload-artifact@v4
         with:

--- a/packages/e2e/tests/monitoring.market.wallet.spec.ts
+++ b/packages/e2e/tests/monitoring.market.wallet.spec.ts
@@ -6,6 +6,7 @@ import { ensureBalances } from "../utils/balance-checker";
 import { deriveAddress } from "../utils/wallet-utils";
 
 test.describe("Test Market Buy/Sell Order feature", () => {
+  test.describe.configure({ retries: 0 });
   let context: BrowserContext;
   const privateKey = process.env.PRIVATE_KEY ?? "private_key";
   let tradePage: TradePage;

--- a/packages/e2e/tests/monitoring.market.wallet.spec.ts
+++ b/packages/e2e/tests/monitoring.market.wallet.spec.ts
@@ -22,19 +22,12 @@ test.describe("Test Market Buy/Sell Order feature", () => {
 
     tradePage = new TradePage(context.pages()[0]);
     await tradePage.goto();
-  });
-
-  test.afterAll(async () => {
-    await context.close();
-  });
-
-  test.beforeEach(async () => {
     await tradePage.connectWallet();
     expect(await tradePage.isError(), "Swap is not available!").toBeFalsy();
   });
 
-  test.afterEach(async () => {
-    await tradePage.logOut();
+  test.afterAll(async () => {
+    await context.close();
   });
 
   // biome-ignore lint/correctness/noEmptyPattern: <explanation>


### PR DESCRIPTION
## What is the purpose of the change:

The non-US geo monitoring tests (EU/SG) in the `Synthetic Geo Monitoring Frontend tests` workflow have been broken since November 2025. Every hourly run for these regions hits the 12-minute job timeout and gets **cancelled** -- but no screenshots, Playwright reports, or error details are ever uploaded.

Two root causes:

1. **Artifacts never uploaded on cancellation** -- GitHub Actions `cancelled` conclusion doesn't match `if: failure()`, so the upload steps are skipped entirely.
2. **Per-test wallet connect/disconnect wasting time** -- The `monitoring.market` spec connects and disconnects the wallet for every test (`beforeEach`/`afterEach`), unlike `monitoring.swap` which connects once. Through a proxy with `slowMo: 300`, each cycle adds ~15-20s. With 4 tests + CI retries, this pushes the total past the 12-minute limit.

### Linear Task

[MER-189: (e2e) Fix geo monitoring tests: artifacts not uploaded on timeout + optimize market test lifecycle](https://linear.app/osmosis/issue/MER-189/e2e-fix-geo-monitoring-tests-artifacts-not-uploaded-on-timeout)

## Brief Changelog

**Workflow (`monitoring-limit-geo-e2e-tests.yml`):**
- Change all upload step conditions from `if: failure()` to `if: failure() || cancelled()` (EU, SG, US trade + limit jobs)
- Change all `set-output` step conditions from `if: failure() || success()` to `if: always()`
- Increase `timeout-minutes`: EU trade 12 -> 20, SG trade 12 -> 15

**Test spec (`monitoring.market.wallet.spec.ts`):**
- Move `connectWallet()` from `beforeEach` to `beforeAll` (matching the `monitoring.swap` pattern that already works in EU/SG)
- Remove per-test `logOut()` in `afterEach`
- Keep all 4 market tests (buy BTC, buy OSMO, sell BTC, sell OSMO)

### CURRENTLY RUNNING WORKFLOW ON THIS BRANCH:
👉  https://github.com/osmosis-labs/osmosis-frontend/actions/runs/23921648464


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to GitHub Actions workflow conditions/timeouts and E2E test setup/teardown, with no production runtime impact.
> 
> **Overview**
> **Fixes flaky/opaque geo monitoring runs** by ensuring Playwright reports are captured even when jobs time out and get cancelled.
> 
> Updates `monitoring-limit-geo-e2e-tests.yml` to run `set-output` steps with `if: always()`, upload artifacts on `failure() || cancelled()`, and increases job timeouts for `fe-trade-eu` (12→20) and `fe-trade-sg` (12→15).
> 
> Optimizes `monitoring.market.wallet.spec.ts` to connect the wallet once in `beforeAll` (and stop per-test logout), reducing repeated setup work and helping the suite stay within CI time limits.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4133b802b178668fc8bf9f72fcfa145a91e13ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->