### PR TITLE
Fix dev script quoting in web package.json

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "knip": "knip",
     "predev": "yarn generate",
-    "dev": "concurrently --raw --kill-others 'next dev' 'yarn watch'",
+    "dev": "concurrently --raw --kill-others \"next dev\" \"yarn watch\"",
     "clean": "rm -rf node_modules; rm -rf .next; rm -rf config/generated",
     "build": "yarn generate && next build",
     "test": "yarn generate && dotenv -c -- jest --passWithNoTests",


### PR DESCRIPTION
Change the dev script to use double quotes for the concurrently subcommands instead of single quotes. This improves cross-shell compatibility (notably on Windows shells that don't recognize single quotes) so "next dev" and "yarn watch" are spawned correctly with --kill-others.

### Linear Task

https://linear.app/osmosis/issue/MTN-32/fix-concurrency-quote-issue-when-building-on-windows

## Testing and Verifying

This change has been tested locally by rebuilding the website and verified content and links are expected