### PR TITLE
ci: switch wallet E2E jobs back to macos-14

### DIFF
--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -141,7 +141,7 @@ jobs:
 
   preview-swap-osmo-tests:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     needs: [wait-for-deployment, check-balances]
     outputs:
       unexpected: ${{ steps.set-output.outputs.unexpected }}
@@ -170,7 +170,10 @@ jobs:
         env:
           BASE_URL: "https://${{ needs.wait-for-deployment.outputs.environment_url }}"
           PRIVATE_KEY: ${{ secrets.E2E_PRIVATE_KEY_PREVIEW }}
-          HEADLESS: "true"
+          # Linux-headless mode (PR #4319) — disabled in favour of macos-14 above due to
+          # Keplr extension popup flakiness in headless Chromium on Linux. To retry the
+          # cheaper Linux runner, switch `runs-on:` to `ubuntu-latest` and uncomment:
+          # HEADLESS: "true"
         run: |
           cd packages/e2e
           npx playwright test swap.osmo.wallet
@@ -190,7 +193,7 @@ jobs:
 
   preview-swap-usdc-tests:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     needs: [wait-for-deployment, preview-swap-osmo-tests, check-balances]
     steps:
       - name: Check out repository
@@ -224,7 +227,10 @@ jobs:
         env:
           BASE_URL: "https://${{ needs.wait-for-deployment.outputs.environment_url }}"
           PRIVATE_KEY: ${{ secrets.E2E_PRIVATE_KEY_PREVIEW }}
-          HEADLESS: "true"
+          # Linux-headless mode (PR #4319) — disabled in favour of macos-14 above due to
+          # Keplr extension popup flakiness in headless Chromium on Linux. To retry the
+          # cheaper Linux runner, switch `runs-on:` to `ubuntu-latest` and uncomment:
+          # HEADLESS: "true"
         run: |
           cd packages/e2e
           npx playwright test swap.usdc.wallet
@@ -239,7 +245,7 @@ jobs:
   preview-portfolio-trx-tests:
     timeout-minutes: 10
     needs: wait-for-deployment
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -264,7 +270,10 @@ jobs:
         env:
           BASE_URL: "https://${{ needs.wait-for-deployment.outputs.environment_url }}"
           PRIVATE_KEY: ${{ secrets.E2E_PRIVATE_KEY_PREVIEW }}
-          HEADLESS: "true"
+          # Linux-headless mode (PR #4319) — disabled in favour of macos-14 above due to
+          # Keplr extension popup flakiness in headless Chromium on Linux. To retry the
+          # cheaper Linux runner, switch `runs-on:` to `ubuntu-latest` and uncomment:
+          # HEADLESS: "true"
         run: |
           cd packages/e2e
           npx playwright test portfolio transactions
@@ -316,7 +325,7 @@ jobs:
 
   preview-trade-tests:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     needs:
       [wait-for-deployment, preview-swap-osmo-tests, preview-swap-usdc-tests, check-balances]
     steps:
@@ -350,7 +359,10 @@ jobs:
         env:
           BASE_URL: "https://${{ needs.wait-for-deployment.outputs.environment_url }}"
           PRIVATE_KEY: ${{ secrets.E2E_PRIVATE_KEY_PREVIEW }}
-          HEADLESS: "true"
+          # Linux-headless mode (PR #4319) — disabled in favour of macos-14 above due to
+          # Keplr extension popup flakiness in headless Chromium on Linux. To retry the
+          # cheaper Linux runner, switch `runs-on:` to `ubuntu-latest` and uncomment:
+          # HEADLESS: "true"
         run: |
           cd packages/e2e
           npx playwright test trade
@@ -364,7 +376,7 @@ jobs:
 
   preview-claim-tests:
     timeout-minutes: 10
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     needs: [wait-for-deployment, check-balances]
     steps:
       - name: Check out repository
@@ -391,7 +403,10 @@ jobs:
         env:
           BASE_URL: "https://${{ needs.wait-for-deployment.outputs.environment_url }}"
           PRIVATE_KEY: ${{ secrets.E2E_PRIVATE_KEY_PREVIEW }}
-          HEADLESS: "true"
+          # Linux-headless mode (PR #4319) — disabled in favour of macos-14 above due to
+          # Keplr extension popup flakiness in headless Chromium on Linux. To retry the
+          # cheaper Linux runner, switch `runs-on:` to `ubuntu-latest` and uncomment:
+          # HEADLESS: "true"
         run: |
           cd packages/e2e
           npx playwright test claim

