### PR TITLE
fix(pools): route uninitialized CL pools to initial-liquidity flow

### DIFF
--- a/packages/server/src/queries/complex/pools/providers/__tests__/sidecar.spec.ts
+++ b/packages/server/src/queries/complex/pools/providers/__tests__/sidecar.spec.ts
@@ -5,7 +5,7 @@ import { setupServer } from "msw/node";
 
 import { SIDECAR_BASE_URL } from "../../../../../env";
 import { calcAssetValue, calcSumCoinsValue, getAsset } from "../../../assets";
-import { getPoolTypeFromChainPool } from "../sidecar";
+import { getPoolTypeFromChainPool, makePoolFromChainPool } from "../sidecar";
 
 export const server = setupServer();
 
@@ -75,6 +75,56 @@ describe("getPoolsFromSidecar", () => {
     const pool = mockSidecarResponse[4];
     const poolType = getPoolTypeFromChainPool(pool.chain_model as any);
     expect(poolType).toBe("cosmwasm");
+  });
+});
+
+describe("makePoolFromChainPool", () => {
+  beforeEach(() => {
+    (getAsset as jest.Mock).mockImplementation(() => mockAsset);
+  });
+
+  it("marks uninitialized CL chain-fallback pools as known zero TVL", () => {
+    const pool = makePoolFromChainPool({
+      chainPool: {
+        address: "osmo1testpooladdress",
+        id: 9999,
+        current_tick_liquidity: "0",
+        token0: "uosmo",
+        token1: "uatom",
+        current_sqrt_price: "0",
+        current_tick: 0,
+        tick_spacing: 100,
+        exponent_at_price_one: -6,
+        spread_factor: "0.002000000000000000",
+        last_liquidity_update: "2026-01-01T00:00:00.000000000Z",
+      } as any,
+      assetLists: [],
+    });
+
+    expect(pool).not.toBeNull();
+    expect(pool?.tvlUnknown).toBe(false);
+  });
+
+  it("keeps CL chain-fallback TVL unknown when pool is initialized", () => {
+    const pool = makePoolFromChainPool({
+      chainPool: {
+        address: "osmo1testpooladdress",
+        id: 10000,
+        current_tick_liquidity: "1",
+        token0: "uosmo",
+        token1: "uatom",
+        current_sqrt_price: "1.000000000000000000",
+        current_tick: 0,
+        tick_spacing: 100,
+        exponent_at_price_one: -6,
+        spread_factor: "0.002000000000000000",
+        last_liquidity_update: "2026-01-01T00:00:00.000000000Z",
+      } as any,
+      assetLists: [],
+    });
+
+    expect(pool).not.toBeNull();
+    expect(pool?.tvlUnknown).toBe(true);
   });
 });
 

