### PR TITLE
feat: add orderbook pool type and filterable cosmwasmpool types

### DIFF
--- a/packages/server/src/queries/complex/pools/env.ts
+++ b/packages/server/src/queries/complex/pools/env.ts
@@ -8,6 +8,8 @@ export const TransmuterPoolCodeIds = IS_TESTNET ? ["3084"] : ["148"];
 export const AlloyedPoolCodeIds = getAlloyedPoolCodeIds(IS_TESTNET);
 const AstroportPclPoolCodeIds = IS_TESTNET ? ["8611"] : ["842"];
 const WhitewhalePoolCodeIds = IS_TESTNET ? ["?"] : ["503", "641"];
+/** Cosmwasm Code Ids confirmed to be orderbook pools in current env. */
+export const OrderbookPoolCodeIds = IS_TESTNET ? ["?"] : ["885"];
 
 export function getCosmwasmPoolTypeFromCodeId(
   codeId: string
@@ -16,6 +18,7 @@ export function getCosmwasmPoolTypeFromCodeId(
   | "cosmwasm-alloyed"
   | "cosmwasm-astroport-pcl"
   | "cosmwasm-whitewhale"
+  | "cosmwasm-orderbook"
   | "cosmwasm" {
   if (TransmuterPoolCodeIds.includes(codeId)) {
     return "cosmwasm-transmuter";
@@ -28,6 +31,9 @@ export function getCosmwasmPoolTypeFromCodeId(
   }
   if (WhitewhalePoolCodeIds.includes(codeId)) {
     return "cosmwasm-whitewhale";
+  }
+  if (OrderbookPoolCodeIds.includes(codeId)) {
+    return "cosmwasm-orderbook";
   }
   return "cosmwasm";
 }

--- a/packages/server/src/queries/complex/pools/index.ts
+++ b/packages/server/src/queries/complex/pools/index.ts
@@ -18,6 +18,7 @@ const allPooltypes = [
   "cosmwasm-alloyed",
   "cosmwasm-astroport-pcl",
   "cosmwasm-whitewhale",
+  "cosmwasm-orderbook",
   "cosmwasm",
 ] as const;
 

--- a/packages/server/src/queries/complex/pools/providers/sidecar.ts
+++ b/packages/server/src/queries/complex/pools/providers/sidecar.ts
@@ -112,17 +112,10 @@ export function getPoolsFromSidecar({
 
       // Filter pools by requested types
       // Since sidecar API can't distinguish cosmwasm subtypes, we filter after type identification
-      // Note: cosmwasm, cosmwasm-astroport-pcl, and cosmwasm-whitewhale are always included
-      const alwaysIncludedTypes: PoolType[] = [
-        "cosmwasm",
-        "cosmwasm-astroport-pcl",
-        "cosmwasm-whitewhale",
-      ];
+      // Note: generic cosmwasm pools are always included as a fallback
       const filteredPools = types
         ? pools.filter(
-            (pool) =>
-              types.includes(pool.type) ||
-              alwaysIncludedTypes.includes(pool.type)
+            (pool) => types.includes(pool.type) || pool.type === "cosmwasm"
           )
         : pools;
 

--- a/packages/web/components/complex/all-pools-table.tsx
+++ b/packages/web/components/complex/all-pools-table.tsx
@@ -130,11 +130,23 @@ const TableControls = () => {
           selectedOptionIds={filters.poolTypesFilter}
           atLeastOneSelected
           options={[
-            { id: "weighted", display: t("components.table.weighted") },
-            { id: "stable", display: t("components.table.stable") },
             {
               id: "concentrated",
               display: t("components.table.concentrated"),
+            },
+            {
+              id: "cosmwasm-orderbook",
+              display: t("components.table.orderbook"),
+            },
+            { id: "weighted", display: t("components.table.weighted") },
+            { id: "stable", display: t("components.table.stable") },
+            {
+              id: "cosmwasm-astroport-pcl",
+              display: t("components.table.astroport"),
+            },
+            {
+              id: "cosmwasm-whitewhale",
+              display: t("components.table.whitewhale"),
             },
             {
               id: "cosmwasm-transmuter",

--- a/packages/web/components/complex/pools-table.tsx
+++ b/packages/web/components/complex/pools-table.tsx
@@ -40,9 +40,12 @@ export type PoolIncentiveFilter = NonNullable<
 
 // These are the options for filtering the pools.
 export const poolFilterTypes: PoolTypeFilter[] = [
+  "concentrated",
+  "cosmwasm-orderbook",
   "weighted",
   "stable",
-  "concentrated",
+  "cosmwasm-astroport-pcl",
+  "cosmwasm-whitewhale",
   "cosmwasm-transmuter",
 ];
 
@@ -87,6 +90,7 @@ interface PoolsTableProps {
   emptyResultsText?: string;
   setSortDirection: (dir: SortDirection) => void;
   setSortKey: (key?: MarketIncentivePoolsSortKey) => void;
+  minLiquidityUsd?: number;
 }
 
 export const PoolsTable = (props: PropsWithChildren<PoolsTableProps>) => {
@@ -113,6 +117,7 @@ export const PoolsTable = (props: PropsWithChildren<PoolsTableProps>) => {
     emptyResultsText,
     setSortDirection,
     setSortKey,
+    minLiquidityUsd = 1_000,
     children,
   } = props;
 
@@ -141,7 +146,6 @@ export const PoolsTable = (props: PropsWithChildren<PoolsTableProps>) => {
         : undefined,
       denoms: filters.denoms,
       // These are all of the pools that we support fetching.
-      // In addition, to pool filters, there are also general cosmwasm pools, Astroport PCL pools, and whitewhale pools.
       // When transmuter is selected, include both transmuter and alloyed pools
       types: [
         ...filters.poolTypesFilter.reduce((acc, type) => {
@@ -156,8 +160,6 @@ export const PoolsTable = (props: PropsWithChildren<PoolsTableProps>) => {
           return acc;
         }, [] as (PoolTypeFilter | "cosmwasm-alloyed")[]),
         "cosmwasm",
-        "cosmwasm-astroport-pcl",
-        "cosmwasm-whitewhale",
       ],
       incentiveTypes: filters.poolIncentivesFilter,
       sort: sortKey
@@ -166,7 +168,7 @@ export const PoolsTable = (props: PropsWithChildren<PoolsTableProps>) => {
             direction: sortParams.allPoolsSortDir,
           }
         : undefined,
-      minLiquidityUsd: 1_000,
+      minLiquidityUsd,
     },
     {
       getNextPageParam: (lastPage) => lastPage.nextCursor,
@@ -574,6 +576,9 @@ const PoolCompositionCell: PoolCellComponent = ({
                         type === "cosmwasm-alloyed" ||
                         type === "cosmwasm"
                     ),
+                    "text-wosmongton-300": Boolean(
+                      type === "cosmwasm-orderbook"
+                    ),
                   })}
                 >
                   {type === "weighted" && (
@@ -607,9 +612,13 @@ const PoolCompositionCell: PoolCellComponent = ({
                   {type === "cosmwasm-alloyed" && (
                     <Icon id="custom-pool" width={16} height={16} />
                   )}
+                  {type === "cosmwasm-orderbook" && (
+                    <Icon id="open-book" width={16} height={16} />
+                  )}
 
                   {type != "cosmwasm-astroport-pcl" &&
                     type != "cosmwasm-whitewhale" &&
+                    type != "cosmwasm-orderbook" &&
                     (spreadFactor ? spreadFactor.toString() : "")}
                 </p>
               </div>
@@ -648,6 +657,9 @@ function getPoolLink(pool: Pool): string {
   }
   if (pool.type === "cosmwasm-whitewhale") {
     return `https://app.whitewhale.money/osmosis/pools/${pool.id}`;
+  }
+  if (pool.type === "cosmwasm-orderbook") {
+    return `/pool/${pool.id}`;
   }
   if (pool.type === "cosmwasm") {
     const contractAddress = getContractAddress(pool);

--- a/packages/web/localizations/de.json
+++ b/packages/web/localizations/de.json
@@ -269,7 +269,7 @@
       "weighted": "Gewichtet",
       "concentrated": "Aufgeladen",
       "transmuter": "Transmuter",
-      "orderbook": "Orderbook",
+      "orderbook": "Orderbuch",
       "astroport": "Astroport",
       "whitewhale": "White Whale",
       "noIncentives": "Keine Anreize"

--- a/packages/web/localizations/de.json
+++ b/packages/web/localizations/de.json
@@ -269,6 +269,9 @@
       "weighted": "Gewichtet",
       "concentrated": "Aufgeladen",
       "transmuter": "Transmuter",
+      "orderbook": "Orderbook",
+      "astroport": "Astroport",
+      "whitewhale": "White Whale",
       "noIncentives": "Keine Anreize"
     }
   },

--- a/packages/web/localizations/en.json
+++ b/packages/web/localizations/en.json
@@ -269,6 +269,9 @@
       "weighted": "Weighted",
       "concentrated": "Supercharged",
       "transmuter": "Transmuter",
+      "orderbook": "Orderbook",
+      "astroport": "Astroport",
+      "whitewhale": "White Whale",
       "noIncentives": "No incentives"
     }
   },

--- a/packages/web/localizations/es.json
+++ b/packages/web/localizations/es.json
@@ -269,7 +269,7 @@
       "weighted": "Weighted",
       "concentrated": "Liquidez concentrada",
       "transmuter": "transmutador",
-      "orderbook": "Orderbook",
+      "orderbook": "Libro de pedidos",
       "astroport": "Astroport",
       "whitewhale": "White Whale",
       "noIncentives": "Sin incentivos"

--- a/packages/web/localizations/es.json
+++ b/packages/web/localizations/es.json
@@ -269,6 +269,9 @@
       "weighted": "Weighted",
       "concentrated": "Liquidez concentrada",
       "transmuter": "transmutador",
+      "orderbook": "Orderbook",
+      "astroport": "Astroport",
+      "whitewhale": "White Whale",
       "noIncentives": "Sin incentivos"
     }
   },

--- a/packages/web/localizations/fa.json
+++ b/packages/web/localizations/fa.json
@@ -269,7 +269,7 @@
       "weighted": "وزن دار",
       "concentrated": "سوپرشارژ شده",
       "transmuter": "تبدیل کننده",
-      "orderbook": "Orderbook",
+      "orderbook": "دفترچه سفارش",
       "astroport": "Astroport",
       "whitewhale": "White Whale",
       "noIncentives": "بدون انگیزه"

--- a/packages/web/localizations/fa.json
+++ b/packages/web/localizations/fa.json
@@ -269,6 +269,9 @@
       "weighted": "وزن دار",
       "concentrated": "سوپرشارژ شده",
       "transmuter": "تبدیل کننده",
+      "orderbook": "Orderbook",
+      "astroport": "Astroport",
+      "whitewhale": "White Whale",
       "noIncentives": "بدون انگیزه"
     }
   },

--- a/packages/web/localizations/fr.json
+++ b/packages/web/localizations/fr.json
@@ -269,6 +269,9 @@
       "weighted": "Pondéré",
       "concentrated": "Liquidité concentrée",
       "transmuter": "Transmutateur",
+      "orderbook": "Orderbook",
+      "astroport": "Astroport",
+      "whitewhale": "White Whale",
       "noIncentives": "Pas d'incitations"
     }
   },

--- a/packages/web/localizations/fr.json
+++ b/packages/web/localizations/fr.json
@@ -269,7 +269,7 @@
       "weighted": "Pondéré",
       "concentrated": "Liquidité concentrée",
       "transmuter": "Transmutateur",
-      "orderbook": "Orderbook",
+      "orderbook": "Carnet de commandes",
       "astroport": "Astroport",
       "whitewhale": "White Whale",
       "noIncentives": "Pas d'incitations"

--- a/packages/web/localizations/gu.json
+++ b/packages/web/localizations/gu.json
@@ -269,6 +269,9 @@
       "weighted": "ભારિત",
       "concentrated": "સુપરચાર્જ્ડ",
       "transmuter": "ટ્રાન્સમ્યુટર",
+      "orderbook": "Orderbook",
+      "astroport": "Astroport",
+      "whitewhale": "White Whale",
       "noIncentives": "કોઈ પ્રોત્સાહન નથી"
     }
   },

--- a/packages/web/localizations/gu.json
+++ b/packages/web/localizations/gu.json
@@ -269,7 +269,7 @@
       "weighted": "ભારિત",
       "concentrated": "સુપરચાર્જ્ડ",
       "transmuter": "ટ્રાન્સમ્યુટર",
-      "orderbook": "Orderbook",
+      "orderbook": "ઓર્ડરબુક",
       "astroport": "Astroport",
       "whitewhale": "White Whale",
       "noIncentives": "કોઈ પ્રોત્સાહન નથી"

--- a/packages/web/localizations/hi.json
+++ b/packages/web/localizations/hi.json
@@ -269,6 +269,9 @@
       "weighted": "भारित",
       "concentrated": "सुपरचार्ज",
       "transmuter": "ट्रांसमीटर",
+      "orderbook": "Orderbook",
+      "astroport": "Astroport",
+      "whitewhale": "White Whale",
       "noIncentives": "कोई प्रोत्साहन नहीं"
     }
   },

--- a/packages/web/localizations/hi.json
+++ b/packages/web/localizations/hi.json
@@ -269,7 +269,7 @@
       "weighted": "भारित",
       "concentrated": "सुपरचार्ज",
       "transmuter": "ट्रांसमीटर",
-      "orderbook": "Orderbook",
+      "orderbook": "ऑर्डरबुक",
       "astroport": "Astroport",
       "whitewhale": "White Whale",
       "noIncentives": "कोई प्रोत्साहन नहीं"

--- a/packages/web/localizations/ja.json
+++ b/packages/web/localizations/ja.json
@@ -269,7 +269,7 @@
       "weighted": "加重",
       "concentrated": "スーパーチャージャー",
       "transmuter": "トランスミューター",
-      "orderbook": "Orderbook",
+      "orderbook": "注文書",
       "astroport": "Astroport",
       "whitewhale": "White Whale",
       "noIncentives": "インセンティブなし"

--- a/packages/web/localizations/ja.json
+++ b/packages/web/localizations/ja.json
@@ -269,6 +269,9 @@
       "weighted": "加重",
       "concentrated": "スーパーチャージャー",
       "transmuter": "トランスミューター",
+      "orderbook": "Orderbook",
+      "astroport": "Astroport",
+      "whitewhale": "White Whale",
       "noIncentives": "インセンティブなし"
     }
   },