--- a/.github/workflows/monitoring-limit-geo-e2e-tests.yml
+++ b/.github/workflows/monitoring-limit-geo-e2e-tests.yml
@@ -14,7 +14,7 @@ jobs:
   fe-swap-us:
     timeout-minutes: 10
     name: prod-fe-swap-us
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -130,7 +130,10 @@ jobs:
         env:
           BASE_URL: "https://app.osmosis.zone"
           PRIVATE_KEY: ${{ secrets.TEST_PRIVATE_KEY_US }}
-          HEADLESS: "true"
+          # Linux-headless mode (PR #4319) — disabled in favour of macos-14 above due to
+          # Keplr extension popup flakiness in headless Chromium on Linux. To retry the
+          # cheaper Linux runner, switch `runs-on:` to `ubuntu-latest` and uncomment:
+          # HEADLESS: "true"
         run: |
           cd packages/e2e
           npx playwright test monitoring.swap
@@ -145,7 +148,7 @@ jobs:
   fe-swap-eu:
     timeout-minutes: 15
     name: prod-fe-swap-eu
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -265,7 +268,10 @@ jobs:
           TEST_PROXY_PASSWORD: ${{ secrets.TEST_PROXY_PASSWORD }}
           PRIVATE_KEY: ${{ secrets.TEST_PRIVATE_KEY_EU }}
           USE_TEST_PROXY: "use"
-          HEADLESS: "true"
+          # Linux-headless mode (PR #4319) — disabled in favour of macos-14 above due to
+          # Keplr extension popup flakiness in headless Chromium on Linux. To retry the
+          # cheaper Linux runner, switch `runs-on:` to `ubuntu-latest` and uncomment:
+          # HEADLESS: "true"
         run: |
           cd packages/e2e
           npx playwright test monitoring.swap
@@ -280,7 +286,7 @@ jobs:
   fe-swap-sg:
     timeout-minutes: 15
     name: prod-fe-swap-sg
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     steps:
       - name: Echo IP
         run: curl -L "https://ipinfo.io" -s
@@ -402,7 +408,10 @@ jobs:
           TEST_PROXY_PASSWORD: ${{ secrets.TEST_PROXY_PASSWORD }}
           PRIVATE_KEY: ${{ secrets.TEST_PRIVATE_KEY_SG }}
           USE_TEST_PROXY: "use"
-          HEADLESS: "true"
+          # Linux-headless mode (PR #4319) — disabled in favour of macos-14 above due to
+          # Keplr extension popup flakiness in headless Chromium on Linux. To retry the
+          # cheaper Linux runner, switch `runs-on:` to `ubuntu-latest` and uncomment:
+          # HEADLESS: "true"
         run: |
           cd packages/e2e
           npx playwright test monitoring.swap
@@ -418,7 +427,7 @@ jobs:
     timeout-minutes: 20
     needs: fe-swap-eu
     name: prod-fe-trade-eu
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     outputs:
       unexpected: ${{ steps.set-output.outputs.unexpected }}
     steps:
@@ -540,7 +549,10 @@ jobs:
           TEST_PROXY_PASSWORD: ${{ secrets.TEST_PROXY_PASSWORD }}
           PRIVATE_KEY: ${{ secrets.TEST_PRIVATE_KEY_EU }}
           USE_TEST_PROXY: "use"
-          HEADLESS: "true"
+          # Linux-headless mode (PR #4319) — disabled in favour of macos-14 above due to
+          # Keplr extension popup flakiness in headless Chromium on Linux. To retry the
+          # cheaper Linux runner, switch `runs-on:` to `ubuntu-latest` and uncomment:
+          # HEADLESS: "true"
         run: |
           cd packages/e2e
           npx playwright test monitoring.market --timeout 180000
@@ -561,7 +573,7 @@ jobs:
     if: failure() || success()
     name: prod-fe-limit-eu
     needs: fe-trade-eu
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     outputs:
       unexpected: ${{ steps.set-output.outputs.unexpected }}
     steps:
@@ -689,7 +701,10 @@ jobs:
           TEST_PROXY_PASSWORD: ${{ secrets.TEST_PROXY_PASSWORD }}
           PRIVATE_KEY: ${{ secrets.TEST_PRIVATE_KEY_EU }}
           USE_TEST_PROXY: "use"
