### PR TITLE
Set minLiquidity to 0 for searches

### DIFF
--- a/packages/web/components/table/asset-info.tsx
+++ b/packages/web/components/table/asset-info.tsx
@@ -204,7 +204,8 @@ export const AssetsInfoTable: FunctionComponent<{
       categories,
       excludeVariants: selectedCategory === "topGainers",
       excludeStablecoins: selectedCategory === "topGainers",
-      minLiquidity: selectedCategory === "topGainers" ? 1000 : searchQuery ? 0 : undefined,
+      minLiquidity:
+        selectedCategory === "topGainers" ? 1000 : searchQuery ? 0 : undefined,
     },
     {
       getNextPageParam: (lastPage) => lastPage.nextCursor,

--- a/packages/web/components/table/asset-info.tsx
+++ b/packages/web/components/table/asset-info.tsx
@@ -204,7 +204,7 @@ export const AssetsInfoTable: FunctionComponent<{
       categories,
       excludeVariants: selectedCategory === "topGainers",
       excludeStablecoins: selectedCategory === "topGainers",
-      minLiquidity: selectedCategory === "topGainers" ? 1000 : undefined,
+      minLiquidity: selectedCategory === "topGainers" ? 1000 : searchQuery ? 0 : undefined,
     },
     {
       getNextPageParam: (lastPage) => lastPage.nextCursor,


### PR DESCRIPTION
When a search query is present, set minLiquidity to 0 so search results include low-liquidity assets. This adjusts the query params in asset-info.tsx to ensure searches return broader results.