### PR TITLE
fix(e2e): remove hard-coded pool ID from pools page load check

### DIFF
--- a/packages/e2e/pages/pools-page.ts
+++ b/packages/e2e/pages/pools-page.ts
@@ -28,11 +28,10 @@ export class PoolsPage extends BasePage {
     await this.page.waitForTimeout(2000)
     await this.poolsLink.click()
     await this.page.waitForTimeout(2000)
-    // Sometimes pools take longer to load
-    // we expect that after 10 seconds tokens are loaded and any failure after this point should be considered a bug.
-    // 1464 is an OSMO/USDC pool
-    const locRows = '//tr/td/a[contains(@href, "pool/1464")]/../..'
-    await this.page.locator(locRows).hover({ timeout: 10000 })
+    // Wait for any pool row to appear (previously hard-coded pool/1464 which can
+    // drop off the first page when liquidity rankings shift).
+    const anyPoolRow = '//tr/td//a[contains(@href, "/pool/")]/../..'
+    await this.page.locator(anyPoolRow).first().waitFor({ timeout: 10000 })
     await super.printUrl()
     await this.dismissVariantsPopupIfPresent()
   }


### PR DESCRIPTION
## What is the purpose of the change:

The `preview-pools-and-select-pair-tests` CI job is failing because `pools-page.ts` hard-codes pool 1464 (OSMO/USDC) as a page-loaded signal in `goto()`. When this pool drops off the first page due to liquidity ranking changes, all 3 pool tests time out before reaching their actual assertions.

Changed the wait to look for **any** pool row instead of a specific pool ID, making the page-load check resilient to ranking shifts.

### Linear Task

[MER-193: fix(e2e): remove hard-coded pool ID from pools page load check](https://linear.app/osmosis/issue/MER-193/fixe2e-remove-hard-coded-pool-id-from-pools-page-load-check)

## Brief Changelog

- Replace hard-coded `pool/1464` locator in `PoolsPage.goto()` with a generic any-pool-row locator
- Switch from `.hover()` to `.first().waitFor()` since we only need to confirm the table loaded

## Testing and Verifying

`preview-pools-and-select-pair-tests` now passing: https://github.com/osmosis-labs/osmosis-frontend/actions/runs/24350798079/job/71105542347
