### PR TITLE
(display)Pools page: Distinguish alloyed pools visually

### DIFF
--- a/packages/web/components/complex/pools-table.tsx
+++ b/packages/web/components/complex/pools-table.tsx
@@ -572,10 +572,9 @@ const PoolCompositionCell: PoolCellComponent = ({
                     "text-ion-400": Boolean(type === "concentrated"),
                     "text-bullish-300": Boolean(type === "stable"),
                     "text-rust-300": Boolean(
-                      type === "cosmwasm-transmuter" ||
-                        type === "cosmwasm-alloyed" ||
-                        type === "cosmwasm"
+                      type === "cosmwasm-transmuter" || type === "cosmwasm"
                     ),
+                    "text-osmoverse-300": Boolean(type === "cosmwasm-alloyed"),
                     "text-wosmongton-300": Boolean(
                       type === "cosmwasm-orderbook"
                     ),
@@ -610,7 +609,7 @@ const PoolCompositionCell: PoolCellComponent = ({
                     <Icon id="custom-pool" width={16} height={16} />
                   )}
                   {type === "cosmwasm-alloyed" && (
-                    <Icon id="custom-pool" width={16} height={16} />
+                    <Icon id="alloyed" width={16} height={16} />
                   )}
                   {type === "cosmwasm-orderbook" && (
                     <Icon id="open-book" width={16} height={16} />


### PR DESCRIPTION
The alloyed pool type currently shares its visual treatment with the generic cosmwasm group on the pools page, same custom-pool icon, same text-rust-300 tint, indistinguishable from any other unbranded cosmwasm pool despite a sprite being available. 

This PR gives cosmwasm-alloyed pools:
  - The dedicated alloyed sprite icon (which already exists in the codebase, previously used only inside variants-conversion.tsx)
  - A distinct text-osmoverse-300 tint, separating them from the rust-tinted transmuter/cosmwasm group
Consistent with how every other pool type (weighted, stable, concentrated, orderbook, astroport, white whale) has its own symbol and tint on this row.

<img width="448" height="392" alt="image" src="https://github.com/user-attachments/assets/4d22c1db-6d70-436b-bdf9-6f7d2404569e" />

## Out of scope
  - The swap route breakdown (split-route.tsx) is intentionally unchanged. Alloyed pools there continue to render alongside transmuter pools with the shared stableswap icon and "Transmuter" label. The implementation context in that UI deliberately conflates them as functionality is identical.

##  Test plan
- [x] Visit /pools and locate any alloyed pool by selections transmuter from the pool type dropdown. Verify the row shows the new alloyed sprite (concentric rings/orbits) instead of the custom-pool gear icon.
- [x] Verify the row tint is the neutral osmoverse-300 lavender rather than the rust red used by transmuter pools.
- [x] Compare side-by-side against a transmuter pool to confirm the two pool types now read as distinct.
- [x] Verify no regressions on adjacent pool types: weighted (purple/wosmongton), stable (green/bullish), concentrated (cyan/ion), orderbook (purple/wosmongton), astroport (PNG image), white whale (PNG image), transmuter (rust + custom-pool), generic cosmwasm (rust + no icon).

##  Risks

  - Visual-only change. No logic or data flow modified.
  - Single conditional touched. The diff is 7 lines in pools-table.tsx.
  - Sprite already used in production elsewhere (variants-conversion.tsx), so no rendering surprises.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only change that adjusts styling and icon selection for `cosmwasm-alloyed` pool rows without affecting data fetching or navigation.
> 
> **Overview**
> Updates the pools table row rendering to make `cosmwasm-alloyed` pools visually distinct from other CosmWasm pool types.
> 
> `cosmwasm-alloyed` now uses a dedicated `alloyed` icon and its own text tint (`text-osmoverse-300`), while the existing rust tint remains for `cosmwasm-transmuter` and generic `cosmwasm` pools.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 467ed4bf3dc68c7c3f4953bc911b367dec0dec96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->