### PR TITLE
fix: asset page to use coinMinimalDenom for pools and orders

### DIFF
--- a/packages/web/components/complex/pools-table.tsx
+++ b/packages/web/components/complex/pools-table.tsx
@@ -87,6 +87,7 @@ interface PoolsTableProps {
   emptyResultsText?: string;
   setSortDirection: (dir: SortDirection) => void;
   setSortKey: (key?: MarketIncentivePoolsSortKey) => void;
+  minLiquidityUsd?: number;
 }
 
 export const PoolsTable = (props: PropsWithChildren<PoolsTableProps>) => {
@@ -113,6 +114,7 @@ export const PoolsTable = (props: PropsWithChildren<PoolsTableProps>) => {
     emptyResultsText,
     setSortDirection,
     setSortKey,
+    minLiquidityUsd = 1_000,
     children,
   } = props;
 
@@ -166,7 +168,7 @@ export const PoolsTable = (props: PropsWithChildren<PoolsTableProps>) => {
             direction: sortParams.allPoolsSortDir,
           }
         : undefined,
-      minLiquidityUsd: 1_000,
+      minLiquidityUsd,
     },
     {
       getNextPageParam: (lastPage) => lastPage.nextCursor,

--- a/packages/web/components/pages/asset-info-page/pools.tsx
+++ b/packages/web/components/pages/asset-info-page/pools.tsx
@@ -13,7 +13,8 @@ import { Button } from "~/components/ui/button";
 import { useTranslation } from "~/hooks";
 
 interface AssetPoolsProps {
-  denom: string;
+  coinMinimalDenom: string;
+  coinDenom: string;
 }
 
 const defaultFilters: PoolsTableFilters = {
@@ -30,15 +31,15 @@ const sortParams: PoolsTabelSortParams = {
 };
 
 export const AssetPools: FunctionComponent<AssetPoolsProps> = (props) => {
-  const { denom } = props;
+  const { coinMinimalDenom, coinDenom } = props;
   const { t } = useTranslation();
 
   const filters = useMemo(
     () => ({
       ...defaultFilters,
-      denoms: [denom],
+      denoms: [coinMinimalDenom],
     }),
-    [denom]
+    [coinMinimalDenom]
   );
 
   return (
@@ -52,7 +53,7 @@ export const AssetPools: FunctionComponent<AssetPoolsProps> = (props) => {
           className=" text-wosmongton-200"
           asChild
         >
-          <Link href={`/pools?searchQuery=${encodeURIComponent(`${denom}`)}`}>
+          <Link href={`/pools?searchQuery=${encodeURIComponent(coinDenom)}`}>
             {t("assets.seeAll")}
           </Link>
         </Button>
@@ -65,7 +66,8 @@ export const AssetPools: FunctionComponent<AssetPoolsProps> = (props) => {
         sortParams={sortParams}
         setSortDirection={noop}
         setSortKey={noop}
-        emptyResultsText={t("search.poolsEmpty", { denom })}
+        minLiquidityUsd={0}
+        emptyResultsText={t("search.poolsEmpty", { denom: coinDenom })}
       />
     </section>
   );

--- a/packages/web/pages/assets/[...denom].tsx
+++ b/packages/web/pages/assets/[...denom].tsx
@@ -171,7 +171,7 @@ const AssetInfoView: FunctionComponent<AssetInfoPageStaticProps> = observer(
         swapToolProps={swapToolProps}
         setPreviousTrade={setPreviousTrade}
         previousTrade={{
-          baseDenom: asset.coinDenom,
+          baseDenom: asset.coinMinimalDenom,
           sendTokenDenom: swapToolProps.initialSendTokenDenom ?? "",
           outTokenDenom: swapToolProps.initialOutTokenDenom ?? "",
           quoteDenom: previousTrade?.quoteDenom ?? "",
@@ -228,7 +228,10 @@ const AssetInfoView: FunctionComponent<AssetInfoPageStaticProps> = observer(
               )}
               <AssetDetails />
               <AssetStats className="hidden xl:flex" />
-              <AssetPools denom={asset.coinDenom} />
+              <AssetPools
+                coinMinimalDenom={asset.coinMinimalDenom}
+                coinDenom={asset.coinDenom}
+              />
               <div className="w-full xl:flex xl:gap-4 1.5lg:flex-col">
                 <div className="hidden w-[26.875rem] shrink-0 xl:order-1 xl:block 1.5lg:order-none 1.5lg:w-full">
                   {SwapTool_}


### PR DESCRIPTION
Previously coinDenom (display symbol) was passed where coinMinimalDenom (IBC denom) was required, causing limit orders to stay greyed out and pools to not show on the asset page.

## What is the purpose of the change:

Fixes issue where limit orders were perpetuality greyed out on an asset page's trade widget.

Also allows Orderbook pools to be shown in the asset page as their liquidity is often reported as 0.

## Testing and Verifying

This change has been tested locally by rebuilding the website and verified content and links are expected