--- a/packages/web/localizations/ko.json
+++ b/packages/web/localizations/ko.json
@@ -269,7 +269,7 @@
       "weighted": "가중치",
       "concentrated": "집중된 유동성",
       "transmuter": "트랜스뮤터",
-      "orderbook": "Orderbook",
+      "orderbook": "주문서",
       "astroport": "Astroport",
       "whitewhale": "White Whale",
       "noIncentives": "인센티브 없음"

--- a/packages/web/localizations/ko.json
+++ b/packages/web/localizations/ko.json
@@ -269,6 +269,9 @@
       "weighted": "가중치",
       "concentrated": "집중된 유동성",
       "transmuter": "트랜스뮤터",
+      "orderbook": "Orderbook",
+      "astroport": "Astroport",
+      "whitewhale": "White Whale",
       "noIncentives": "인센티브 없음"
     }
   },

--- a/packages/web/localizations/pl.json
+++ b/packages/web/localizations/pl.json
@@ -269,6 +269,9 @@
       "weighted": "Ważone",
       "concentrated": "Skoncentrowana płynność",
       "transmuter": "Transmutator",
+      "orderbook": "Orderbook",
+      "astroport": "Astroport",
+      "whitewhale": "White Whale",
       "noIncentives": "Brak zachęt"
     }
   },

