### PR TITLE
fix: fetch low-liquidity pools before join tx if not in cache

### DIFF
--- a/packages/stores/src/account/osmosis/index.ts
+++ b/packages/stores/src/account/osmosis/index.ts
@@ -375,7 +375,7 @@ export class OsmosisAccountImpl {
     const mkp = this.makeCoinPretty;
 
     // If not in cache, it might be a low-liquidity pool that wasn't fetched initially
-    let queryPoolForJoin = queries.queryPools.getPool(poolId);
+    const queryPoolForJoin = queries.queryPools.getPool(poolId);
     if (!queryPoolForJoin) {
       try {
         await queries.queryPools.fetchRemainingPools({ minLiquidity: 0 });
@@ -493,7 +493,7 @@ export class OsmosisAccountImpl {
     const queries = this.queries;
 
     // If not in cache, it might be a low-liquidity pool that wasn't fetched initially
-    let queryPoolForJoinSwap = queries.queryPools.getPool(poolId);
+    const queryPoolForJoinSwap = queries.queryPools.getPool(poolId);
     if (!queryPoolForJoinSwap) {
       try {
         await queries.queryPools.fetchRemainingPools({ minLiquidity: 0 });

--- a/packages/stores/src/account/osmosis/index.ts
+++ b/packages/stores/src/account/osmosis/index.ts
@@ -374,6 +374,16 @@ export class OsmosisAccountImpl {
     const queries = this.queries;
     const mkp = this.makeCoinPretty;
 
+    // If not in cache, it might be a low-liquidity pool that wasn't fetched initially
+    let queryPoolForJoin = queries.queryPools.getPool(poolId);
+    if (!queryPoolForJoin) {
+      try {
+        await queries.queryPools.fetchRemainingPools({ minLiquidity: 0 });
+      } catch (e) {
+        console.error(`Failed to fetch remaining pools for pool ${poolId}:`, e);
+      }
+    }
+
     await this.base.signAndBroadcast(
       this.chainId,
       "joinPool",
@@ -481,6 +491,16 @@ export class OsmosisAccountImpl {
     onFulfill?: (tx: DeliverTxResponse) => void
   ) {
     const queries = this.queries;
+
+    // If not in cache, it might be a low-liquidity pool that wasn't fetched initially
+    let queryPoolForJoinSwap = queries.queryPools.getPool(poolId);
+    if (!queryPoolForJoinSwap) {
+      try {
+        await queries.queryPools.fetchRemainingPools({ minLiquidity: 0 });
+      } catch (e) {
+        console.error(`Failed to fetch remaining pools for pool ${poolId}:`, e);
+      }
+    }
 
     await this.base.signAndBroadcast(
       this.chainId,


### PR DESCRIPTION
Mirrors the fetchRemainingPools fallback already used in sendCreateConcentratedLiquidityPositionMsg so that weighted/stable pools with zero or low liquidity (filtered out on initial load) can be found when the user tries to add liquidity.

This prevented generating the transaction to add liquidity to low-liquidity pools unless they were in the cache.