-          HEADLESS: "true"
+          # Linux-headless mode (PR #4319) — disabled in favour of macos-14 above due to
+          # Keplr extension popup flakiness in headless Chromium on Linux. To retry the
+          # cheaper Linux runner, switch `runs-on:` to `ubuntu-latest` and uncomment:
+          # HEADLESS: "true"
         run: |
           cd packages/e2e
           npx playwright test monitoring.limit --timeout 180000
@@ -709,7 +724,7 @@ jobs:
     timeout-minutes: 15
     needs: fe-swap-sg
     name: prod-fe-trade-sg
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     outputs:
       unexpected: ${{ steps.set-output.outputs.unexpected }}
     steps:
@@ -831,7 +846,10 @@ jobs:
           TEST_PROXY_PASSWORD: ${{ secrets.TEST_PROXY_PASSWORD }}
           PRIVATE_KEY: ${{ secrets.TEST_PRIVATE_KEY_SG }}
           USE_TEST_PROXY: "use"
-          HEADLESS: "true"
+          # Linux-headless mode (PR #4319) — disabled in favour of macos-14 above due to
+          # Keplr extension popup flakiness in headless Chromium on Linux. To retry the
+          # cheaper Linux runner, switch `runs-on:` to `ubuntu-latest` and uncomment:
+          # HEADLESS: "true"
         run: |
           cd packages/e2e
           npx playwright test monitoring.market --timeout 90000
@@ -851,7 +869,7 @@ jobs:
     timeout-minutes: 10
     needs: fe-swap-us
     name: prod-fe-trade-us
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     outputs:
       unexpected: ${{ steps.set-output.outputs.unexpected }}
     steps:
@@ -970,7 +988,10 @@ jobs:
         env:
           BASE_URL: "https://app.osmosis.zone"
           PRIVATE_KEY: ${{ secrets.TEST_PRIVATE_KEY_US }}
-          HEADLESS: "true"
+          # Linux-headless mode (PR #4319) — disabled in favour of macos-14 above due to
+          # Keplr extension popup flakiness in headless Chromium on Linux. To retry the
+          # cheaper Linux runner, switch `runs-on:` to `ubuntu-latest` and uncomment:
+          # HEADLESS: "true"
         run: |
           cd packages/e2e
           npx playwright test monitoring.market --timeout 90000
@@ -991,7 +1012,7 @@ jobs:
     if: failure() || success()
     needs: fe-trade-us
     name: prod-fe-limit-us
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     outputs:
       unexpected: ${{ steps.set-output.outputs.unexpected }}
     steps:
@@ -1116,7 +1137,10 @@ jobs:
         env:
           BASE_URL: "https://app.osmosis.zone"
           PRIVATE_KEY: ${{ secrets.TEST_PRIVATE_KEY_US }}
-          HEADLESS: "true"
+          # Linux-headless mode (PR #4319) — disabled in favour of macos-14 above due to
+          # Keplr extension popup flakiness in headless Chromium on Linux. To retry the
+          # cheaper Linux runner, switch `runs-on:` to `ubuntu-latest` and uncomment:
+          # HEADLESS: "true"
         run: |
           cd packages/e2e
           npx playwright test monitoring.limit --timeout 180000

--- a/.github/workflows/prod-frontend-e2e-tests.yml
+++ b/.github/workflows/prod-frontend-e2e-tests.yml
@@ -139,7 +139,7 @@ jobs:
           fi
 
   prod-e2e-tests:
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     timeout-minutes: 20
     needs: [wait-for-deployment, check-balances]
     environment:
@@ -169,7 +169,10 @@ jobs:
         env:
           BASE_URL: "https://app.osmosis.zone"
           PRIVATE_KEY: ${{ secrets.E2E_PRIVATE_KEY_PREVIEW }}
-          HEADLESS: "true"
+          # Linux-headless mode (PR #4319) — disabled in favour of macos-14 above due to
+          # Keplr extension popup flakiness in headless Chromium on Linux. To retry the
+          # cheaper Linux runner, switch `runs-on:` to `ubuntu-latest` and uncomment:
+          # HEADLESS: "true"
         run: |
           cd packages/e2e
           npx playwright test transactions portfolio swap.osmo.wallet


### PR DESCRIPTION
## What is the purpose of the change:

Revert the 14 wallet-using E2E jobs from ubuntu-latest back to macos-14 