--- a/packages/web/localizations/pl.json
+++ b/packages/web/localizations/pl.json
@@ -269,7 +269,7 @@
       "weighted": "Ważone",
       "concentrated": "Skoncentrowana płynność",
       "transmuter": "Transmutator",
-      "orderbook": "Orderbook",
+      "orderbook": "Księga zamówień",
       "astroport": "Astroport",
       "whitewhale": "White Whale",
       "noIncentives": "Brak zachęt"

--- a/packages/web/localizations/pt-br.json
+++ b/packages/web/localizations/pt-br.json
@@ -269,6 +269,9 @@
       "weighted": "Ponderado",
       "concentrated": "Liquidez concentrada",
       "transmuter": "Transmutador",
+      "orderbook": "Orderbook",
+      "astroport": "Astroport",
+      "whitewhale": "White Whale",
       "noIncentives": "Sem incentivos"
     }
   },

--- a/packages/web/localizations/pt-br.json
+++ b/packages/web/localizations/pt-br.json
@@ -269,7 +269,7 @@
       "weighted": "Ponderado",
       "concentrated": "Liquidez concentrada",
       "transmuter": "Transmutador",
-      "orderbook": "Orderbook",
+      "orderbook": "Carteira de pedidos",
       "astroport": "Astroport",
       "whitewhale": "White Whale",
       "noIncentives": "Sem incentivos"