--- a/packages/server/src/queries/complex/pools/providers/sidecar.ts
+++ b/packages/server/src/queries/complex/pools/providers/sidecar.ts
@@ -492,6 +492,17 @@ export function makePoolFromChainPool({
   const balancesSynthed =
     balances === null && "current_sqrt_price" in chainPool;
 
+  // Concentrated liquidity pools only set `current_sqrt_price` (and any
+  // `current_tick_liquidity`) when the first position is created. If both are
+  // zero, the pool genuinely has no liquidity and TVL is known to be zero
+  // rather than unknown. Without this, chain-fallback CL pools whose tokens
+  // lack an SQS price route would be misclassified as inactive instead of
+  // uninitialized, sending users into the wrong add-liquidity flow.
+  const isUninitializedConcentratedPool =
+    "current_sqrt_price" in chainPool &&
+    parseFloat(chainPool.current_sqrt_price) === 0 &&
+    parseFloat(chainPool.current_tick_liquidity) === 0;
+
   const effectiveBalances =
     balances ??
     (balancesSynthed
@@ -538,7 +549,7 @@ export function makePoolFromChainPool({
     spreadFactor: new RatePretty(spreadFactor),
     reserveCoins,
     totalFiatValueLocked: new PricePretty(DEFAULT_VS_CURRENCY, 0),
-    tvlUnknown: balancesSynthed,
+    tvlUnknown: balancesSynthed && !isUninitializedConcentratedPool,
     // No incentives or market data available from chain
     incentives: {
       aprBreakdown: undefined,

--- a/packages/web/components/pool-detail/concentrated.tsx
+++ b/packages/web/components/pool-detail/concentrated.tsx
@@ -167,16 +167,20 @@ export const ConcentratedLiquidityPool: FunctionComponent<{ poolId: string }> =
       ? parseFloat(currentTickLiquidity) === 0
       : false;
 
-    // Tier 2: Inactive Pool - has TVL but no in range liquidity at current price
-    // This happens when all liquidity positions are out of range
-    // Check this FIRST because a pool can have out-of-range liquidity (TVL > 0)
-    // with zero tick liquidity and zero sqrt price
-    const isInactivePool = isTickLiquidityZero && hasTVL;
+    // Tier 1: Uninitialized Pool - has never been initialized (no first
+    // position created). On Osmosis CL, current_sqrt_price only becomes
+    // non-zero when the first position is created, so this is a reliable
+    // chain-derived signal regardless of whether TVL is known. Avoid relying
+    // on hasTVL here so a future regression in the TVL signal cannot route
+    // an uninitialized pool into the inactive flow.
+    const isUninitializedPool = isSqrtPriceZero && isTickLiquidityZero;
 
-    // Tier 1: Uninitialized Pool - has never been initialized (no price set)
-    // Only classify as uninitialized if there's NO TVL at all
-    const isUninitializedPool =
-      isSqrtPriceZero && isTickLiquidityZero && !hasTVL;
+    // Tier 2: Inactive Pool - has TVL but no in range liquidity at current price
+    // This happens when all liquidity positions are out of range. Made
+    // mutually exclusive with the uninitialized tier above so a pool with
+    // zero sqrt price never registers as inactive.
+    const isInactivePool =
+      !isUninitializedPool && isTickLiquidityZero && hasTVL;
 
     return (
       <main className="m-auto flex min-h-screen max-w-container flex-col gap-8 px-8 py-4 md:gap-4 md:p-4">

--- a/packages/web/modals/add-liquidity.tsx
+++ b/packages/web/modals/add-liquidity.tsx
@@ -108,11 +108,14 @@ export const AddLiquidityModal: FunctionComponent<
       ? parseFloat(currentTickLiquidity) === 0
       : false;
 
-    // Tier 1: Uninitialized Pool - has never been initialized (no price set)
-    // Only classify as uninitialized if there's NO TVL at all
-    // Note: Inactive pools (TVL > 0 but zero tick liquidity) are handled inside AddConcLiquidity component
-    const isUninitializedPool =
-      isSqrtPriceZero && isTickLiquidityZero && !hasTVL;
+    // Tier 1: Uninitialized Pool - has never been initialized (no first
+    // position created). On Osmosis CL, current_sqrt_price only becomes
+    // non-zero when the first position is created, so this is a reliable
+    // chain-derived signal regardless of whether TVL is known. Avoid relying
+    // on hasTVL here so a future regression in the TVL signal cannot route
+    // an uninitialized pool into the inactive flow.
+    // Note: Inactive pools (positions exist but all out of range) are handled inside AddConcLiquidity component
+    const isUninitializedPool = isSqrtPriceZero && isTickLiquidityZero;
 
     // For uninitialized pools (but NOT inactive pools), show the initial liquidity addition interface
     // Inactive pools already have out-of-range liquidity, so they should use the normal add liquidity flow

--- a/packages/web/modals/add-liquidity.tsx
+++ b/packages/web/modals/add-liquidity.tsx
@@ -97,8 +97,6 @@ export const AddLiquidityModal: FunctionComponent<
     const poolRaw = pool.raw as ConcentratedPoolRawResponse;
     const currentSqrtPrice = poolRaw?.current_sqrt_price;
     const currentTickLiquidity = poolRaw?.current_tick_liquidity;
-    const hasTVL =
-      pool.tvlUnknown || !pool.totalFiatValueLocked.toDec().isZero();
 
     // Check if values are zero (handles both "0" and "0.000000..." strings)
     const isSqrtPriceZero = currentSqrtPrice


### PR DESCRIPTION
## Linear

[MTN-67: Fix add-liquidity flow on uninitialized CL pools](https://linear.app/osmosis/issue/MTN-67/fix-add-liquidity-flow-on-uninitialized-cl-pools)

## TL;DR

A brand-new CL pool whose token has no SQS USD price (e.g. [pool/3442](https://app.osmosis.zone/pool/3442), Nether/ATOM) is misclassified as **Inactive** instead of **Uninitialized**. As a result:

- The pool detail page renders the "Pool Out of Range" header with an "Add Liquidity" CTA, instead of the "Initialize Pool" CTA.
- The CTA opens `<AddConcLiquidity>` (the generic price-range + strategy modal), which assumes a non-zero `current_sqrt_price` to derive the range and 50/50 split. With `current_sqrt_price = 0` the submit button is permanently stuck at "Invalid price range" and the user cannot create any position.
- The correct destination is `<AddInitialLiquidity>` ("Initial liquidity will be deposited as a full range position"), which broadcasts `sendCreateConcentratedLiquidityInitialFullRangePositionMsg` with `lowerTick = minTick`, `upperTick = maxTick` — the only message the chain accepts before a pool is initialized.

We mark chain-fallback CL pools as known-zero TVL when the chain itself reports they were never initialized, and harden the UI classification so the routing decision no longer depends on a TVL heuristic for a state we can read directly from chain data.

## Concepts (so the rest reads cleanly)

A CL pool sits in exactly one of three states. They are derivable directly from chain values, no TVL guessing required:

| State | `current_sqrt_price` | `current_tick_liquidity` | Meaning |
| --- | --- | --- | --- |
| **Uninitialized** | `0` | `0` | No first position has ever been created. |
| **Inactive** | `> 0` | `0` | Positions exist but all are out of range. |
| **Active** | `> 0` | `> 0` | At least one in-range position. |

Two files have to dispatch on these states:

- **`packages/web/components/pool-detail/concentrated.tsx`** — the pool detail page renders distinct copy/CTAs for all three states, so it needs to compute both `isUninitializedPool` and `isInactivePool`.
- **`packages/web/modals/add-liquidity.tsx`** — only branches *Uninitialized* vs *not-Uninitialized*. The inactive special-casing is handled downstream inside `<AddConcLiquidity>` via `addLiquidityConfig.isInactivePool` (a separate getter on the mobx config). So this file only needs `isUninitializedPool` and never has to look at `hasTVL`.

`hasTVL` is the existing heuristic `pool.tvlUnknown || totalFiatValueLocked > 0`. It's only useful for distinguishing **Active** from **Inactive** (both have non-zero sqrt price), and is unreliable for **Uninitialized** when SQS lacks data — which is exactly what bit us.

## Root cause

For pool 3442:

1. SQS returns the pool but with empty `balances` (no liquidity), so `getListedReservesFromSidecarPool` throws and the SQS path filters the pool out.
2. `getPool` falls back to `makePoolFromChainPool`, which always sets `tvlUnknown: true` for chain-fallback CL pools.
3. The UI sees `hasTVL = true` and the previous rule `isUninitializedPool = isSqrtPriceZero && isTickLiquidityZero && !hasTVL` evaluates to `false`. The pool is misclassified as Inactive and the user goes through the wrong flow.

## The fix (3 small changes)

### 1. Server — `packages/server/src/queries/complex/pools/providers/sidecar.ts`

In `makePoolFromChainPool`, when the chain pool is a CL pool with both `current_sqrt_price === 0` and `current_tick_liquidity === 0`, set `tvlUnknown: false`. The chain itself tells us the pool was never initialized, so TVL is genuinely zero — not unknown.

This single change is what unblocks pool 3442.

### 2. Pool detail page — `packages/web/components/pool-detail/concentrated.tsx`

Make the classification match the chain-truth table above and keep the two non-active tiers mutually exclusive:

```ts
// Before
const isInactivePool      = isTickLiquidityZero && hasTVL;
const isUninitializedPool = isSqrtPriceZero && isTickLiquidityZero && !hasTVL;

// After
const isUninitializedPool = isSqrtPriceZero && isTickLiquidityZero;
const isInactivePool      = !isUninitializedPool && isTickLiquidityZero && hasTVL;
```

`hasTVL` is **kept** here because Inactive vs Active still relies on it.

### 3. Add-liquidity modal — `packages/web/modals/add-liquidity.tsx`

This file only checks for Uninitialized (Inactive is handled by the downstream component, see Concepts), so:

```ts
// Before
const isUninitializedPool = isSqrtPriceZero && isTickLiquidityZero && !hasTVL;

// After
const isUninitializedPool = isSqrtPriceZero && isTickLiquidityZero;
```

`hasTVL` had no other reader in this file, so it's removed alongside the change. (Vercel `tsc` enforces unused locals.)

Changes 2 and 3 are defense-in-depth — they remove the dependence on TVL signals for a state we can read directly from the chain, so a future regression upstream (e.g. another `tvlUnknown` edge case) can't reintroduce this bug.

## Tests

- New unit tests in `packages/server/src/queries/complex/pools/providers/__tests__/sidecar.spec.ts` cover `makePoolFromChainPool` for both:
  - uninitialized CL chain-fallback pool → `tvlUnknown === false`
  - initialized CL chain-fallback pool → `tvlUnknown === true`
- `yarn workspace @osmosis-labs/server test --testPathPattern="sidecar"` → 7 / 7 passing.

## Manual QA

- [x] `/pool/3442` shows **Initialize pool**; the modal renders `AddInitialLiquidity` and broadcasts `MsgCreatePosition` with `lowerTick = minTick`, `upperTick = maxTick`.
- [x] An existing Inactive CL pool (positions exist but all out of range) still routes to the inactive flow — no regression.
- [x] An existing Active CL pool is unaffected.

## Out of scope

- Adding a USD price route for Nether or any specific asset.
- Magma/Quasar managed-vault UI work.