## Linear Task
[MTN-4: (E2E) Improve flakiness for proxy geo tests](https://linear.app/osmosis/issue/MTN-4/e2e-improve-flakiness-for-proxy-geo-tests)

## Brief Changelog

Revert the 14 wallet-using E2E jobs from ubuntu-latest back to macos-14 (frontend-e2e-tests.yml: 5, prod-frontend-e2e-tests.yml: 1, monitoring-limit-geo-e2e-tests.yml: 8). The headed-mode macOS runners avoid Keplr extension popup flakiness we saw under headless Chromium on Linux after the PR #4319 migration.

Keep `HEADLESS: `true`` as a commented YAML block (with context and a pointer to PR #4319) next to each affected job's `env:` so the cheaper Linux-headless option remains discoverable for future maintainers. The Keplr helper code added in PR #4319 already supports both modes (reads `process.env.HEADLESS`, defaults false), so re-enabling will be a workflow-only change.


## Testing and Verifying

CI workflows triggered on this branch:

- [x] [Preview frontend E2E tests](https://github.com/osmosis-labs/osmosis-frontend/actions/runs/25156794539) — 5 wallet jobs from `frontend-e2e-tests.yml` (`preview-swap-osmo-tests`, `preview-swap-usdc-tests`, `preview-portfolio-trx-tests`, `preview-trade-tests`, `preview-claim-tests`) — auto-triggered by push — **5/5 passed on first attempt**
- [x] [Production frontend E2E tests](https://github.com/osmosis-labs/osmosis-frontend/actions/runs/25157012874) — 1 wallet job from `prod-frontend-e2e-tests.yml` (`prod-e2e-tests`) — `workflow_dispatch` — first attempt: 15 tests passed (5.7m), but a known teardown race (`keplr-helper.ts:131` / `base-page.ts:92` `logOut()` `connectedWalletBtn.click` 2s timeout — same toast-vs-wallet-button race PR #4319's `dismissAllToasts()` was meant to fix) caused a non-test error and exit 1; **passed cleanly on retry (attempt 2)**
- [x] [Synthetic Geo Monitoring Frontend tests](https://github.com/osmosis-labs/osmosis-frontend/actions/runs/25157011357) — 8 wallet jobs from `monitoring-limit-geo-e2e-tests.yml` (`fe-swap-us`, `fe-swap-eu`, `fe-swap-sg`, `fe-trade-eu`, `fe-limit-eu`, `fe-trade-sg`, `fe-trade-us`, `fe-limit-us`) — `workflow_dispatch` — **5/8 passed both attempts; 3/8 failed both attempts** — see breakdown below

### Monitoring breakdown

Healthy on `macos-14` (matches their `stage`/Linux baseline):
- ✅ `fe-swap-us` (no proxy), `fe-swap-eu` (proxy), `fe-swap-sg` (proxy)
- ✅ `fe-trade-us` (no proxy), `fe-limit-us` (no proxy)

Failed both attempts on `macos-14`, **also failing every scheduled run on `stage`/Linux for 12+ hours pre-dating this PR** (the most recent 8 cron runs on `stage` all concluded `failure` on the same 3 jobs):
- ❌ `fe-trade-eu` (proxy) — `Timed out 40000ms waiting for ... toBeVisible` for the "Transaction Successful" toast on Market Buy/Sell BTC and OSMO
- ❌ `fe-trade-sg` (proxy) — same failure mode
- ❌ `fe-limit-eu` (proxy, depends on `fe-trade-eu`) — same toast timeout on limit buy/sell

The pattern (US no-proxy passes, EU/SG `swap` passes, EU/SG `trade`/`limit` fails) matches exactly what's been failing on `stage` overnight on Linux. **Not a macOS regression.** Most likely test-side issues with proxied prod traffic for the market/limit flows; should be triaged in a separate PR.

### Conclusion

Every wallet job with a healthy `stage` baseline passed on `macos-14`. The teardown `logOut` race is a pre-existing flake handled by retry. The 3 proxy-routed market/limit jobs that failed match the exact set already red on `stage`/Linux. The macOS migration is a no-regression revert.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes that alter the GitHub Actions runner OS for multiple E2E jobs; primary risk is longer/changed CI execution characteristics rather than product behavior.
> 
> **Overview**
> Switches wallet-using Playwright E2E jobs from `ubuntu-latest` back to `macos-14` across preview, production, and geo-monitoring workflows to reduce Keplr extension popup flakiness.
> 
> Keeps the prior Linux headless configuration as commented `HEADLESS: "true"` guidance next to each affected job so the cheaper `ubuntu-latest` option can be re-enabled with a workflow-only change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2402fada7652a4a7a70f99eb240681026b84b04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