--- a/packages/web/localizations/ro.json
+++ b/packages/web/localizations/ro.json
@@ -269,7 +269,7 @@
       "weighted": "Ponderat",
       "concentrated": "Lichiditate concentrată",
       "transmuter": "Transmutator",
-      "orderbook": "Orderbook",
+      "orderbook": "Carnet de comandă",
       "astroport": "Astroport",
       "whitewhale": "White Whale",
       "noIncentives": "Fără incentivi"

--- a/packages/web/localizations/ro.json
+++ b/packages/web/localizations/ro.json
@@ -269,6 +269,9 @@
       "weighted": "Ponderat",
       "concentrated": "Lichiditate concentrată",
       "transmuter": "Transmutator",
+      "orderbook": "Orderbook",
+      "astroport": "Astroport",
+      "whitewhale": "White Whale",
       "noIncentives": "Fără incentivi"
     }
   },

--- a/packages/web/localizations/ru.json
+++ b/packages/web/localizations/ru.json
@@ -269,7 +269,7 @@
       "weighted": "Взвешенный",
       "concentrated": "Заряженный",
       "transmuter": "Трансмутатор",
-      "orderbook": "Orderbook",
+      "orderbook": "Книга заказов",
       "astroport": "Astroport",
       "whitewhale": "White Whale",
       "noIncentives": "Никаких стимулов"

--- a/packages/web/localizations/ru.json
+++ b/packages/web/localizations/ru.json
@@ -269,6 +269,9 @@
       "weighted": "Взвешенный",
       "concentrated": "Заряженный",
       "transmuter": "Трансмутатор",
+      "orderbook": "Orderbook",
+      "astroport": "Astroport",
+      "whitewhale": "White Whale",
       "noIncentives": "Никаких стимулов"
     }
   },

--- a/packages/web/localizations/scripts/omitted-keys.mjs
+++ b/packages/web/localizations/scripts/omitted-keys.mjs
@@ -1,9 +1,6 @@
 /** Add key paths here to skip them in localizations tests. */
 export const omittedKeyPaths = [
   "assets.categories",
-  "components.table.orderbook",
-  "components.table.astroport",
-  "components.table.whitewhale",
   "limitOrders.historyTable.columns",
   "transfer.nomic.estimatedTime",
 ];

--- a/packages/web/localizations/scripts/omitted-keys.mjs
+++ b/packages/web/localizations/scripts/omitted-keys.mjs
@@ -1,6 +1,9 @@
 /** Add key paths here to skip them in localizations tests. */
 export const omittedKeyPaths = [
   "assets.categories",
+  "components.table.orderbook",
+  "components.table.astroport",
+  "components.table.whitewhale",
   "limitOrders.historyTable.columns",
   "transfer.nomic.estimatedTime",
 ];

--- a/packages/web/localizations/tr.json
+++ b/packages/web/localizations/tr.json
@@ -269,7 +269,7 @@
       "weighted": "Ağırlıklı",
       "concentrated": "Konsantre likidite",
       "transmuter": "Dönüştürücü",
-      "orderbook": "Orderbook",
+      "orderbook": "Sipariş Defteri",
       "astroport": "Astroport",
       "whitewhale": "White Whale",
       "noIncentives": "Teşvik yok"

--- a/packages/web/localizations/tr.json
+++ b/packages/web/localizations/tr.json
@@ -269,6 +269,9 @@
       "weighted": "Ağırlıklı",
       "concentrated": "Konsantre likidite",
       "transmuter": "Dönüştürücü",
+      "orderbook": "Orderbook",
+      "astroport": "Astroport",
+      "whitewhale": "White Whale",
       "noIncentives": "Teşvik yok"
     }
   },

--- a/packages/web/localizations/zh-cn.json
+++ b/packages/web/localizations/zh-cn.json
@@ -269,6 +269,9 @@
       "weighted": "加权",
       "concentrated": "流动性集中",
       "transmuter": "转化器",
+      "orderbook": "Orderbook",
+      "astroport": "Astroport",
+      "whitewhale": "White Whale",
       "noIncentives": "无激励"
     }
   },

--- a/packages/web/localizations/zh-cn.json
+++ b/packages/web/localizations/zh-cn.json
@@ -269,7 +269,7 @@
       "weighted": "加权",
       "concentrated": "流动性集中",
       "transmuter": "转化器",
-      "orderbook": "Orderbook",
+      "orderbook": "订单簿",
       "astroport": "Astroport",
       "whitewhale": "White Whale",
       "noIncentives": "无激励"

--- a/packages/web/localizations/zh-hk.json
+++ b/packages/web/localizations/zh-hk.json
@@ -269,6 +269,9 @@
       "weighted": "加權",
       "concentrated": "流動性集中",
       "transmuter": "轉換器",
+      "orderbook": "Orderbook",
+      "astroport": "Astroport",
+      "whitewhale": "White Whale",
       "noIncentives": "無激勵"
     }
   },

--- a/packages/web/localizations/zh-hk.json
+++ b/packages/web/localizations/zh-hk.json
@@ -269,7 +269,7 @@
       "weighted": "加權",
       "concentrated": "流動性集中",
       "transmuter": "轉換器",
-      "orderbook": "Orderbook",
+      "orderbook": "訂單簿",
       "astroport": "Astroport",
       "whitewhale": "White Whale",
       "noIncentives": "無激勵"

--- a/packages/web/localizations/zh-tw.json
+++ b/packages/web/localizations/zh-tw.json
@@ -269,6 +269,9 @@
       "weighted": "加權",
       "concentrated": "集中流動性",
       "transmuter": "轉換器",
+      "orderbook": "Orderbook",
+      "astroport": "Astroport",
+      "whitewhale": "White Whale",
       "noIncentives": "無激勵"
     }
   },

--- a/packages/web/localizations/zh-tw.json
+++ b/packages/web/localizations/zh-tw.json
@@ -269,7 +269,7 @@
       "weighted": "加權",
       "concentrated": "集中流動性",
       "transmuter": "轉換器",
-      "orderbook": "Orderbook",
+      "orderbook": "訂單簿",
       "astroport": "Astroport",
       "whitewhale": "White Whale",
       "noIncentives": "無激勵"


### PR DESCRIPTION
## What is the purpose of the change:
Adds filtering and sorting for several pool types that were included all the time before.
Allows Orderbook pools to be forwarded to an intermediary page before direction to Celatone.

## Brief Changelog

  - Added cosmwasm-orderbook as a recognised pool type using code ID 885, alongside the existing cosmwasm subtypes. Orderbook pools get their own icon (open-book), colour (text-wosmongton-300), and pool page link. Spread factor is not displayed for orderbook pools since it's not applicable.
  - Moved Astroport PCL and White Whale out of a server-side alwaysIncludedTypes bypass that was causing them to appear in the pools table regardless of filter selection. They now respect the filter dropdown like all other types.
  - Added Orderbook, Astroport, and White Whale as explicit options in the pools table filter dropdown, in the order: Supercharged, Orderbook, Weighted, Stableswap, Astroport, White Whale, Transmuter. All are selected by default except Transmuter (unchanged from before).
  - Added localisation strings for the three new filter labels.

## Testing and Verifying

This change has been tested locally by rebuilding the website and verified content and links are expected