### PR TITLE
fix(bridge): resolve Wormhole VAA from Osmosis tx and support Sui (MTN-74)

### DIFF
--- a/packages/web/components/bridge/__tests__/wormhole-redeem.spec.tsx
+++ b/packages/web/components/bridge/__tests__/wormhole-redeem.spec.tsx
@@ -325,7 +325,7 @@ describe("lookupOsmosisIbcPacket", () => {
     expect(global.fetch).toHaveBeenCalledTimes(2);
   });
 
-  it("throws when every LCD fails", async () => {
+  it("throws a provider-outage error when every LCD returns 5xx", async () => {
     global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 503 });
 
     await expect(
@@ -334,6 +334,44 @@ describe("lookupOsmosisIbcPacket", () => {
         "https://lcd-b.example",
       ])
     ).rejects.toThrow(/Could not fetch Osmosis tx/);
+  });
+
+  it("throws a tx-not-found error when every LCD returns 404", async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 404 });
+
+    await expect(
+      lookupOsmosisIbcPacket(OSMOSIS_HASH, [
+        "https://lcd-a.example",
+        "https://lcd-b.example",
+      ])
+    ).rejects.toThrow(/Osmosis transaction not found/);
+  });
+
+  it("returns null when the tx exists but has no Wormhole gateway send_packet", async () => {
+    global.fetch = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        tx_response: {
+          events: [
+            {
+              type: "send_packet",
+              attributes: [
+                { key: "packet_sequence", value: "1" },
+                // A different IBC channel, not the Wormhole gateway. We must
+                // not silently follow this packet to wormchain.
+                { key: "packet_src_channel", value: "channel-0" },
+                { key: "packet_dst_channel", value: "channel-141" },
+              ],
+            },
+          ],
+        },
+      }),
+    });
+
+    const packet = await lookupOsmosisIbcPacket(OSMOSIS_HASH, [
+      "https://lcd-a.example",
+    ]);
+    expect(packet).toBeNull();
   });
 });
 

--- a/packages/web/components/bridge/__tests__/wormhole-redeem.spec.tsx
+++ b/packages/web/components/bridge/__tests__/wormhole-redeem.spec.tsx
@@ -43,7 +43,7 @@ jest.mock("@osmosis-labs/utils", () => ({
 // `@mysten/wallet-standard` ships as ESM-only and isn't run through Jest's
 // transform pipeline, so we stub the surface our code touches.
 jest.mock("@mysten/wallet-standard", () => ({
-  getWallets: jest.fn(() => ({ get: () => [] })),
+  getWallets: jest.fn(() => ({ get: () => [], on: () => () => {} })),
   signAndExecuteTransaction: jest.fn(),
 }));
 

--- a/packages/web/components/bridge/__tests__/wormhole-redeem.spec.tsx
+++ b/packages/web/components/bridge/__tests__/wormhole-redeem.spec.tsx
@@ -40,6 +40,13 @@ jest.mock("@osmosis-labs/utils", () => ({
   ),
 }));
 
+// `@mysten/wallet-standard` ships as ESM-only and isn't run through Jest's
+// transform pipeline, so we stub the surface our code touches.
+jest.mock("@mysten/wallet-standard", () => ({
+  getWallets: jest.fn(() => ({ get: () => [] })),
+  signAndExecuteTransaction: jest.fn(),
+}));
+
 import {
   checkIfRedeemed,
   findWormchainRecvTx,

--- a/packages/web/components/bridge/__tests__/wormhole-redeem.spec.tsx
+++ b/packages/web/components/bridge/__tests__/wormhole-redeem.spec.tsx
@@ -1,5 +1,6 @@
 import "@testing-library/jest-dom";
 
+import { apiClient } from "@osmosis-labs/utils";
 import { render, screen } from "@testing-library/react";
 import React from "react";
 
@@ -34,9 +35,20 @@ jest.mock("@osmosis-labs/utils", () => ({
   shorten: jest.fn((s: string) =>
     s.length > 13 ? `${s.slice(0, 6)}...${s.slice(-5)}` : s
   ),
+  getSolanaExplorerUrl: jest.fn(
+    ({ hash }: { hash: string }) => `https://solscan.io/tx/${hash}`
+  ),
 }));
 
-import { checkIfRedeemed, WormholeRedeem } from "../wormhole-redeem";
+import {
+  checkIfRedeemed,
+  findWormchainRecvTx,
+  lookupOsmosisIbcPacket,
+  resolveOperation,
+  WormholeRedeem,
+} from "../wormhole-redeem";
+
+const mockedApiClient = apiClient as unknown as jest.Mock;
 
 const makeOperation = (overrides = {}) => ({
   id: "test-op",
@@ -147,5 +159,328 @@ describe("WormholeRedeem", () => {
 
     const button = screen.getByText("Lookup");
     expect(button).toBeDisabled();
+  });
+});
+
+const OSMOSIS_TX_EVENTS_FIXTURE = {
+  tx_response: {
+    events: [
+      {
+        type: "send_packet",
+        attributes: [
+          {
+            key: "packet_data",
+            value: JSON.stringify({
+              amount: "1430080000",
+              denom:
+                "transfer/channel-2186/factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/46YEtoSN1AcwgGSRoWruoS6bnVh8XpMp5aQTpKohCJYh",
+              memo: JSON.stringify({
+                gateway_ibc_token_bridge_payload: {
+                  gateway_transfer: {
+                    chain: 21,
+                    nonce: 6842,
+                    recipient: "8kM+eKz+5u9Ycfebyyhr4y3dcLS/4zaKwfNMW2i2G7A=",
+                    fee: "0",
+                  },
+                },
+              }),
+              receiver:
+                "wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx",
+              sender: "osmo1kwm9s5hjcvtxj9df6z5lxut2ecvaxstdyaz89m",
+            }),
+          },
+          { key: "packet_sequence", value: "43411" },
+          { key: "packet_src_channel", value: "channel-2186" },
+          { key: "packet_dst_channel", value: "channel-3" },
+        ],
+      },
+      {
+        type: "ibc_transfer",
+        attributes: [
+          {
+            key: "memo",
+            value: JSON.stringify({
+              gateway_ibc_token_bridge_payload: {
+                gateway_transfer: {
+                  chain: 21,
+                  nonce: 6842,
+                  recipient: "8kM+eKz+5u9Ycfebyyhr4y3dcLS/4zaKwfNMW2i2G7A=",
+                  fee: "0",
+                },
+              },
+            }),
+          },
+        ],
+      },
+    ],
+  },
+};
+
+const OPERATION_SUI_COMPLETED = {
+  id: "3104/aeb534c45c3049d380b9d9b966f9895f53abd4301bfaff407fa09dea8ae7a924/51994",
+  emitterChain: 3104,
+  emitterAddress: {
+    hex: "aeb534c45c3049d380b9d9b966f9895f53abd4301bfaff407fa09dea8ae7a924",
+    native:
+      "wormhole1466nf3zuxpya8q9emxukd7vftaf6h4psr0a07srl5zw74zh84yjq4lyjmh",
+  },
+  sequence: "51994",
+  vaa: { raw: btoa("fake-sui-vaa-bytes"), guardianSetIndex: 6 },
+  content: {
+    payload: {
+      payloadType: 1,
+      amount: "1430080000",
+      tokenAddress:
+        "0x9258181f5ceac8dbffb7030890243caed69a9599d2886d957a9cb7656af3bdb3",
+      tokenChain: 21,
+      toAddress:
+        "0xf2433e78acfee6ef5871f79bcb286be32ddd70b4bfe3368ac1f34c5b68b61bb0",
+      toChain: 21,
+      fee: "0",
+    },
+    standarizedProperties: {
+      appIds: ["PORTAL_TOKEN_BRIDGE"],
+      fromChain: 3104,
+      fromAddress: "",
+      toChain: 21,
+      toAddress:
+        "0xf2433e78acfee6ef5871f79bcb286be32ddd70b4bfe3368ac1f34c5b68b61bb0",
+      tokenChain: 21,
+      tokenAddress:
+        "0x9258181f5ceac8dbffb7030890243caed69a9599d2886d957a9cb7656af3bdb3",
+      amount: "1430080000",
+      fee: "0",
+    },
+  },
+  sourceChain: {
+    chainId: 3104,
+    timestamp: "2026-05-07T03:09:53Z",
+    transaction: {
+      txHash:
+        "0x6fd35ac0a9cf306fcf76c3d18d201aa5a152082caf0e58a6af47c07716953390",
+    },
+    from: "",
+    status: "confirmed",
+  },
+  targetChain: {
+    chainId: 21,
+    timestamp: "2026-05-07T21:29:11Z",
+    transaction: {
+      txHash: "6JagZJ2r2R5tCnXxdsoNirQgkK9fYXK2Avp4oqQoioFY",
+    },
+    status: "completed",
+  },
+  data: {
+    symbol: "SUI",
+    tokenAmount: "14.3008",
+    usdAmount: "13.87659536",
+  },
+};
+
+const OSMOSIS_HASH =
+  "76E201188AADA09CB977FD72626C857FB12253D86608B7E3E9F17F434818BED4";
+const WORMCHAIN_HASH =
+  "6FD35AC0A9CF306FCF76C3D18D201AA5A152082CAF0E58A6AF47C07716953390";
+
+describe("lookupOsmosisIbcPacket", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  it("extracts the gateway packet sequence + memo from the first LCD that responds", async () => {
+    global.fetch = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => OSMOSIS_TX_EVENTS_FIXTURE,
+    });
+
+    const packet = await lookupOsmosisIbcPacket(OSMOSIS_HASH, [
+      "https://lcd-a.example",
+    ]);
+    expect(packet).toEqual({
+      sequence: "43411",
+      srcChannel: "channel-2186",
+      dstChannel: "channel-3",
+      destinationChain: 21,
+      recipientBase64: "8kM+eKz+5u9Ycfebyyhr4y3dcLS/4zaKwfNMW2i2G7A=",
+    });
+  });
+
+  it("falls back to the next LCD on non-200 responses", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 404 })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => OSMOSIS_TX_EVENTS_FIXTURE,
+      });
+
+    const packet = await lookupOsmosisIbcPacket(OSMOSIS_HASH, [
+      "https://lcd-a.example",
+      "https://lcd-b.example",
+    ]);
+    expect(packet?.sequence).toBe("43411");
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws when every LCD fails", async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 503 });
+
+    await expect(
+      lookupOsmosisIbcPacket(OSMOSIS_HASH, [
+        "https://lcd-a.example",
+        "https://lcd-b.example",
+      ])
+    ).rejects.toThrow(/Could not fetch Osmosis tx/);
+  });
+});
+
+describe("findWormchainRecvTx", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("URL-encodes the Tendermint query and returns the first match hash", async () => {
+    const fetchMock = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        result: { txs: [{ hash: WORMCHAIN_HASH }], total_count: "1" },
+      }),
+    });
+    global.fetch = fetchMock;
+
+    const hash = await findWormchainRecvTx({
+      sequence: "43411",
+      srcChannel: "channel-2186",
+      wormchainRpc: "https://wormchain-rpc.example",
+    });
+    expect(hash).toBe(WORMCHAIN_HASH);
+    const calledUrl = fetchMock.mock.calls[0][0] as string;
+    expect(calledUrl).toContain("https://wormchain-rpc.example/tx_search?query=");
+    // The quoted query value should be URL-encoded (quote -> %22, etc.)
+    expect(decodeURIComponent(calledUrl.split("query=")[1])).toBe(
+      `"recv_packet.packet_sequence='43411' AND recv_packet.packet_src_channel='channel-2186'"`
+    );
+  });
+
+  it("returns null when wormchain has not received the packet yet", async () => {
+    global.fetch = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ result: { txs: [], total_count: "0" } }),
+    });
+
+    const hash = await findWormchainRecvTx({
+      sequence: "99999",
+      srcChannel: "channel-2186",
+    });
+    expect(hash).toBeNull();
+  });
+});
+
+describe("resolveOperation", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  it("returns the operation directly when Wormholescan indexes the user-supplied hash", async () => {
+    mockedApiClient.mockResolvedValueOnce({
+      operations: [OPERATION_SUI_COMPLETED],
+    });
+    const fetchSpy = jest.fn();
+    global.fetch = fetchSpy;
+
+    const resolved = await resolveOperation(WORMCHAIN_HASH);
+    expect(resolved).toEqual({
+      operation: OPERATION_SUI_COMPLETED,
+      resolvedTxHash: WORMCHAIN_HASH,
+      derivedFromOsmosis: false,
+    });
+    // No fallback chain hit when Wormholescan already has the operation.
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(mockedApiClient).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to Osmosis LCD -> wormchain RPC when Wormholescan does not index the hash", async () => {
+    // 1st call (direct lookup): empty result
+    // 2nd call (after wormchain resolution): the operation
+    mockedApiClient
+      .mockResolvedValueOnce({ operations: [] })
+      .mockResolvedValueOnce({ operations: [OPERATION_SUI_COMPLETED] });
+
+    global.fetch = jest
+      .fn()
+      // Osmosis LCD
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => OSMOSIS_TX_EVENTS_FIXTURE,
+      })
+      // Wormchain tx_search
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          result: { txs: [{ hash: WORMCHAIN_HASH }] },
+        }),
+      });
+
+    const resolved = await resolveOperation(OSMOSIS_HASH);
+    expect(resolved.operation).toEqual(OPERATION_SUI_COMPLETED);
+    expect(resolved.resolvedTxHash).toBe(WORMCHAIN_HASH);
+    expect(resolved.derivedFromOsmosis).toBe(true);
+    expect(mockedApiClient).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws a guardian-pending error when wormchain has the recv but Wormholescan has no VAA yet", async () => {
+    mockedApiClient
+      .mockResolvedValueOnce({ operations: [] })
+      .mockResolvedValueOnce({ operations: [] });
+
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => OSMOSIS_TX_EVENTS_FIXTURE,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: { txs: [{ hash: WORMCHAIN_HASH }] } }),
+      });
+
+    await expect(resolveOperation(OSMOSIS_HASH)).rejects.toThrow(
+      /guardians may still be signing/i
+    );
+  });
+
+  it("throws when wormchain has not received the packet yet (pending relay)", async () => {
+    mockedApiClient.mockResolvedValueOnce({ operations: [] });
+
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => OSMOSIS_TX_EVENTS_FIXTURE,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: { txs: [] } }),
+      });
+
+    await expect(resolveOperation(OSMOSIS_HASH)).rejects.toThrow(
+      /has not been relayed yet/i
+    );
+  });
+
+  it("rejects non-Cosmos-format hashes with the user-facing 'not found' message", async () => {
+    mockedApiClient.mockResolvedValueOnce({ operations: [] });
+
+    await expect(
+      resolveOperation("not-a-cosmos-hash-just-some-garbage-input")
+    ).rejects.toThrow(/Transaction not found/);
   });
 });

--- a/packages/web/components/bridge/__tests__/wormhole-redeem.spec.tsx
+++ b/packages/web/components/bridge/__tests__/wormhole-redeem.spec.tsx
@@ -360,7 +360,9 @@ describe("findWormchainRecvTx", () => {
     });
     expect(hash).toBe(WORMCHAIN_HASH);
     const calledUrl = fetchMock.mock.calls[0][0] as string;
-    expect(calledUrl).toContain("https://wormchain-rpc.example/tx_search?query=");
+    expect(calledUrl).toContain(
+      "https://wormchain-rpc.example/tx_search?query="
+    );
     // The quoted query value should be URL-encoded (quote -> %22, etc.)
     expect(decodeURIComponent(calledUrl.split("query=")[1])).toBe(
       `"recv_packet.packet_sequence='43411' AND recv_packet.packet_src_channel='channel-2186'"`

--- a/packages/web/components/bridge/__tests__/wormhole-redeem.spec.tsx
+++ b/packages/web/components/bridge/__tests__/wormhole-redeem.spec.tsx
@@ -401,7 +401,7 @@ describe("findWormchainRecvTx", () => {
     const hash = await findWormchainRecvTx({
       sequence: "43411",
       srcChannel: "channel-2186",
-      wormchainRpc: "https://wormchain-rpc.example",
+      wormchainRpcs: ["https://wormchain-rpc.example"],
     });
     expect(hash).toBe(WORMCHAIN_HASH);
     const calledUrl = fetchMock.mock.calls[0][0] as string;
@@ -425,6 +425,43 @@ describe("findWormchainRecvTx", () => {
       srcChannel: "channel-2186",
     });
     expect(hash).toBeNull();
+  });
+
+  it("falls back to the next Wormchain RPC on a non-200 response", async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 502 })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: { txs: [{ hash: WORMCHAIN_HASH }] } }),
+      });
+    global.fetch = fetchMock;
+
+    const hash = await findWormchainRecvTx({
+      sequence: "43411",
+      srcChannel: "channel-2186",
+      wormchainRpcs: [
+        "https://wormchain-rpc-a.example",
+        "https://wormchain-rpc-b.example",
+      ],
+    });
+    expect(hash).toBe(WORMCHAIN_HASH);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws when every Wormchain RPC is down", async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 503 });
+
+    await expect(
+      findWormchainRecvTx({
+        sequence: "1",
+        srcChannel: "channel-2186",
+        wormchainRpcs: [
+          "https://wormchain-rpc-a.example",
+          "https://wormchain-rpc-b.example",
+        ],
+      })
+    ).rejects.toThrow(/Could not query Wormchain RPC/);
   });
 });
 
@@ -529,5 +566,17 @@ describe("resolveOperation", () => {
     await expect(
       resolveOperation("not-a-cosmos-hash-just-some-garbage-input")
     ).rejects.toThrow(/Transaction not found/);
+  });
+
+  it("surfaces both possibilities when a 64-byte hex hash is on neither Wormholescan nor any Osmosis LCD", async () => {
+    // The hash format alone can't disambiguate: it could be a wrong
+    // Osmosis hash, or a valid Wormchain receive that Wormholescan
+    // simply hasn't indexed yet. The error must say so.
+    mockedApiClient.mockResolvedValueOnce({ operations: [] });
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 404 });
+
+    await expect(resolveOperation(OSMOSIS_HASH)).rejects.toThrow(
+      /Wormchain receive hash/i
+    );
   });
 });

--- a/packages/web/components/bridge/__tests__/wormhole-sui.spec.ts
+++ b/packages/web/components/bridge/__tests__/wormhole-sui.spec.ts
@@ -1,5 +1,10 @@
+type RegisteredWallet = { name: string };
+const mockGet: jest.Mock<RegisteredWallet[], []> = jest.fn(() => []);
+const mockOn: jest.Mock<() => void, [string, () => void]> = jest.fn(
+  (_event: string, _listener: () => void) => () => undefined
+);
 jest.mock("@mysten/wallet-standard", () => ({
-  getWallets: jest.fn(() => ({ get: () => [] })),
+  getWallets: jest.fn(() => ({ get: mockGet, on: mockOn })),
   signAndExecuteTransaction: jest.fn(),
 }));
 
@@ -9,11 +14,20 @@ import {
   executeSuiRedeem,
   getCoinTypeForSuiVAA,
   getSuiPackageIds,
+  listAvailableSuiWallets,
   normalizeSuiAddress,
+  subscribeToAvailableSuiWallets,
   SuiRedeemError,
   WORMHOLE_SUI_CORE_STATE,
   WORMHOLE_SUI_TOKEN_BRIDGE_STATE,
 } from "../wormhole-sui";
+
+afterEach(() => {
+  mockGet.mockReset();
+  mockGet.mockReturnValue([]);
+  mockOn.mockReset();
+  mockOn.mockImplementation(() => () => undefined);
+});
 
 describe("normalizeSuiAddress", () => {
   it("pads short hex strings to 32 bytes and lowercases", () => {
@@ -202,8 +216,10 @@ describe("executeSuiRedeem", () => {
   const recipient =
     "0xf2433e78acfee6ef5871f79bcb286be32ddd70b4bfe3368ac1f34c5b68b61bb0";
 
-  it("rejects when the connected Slush account isn't the recipient", async () => {
-    const slush = {
+  it("rejects when the connected Sui account isn't the recipient", async () => {
+    const connection = {
+      id: "slush" as const,
+      displayName: "Slush",
       address:
         "0x1111111111111111111111111111111111111111111111111111111111111111",
       wallet: {} as never,
@@ -216,7 +232,7 @@ describe("executeSuiRedeem", () => {
         tokenChain: 21,
         tokenAddressHex:
           "0x9258181f5ceac8dbffb7030890243caed69a9599d2886d957a9cb7656af3bdb3",
-        slush,
+        connection,
         suiClient: {
           getObject: jest.fn(),
           waitForTransaction: jest.fn(),
@@ -225,8 +241,38 @@ describe("executeSuiRedeem", () => {
     ).rejects.toMatchObject({ code: "wallet_mismatch" });
   });
 
+  it("includes the connected wallet displayName in the mismatch error so users know which wallet to switch", async () => {
+    const connection = {
+      id: "phantom" as const,
+      displayName: "Phantom",
+      address:
+        "0x1111111111111111111111111111111111111111111111111111111111111111",
+      wallet: {} as never,
+    };
+
+    await expect(
+      executeSuiRedeem({
+        vaaBase64: btoa("vaa"),
+        recipient,
+        tokenChain: 21,
+        tokenAddressHex:
+          "0x9258181f5ceac8dbffb7030890243caed69a9599d2886d957a9cb7656af3bdb3",
+        connection,
+        suiClient: {
+          getObject: jest.fn(),
+          waitForTransaction: jest.fn(),
+        },
+      })
+    ).rejects.toMatchObject({
+      code: "wallet_mismatch",
+      message: expect.stringContaining("Phantom"),
+    });
+  });
+
   it("rejects unsupported tokens before touching the wallet", async () => {
-    const slush = {
+    const connection = {
+      id: "slush" as const,
+      displayName: "Slush",
       address: recipient,
       wallet: {} as never,
     };
@@ -239,7 +285,7 @@ describe("executeSuiRedeem", () => {
         tokenChain: 2,
         tokenAddressHex:
           "0x000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-        slush,
+        connection,
         suiClient: {
           getObject,
           waitForTransaction: jest.fn(),
@@ -247,5 +293,68 @@ describe("executeSuiRedeem", () => {
       })
     ).rejects.toMatchObject({ code: "unsupported_token" });
     expect(getObject).not.toHaveBeenCalled();
+  });
+});
+
+describe("listAvailableSuiWallets", () => {
+  it("returns an empty list when no allowlisted wallets are registered", () => {
+    mockGet.mockReturnValue([{ name: "Random Other Wallet" }]);
+    expect(listAvailableSuiWallets()).toEqual([]);
+  });
+
+  it("returns Slush before Phantom (registry order) when both are present", () => {
+    // Registered in reverse order to make sure we sort by registry, not
+    // by Wallet Standard registration order.
+    mockGet.mockReturnValue([
+      { name: "Phantom" },
+      { name: "Slush" },
+      { name: "Some Other Wallet" },
+    ]);
+
+    const result = listAvailableSuiWallets();
+    expect(result.map((w) => w.id)).toEqual(["slush", "phantom"]);
+    expect(result[0].displayName).toBe("Slush");
+    expect(result[1].displayName).toBe("Phantom");
+  });
+
+  it("accepts Slush legacy names (`Sui Wallet`)", () => {
+    mockGet.mockReturnValue([{ name: "Sui Wallet" }]);
+    const result = listAvailableSuiWallets();
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("slush");
+  });
+});
+
+describe("subscribeToAvailableSuiWallets", () => {
+  it("emits the initial snapshot and re-emits on register/unregister events", () => {
+    const listeners: Record<string, () => void> = {};
+    mockOn.mockImplementation((event: string, listener: () => void) => {
+      listeners[event] = listener;
+      return () => {
+        delete listeners[event];
+      };
+    });
+    mockGet.mockReturnValue([{ name: "Slush" }]);
+
+    const callback = jest.fn();
+    const unsubscribe = subscribeToAvailableSuiWallets(callback);
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback.mock.calls[0][0].map((w: { id: string }) => w.id)).toEqual([
+      "slush",
+    ]);
+
+    // Simulate a Phantom wallet registering after subscription.
+    mockGet.mockReturnValue([{ name: "Slush" }, { name: "Phantom" }]);
+    listeners.register?.();
+
+    expect(callback).toHaveBeenCalledTimes(2);
+    expect(callback.mock.calls[1][0].map((w: { id: string }) => w.id)).toEqual([
+      "slush",
+      "phantom",
+    ]);
+
+    unsubscribe();
+    expect(Object.keys(listeners)).toEqual([]);
   });
 });

--- a/packages/web/components/bridge/__tests__/wormhole-sui.spec.ts
+++ b/packages/web/components/bridge/__tests__/wormhole-sui.spec.ts
@@ -1,5 +1,10 @@
-type RegisteredWallet = { name: string };
-const mockGet: jest.Mock<RegisteredWallet[], []> = jest.fn(() => []);
+type StubAccount = { address: string; chains: readonly string[] };
+type StubWallet = {
+  name: string;
+  accounts?: readonly StubAccount[];
+  features?: { "standard:connect"?: { connect: jest.Mock } };
+};
+const mockGet: jest.Mock<StubWallet[], []> = jest.fn(() => []);
 const mockOn: jest.Mock<() => void, [string, () => void]> = jest.fn(
   (_event: string, _listener: () => void) => () => undefined
 );
@@ -10,6 +15,7 @@ jest.mock("@mysten/wallet-standard", () => ({
 
 import {
   buildSuiRedeemTransaction,
+  connectSuiWallet,
   decodeBase64Vaa,
   executeSuiRedeem,
   getCoinTypeForSuiVAA,
@@ -356,5 +362,82 @@ describe("subscribeToAvailableSuiWallets", () => {
 
     unsubscribe();
     expect(Object.keys(listeners)).toEqual([]);
+  });
+});
+
+describe("connectSuiWallet", () => {
+  const SOLANA_ACCOUNT_BASE58 = "edvlfr6qnkbaphdwexqykgtcydyo4pmcvvdyfraapq6u";
+  const SUI_ACCOUNT_A =
+    "0x6c26da690be0f43f255a659dea1eaf7cca3dbc6ec431c300d61b0030e5a1897b";
+  const SUI_ACCOUNT_B =
+    "0xf2433e78acfee6ef5871f79bcb286be32ddd70b4bfe3368ac1f34c5b68b61bb0";
+
+  function makeStub(
+    name: string,
+    accounts: readonly StubAccount[]
+  ): StubWallet {
+    return {
+      name,
+      accounts,
+      features: { "standard:connect": { connect: jest.fn() } },
+    };
+  }
+
+  it("picks the Sui account out of a multi-chain Phantom wallet (bug: was picking Solana)", async () => {
+    // Reproduces the live bug: Phantom's `accounts[0]` is its Solana
+    // account, which when padded as hex produced the malformed
+    // 0x00…edvlfr… address the user saw.
+    mockGet.mockReturnValue([
+      makeStub("Phantom", [
+        { address: SOLANA_ACCOUNT_BASE58, chains: ["solana:mainnet"] },
+        { address: SUI_ACCOUNT_A, chains: ["sui:mainnet"] },
+      ]),
+    ]);
+
+    const conn = await connectSuiWallet("phantom");
+    expect(conn.address).toBe(SUI_ACCOUNT_A);
+    // The malformed pad-with-zeros form must not appear.
+    expect(conn.address).not.toContain(SOLANA_ACCOUNT_BASE58);
+  });
+
+  it("prefers the account matching `preferredAddress` so multi-Sui-account users skip the mismatch step", async () => {
+    mockGet.mockReturnValue([
+      makeStub("Slush", [
+        { address: SUI_ACCOUNT_A, chains: ["sui:mainnet"] },
+        { address: SUI_ACCOUNT_B, chains: ["sui:mainnet"] },
+      ]),
+    ]);
+
+    const conn = await connectSuiWallet("slush", SUI_ACCOUNT_B);
+    expect(conn.address).toBe(SUI_ACCOUNT_B);
+  });
+
+  it("falls back to the first Sui account when the preferred address is not present", async () => {
+    mockGet.mockReturnValue([
+      makeStub("Slush", [{ address: SUI_ACCOUNT_A, chains: ["sui:mainnet"] }]),
+    ]);
+
+    const conn = await connectSuiWallet("slush", SUI_ACCOUNT_B);
+    expect(conn.address).toBe(SUI_ACCOUNT_A);
+  });
+
+  it("throws no_sui_account when the wallet connects but exposes no Sui mainnet accounts", async () => {
+    mockGet.mockReturnValue([
+      makeStub("Phantom", [
+        { address: SOLANA_ACCOUNT_BASE58, chains: ["solana:mainnet"] },
+      ]),
+    ]);
+
+    await expect(connectSuiWallet("phantom")).rejects.toMatchObject({
+      code: "no_sui_account",
+      message: expect.stringContaining("Phantom"),
+    });
+  });
+
+  it("throws wallet_not_installed when the requested wallet is not registered", async () => {
+    mockGet.mockReturnValue([]);
+    await expect(connectSuiWallet("slush")).rejects.toMatchObject({
+      code: "wallet_not_installed",
+    });
   });
 });

--- a/packages/web/components/bridge/__tests__/wormhole-sui.spec.ts
+++ b/packages/web/components/bridge/__tests__/wormhole-sui.spec.ts
@@ -1,9 +1,27 @@
 type StubAccount = { address: string; chains: readonly string[] };
+type StubWalletFeatures = {
+  "standard:connect"?: { connect: jest.Mock };
+  "sui:signAndExecuteTransaction"?: object;
+};
 type StubWallet = {
   name: string;
   accounts?: readonly StubAccount[];
-  features?: { "standard:connect"?: { connect: jest.Mock } };
+  features?: StubWalletFeatures;
 };
+
+/**
+ * Default features for a Sui-capable Wallet Standard wallet. Used by
+ * helpers throughout the file so individual tests can override only
+ * what they care about (e.g. omit `sui:signAndExecuteTransaction` to
+ * simulate a Solana-only Phantom build).
+ */
+function suiCapableFeatures(): StubWalletFeatures {
+  return {
+    "standard:connect": { connect: jest.fn() },
+    "sui:signAndExecuteTransaction": {},
+  };
+}
+
 const mockGet: jest.Mock<StubWallet[], []> = jest.fn(() => []);
 const mockOn: jest.Mock<() => void, [string, () => void]> = jest.fn(
   (_event: string, _listener: () => void) => () => undefined
@@ -304,7 +322,9 @@ describe("executeSuiRedeem", () => {
 
 describe("listAvailableSuiWallets", () => {
   it("returns an empty list when no allowlisted wallets are registered", () => {
-    mockGet.mockReturnValue([{ name: "Random Other Wallet" }]);
+    mockGet.mockReturnValue([
+      { name: "Random Other Wallet", features: suiCapableFeatures() },
+    ]);
     expect(listAvailableSuiWallets()).toEqual([]);
   });
 
@@ -312,9 +332,9 @@ describe("listAvailableSuiWallets", () => {
     // Registered in reverse order to make sure we sort by registry, not
     // by Wallet Standard registration order.
     mockGet.mockReturnValue([
-      { name: "Phantom" },
-      { name: "Slush" },
-      { name: "Some Other Wallet" },
+      { name: "Phantom", features: suiCapableFeatures() },
+      { name: "Slush", features: suiCapableFeatures() },
+      { name: "Some Other Wallet", features: suiCapableFeatures() },
     ]);
 
     const result = listAvailableSuiWallets();
@@ -324,10 +344,23 @@ describe("listAvailableSuiWallets", () => {
   });
 
   it("accepts Slush legacy names (`Sui Wallet`)", () => {
-    mockGet.mockReturnValue([{ name: "Sui Wallet" }]);
+    mockGet.mockReturnValue([
+      { name: "Sui Wallet", features: suiCapableFeatures() },
+    ]);
     const result = listAvailableSuiWallets();
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe("slush");
+  });
+
+  it("skips a name-matching wallet that doesn't advertise the Sui sign feature", () => {
+    // Phantom registers a separate Solana-only wallet under the same
+    // "Phantom" name; if it doesn't expose sui:signAndExecuteTransaction
+    // we can't redeem through it and shouldn't offer it as an option.
+    const solanaOnly: StubWalletFeatures = {
+      "standard:connect": { connect: jest.fn() },
+    };
+    mockGet.mockReturnValue([{ name: "Phantom", features: solanaOnly }]);
+    expect(listAvailableSuiWallets()).toEqual([]);
   });
 });
 
@@ -340,7 +373,9 @@ describe("subscribeToAvailableSuiWallets", () => {
         delete listeners[event];
       };
     });
-    mockGet.mockReturnValue([{ name: "Slush" }]);
+    mockGet.mockReturnValue([
+      { name: "Slush", features: suiCapableFeatures() },
+    ]);
 
     const callback = jest.fn();
     const unsubscribe = subscribeToAvailableSuiWallets(callback);
@@ -351,7 +386,10 @@ describe("subscribeToAvailableSuiWallets", () => {
     ]);
 
     // Simulate a Phantom wallet registering after subscription.
-    mockGet.mockReturnValue([{ name: "Slush" }, { name: "Phantom" }]);
+    mockGet.mockReturnValue([
+      { name: "Slush", features: suiCapableFeatures() },
+      { name: "Phantom", features: suiCapableFeatures() },
+    ]);
     listeners.register?.();
 
     expect(callback).toHaveBeenCalledTimes(2);
@@ -374,12 +412,13 @@ describe("connectSuiWallet", () => {
 
   function makeStub(
     name: string,
-    accounts: readonly StubAccount[]
+    accounts: readonly StubAccount[],
+    featureOverrides?: Partial<StubWalletFeatures>
   ): StubWallet {
     return {
       name,
       accounts,
-      features: { "standard:connect": { connect: jest.fn() } },
+      features: { ...suiCapableFeatures(), ...featureOverrides },
     };
   }
 
@@ -437,6 +476,38 @@ describe("connectSuiWallet", () => {
   it("throws wallet_not_installed when the requested wallet is not registered", async () => {
     mockGet.mockReturnValue([]);
     await expect(connectSuiWallet("slush")).rejects.toMatchObject({
+      code: "wallet_not_installed",
+    });
+  });
+
+  it("accepts a Phantom Sui account that has an empty per-account chains array (Phantom quirk)", async () => {
+    // Phantom doesn't always populate `chains` for its Sui account but
+    // the address shape is unambiguously Sui (32-byte hex). Without
+    // this allowance the user gets a misleading no_sui_account error
+    // despite having a funded Sui account in Phantom — the live repro
+    // bug behind this fix.
+    mockGet.mockReturnValue([
+      makeStub("Phantom", [
+        { address: SOLANA_ACCOUNT_BASE58, chains: ["solana:mainnet"] },
+        { address: SUI_ACCOUNT_A, chains: [] },
+      ]),
+    ]);
+
+    const conn = await connectSuiWallet("phantom");
+    expect(conn.address).toBe(SUI_ACCOUNT_A);
+  });
+
+  it("throws wallet_not_installed when a name-matching wallet lacks sui:signAndExecuteTransaction", async () => {
+    // Solana-only Phantom build: same name, no Sui sign feature.
+    mockGet.mockReturnValue([
+      {
+        name: "Phantom",
+        accounts: [{ address: SUI_ACCOUNT_A, chains: ["sui:mainnet"] }],
+        features: { "standard:connect": { connect: jest.fn() } },
+      },
+    ]);
+
+    await expect(connectSuiWallet("phantom")).rejects.toMatchObject({
       code: "wallet_not_installed",
     });
   });

--- a/packages/web/components/bridge/__tests__/wormhole-sui.spec.ts
+++ b/packages/web/components/bridge/__tests__/wormhole-sui.spec.ts
@@ -1,0 +1,251 @@
+jest.mock("@mysten/wallet-standard", () => ({
+  getWallets: jest.fn(() => ({ get: () => [] })),
+  signAndExecuteTransaction: jest.fn(),
+}));
+
+import {
+  buildSuiRedeemTransaction,
+  decodeBase64Vaa,
+  executeSuiRedeem,
+  getCoinTypeForSuiVAA,
+  getSuiPackageIds,
+  normalizeSuiAddress,
+  SuiRedeemError,
+  WORMHOLE_SUI_CORE_STATE,
+  WORMHOLE_SUI_TOKEN_BRIDGE_STATE,
+} from "../wormhole-sui";
+
+describe("normalizeSuiAddress", () => {
+  it("pads short hex strings to 32 bytes and lowercases", () => {
+    expect(normalizeSuiAddress("0xABC")).toBe(
+      "0x0000000000000000000000000000000000000000000000000000000000000abc"
+    );
+  });
+
+  it("leaves fully-formed 32-byte addresses alone", () => {
+    const addr =
+      "0xf2433e78acfee6ef5871f79bcb286be32ddd70b4bfe3368ac1f34c5b68b61bb0";
+    expect(normalizeSuiAddress(addr)).toBe(addr);
+  });
+
+  it("accepts un-prefixed hex and lowercases mixed case", () => {
+    expect(
+      normalizeSuiAddress(
+        "F2433E78ACFEE6EF5871F79BCB286BE32DDD70B4BFE3368AC1F34C5B68B61BB0"
+      )
+    ).toBe(
+      "0xf2433e78acfee6ef5871f79bcb286be32ddd70b4bfe3368ac1f34c5b68b61bb0"
+    );
+  });
+});
+
+describe("getCoinTypeForSuiVAA", () => {
+  it("returns 0x2::sui::SUI for the canonical SUI native address", () => {
+    expect(
+      getCoinTypeForSuiVAA(
+        21,
+        "0x9258181f5ceac8dbffb7030890243caed69a9599d2886d957a9cb7656af3bdb3"
+      )
+    ).toBe("0x2::sui::SUI");
+  });
+
+  it("normalizes the address before lookup (works without the 0x prefix)", () => {
+    expect(
+      getCoinTypeForSuiVAA(
+        21,
+        "9258181f5ceac8dbffb7030890243caed69a9599d2886d957a9cb7656af3bdb3"
+      )
+    ).toBe("0x2::sui::SUI");
+  });
+
+  it("throws SuiRedeemError(unsupported_token) for unknown tokens", () => {
+    expect(() =>
+      getCoinTypeForSuiVAA(
+        2, // chain 2 = Ethereum (e.g. USDC bridged from ETH)
+        "0x000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+      )
+    ).toThrow(SuiRedeemError);
+    try {
+      getCoinTypeForSuiVAA(2, "0xdeadbeef");
+    } catch (err) {
+      expect(err).toBeInstanceOf(SuiRedeemError);
+      expect((err as SuiRedeemError).code).toBe("unsupported_token");
+    }
+  });
+});
+
+describe("decodeBase64Vaa", () => {
+  it("round-trips through atob to produce bytes", () => {
+    const bytes = decodeBase64Vaa(btoa("hello"));
+    expect(Array.from(bytes)).toEqual([
+      "h".charCodeAt(0),
+      "e".charCodeAt(0),
+      "l".charCodeAt(0),
+      "l".charCodeAt(0),
+      "o".charCodeAt(0),
+    ]);
+  });
+});
+
+describe("getSuiPackageIds", () => {
+  it("returns the upgrade_cap.fields.package from both state objects", async () => {
+    const getObject = jest.fn(async ({ id }: { id: string }) => {
+      if (id === WORMHOLE_SUI_CORE_STATE) {
+        return {
+          data: {
+            content: {
+              dataType: "moveObject",
+              fields: {
+                upgrade_cap: { fields: { package: "0xcorePkgAbc" } },
+              },
+            },
+          },
+        };
+      }
+      if (id === WORMHOLE_SUI_TOKEN_BRIDGE_STATE) {
+        return {
+          data: {
+            content: {
+              dataType: "moveObject",
+              fields: {
+                upgrade_cap: { fields: { package: "0xtbPkgDef" } },
+              },
+            },
+          },
+        };
+      }
+      throw new Error(`unexpected id: ${id}`);
+    });
+
+    const ids = await getSuiPackageIds({ getObject });
+    expect(ids.corePackageId).toBe("0xcorePkgAbc");
+    expect(ids.tokenBridgePackageId).toBe("0xtbPkgDef");
+    expect(getObject).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws when the state object isn't a Move object", async () => {
+    const getObject = jest.fn(async () => ({
+      data: { content: { dataType: "package" } },
+    }));
+
+    await expect(getSuiPackageIds({ getObject })).rejects.toThrow(
+      SuiRedeemError
+    );
+  });
+
+  it("throws when the upgrade_cap.package field is missing", async () => {
+    const getObject = jest.fn(async () => ({
+      data: {
+        content: {
+          dataType: "moveObject",
+          fields: { upgrade_cap: { fields: {} } },
+        },
+      },
+    }));
+
+    await expect(getSuiPackageIds({ getObject })).rejects.toThrow(
+      SuiRedeemError
+    );
+  });
+});
+
+describe("buildSuiRedeemTransaction", () => {
+  // Avoid base64 decoding noise in the move-call shape assertions: a tiny
+  // payload is fine for asserting structure.
+  const vaaBase64 = btoa("X");
+  const FAKE_CORE_PKG =
+    "0x1111111111111111111111111111111111111111111111111111111111111111";
+  const FAKE_TB_PKG =
+    "0x2222222222222222222222222222222222222222222222222222222222222222";
+
+  it("emits the five Wormhole Move calls in the canonical order", async () => {
+    const tx = await buildSuiRedeemTransaction({
+      vaaBase64,
+      coinType: "0x2::sui::SUI",
+      packageIds: {
+        corePackageId: FAKE_CORE_PKG,
+        tokenBridgePackageId: FAKE_TB_PKG,
+      },
+    });
+
+    const commands = tx
+      .getData()
+      .commands.filter(
+        (c): c is typeof c & { MoveCall: NonNullable<typeof c.MoveCall> } =>
+          Boolean(c.MoveCall)
+      );
+    expect(commands).toHaveLength(5);
+
+    const targets = commands.map(
+      (c) =>
+        `${c.MoveCall.package}::${c.MoveCall.module}::${c.MoveCall.function}`
+    );
+    expect(targets).toEqual([
+      `${FAKE_CORE_PKG}::vaa::parse_and_verify`,
+      `${FAKE_TB_PKG}::vaa::verify_only_once`,
+      `${FAKE_TB_PKG}::complete_transfer::authorize_transfer`,
+      `${FAKE_TB_PKG}::complete_transfer::redeem_relayer_payout`,
+      `${FAKE_TB_PKG}::coin_utils::return_nonzero`,
+    ]);
+
+    // The three CoinType-parametric calls must carry the type argument.
+    expect(commands[2].MoveCall.typeArguments).toEqual(["0x2::sui::SUI"]);
+    expect(commands[3].MoveCall.typeArguments).toEqual(["0x2::sui::SUI"]);
+    expect(commands[4].MoveCall.typeArguments).toEqual(["0x2::sui::SUI"]);
+    // The VAA verification calls are not CoinType-generic.
+    expect(commands[0].MoveCall.typeArguments).toEqual([]);
+    expect(commands[1].MoveCall.typeArguments).toEqual([]);
+  });
+});
+
+describe("executeSuiRedeem", () => {
+  const recipient =
+    "0xf2433e78acfee6ef5871f79bcb286be32ddd70b4bfe3368ac1f34c5b68b61bb0";
+
+  it("rejects when the connected Slush account isn't the recipient", async () => {
+    const slush = {
+      address:
+        "0x1111111111111111111111111111111111111111111111111111111111111111",
+      wallet: {} as never,
+    };
+
+    await expect(
+      executeSuiRedeem({
+        vaaBase64: btoa("vaa"),
+        recipient,
+        tokenChain: 21,
+        tokenAddressHex:
+          "0x9258181f5ceac8dbffb7030890243caed69a9599d2886d957a9cb7656af3bdb3",
+        slush,
+        suiClient: {
+          getObject: jest.fn(),
+          waitForTransaction: jest.fn(),
+        },
+      })
+    ).rejects.toMatchObject({ code: "wallet_mismatch" });
+  });
+
+  it("rejects unsupported tokens before touching the wallet", async () => {
+    const slush = {
+      address: recipient,
+      wallet: {} as never,
+    };
+    const getObject = jest.fn();
+
+    await expect(
+      executeSuiRedeem({
+        vaaBase64: btoa("vaa"),
+        recipient,
+        tokenChain: 2,
+        tokenAddressHex:
+          "0x000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        slush,
+        suiClient: {
+          getObject,
+          waitForTransaction: jest.fn(),
+        },
+      })
+    ).rejects.toMatchObject({ code: "unsupported_token" });
+    expect(getObject).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/components/bridge/wormhole-redeem.tsx
+++ b/packages/web/components/bridge/wormhole-redeem.tsx
@@ -11,6 +11,14 @@ import { FunctionComponent, useCallback, useEffect, useState } from "react";
 import { Spinner } from "~/components/loaders";
 import { formatPretty } from "~/utils/formatter";
 
+import {
+  connectSlush,
+  executeSuiRedeem,
+  getCoinTypeForSuiVAA,
+  type SlushConnection,
+  SuiRedeemError,
+} from "./wormhole-sui";
+
 const WORMHOLESCAN_API = "https://api.wormholescan.io/api/v1";
 const WORMHOLESCAN_UI = "https://wormholescan.io";
 const SOLANA_RPC = "https://solana-rpc.publicnode.com";
@@ -131,9 +139,11 @@ type RedeemStatus =
   | "error";
 
 const PHANTOM_DOWNLOAD_URL = "https://phantom.app/";
+const SLUSH_DOWNLOAD_URL = "https://slush.app/";
 
 type RedeemError =
   | { type: "phantom_not_installed" }
+  | { type: "slush_not_installed" }
   | { type: "generic"; message: string }
   | null;
 
@@ -395,11 +405,10 @@ function getDestinationExplorerUrl(
 }
 
 /**
- * Redemption panel for non-Solana destinations. We don't ship a native
- * Sui/EVM wallet integration here — instead we surface the looked-up VAA
- * and deep-link to Wormholescan's existing multi-chain redeem UI, which
- * already supports Sui (Sui Wallet/Suiet/Backpack), EVM (MetaMask), and
- * other Wormhole destinations via Wallet Standard.
+ * Generic fallback panel for destinations we don't natively support
+ * here (EVM chains, etc.) and for Sui transfers carrying token types
+ * the native redeem path doesn't know about. Surfaces the resolved
+ * VAA and deep-links to Wormholescan's multi-chain redeem UI.
  */
 const NonSolanaRedeemPanel: FunctionComponent<{
   operation: OperationData;
@@ -466,6 +475,110 @@ const NonSolanaRedeemPanel: FunctionComponent<{
   );
 };
 
+/**
+ * Native Sui redemption panel using Slush (formerly "Sui Wallet").
+ * Speaks the Sui Wallet Standard directly via `@mysten/wallet-standard`,
+ * with no React adapter / dApp-kit dependency. If the token type isn't
+ * in the known mapping we fall through to `NonSolanaRedeemPanel`.
+ */
+const SuiRedeemPanel: FunctionComponent<{
+  operation: OperationData;
+  wormholescanHash: string;
+  onCopy: (value: string, hint: string) => void;
+  copyHint: string | null;
+  slush: SlushConnection | null;
+  onConnectSlush: () => Promise<void>;
+  onRedeem: () => Promise<void>;
+  isLoading: boolean;
+  status: RedeemStatus;
+}> = ({
+  operation,
+  wormholescanHash,
+  onCopy,
+  copyHint,
+  slush,
+  onConnectSlush,
+  onRedeem,
+  isLoading,
+  status,
+}) => {
+  const recipient = operation.content.standarizedProperties.toAddress;
+  const tokenChain = operation.content.payload.tokenChain;
+  const tokenAddress = operation.content.payload.tokenAddress;
+
+  // If we don't recognize the token type we fall back to the generic
+  // Wormholescan-link panel: the on-chain CoinType lookup requires
+  // a chain-specific dynamic-field walk we deliberately don't ship.
+  try {
+    getCoinTypeForSuiVAA(tokenChain, tokenAddress);
+  } catch (err) {
+    if (err instanceof SuiRedeemError && err.code === "unsupported_token") {
+      return (
+        <NonSolanaRedeemPanel
+          operation={operation}
+          wormholescanHash={wormholescanHash}
+          onCopy={onCopy}
+          copyHint={copyHint}
+        />
+      );
+    }
+    throw err;
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="rounded-lg border border-ammelia-600 bg-ammelia-600/10 p-3 text-sm text-ammelia-200">
+        VAA is signed and ready. Connect Slush to redeem natively on Sui.
+      </div>
+
+      <div className="rounded-lg bg-osmoverse-900 p-3 text-sm">
+        <div className="mb-2 flex items-center justify-between">
+          <span className="text-osmoverse-400">Recipient (Sui)</span>
+          <button
+            onClick={() => onCopy(recipient, "recipient")}
+            className="text-xs text-wosmongton-300 underline"
+          >
+            {copyHint === "recipient" ? "Copied" : "Copy"}
+          </button>
+        </div>
+        <div className="break-all font-mono text-xs text-white-full">
+          {recipient}
+        </div>
+      </div>
+
+      {!slush ? (
+        <button
+          onClick={onConnectSlush}
+          disabled={isLoading}
+          className="w-full rounded-lg bg-wosmongton-700 px-4 py-3 text-sm font-medium text-white-full transition-colors hover:bg-wosmongton-600 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Connect Slush Wallet
+        </button>
+      ) : (
+        <div className="space-y-3">
+          <div className="flex items-center justify-between rounded-lg bg-osmoverse-900 p-3 text-sm">
+            <span className="text-osmoverse-400">Connected Slush account</span>
+            <span className="font-mono text-xs text-white-full">
+              {shorten(slush.address)}
+            </span>
+          </div>
+          <button
+            onClick={onRedeem}
+            disabled={isLoading}
+            className="w-full rounded-lg bg-wosmongton-700 px-4 py-3 text-sm font-medium text-white-full transition-colors hover:bg-wosmongton-600 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {status === "signing"
+              ? "Confirm in Slush..."
+              : status === "submitting"
+              ? "Submitting on Sui..."
+              : "Redeem on Sui"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
 export const WormholeRedeem: FunctionComponent = () => {
   const [txHash, setTxHash] = useState("");
   const [status, setStatus] = useState<RedeemStatus>("idle");
@@ -482,6 +595,10 @@ export const WormholeRedeem: FunctionComponent = () => {
   const [copyHint, setCopyHint] = useState<string | null>(null);
 
   const [phantom, setPhantom] = useState<any>(null);
+  const [slush, setSlush] = useState<SlushConnection | null>(null);
+  const [suiRedeemTxDigest, setSuiRedeemTxDigest] = useState<string | null>(
+    null
+  );
 
   useEffect(() => {
     const detect = () =>
@@ -595,6 +712,50 @@ export const WormholeRedeem: FunctionComponent = () => {
     phantom.on?.("accountChanged", onAccountChanged);
     return () => phantom.off?.("accountChanged", onAccountChanged);
   }, [phantom]);
+
+  const connectSlushWallet = useCallback(async () => {
+    setError(null);
+    try {
+      const conn = await connectSlush();
+      setSlush(conn);
+    } catch (err) {
+      if (err instanceof SuiRedeemError && err.code === "slush_not_installed") {
+        setError({ type: "slush_not_installed" });
+        return;
+      }
+      setError({
+        type: "generic",
+        message:
+          err instanceof Error ? err.message : "Failed to connect Slush.",
+      });
+    }
+  }, []);
+
+  const executeSuiRedeemFlow = useCallback(async () => {
+    if (!operation || !slush) return;
+    setError(null);
+    setSuiRedeemTxDigest(null);
+
+    try {
+      setStatus("signing");
+      const digest = await executeSuiRedeem({
+        vaaBase64: operation.vaa.raw,
+        recipient: operation.content.standarizedProperties.toAddress,
+        tokenChain: operation.content.payload.tokenChain,
+        tokenAddressHex: operation.content.payload.tokenAddress,
+        slush,
+      });
+      setStatus("submitting");
+      setSuiRedeemTxDigest(digest);
+      setStatus("success");
+    } catch (err) {
+      setError({
+        type: "generic",
+        message: err instanceof Error ? err.message : "Sui redeem failed",
+      });
+      setStatus("error");
+    }
+  }, [operation, slush]);
 
   const executeRedeem = useCallback(async () => {
     if (!operation || !solanaWallet || !phantom) return;
@@ -737,7 +898,7 @@ export const WormholeRedeem: FunctionComponent = () => {
         <p className="mb-4 text-sm text-osmoverse-300">
           If you have a Wormhole bridge transfer from Osmosis that is stuck,
           paste the Osmosis transaction hash below to look it up and complete
-          the redemption on Solana.
+          the redemption on Solana (Phantom) or Sui (Slush).
         </p>
 
         {/* TX Hash Input */}
@@ -778,6 +939,19 @@ export const WormholeRedeem: FunctionComponent = () => {
                   Install Phantom
                 </a>{" "}
                 to redeem.
+              </>
+            ) : error.type === "slush_not_installed" ? (
+              <>
+                Slush wallet not detected.{" "}
+                <a
+                  href={SLUSH_DOWNLOAD_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline"
+                >
+                  Install Slush
+                </a>{" "}
+                to redeem on Sui.
               </>
             ) : (
               error.message
@@ -949,8 +1123,25 @@ export const WormholeRedeem: FunctionComponent = () => {
                 </>
               )}
 
+            {status !== "already_redeemed" &&
+              operation.content.payload.toChain === CHAIN_ID.sui &&
+              resolvedTxHash && (
+                <SuiRedeemPanel
+                  operation={operation}
+                  wormholescanHash={resolvedTxHash}
+                  onCopy={copyToClipboard}
+                  copyHint={copyHint}
+                  slush={slush}
+                  onConnectSlush={connectSlushWallet}
+                  onRedeem={executeSuiRedeemFlow}
+                  isLoading={isLoading}
+                  status={status}
+                />
+              )}
+
             {status === "ready" &&
               operation.content.payload.toChain !== CHAIN_ID.solana &&
+              operation.content.payload.toChain !== CHAIN_ID.sui &&
               resolvedTxHash && (
                 <NonSolanaRedeemPanel
                   operation={operation}
@@ -960,12 +1151,45 @@ export const WormholeRedeem: FunctionComponent = () => {
                 />
               )}
 
+            {suiRedeemTxDigest && (
+              <div
+                className={`rounded-lg border p-3 text-sm ${
+                  status === "success"
+                    ? "border-bullish-600 bg-bullish-600/10 text-bullish-200"
+                    : "border-ammelia-600 bg-ammelia-600/10 text-ammelia-200"
+                }`}
+              >
+                {status === "success"
+                  ? "Transfer redeemed on Sui."
+                  : "Redeem submitted to Sui."}
+                <a
+                  href={`https://suiscan.xyz/mainnet/tx/${encodeURIComponent(
+                    suiRedeemTxDigest
+                  )}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="ml-1 underline"
+                >
+                  View on Suiscan
+                </a>
+              </div>
+            )}
+
             {(status === "signing" || status === "submitting") && (
               <div className="flex items-center gap-2 text-sm text-osmoverse-300">
                 <Spinner className="h-4 w-4" />
-                {status === "signing"
-                  ? "Waiting for wallet signature..."
-                  : "Submitting transaction to Solana..."}
+                {(() => {
+                  const isSui =
+                    operation.content.payload.toChain === CHAIN_ID.sui;
+                  if (status === "signing") {
+                    return isSui
+                      ? "Waiting for Slush signature..."
+                      : "Waiting for wallet signature...";
+                  }
+                  return isSui
+                    ? "Submitting transaction to Sui..."
+                    : "Submitting transaction to Solana...";
+                })()}
               </div>
             )}
 

--- a/packages/web/components/bridge/wormhole-redeem.tsx
+++ b/packages/web/components/bridge/wormhole-redeem.tsx
@@ -12,11 +12,16 @@ import { Spinner } from "~/components/loaders";
 import { formatPretty } from "~/utils/formatter";
 
 import {
-  connectSlush,
+  type AvailableSuiWallet,
+  connectSuiWallet,
   executeSuiRedeem,
   getCoinTypeForSuiVAA,
-  type SlushConnection,
+  listAvailableSuiWallets,
+  subscribeToAvailableSuiWallets,
+  SUI_WALLET_REGISTRY,
   SuiRedeemError,
+  type SuiWalletConnection,
+  type SuiWalletId,
 } from "./wormhole-sui";
 
 const WORMHOLESCAN_API = "https://api.wormholescan.io/api/v1";
@@ -169,11 +174,10 @@ type RedeemStatus =
   | "error";
 
 const PHANTOM_DOWNLOAD_URL = "https://phantom.app/";
-const SLUSH_DOWNLOAD_URL = "https://slush.app/";
 
 type RedeemError =
   | { type: "phantom_not_installed" }
-  | { type: "slush_not_installed" }
+  | { type: "sui_wallet_not_installed" }
   | { type: "generic"; message: string }
   | null;
 
@@ -541,18 +545,20 @@ const NonSolanaRedeemPanel: FunctionComponent<{
 };
 
 /**
- * Native Sui redemption panel using Slush (formerly "Sui Wallet").
- * Speaks the Sui Wallet Standard directly via `@mysten/wallet-standard`,
- * with no React adapter / dApp-kit dependency. If the token type isn't
- * in the known mapping we fall through to `NonSolanaRedeemPanel`.
+ * Native Sui redemption panel. Speaks the Sui Wallet Standard directly
+ * via `@mysten/wallet-standard`, with no React adapter / dApp-kit
+ * dependency. Detects allowlisted Sui wallets (Slush + Phantom) and
+ * lets the user pick which one to connect. If the token type isn't in
+ * the known mapping we fall through to `NonSolanaRedeemPanel`.
  */
 const SuiRedeemPanel: FunctionComponent<{
   operation: OperationData;
   wormholescanHash: string;
   onCopy: (value: string, hint: string) => void;
   copyHint: string | null;
-  slush: SlushConnection | null;
-  onConnectSlush: () => Promise<void>;
+  availableSuiWallets: AvailableSuiWallet[];
+  connection: SuiWalletConnection | null;
+  onConnect: (walletId: SuiWalletId) => Promise<void>;
   onRedeem: () => Promise<void>;
   isLoading: boolean;
   status: RedeemStatus;
@@ -561,8 +567,9 @@ const SuiRedeemPanel: FunctionComponent<{
   wormholescanHash,
   onCopy,
   copyHint,
-  slush,
-  onConnectSlush,
+  availableSuiWallets,
+  connection,
+  onConnect,
   onRedeem,
   isLoading,
   status,
@@ -593,7 +600,8 @@ const SuiRedeemPanel: FunctionComponent<{
   return (
     <div className="space-y-3">
       <div className="rounded-lg border border-ammelia-600 bg-ammelia-600/10 p-3 text-sm text-ammelia-200">
-        VAA is signed and ready. Connect Slush to redeem natively on Sui.
+        VAA is signed and ready. Connect a Sui wallet (Slush or Phantom) to
+        redeem natively on Sui.
       </div>
 
       <div className="rounded-lg bg-osmoverse-900 p-3 text-sm">
@@ -611,20 +619,48 @@ const SuiRedeemPanel: FunctionComponent<{
         </div>
       </div>
 
-      {!slush ? (
-        <button
-          onClick={onConnectSlush}
-          disabled={isLoading}
-          className="w-full rounded-lg bg-wosmongton-700 px-4 py-3 text-sm font-medium text-white-full transition-colors hover:bg-wosmongton-600 disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          Connect Slush Wallet
-        </button>
+      {!connection ? (
+        availableSuiWallets.length === 0 ? (
+          <div className="rounded-lg border border-osmoverse-600 bg-osmoverse-900 p-3 text-sm text-osmoverse-200">
+            <div className="mb-2">
+              No supported Sui wallet detected. Install one to redeem natively:
+            </div>
+            <div className="flex flex-col gap-1">
+              {SUI_WALLET_REGISTRY.map((descriptor) => (
+                <a
+                  key={descriptor.id}
+                  href={descriptor.downloadUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-wosmongton-300 underline"
+                >
+                  Install {descriptor.displayName}
+                </a>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {availableSuiWallets.map((w) => (
+              <button
+                key={w.id}
+                onClick={() => onConnect(w.id)}
+                disabled={isLoading}
+                className="w-full rounded-lg bg-wosmongton-700 px-4 py-3 text-sm font-medium text-white-full transition-colors hover:bg-wosmongton-600 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Connect {w.displayName}
+              </button>
+            ))}
+          </div>
+        )
       ) : (
         <div className="space-y-3">
           <div className="flex items-center justify-between rounded-lg bg-osmoverse-900 p-3 text-sm">
-            <span className="text-osmoverse-400">Connected Slush account</span>
+            <span className="text-osmoverse-400">
+              Connected {connection.displayName} account
+            </span>
             <span className="font-mono text-xs text-white-full">
-              {shorten(slush.address)}
+              {shorten(connection.address)}
             </span>
           </div>
           <button
@@ -633,7 +669,7 @@ const SuiRedeemPanel: FunctionComponent<{
             className="w-full rounded-lg bg-wosmongton-700 px-4 py-3 text-sm font-medium text-white-full transition-colors hover:bg-wosmongton-600 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {status === "signing"
-              ? "Confirm in Slush..."
+              ? `Confirm in ${connection.displayName}...`
               : status === "submitting"
               ? "Submitting on Sui..."
               : "Redeem on Sui"}
@@ -660,7 +696,11 @@ export const WormholeRedeem: FunctionComponent = () => {
   const [copyHint, setCopyHint] = useState<string | null>(null);
 
   const [phantom, setPhantom] = useState<any>(null);
-  const [slush, setSlush] = useState<SlushConnection | null>(null);
+  const [suiConnection, setSuiConnection] =
+    useState<SuiWalletConnection | null>(null);
+  const [availableSuiWallets, setAvailableSuiWallets] = useState<
+    AvailableSuiWallet[]
+  >(() => listAvailableSuiWallets());
   const [suiRedeemTxDigest, setSuiRedeemTxDigest] = useState<string | null>(
     null
   );
@@ -683,6 +723,10 @@ export const WormholeRedeem: FunctionComponent = () => {
       clearTimeout(timer);
     };
   }, []);
+
+  // Wallet Standard registers asynchronously; subscribe so wallets that
+  // load after this component mounts are picked up without a refresh.
+  useEffect(() => subscribeToAvailableSuiWallets(setAvailableSuiWallets), []);
 
   const lookupTransaction = useCallback(async () => {
     const hash = txHash.trim();
@@ -779,26 +823,29 @@ export const WormholeRedeem: FunctionComponent = () => {
     return () => phantom.off?.("accountChanged", onAccountChanged);
   }, [phantom]);
 
-  const connectSlushWallet = useCallback(async () => {
+  const connectSui = useCallback(async (walletId: SuiWalletId) => {
     setError(null);
     try {
-      const conn = await connectSlush();
-      setSlush(conn);
+      const conn = await connectSuiWallet(walletId);
+      setSuiConnection(conn);
     } catch (err) {
-      if (err instanceof SuiRedeemError && err.code === "slush_not_installed") {
-        setError({ type: "slush_not_installed" });
+      if (
+        err instanceof SuiRedeemError &&
+        err.code === "wallet_not_installed"
+      ) {
+        setError({ type: "sui_wallet_not_installed" });
         return;
       }
       setError({
         type: "generic",
         message:
-          err instanceof Error ? err.message : "Failed to connect Slush.",
+          err instanceof Error ? err.message : "Failed to connect Sui wallet.",
       });
     }
   }, []);
 
   const executeSuiRedeemFlow = useCallback(async () => {
-    if (!operation || !slush) return;
+    if (!operation || !suiConnection) return;
     setError(null);
     setSuiRedeemTxDigest(null);
 
@@ -809,7 +856,7 @@ export const WormholeRedeem: FunctionComponent = () => {
         recipient: operation.content.standarizedProperties.toAddress,
         tokenChain: operation.content.payload.tokenChain,
         tokenAddressHex: operation.content.payload.tokenAddress,
-        slush,
+        connection: suiConnection,
       });
       setStatus("submitting");
       setSuiRedeemTxDigest(digest);
@@ -821,7 +868,7 @@ export const WormholeRedeem: FunctionComponent = () => {
       });
       setStatus("error");
     }
-  }, [operation, slush]);
+  }, [operation, suiConnection]);
 
   const executeRedeem = useCallback(async () => {
     if (!operation || !solanaWallet || !phantom) return;
@@ -964,7 +1011,7 @@ export const WormholeRedeem: FunctionComponent = () => {
         <p className="mb-4 text-sm text-osmoverse-300">
           If you have a Wormhole bridge transfer from Osmosis that is stuck,
           paste the Osmosis transaction hash below to look it up and complete
-          the redemption on Solana (Phantom) or Sui (Slush).
+          the redemption on Solana (Phantom) or Sui (Slush or Phantom).
         </p>
 
         {/* TX Hash Input */}
@@ -1006,17 +1053,22 @@ export const WormholeRedeem: FunctionComponent = () => {
                 </a>{" "}
                 to redeem.
               </>
-            ) : error.type === "slush_not_installed" ? (
+            ) : error.type === "sui_wallet_not_installed" ? (
               <>
-                Slush wallet not detected.{" "}
-                <a
-                  href={SLUSH_DOWNLOAD_URL}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="underline"
-                >
-                  Install Slush
-                </a>{" "}
+                No supported Sui wallet detected. Install{" "}
+                {SUI_WALLET_REGISTRY.map((descriptor, idx) => (
+                  <span key={descriptor.id}>
+                    <a
+                      href={descriptor.downloadUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline"
+                    >
+                      {descriptor.displayName}
+                    </a>
+                    {idx < SUI_WALLET_REGISTRY.length - 1 ? " or " : ""}
+                  </span>
+                ))}{" "}
                 to redeem on Sui.
               </>
             ) : (
@@ -1198,8 +1250,9 @@ export const WormholeRedeem: FunctionComponent = () => {
                   wormholescanHash={resolvedTxHash}
                   onCopy={copyToClipboard}
                   copyHint={copyHint}
-                  slush={slush}
-                  onConnectSlush={connectSlushWallet}
+                  availableSuiWallets={availableSuiWallets}
+                  connection={suiConnection}
+                  onConnect={connectSui}
                   onRedeem={executeSuiRedeemFlow}
                   isLoading={isLoading}
                   status={status}
@@ -1249,9 +1302,12 @@ export const WormholeRedeem: FunctionComponent = () => {
                   const isSui =
                     operation.content.payload.toChain === CHAIN_ID.sui;
                   if (status === "signing") {
-                    return isSui
-                      ? "Waiting for Slush signature..."
-                      : "Waiting for wallet signature...";
+                    if (isSui) {
+                      return suiConnection
+                        ? `Waiting for ${suiConnection.displayName} signature...`
+                        : "Waiting for your Sui wallet signature...";
+                    }
+                    return "Waiting for wallet signature...";
                   }
                   return isSui
                     ? "Submitting transaction to Sui..."

--- a/packages/web/components/bridge/wormhole-redeem.tsx
+++ b/packages/web/components/bridge/wormhole-redeem.tsx
@@ -823,26 +823,38 @@ export const WormholeRedeem: FunctionComponent = () => {
     return () => phantom.off?.("accountChanged", onAccountChanged);
   }, [phantom]);
 
-  const connectSui = useCallback(async (walletId: SuiWalletId) => {
-    setError(null);
-    try {
-      const conn = await connectSuiWallet(walletId);
-      setSuiConnection(conn);
-    } catch (err) {
-      if (
-        err instanceof SuiRedeemError &&
-        err.code === "wallet_not_installed"
-      ) {
-        setError({ type: "sui_wallet_not_installed" });
-        return;
+  const connectSui = useCallback(
+    async (walletId: SuiWalletId) => {
+      setError(null);
+      try {
+        // Pass the VAA recipient so multi-account wallets can land on
+        // the right Sui account on first try, skipping the
+        // wallet_mismatch round-trip.
+        const recipient = operation?.content.standarizedProperties.toAddress;
+        const conn = await connectSuiWallet(walletId, recipient);
+        setSuiConnection(conn);
+      } catch (err) {
+        if (
+          err instanceof SuiRedeemError &&
+          err.code === "wallet_not_installed"
+        ) {
+          setError({ type: "sui_wallet_not_installed" });
+          return;
+        }
+        // `no_sui_account` falls through to the generic branch so the
+        // user sees the specific "create a Sui account in <wallet>"
+        // message rather than the dual install-link copy.
+        setError({
+          type: "generic",
+          message:
+            err instanceof Error
+              ? err.message
+              : "Failed to connect Sui wallet.",
+        });
       }
-      setError({
-        type: "generic",
-        message:
-          err instanceof Error ? err.message : "Failed to connect Sui wallet.",
-      });
-    }
-  }, []);
+    },
+    [operation]
+  );
 
   const executeSuiRedeemFlow = useCallback(async () => {
     if (!operation || !suiConnection) return;

--- a/packages/web/components/bridge/wormhole-redeem.tsx
+++ b/packages/web/components/bridge/wormhole-redeem.tsx
@@ -204,12 +204,19 @@ export async function lookupOsmosisIbcPacket(
   osmosisTxHash: string,
   lcds: readonly string[] = OSMOSIS_LCDS
 ): Promise<OsmosisSendPacket | null> {
+  let seenNotFound = false;
   let lastError: unknown = null;
   for (const lcd of lcds) {
     try {
       const res = await fetch(
         `${lcd}/cosmos/tx/v1beta1/txs/${encodeURIComponent(osmosisTxHash)}`
       );
+      if (res.status === 404) {
+        // Could be a wrong/unknown hash, or this provider has simply pruned
+        // older blocks. Try the next LCD before deciding it's truly missing.
+        seenNotFound = true;
+        continue;
+      }
       if (!res.ok) {
         lastError = new Error(`${lcd} returned ${res.status}`);
         continue;
@@ -217,11 +224,13 @@ export async function lookupOsmosisIbcPacket(
       const json = (await res.json()) as CosmosTxResponse;
       const events = json.tx_response?.events ?? [];
 
+      // Only accept a send_packet that actually uses the Wormhole gateway
+      // channel. Any other IBC transfer in this tx is unrelated and would
+      // resolve to a different (irrelevant) Wormchain packet.
       const sendPackets = events.filter((e) => e.type === "send_packet");
       const gatewayPacket = sendPackets.find(
         (e) =>
-          getAttr(e, "packet_src_channel") ===
-          OSMOSIS_WORMHOLE_GATEWAY_CHANNEL
+          getAttr(e, "packet_src_channel") === OSMOSIS_WORMHOLE_GATEWAY_CHANNEL
       );
       if (!gatewayPacket) return null;
 
@@ -255,6 +264,15 @@ export async function lookupOsmosisIbcPacket(
     } catch (err) {
       lastError = err;
     }
+  }
+  // If every LCD we tried returned 404 and nothing else failed, the tx
+  // genuinely does not exist (or none of the configured providers retain
+  // it). Surface a tx-not-found error rather than a generic provider
+  // outage so the user can correct the hash.
+  if (!lastError && seenNotFound) {
+    throw new Error(
+      "Osmosis transaction not found. Double-check the hash and that it was broadcast on Osmosis mainnet."
+    );
   }
   if (lastError) {
     throw new Error(

--- a/packages/web/components/bridge/wormhole-redeem.tsx
+++ b/packages/web/components/bridge/wormhole-redeem.tsx
@@ -12,9 +12,56 @@ import { Spinner } from "~/components/loaders";
 import { formatPretty } from "~/utils/formatter";
 
 const WORMHOLESCAN_API = "https://api.wormholescan.io/api/v1";
+const WORMHOLESCAN_UI = "https://wormholescan.io";
 const SOLANA_RPC = "https://solana-rpc.publicnode.com";
+const WORMCHAIN_RPC = "https://wormchain-rpc.polkachu.com";
+
+// Wormhole gateway channel from Osmosis -> Wormchain (the IBC translator).
+// MsgTransfer's source_channel on Osmosis is `channel-2186`; on Wormchain
+// the corresponding `dst_channel` is `channel-3`.
+const OSMOSIS_WORMHOLE_GATEWAY_CHANNEL = "channel-2186";
+
+// LCD fallbacks for Osmosis tx lookup. Individual providers flake (503/404
+// for txs older than their pruning window); we try them in order on
+// non-200 responses.
+const OSMOSIS_LCDS = [
+  "https://rest.cosmos.directory/osmosis",
+  "https://osmosis-rest.publicnode.com",
+  "https://lcd.osmosis.zone",
+];
 
 const TOKEN_BRIDGE_PROGRAM_ID = "wormDTUJ6AWPNvk59vGQbDvGJmqbDTdgWgAqcLBCgUb";
+
+// Wormhole chain IDs we render explicitly. See
+// https://docs.wormhole.com/wormhole/reference/constants
+const CHAIN_ID = {
+  solana: 1,
+  sui: 21,
+} as const;
+
+const CHAIN_LABEL: Record<number, string> = {
+  1: "Solana",
+  2: "Ethereum",
+  4: "BSC",
+  5: "Polygon",
+  6: "Avalanche",
+  10: "Fantom",
+  14: "Celo",
+  16: "Moonbeam",
+  19: "Injective",
+  20: "Osmosis",
+  21: "Sui",
+  22: "Aptos",
+  23: "Arbitrum",
+  24: "Optimism",
+  30: "Base",
+  32: "Sei",
+  3104: "Wormchain",
+};
+
+function getChainLabel(chainId: number): string {
+  return CHAIN_LABEL[chainId] ?? `chain ${chainId}`;
+}
 
 interface OperationData {
   id: string;
@@ -90,6 +137,319 @@ type RedeemError =
   | { type: "generic"; message: string }
   | null;
 
+// 64-char hex (e.g. an Osmosis/Wormchain tx hash). Solana sigs are base58
+// and therefore won't match this pattern, so we can safely use it to
+// decide whether to attempt the Osmosis LCD fallback.
+const COSMOS_TX_HASH_RE = /^[0-9a-fA-F]{64}$/;
+
+interface OsmosisSendPacket {
+  sequence: string;
+  srcChannel: string;
+  dstChannel: string;
+  destinationChain?: number;
+  recipientBase64?: string;
+}
+
+interface CosmosTxEvent {
+  type: string;
+  attributes: { key: string; value: string }[];
+}
+
+interface CosmosTxResponse {
+  tx_response?: {
+    events?: CosmosTxEvent[];
+  };
+}
+
+interface WormchainTxSearchResponse {
+  result?: {
+    txs?: { hash: string }[];
+    total_count?: string;
+  };
+}
+
+const getAttr = (event: CosmosTxEvent, key: string): string | undefined =>
+  event.attributes.find((a) => a.key === key)?.value;
+
+/**
+ * Parse the gateway memo embedded in an Osmosis -> Wormchain MsgTransfer.
+ * Returns the destination Wormhole chain id and base64 recipient when present.
+ */
+function parseGatewayMemo(
+  memo: string | undefined
+): Pick<OsmosisSendPacket, "destinationChain" | "recipientBase64"> {
+  if (!memo) return {};
+  try {
+    const parsed = JSON.parse(memo);
+    const payload =
+      parsed?.gateway_ibc_token_bridge_payload?.gateway_transfer ?? {};
+    return {
+      destinationChain:
+        typeof payload.chain === "number" ? payload.chain : undefined,
+      recipientBase64:
+        typeof payload.recipient === "string" ? payload.recipient : undefined,
+    };
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Look up an Osmosis transaction and extract the Wormhole gateway IBC packet
+ * (sequence + channels + memo). Returns null if no Wormhole gateway transfer
+ * was found in the tx. Tries multiple LCD providers because individual
+ * endpoints frequently 404/503 on older blocks.
+ */
+export async function lookupOsmosisIbcPacket(
+  osmosisTxHash: string,
+  lcds: readonly string[] = OSMOSIS_LCDS
+): Promise<OsmosisSendPacket | null> {
+  let lastError: unknown = null;
+  for (const lcd of lcds) {
+    try {
+      const res = await fetch(
+        `${lcd}/cosmos/tx/v1beta1/txs/${encodeURIComponent(osmosisTxHash)}`
+      );
+      if (!res.ok) {
+        lastError = new Error(`${lcd} returned ${res.status}`);
+        continue;
+      }
+      const json = (await res.json()) as CosmosTxResponse;
+      const events = json.tx_response?.events ?? [];
+
+      const sendPackets = events.filter((e) => e.type === "send_packet");
+      const gatewayPacket =
+        sendPackets.find(
+          (e) => getAttr(e, "packet_src_channel") ===
+            OSMOSIS_WORMHOLE_GATEWAY_CHANNEL
+        ) ?? sendPackets[0];
+      if (!gatewayPacket) return null;
+
+      const sequence = getAttr(gatewayPacket, "packet_sequence");
+      const srcChannel = getAttr(gatewayPacket, "packet_src_channel");
+      const dstChannel = getAttr(gatewayPacket, "packet_dst_channel");
+      if (!sequence || !srcChannel || !dstChannel) return null;
+
+      // The user-supplied memo is also surfaced as an attribute on the
+      // `ibc_transfer` event; fall back to parsing `packet_data` if that
+      // event is missing in this LCD's response format.
+      const ibcTransfer = events.find((e) => e.type === "ibc_transfer");
+      let memo = ibcTransfer ? getAttr(ibcTransfer, "memo") : undefined;
+      if (!memo) {
+        const packetData = getAttr(gatewayPacket, "packet_data");
+        if (packetData) {
+          try {
+            memo = JSON.parse(packetData)?.memo;
+          } catch {
+            // ignore
+          }
+        }
+      }
+
+      return {
+        sequence,
+        srcChannel,
+        dstChannel,
+        ...parseGatewayMemo(memo),
+      };
+    } catch (err) {
+      lastError = err;
+    }
+  }
+  if (lastError) {
+    throw new Error(
+      `Could not fetch Osmosis tx from any LCD: ${
+        lastError instanceof Error ? lastError.message : String(lastError)
+      }`
+    );
+  }
+  return null;
+}
+
+/**
+ * Find the Wormchain `recv_packet` tx that corresponds to an Osmosis
+ * send_packet. Wormholescan indexes Wormhole VAAs under this tx hash
+ * (the Osmosis hash is never indexed for gateway transfers).
+ */
+export async function findWormchainRecvTx({
+  sequence,
+  srcChannel,
+  wormchainRpc = WORMCHAIN_RPC,
+}: {
+  sequence: string;
+  srcChannel: string;
+  wormchainRpc?: string;
+}): Promise<string | null> {
+  // Tendermint RPC requires the query value to be a quoted string.
+  const query = `"recv_packet.packet_sequence='${sequence}' AND recv_packet.packet_src_channel='${srcChannel}'"`;
+  const url = `${wormchainRpc}/tx_search?query=${encodeURIComponent(query)}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Wormchain tx_search returned ${res.status}`);
+  }
+  const json = (await res.json()) as WormchainTxSearchResponse;
+  return json.result?.txs?.[0]?.hash ?? null;
+}
+
+interface ResolvedOperation {
+  operation: OperationData;
+  /** The Wormchain (or other emitter chain) tx hash that Wormholescan
+   *  indexed the VAA under. Useful for deep links. */
+  resolvedTxHash: string;
+  /** True when we had to derive the wormchain hash from an Osmosis tx. */
+  derivedFromOsmosis: boolean;
+}
+
+async function fetchOperation(
+  txHash: string
+): Promise<OperationData | null> {
+  const json = await apiClient<{ operations?: OperationData[] }>(
+    `${WORMHOLESCAN_API}/operations?txHash=${encodeURIComponent(txHash)}`
+  );
+  return json.operations?.[0] ?? null;
+}
+
+/**
+ * Resolve a user-supplied tx hash to a Wormhole operation. The hash may be
+ * either the actual Wormhole emitter tx (e.g. a Wormchain hash) — in which
+ * case Wormholescan indexes it directly — or an Osmosis tx hash, in which
+ * case we follow the IBC packet to the Wormchain receive tx first.
+ */
+export async function resolveOperation(
+  userHash: string
+): Promise<ResolvedOperation> {
+  const direct = await fetchOperation(userHash);
+  if (direct) {
+    return {
+      operation: direct,
+      resolvedTxHash: userHash,
+      derivedFromOsmosis: false,
+    };
+  }
+
+  if (!COSMOS_TX_HASH_RE.test(userHash)) {
+    throw new Error(
+      "Transaction not found. Make sure this is a Wormhole bridge transaction hash."
+    );
+  }
+
+  const packet = await lookupOsmosisIbcPacket(userHash);
+  if (!packet) {
+    throw new Error(
+      "Transaction not found on Wormholescan and no Wormhole gateway IBC transfer was found in this Osmosis transaction."
+    );
+  }
+
+  const wormchainHash = await findWormchainRecvTx({
+    sequence: packet.sequence,
+    srcChannel: packet.srcChannel,
+  });
+  if (!wormchainHash) {
+    throw new Error(
+      "Found the Osmosis send packet but the corresponding Wormchain receive has not been relayed yet. Try again in a minute."
+    );
+  }
+
+  const op = await fetchOperation(wormchainHash);
+  if (!op) {
+    throw new Error(
+      `Found the Wormchain receive (${wormchainHash}) but Wormholescan has not indexed a VAA for it yet. The guardians may still be signing — try again in a minute.`
+    );
+  }
+
+  return {
+    operation: op,
+    resolvedTxHash: wormchainHash,
+    derivedFromOsmosis: true,
+  };
+}
+
+function getDestinationExplorerUrl(
+  toChain: number,
+  hash: string
+): string | null {
+  switch (toChain) {
+    case CHAIN_ID.solana:
+      return getSolanaExplorerUrl({ hash });
+    case CHAIN_ID.sui:
+      return `https://suiscan.xyz/mainnet/tx/${encodeURIComponent(hash)}`;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Redemption panel for non-Solana destinations. We don't ship a native
+ * Sui/EVM wallet integration here — instead we surface the looked-up VAA
+ * and deep-link to Wormholescan's existing multi-chain redeem UI, which
+ * already supports Sui (Sui Wallet/Suiet/Backpack), EVM (MetaMask), and
+ * other Wormhole destinations via Wallet Standard.
+ */
+const NonSolanaRedeemPanel: FunctionComponent<{
+  operation: OperationData;
+  wormholescanHash: string;
+  onCopy: (value: string, hint: string) => void;
+  copyHint: string | null;
+}> = ({ operation, wormholescanHash, onCopy, copyHint }) => {
+  const toChainId = operation.content.payload.toChain;
+  const chainLabel = getChainLabel(toChainId);
+  const vaa = operation.vaa.raw;
+  const recipient = operation.content.standarizedProperties.toAddress;
+  const wormholescanUrl = `${WORMHOLESCAN_UI}/#/tx/${encodeURIComponent(
+    wormholescanHash
+  )}?network=Mainnet`;
+
+  return (
+    <div className="space-y-3">
+      <div className="rounded-lg border border-ammelia-600 bg-ammelia-600/10 p-3 text-sm text-ammelia-200">
+        VAA is signed and ready. To redeem on {chainLabel}, open this operation
+        on Wormholescan and connect a {chainLabel} wallet. Wormholescan&apos;s
+        redeem flow supports Sui Wallet, Suiet, Backpack, and other Wallet
+        Standard wallets.
+      </div>
+
+      <div className="rounded-lg bg-osmoverse-900 p-3 text-sm">
+        <div className="mb-2 flex items-center justify-between">
+          <span className="text-osmoverse-400">Recipient ({chainLabel})</span>
+          <button
+            onClick={() => onCopy(recipient, "recipient")}
+            className="text-xs text-wosmongton-300 underline"
+          >
+            {copyHint === "recipient" ? "Copied" : "Copy"}
+          </button>
+        </div>
+        <div className="break-all font-mono text-xs text-white-full">
+          {recipient}
+        </div>
+      </div>
+
+      <div className="rounded-lg bg-osmoverse-900 p-3 text-sm">
+        <div className="mb-2 flex items-center justify-between">
+          <span className="text-osmoverse-400">VAA (base64)</span>
+          <button
+            onClick={() => onCopy(vaa, "vaa")}
+            className="text-xs text-wosmongton-300 underline"
+          >
+            {copyHint === "vaa" ? "Copied" : "Copy"}
+          </button>
+        </div>
+        <div className="max-h-24 overflow-y-auto break-all font-mono text-[10px] text-osmoverse-300">
+          {vaa}
+        </div>
+      </div>
+
+      <a
+        href={wormholescanUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="block w-full rounded-lg bg-wosmongton-700 px-4 py-3 text-center text-sm font-medium text-white-full transition-colors hover:bg-wosmongton-600"
+      >
+        Open on Wormholescan to redeem
+      </a>
+    </div>
+  );
+};
+
 export const WormholeRedeem: FunctionComponent = () => {
   const [txHash, setTxHash] = useState("");
   const [status, setStatus] = useState<RedeemStatus>("idle");
@@ -98,6 +458,12 @@ export const WormholeRedeem: FunctionComponent = () => {
   const [solanaWallet, setSolanaWallet] = useState<string | null>(null);
   const [redeemTxHashes, setRedeemTxHashes] = useState<string[]>([]);
   const [lookedUpTxHash, setLookedUpTxHash] = useState("");
+  // The Wormhole emitter-chain tx hash Wormholescan indexed the VAA under.
+  // Equals `lookedUpTxHash` when the user pasted the emitter hash directly;
+  // set to the discovered Wormchain hash when we resolved an Osmosis tx.
+  const [resolvedTxHash, setResolvedTxHash] = useState<string | null>(null);
+  const [derivedFromOsmosis, setDerivedFromOsmosis] = useState(false);
+  const [copyHint, setCopyHint] = useState<string | null>(null);
 
   const [phantom, setPhantom] = useState<any>(null);
 
@@ -129,18 +495,12 @@ export const WormholeRedeem: FunctionComponent = () => {
     setError(null);
     setRedeemTxHashes([]);
     setLookedUpTxHash(hash);
+    setResolvedTxHash(null);
+    setDerivedFromOsmosis(false);
 
     try {
-      const json = await apiClient<{ operations?: OperationData[] }>(
-        `${WORMHOLESCAN_API}/operations?txHash=${encodeURIComponent(hash)}`
-      );
-      if (!json.operations?.length) {
-        throw new Error(
-          "Transaction not found. Make sure this is a Wormhole bridge transaction hash."
-        );
-      }
-
-      const op = json.operations[0] as OperationData;
+      const { operation: op, resolvedTxHash: wormHash, derivedFromOsmosis: derived } =
+        await resolveOperation(hash);
 
       if (!op.vaa?.raw) {
         throw new Error(
@@ -148,26 +508,29 @@ export const WormholeRedeem: FunctionComponent = () => {
         );
       }
 
-      if (op.content.payload.toChain !== 1) {
-        throw new Error(
-          `This transfer's destination is chain ${op.content.payload.toChain}, not Solana (1). This tool only supports Solana redemptions.`
-        );
-      }
-
       setOperation(op);
+      setResolvedTxHash(wormHash);
+      setDerivedFromOsmosis(derived);
 
+      // Already-redeemed detection is generic across destination chains:
+      // Wormholescan reports `targetChain.status === "completed"` once the
+      // VAA has been replayed on the destination chain.
       if (op.targetChain?.status === "completed") {
         setStatus("already_redeemed");
         return;
       }
 
-      setStatus("checking_solana");
-      const redeemed = await checkIfRedeemed(op);
-      if (redeemed) {
-        setStatus("already_redeemed");
-      } else {
-        setStatus("ready");
+      // The on-chain claim-PDA check is Solana-specific. For other chains
+      // we rely on Wormholescan's targetChain status above and fall
+      // straight through to the ready state.
+      if (op.content.payload.toChain === CHAIN_ID.solana) {
+        setStatus("checking_solana");
+        const redeemed = await checkIfRedeemed(op);
+        setStatus(redeemed ? "already_redeemed" : "ready");
+        return;
       }
+
+      setStatus("ready");
     } catch (err: unknown) {
       setError({
         type: "generic",
@@ -177,6 +540,19 @@ export const WormholeRedeem: FunctionComponent = () => {
       setStatus("error");
     }
   }, [txHash]);
+
+  const copyToClipboard = useCallback(
+    async (value: string, hint: string) => {
+      try {
+        await navigator.clipboard.writeText(value);
+        setCopyHint(hint);
+        setTimeout(() => setCopyHint(null), 2000);
+      } catch {
+        // ignore - clipboard may be unavailable in some environments
+      }
+    },
+    []
+  );
 
   const connectWallet = useCallback(async () => {
     if (!phantom) {
@@ -423,7 +799,9 @@ export const WormholeRedeem: FunctionComponent = () => {
                   )}
                 </span>
 
-                <span className="text-osmoverse-400">To (Solana)</span>
+                <span className="text-osmoverse-400">
+                  To ({getChainLabel(operation.content.payload.toChain)})
+                </span>
                 <span className="text-right font-mono text-xs text-white-full">
                   {shorten(operation.content.standarizedProperties.toAddress, {
                     prefixLength: 8,
@@ -437,6 +815,27 @@ export const WormholeRedeem: FunctionComponent = () => {
                     operation.sourceChain.timestamp
                   ).toLocaleDateString()}
                 </span>
+
+                {derivedFromOsmosis && resolvedTxHash && (
+                  <>
+                    <span className="text-osmoverse-400">Wormchain receive</span>
+                    <span className="text-right">
+                      <a
+                        href={`${WORMHOLESCAN_UI}/#/tx/${encodeURIComponent(
+                          resolvedTxHash
+                        )}?network=Mainnet`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="font-mono text-xs text-wosmongton-300 underline"
+                      >
+                        {shorten(resolvedTxHash, {
+                          prefixLength: 8,
+                          suffixLength: 8,
+                        })}
+                      </a>
+                    </span>
+                  </>
+                )}
               </div>
             </div>
 
@@ -448,70 +847,99 @@ export const WormholeRedeem: FunctionComponent = () => {
               </div>
             )}
 
-            {status === "already_redeemed" && (
-              <div className="rounded-lg border border-bullish-600 bg-bullish-600/10 p-3 text-sm text-bullish-200">
-                This transfer has already been redeemed on Solana.
-                {operation.targetChain?.transaction?.txHash ? (
-                  <a
-                    href={getSolanaExplorerUrl({
-                      hash: operation.targetChain.transaction.txHash,
-                    })}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="ml-1 underline"
-                  >
-                    View on Solscan
-                  </a>
-                ) : (
-                  <a
-                    href={`https://wormholescan.io/#/tx/${encodeURIComponent(
-                      operation.sourceChain.attribute?.value?.originTxHash ||
-                        lookedUpTxHash
-                    )}?network=Mainnet`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="ml-1 underline"
-                  >
-                    View on Wormholescan
-                  </a>
-                )}
-              </div>
-            )}
-
-            {status === "ready" && !solanaWallet && (
-              <div className="space-y-3">
-                <div className="rounded-lg border border-ammelia-600 bg-ammelia-600/10 p-3 text-sm text-ammelia-200">
-                  VAA is signed and ready. Connect your Solana wallet to redeem.
+            {status === "already_redeemed" && (() => {
+              const toChainId = operation.content.payload.toChain;
+              const destHash = operation.targetChain?.transaction?.txHash;
+              const destExplorerUrl = destHash
+                ? getDestinationExplorerUrl(toChainId, destHash)
+                : null;
+              const wormholescanHash =
+                resolvedTxHash ||
+                operation.sourceChain.attribute?.value?.originTxHash ||
+                lookedUpTxHash;
+              return (
+                <div className="rounded-lg border border-bullish-600 bg-bullish-600/10 p-3 text-sm text-bullish-200">
+                  This transfer has already been redeemed on{" "}
+                  {getChainLabel(toChainId)}.
+                  {destExplorerUrl ? (
+                    <a
+                      href={destExplorerUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="ml-1 underline"
+                    >
+                      View on{" "}
+                      {toChainId === CHAIN_ID.solana ? "Solscan" : "Suiscan"}
+                    </a>
+                  ) : (
+                    <a
+                      href={`${WORMHOLESCAN_UI}/#/tx/${encodeURIComponent(
+                        wormholescanHash
+                      )}?network=Mainnet`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="ml-1 underline"
+                    >
+                      View on Wormholescan
+                    </a>
+                  )}
                 </div>
-                <button
-                  onClick={connectWallet}
-                  className="w-full rounded-lg bg-wosmongton-700 px-4 py-3 text-sm font-medium text-white-full transition-colors hover:bg-wosmongton-600"
-                >
-                  {phantom
-                    ? "Connect Phantom Wallet"
-                    : "Install Phantom Wallet"}
-                </button>
-              </div>
-            )}
+              );
+            })()}
 
-            {status === "ready" && solanaWallet && (
-              <div className="space-y-3">
-                <div className="flex items-center justify-between rounded-lg bg-osmoverse-900 p-3 text-sm">
-                  <span className="text-osmoverse-400">Connected Wallet</span>
-                  <span className="font-mono text-xs text-white-full">
-                    {shorten(solanaWallet)}
-                  </span>
-                </div>
+            {status === "ready" &&
+              operation.content.payload.toChain === CHAIN_ID.solana && (
+                <>
+                  {!solanaWallet && (
+                    <div className="space-y-3">
+                      <div className="rounded-lg border border-ammelia-600 bg-ammelia-600/10 p-3 text-sm text-ammelia-200">
+                        VAA is signed and ready. Connect your Solana wallet to
+                        redeem.
+                      </div>
+                      <button
+                        onClick={connectWallet}
+                        className="w-full rounded-lg bg-wosmongton-700 px-4 py-3 text-sm font-medium text-white-full transition-colors hover:bg-wosmongton-600"
+                      >
+                        {phantom
+                          ? "Connect Phantom Wallet"
+                          : "Install Phantom Wallet"}
+                      </button>
+                    </div>
+                  )}
 
-                <button
-                  onClick={executeRedeem}
-                  disabled={isLoading}
-                  className="w-full rounded-lg bg-wosmongton-700 px-4 py-3 text-sm font-medium text-white-full transition-colors hover:bg-wosmongton-600 disabled:cursor-not-allowed disabled:opacity-50"
-                >
-                  Redeem on Solana
-                </button>
-              </div>
-            )}
+                  {solanaWallet && (
+                    <div className="space-y-3">
+                      <div className="flex items-center justify-between rounded-lg bg-osmoverse-900 p-3 text-sm">
+                        <span className="text-osmoverse-400">
+                          Connected Wallet
+                        </span>
+                        <span className="font-mono text-xs text-white-full">
+                          {shorten(solanaWallet)}
+                        </span>
+                      </div>
+
+                      <button
+                        onClick={executeRedeem}
+                        disabled={isLoading}
+                        className="w-full rounded-lg bg-wosmongton-700 px-4 py-3 text-sm font-medium text-white-full transition-colors hover:bg-wosmongton-600 disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        Redeem on Solana
+                      </button>
+                    </div>
+                  )}
+                </>
+              )}
+
+            {status === "ready" &&
+              operation.content.payload.toChain !== CHAIN_ID.solana &&
+              resolvedTxHash && (
+                <NonSolanaRedeemPanel
+                  operation={operation}
+                  wormholescanHash={resolvedTxHash}
+                  onCopy={copyToClipboard}
+                  copyHint={copyHint}
+                />
+              )}
 
             {(status === "signing" || status === "submitting") && (
               <div className="flex items-center gap-2 text-sm text-osmoverse-300">

--- a/packages/web/components/bridge/wormhole-redeem.tsx
+++ b/packages/web/components/bridge/wormhole-redeem.tsx
@@ -22,7 +22,6 @@ import {
 const WORMHOLESCAN_API = "https://api.wormholescan.io/api/v1";
 const WORMHOLESCAN_UI = "https://wormholescan.io";
 const SOLANA_RPC = "https://solana-rpc.publicnode.com";
-const WORMCHAIN_RPC = "https://wormchain-rpc.polkachu.com";
 
 // Wormhole gateway channel from Osmosis -> Wormchain (the IBC translator).
 // MsgTransfer's source_channel on Osmosis is `channel-2186`; on Wormchain
@@ -37,6 +36,37 @@ const OSMOSIS_LCDS = [
   "https://osmosis-rest.publicnode.com",
   "https://lcd.osmosis.zone",
 ];
+
+// Wormchain RPC fallbacks. Same rationale as `OSMOSIS_LCDS`: a single
+// provider going down would otherwise break recovery for every user.
+const WORMCHAIN_RPCS = [
+  "https://wormchain-rpc.polkachu.com",
+  "https://wormchain-rpc.publicnode.com",
+];
+
+const FETCH_TIMEOUT_MS = 5000;
+
+/**
+ * `fetch` with a hard timeout. A hung LCD/RPC would otherwise block the
+ * whole resolution path and leave the widget stuck in `looking_up`.
+ */
+async function fetchWithTimeout(
+  url: string,
+  {
+    timeoutMs = FETCH_TIMEOUT_MS,
+    ...init
+  }: RequestInit & {
+    timeoutMs?: number;
+  } = {}
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
 
 const TOKEN_BRIDGE_PROGRAM_ID = "wormDTUJ6AWPNvk59vGQbDvGJmqbDTdgWgAqcLBCgUb";
 
@@ -218,7 +248,7 @@ export async function lookupOsmosisIbcPacket(
   let lastError: unknown = null;
   for (const lcd of lcds) {
     try {
-      const res = await fetch(
+      const res = await fetchWithTimeout(
         `${lcd}/cosmos/tx/v1beta1/txs/${encodeURIComponent(osmosisTxHash)}`
       );
       if (res.status === 404) {
@@ -298,25 +328,42 @@ export async function lookupOsmosisIbcPacket(
  * Find the Wormchain `recv_packet` tx that corresponds to an Osmosis
  * send_packet. Wormholescan indexes Wormhole VAAs under this tx hash
  * (the Osmosis hash is never indexed for gateway transfers).
+ *
+ * Iterates the configured Wormchain RPCs and returns on the first
+ * provider that responds successfully, so a single endpoint outage
+ * doesn't break recovery. Throws only if every provider fails.
  */
 export async function findWormchainRecvTx({
   sequence,
   srcChannel,
-  wormchainRpc = WORMCHAIN_RPC,
+  wormchainRpcs = WORMCHAIN_RPCS,
 }: {
   sequence: string;
   srcChannel: string;
-  wormchainRpc?: string;
+  wormchainRpcs?: readonly string[];
 }): Promise<string | null> {
   // Tendermint RPC requires the query value to be a quoted string.
   const query = `"recv_packet.packet_sequence='${sequence}' AND recv_packet.packet_src_channel='${srcChannel}'"`;
-  const url = `${wormchainRpc}/tx_search?query=${encodeURIComponent(query)}`;
-  const res = await fetch(url);
-  if (!res.ok) {
-    throw new Error(`Wormchain tx_search returned ${res.status}`);
+  let lastError: unknown = null;
+  for (const rpc of wormchainRpcs) {
+    try {
+      const url = `${rpc}/tx_search?query=${encodeURIComponent(query)}`;
+      const res = await fetchWithTimeout(url);
+      if (!res.ok) {
+        lastError = new Error(`${rpc} returned ${res.status}`);
+        continue;
+      }
+      const json = (await res.json()) as WormchainTxSearchResponse;
+      return json.result?.txs?.[0]?.hash ?? null;
+    } catch (err) {
+      lastError = err;
+    }
   }
-  const json = (await res.json()) as WormchainTxSearchResponse;
-  return json.result?.txs?.[0]?.hash ?? null;
+  throw new Error(
+    `Could not query Wormchain RPC: ${
+      lastError instanceof Error ? lastError.message : String(lastError)
+    }`
+  );
 }
 
 interface ResolvedOperation {
@@ -359,7 +406,25 @@ export async function resolveOperation(
     );
   }
 
-  const packet = await lookupOsmosisIbcPacket(userHash);
+  // The hash format alone can't tell us whether this is an Osmosis tx or
+  // an as-yet-unindexed Wormchain receive — they're both 64-char hex.
+  // Catch the "not found on Osmosis" path and surface both possibilities
+  // so the user can wait-and-retry rather than thinking they typed the
+  // wrong hash.
+  let packet: OsmosisSendPacket | null;
+  try {
+    packet = await lookupOsmosisIbcPacket(userHash);
+  } catch (err) {
+    if (
+      err instanceof Error &&
+      err.message.startsWith("Osmosis transaction not found")
+    ) {
+      throw new Error(
+        "Transaction not found on Wormholescan and no matching Osmosis transaction was located. If this is a Wormchain receive hash, the guardians may still be signing — try again in a minute. Otherwise, double-check the hash."
+      );
+    }
+    throw err;
+  }
   if (!packet) {
     throw new Error(
       "Transaction not found on Wormholescan and no Wormhole gateway IBC transfer was found in this Osmosis transaction."
@@ -627,6 +692,7 @@ export const WormholeRedeem: FunctionComponent = () => {
     setOperation(null);
     setError(null);
     setRedeemTxHashes([]);
+    setSuiRedeemTxDigest(null);
     setLookedUpTxHash(hash);
     setResolvedTxHash(null);
     setDerivedFromOsmosis(false);
@@ -1124,6 +1190,7 @@ export const WormholeRedeem: FunctionComponent = () => {
               )}
 
             {status !== "already_redeemed" &&
+              status !== "success" &&
               operation.content.payload.toChain === CHAIN_ID.sui &&
               resolvedTxHash && (
                 <SuiRedeemPanel

--- a/packages/web/components/bridge/wormhole-redeem.tsx
+++ b/packages/web/components/bridge/wormhole-redeem.tsx
@@ -218,12 +218,11 @@ export async function lookupOsmosisIbcPacket(
       const events = json.tx_response?.events ?? [];
 
       const sendPackets = events.filter((e) => e.type === "send_packet");
-      const gatewayPacket =
-        sendPackets.find(
-          (e) =>
-            getAttr(e, "packet_src_channel") ===
-            OSMOSIS_WORMHOLE_GATEWAY_CHANNEL
-        ) ?? sendPackets[0];
+      const gatewayPacket = sendPackets.find(
+        (e) =>
+          getAttr(e, "packet_src_channel") ===
+          OSMOSIS_WORMHOLE_GATEWAY_CHANNEL
+      );
       if (!gatewayPacket) return null;
 
       const sequence = getAttr(gatewayPacket, "packet_sequence");

--- a/packages/web/components/bridge/wormhole-redeem.tsx
+++ b/packages/web/components/bridge/wormhole-redeem.tsx
@@ -220,7 +220,8 @@ export async function lookupOsmosisIbcPacket(
       const sendPackets = events.filter((e) => e.type === "send_packet");
       const gatewayPacket =
         sendPackets.find(
-          (e) => getAttr(e, "packet_src_channel") ===
+          (e) =>
+            getAttr(e, "packet_src_channel") ===
             OSMOSIS_WORMHOLE_GATEWAY_CHANNEL
         ) ?? sendPackets[0];
       if (!gatewayPacket) return null;
@@ -300,9 +301,7 @@ interface ResolvedOperation {
   derivedFromOsmosis: boolean;
 }
 
-async function fetchOperation(
-  txHash: string
-): Promise<OperationData | null> {
+async function fetchOperation(txHash: string): Promise<OperationData | null> {
   const json = await apiClient<{ operations?: OperationData[] }>(
     `${WORMHOLESCAN_API}/operations?txHash=${encodeURIComponent(txHash)}`
   );
@@ -499,8 +498,11 @@ export const WormholeRedeem: FunctionComponent = () => {
     setDerivedFromOsmosis(false);
 
     try {
-      const { operation: op, resolvedTxHash: wormHash, derivedFromOsmosis: derived } =
-        await resolveOperation(hash);
+      const {
+        operation: op,
+        resolvedTxHash: wormHash,
+        derivedFromOsmosis: derived,
+      } = await resolveOperation(hash);
 
       if (!op.vaa?.raw) {
         throw new Error(
@@ -541,18 +543,15 @@ export const WormholeRedeem: FunctionComponent = () => {
     }
   }, [txHash]);
 
-  const copyToClipboard = useCallback(
-    async (value: string, hint: string) => {
-      try {
-        await navigator.clipboard.writeText(value);
-        setCopyHint(hint);
-        setTimeout(() => setCopyHint(null), 2000);
-      } catch {
-        // ignore - clipboard may be unavailable in some environments
-      }
-    },
-    []
-  );
+  const copyToClipboard = useCallback(async (value: string, hint: string) => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopyHint(hint);
+      setTimeout(() => setCopyHint(null), 2000);
+    } catch {
+      // ignore - clipboard may be unavailable in some environments
+    }
+  }, []);
 
   const connectWallet = useCallback(async () => {
     if (!phantom) {
@@ -818,7 +817,9 @@ export const WormholeRedeem: FunctionComponent = () => {
 
                 {derivedFromOsmosis && resolvedTxHash && (
                   <>
-                    <span className="text-osmoverse-400">Wormchain receive</span>
+                    <span className="text-osmoverse-400">
+                      Wormchain receive
+                    </span>
                     <span className="text-right">
                       <a
                         href={`${WORMHOLESCAN_UI}/#/tx/${encodeURIComponent(
@@ -847,45 +848,46 @@ export const WormholeRedeem: FunctionComponent = () => {
               </div>
             )}
 
-            {status === "already_redeemed" && (() => {
-              const toChainId = operation.content.payload.toChain;
-              const destHash = operation.targetChain?.transaction?.txHash;
-              const destExplorerUrl = destHash
-                ? getDestinationExplorerUrl(toChainId, destHash)
-                : null;
-              const wormholescanHash =
-                resolvedTxHash ||
-                operation.sourceChain.attribute?.value?.originTxHash ||
-                lookedUpTxHash;
-              return (
-                <div className="rounded-lg border border-bullish-600 bg-bullish-600/10 p-3 text-sm text-bullish-200">
-                  This transfer has already been redeemed on{" "}
-                  {getChainLabel(toChainId)}.
-                  {destExplorerUrl ? (
-                    <a
-                      href={destExplorerUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="ml-1 underline"
-                    >
-                      View on{" "}
-                      {toChainId === CHAIN_ID.solana ? "Solscan" : "Suiscan"}
-                    </a>
-                  ) : (
-                    <a
-                      href={`${WORMHOLESCAN_UI}/#/tx/${encodeURIComponent(
-                        wormholescanHash
-                      )}?network=Mainnet`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="ml-1 underline"
-                    >
-                      View on Wormholescan
-                    </a>
-                  )}
-                </div>
-              );
-            })()}
+            {status === "already_redeemed" &&
+              (() => {
+                const toChainId = operation.content.payload.toChain;
+                const destHash = operation.targetChain?.transaction?.txHash;
+                const destExplorerUrl = destHash
+                  ? getDestinationExplorerUrl(toChainId, destHash)
+                  : null;
+                const wormholescanHash =
+                  resolvedTxHash ||
+                  operation.sourceChain.attribute?.value?.originTxHash ||
+                  lookedUpTxHash;
+                return (
+                  <div className="rounded-lg border border-bullish-600 bg-bullish-600/10 p-3 text-sm text-bullish-200">
+                    This transfer has already been redeemed on{" "}
+                    {getChainLabel(toChainId)}.
+                    {destExplorerUrl ? (
+                      <a
+                        href={destExplorerUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="ml-1 underline"
+                      >
+                        View on{" "}
+                        {toChainId === CHAIN_ID.solana ? "Solscan" : "Suiscan"}
+                      </a>
+                    ) : (
+                      <a
+                        href={`${WORMHOLESCAN_UI}/#/tx/${encodeURIComponent(
+                          wormholescanHash
+                        )}?network=Mainnet`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="ml-1 underline"
+                      >
+                        View on Wormholescan
+                      </a>
+                    )}
+                  </div>
+                );
+              })()}
 
             {status === "ready" &&
               operation.content.payload.toChain === CHAIN_ID.solana && (

--- a/packages/web/components/bridge/wormhole-sui.ts
+++ b/packages/web/components/bridge/wormhole-sui.ts
@@ -15,10 +15,13 @@
  * `upgrade_cap.fields.package`, so we don't have to redeploy this
  * widget on Wormhole contract upgrades.
  *
- * Wallet integration is Slush-only via the Wallet Standard protocol
- * (`@mysten/wallet-standard`). Slush is the rebrand of the Mysten Labs
- * "Sui Wallet" extension; older builds still register under the legacy
- * name so we accept both.
+ * Wallet integration speaks the Sui Wallet Standard protocol directly
+ * (`@mysten/wallet-standard`) so we don't ship a dApp-kit dependency.
+ * We allowlist by `wallet.name` rather than auto-connecting to anything
+ * advertised on the page: a malicious extension could otherwise register
+ * a Wallet Standard wallet with a misleading name. Supported wallets are
+ * Slush (formerly "Sui Wallet") and Phantom (which has multi-chain Sui
+ * support); both register via Wallet Standard.
  */
 
 import type { WalletWithRequiredFeatures } from "@mysten/wallet-standard";
@@ -60,30 +63,58 @@ export const KNOWN_SUI_COIN_TYPES: Record<string, string> = {
     "0x2::sui::SUI",
 };
 
-const SLUSH_WALLET_NAMES = new Set([
-  "Slush",
-  "Slush — A Sui wallet",
-  "Sui Wallet",
-]);
+export type SuiWalletId = "slush" | "phantom";
+
+/**
+ * Allowlisted Wallet Standard descriptors. Order matters: we render
+ * connect buttons in this order, with Slush first because it is the
+ * Mysten-native Sui wallet. Phantom is supported as a secondary option
+ * for users who already have it installed for Solana.
+ *
+ * Each descriptor lists every `wallet.name` we accept. Slush has shipped
+ * under multiple names during its rebrand; Phantom only registers as
+ * "Phantom".
+ */
+export interface SuiWalletDescriptor {
+  id: SuiWalletId;
+  displayName: string;
+  walletNames: ReadonlySet<string>;
+  downloadUrl: string;
+}
+
+export const SUI_WALLET_REGISTRY: readonly SuiWalletDescriptor[] = [
+  {
+    id: "slush",
+    displayName: "Slush",
+    walletNames: new Set(["Slush", "Slush — A Sui wallet", "Sui Wallet"]),
+    downloadUrl: "https://slush.app/",
+  },
+  {
+    id: "phantom",
+    displayName: "Phantom",
+    walletNames: new Set(["Phantom"]),
+    downloadUrl: "https://phantom.app/",
+  },
+];
+
+const SUI_WALLET_BY_ID: Record<SuiWalletId, SuiWalletDescriptor> =
+  SUI_WALLET_REGISTRY.reduce((acc, descriptor) => {
+    acc[descriptor.id] = descriptor;
+    return acc;
+  }, {} as Record<SuiWalletId, SuiWalletDescriptor>);
+
+type SuiRedeemErrorCode =
+  | "wallet_not_installed"
+  | "unsupported_token"
+  | "wallet_mismatch"
+  | "wallet_rejected"
+  | "rpc_error";
 
 export class SuiRedeemError extends Error {
   /** Stable error code so the UI can branch without string-matching. */
-  readonly code:
-    | "slush_not_installed"
-    | "unsupported_token"
-    | "wallet_mismatch"
-    | "wallet_rejected"
-    | "rpc_error";
+  readonly code: SuiRedeemErrorCode;
 
-  constructor(
-    code:
-      | "slush_not_installed"
-      | "unsupported_token"
-      | "wallet_mismatch"
-      | "wallet_rejected"
-      | "rpc_error",
-    message: string
-  ) {
+  constructor(code: SuiRedeemErrorCode, message: string) {
     super(message);
     this.code = code;
     this.name = "SuiRedeemError";
@@ -251,42 +282,112 @@ export async function buildSuiRedeemTransaction({
   return tx;
 }
 
-export interface SlushConnection {
+export interface SuiWalletConnection {
+  id: SuiWalletId;
+  displayName: string;
   wallet: WalletWithRequiredFeatures;
   address: string;
 }
 
+export interface AvailableSuiWallet {
+  id: SuiWalletId;
+  displayName: string;
+  wallet: WalletWithRequiredFeatures;
+}
+
+function findWalletByDescriptor(
+  wallets: readonly { name: string }[],
+  descriptor: SuiWalletDescriptor
+): WalletWithRequiredFeatures | undefined {
+  return wallets.find((w) => descriptor.walletNames.has(w.name)) as
+    | WalletWithRequiredFeatures
+    | undefined;
+}
+
 /**
- * Locate the Slush wallet (formerly "Sui Wallet") and request a
- * connection. Throws `slush_not_installed` if the user has no
- * compatible Sui wallet registered via Wallet Standard.
+ * Snapshot the currently registered Sui wallets that match our
+ * allowlist, in registry order (Slush first, Phantom second). Useful
+ * for rendering a one-button-per-wallet picker. Returns an empty
+ * array in non-browser environments so SSR doesn't blow up.
  */
-export async function connectSlush(): Promise<SlushConnection> {
+export function listAvailableSuiWallets(): AvailableSuiWallet[] {
+  if (typeof window === "undefined") return [];
+  const walletsApi = getWallets();
+  const allWallets = walletsApi.get();
+  const result: AvailableSuiWallet[] = [];
+  for (const descriptor of SUI_WALLET_REGISTRY) {
+    const wallet = findWalletByDescriptor(allWallets, descriptor);
+    if (wallet) {
+      result.push({
+        id: descriptor.id,
+        displayName: descriptor.displayName,
+        wallet,
+      });
+    }
+  }
+  return result;
+}
+
+/**
+ * Subscribe to Wallet Standard register/unregister events so the UI
+ * picks up wallets that load after the widget mounts. Returns an
+ * unsubscribe function. The callback fires once immediately with the
+ * current snapshot so callers don't have to also poll separately.
+ */
+export function subscribeToAvailableSuiWallets(
+  callback: (wallets: AvailableSuiWallet[]) => void
+): () => void {
+  if (typeof window === "undefined") return () => {};
+  const walletsApi = getWallets();
+  const notify = () => callback(listAvailableSuiWallets());
+  const unsubRegister = walletsApi.on("register", notify);
+  const unsubUnregister = walletsApi.on("unregister", notify);
+  notify();
+  return () => {
+    unsubRegister();
+    unsubUnregister();
+  };
+}
+
+/**
+ * Locate the requested Sui wallet via Wallet Standard and request a
+ * connection. Throws `wallet_not_installed` if no compatible wallet
+ * is registered for the given id.
+ */
+export async function connectSuiWallet(
+  walletId: SuiWalletId
+): Promise<SuiWalletConnection> {
   if (typeof window === "undefined") {
     throw new SuiRedeemError(
-      "slush_not_installed",
-      "Slush wallet detection is only available in the browser."
+      "wallet_not_installed",
+      "Sui wallet detection is only available in the browser."
+    );
+  }
+
+  const descriptor = SUI_WALLET_BY_ID[walletId];
+  if (!descriptor) {
+    throw new SuiRedeemError(
+      "wallet_not_installed",
+      `Unknown Sui wallet id: ${walletId}`
     );
   }
 
   const walletsApi = getWallets();
   const allWallets = walletsApi.get();
-  const slush = allWallets.find((w) => SLUSH_WALLET_NAMES.has(w.name)) as
-    | WalletWithRequiredFeatures
-    | undefined;
+  const wallet = findWalletByDescriptor(allWallets, descriptor);
 
-  if (!slush) {
+  if (!wallet) {
     throw new SuiRedeemError(
-      "slush_not_installed",
-      "Slush wallet was not detected. Install the Slush extension and refresh."
+      "wallet_not_installed",
+      `${descriptor.displayName} wallet was not detected. Install the ${descriptor.displayName} extension and refresh.`
     );
   }
 
-  const connectFeature = slush.features["standard:connect"];
+  const connectFeature = wallet.features["standard:connect"];
   if (!connectFeature) {
     throw new SuiRedeemError(
-      "slush_not_installed",
-      "Slush wallet is missing the standard:connect feature."
+      "wallet_not_installed",
+      `${descriptor.displayName} wallet is missing the standard:connect feature.`
     );
   }
 
@@ -295,25 +396,33 @@ export async function connectSlush(): Promise<SlushConnection> {
   } catch (err) {
     throw new SuiRedeemError(
       "wallet_rejected",
-      err instanceof Error ? err.message : "Slush rejected the connection."
+      err instanceof Error
+        ? err.message
+        : `${descriptor.displayName} rejected the connection.`
     );
   }
 
-  const account = slush.accounts[0];
+  const account = wallet.accounts[0];
   if (!account) {
     throw new SuiRedeemError(
       "wallet_rejected",
-      "Slush returned no accounts. Unlock the wallet and try again."
+      `${descriptor.displayName} returned no accounts. Unlock the wallet and try again.`
     );
   }
 
-  return { wallet: slush, address: account.address };
+  return {
+    id: descriptor.id,
+    displayName: descriptor.displayName,
+    wallet,
+    address: account.address,
+  };
 }
 
 /**
- * End-to-end Sui redeem against Slush. Caller is expected to have
- * already verified the connected wallet address matches the VAA
- * recipient (we do it here too as a defensive check).
+ * End-to-end Sui redeem against a Wallet-Standard-compliant wallet
+ * (Slush or Phantom). Caller is expected to have already verified the
+ * connected wallet address matches the VAA recipient (we do it here
+ * too as a defensive check).
  *
  * Returns the Sui transaction digest on success.
  */
@@ -322,22 +431,22 @@ export async function executeSuiRedeem({
   recipient,
   tokenChain,
   tokenAddressHex,
-  slush,
+  connection,
   suiClient,
 }: {
   vaaBase64: string;
   recipient: string;
   tokenChain: number;
   tokenAddressHex: string;
-  slush: SlushConnection;
+  connection: SuiWalletConnection;
   suiClient?: SuiClientLike;
 }): Promise<string> {
   const normalizedRecipient = normalizeSuiAddress(recipient);
-  const normalizedSlush = normalizeSuiAddress(slush.address);
-  if (normalizedRecipient !== normalizedSlush) {
+  const normalizedSender = normalizeSuiAddress(connection.address);
+  if (normalizedRecipient !== normalizedSender) {
     throw new SuiRedeemError(
       "wallet_mismatch",
-      `Connected Slush account (${normalizedSlush}) is not the VAA recipient (${normalizedRecipient}). Redemption credits the recipient regardless, but Slush will refuse to pay gas for a stranger's claim. Switch accounts in Slush.`
+      `Connected ${connection.displayName} account (${normalizedSender}) is not the VAA recipient (${normalizedRecipient}). Redemption credits the recipient regardless, but ${connection.displayName} will refuse to pay gas for a stranger's claim. Switch accounts in your wallet.`
     );
   }
 
@@ -358,26 +467,27 @@ export async function executeSuiRedeem({
     coinType,
     packageIds,
   });
-  tx.setSender(slush.address);
+  tx.setSender(connection.address);
 
   const { signAndExecuteTransaction } = await import("@mysten/wallet-standard");
 
   // The wallet may have switched accounts (or locked entirely) between
-  // `connectSlush()` and now, so re-resolve the account before signing
-  // instead of trusting the cached one with a non-null assertion.
-  const account = slush.wallet.accounts.find(
-    (a) => a.address === slush.address
+  // `connectSuiWallet()` and now, so re-resolve the account before
+  // signing instead of trusting the cached one with a non-null
+  // assertion.
+  const account = connection.wallet.accounts.find(
+    (a) => a.address === connection.address
   );
   if (!account) {
     throw new SuiRedeemError(
       "wallet_rejected",
-      "The connected Slush account is no longer available. Reconnect and try again."
+      `The connected ${connection.displayName} account is no longer available. Reconnect and try again.`
     );
   }
 
   let digest: string;
   try {
-    const result = await signAndExecuteTransaction(slush.wallet, {
+    const result = await signAndExecuteTransaction(connection.wallet, {
       transaction: tx,
       account,
       chain: SUI_MAINNET_CHAIN,
@@ -386,7 +496,9 @@ export async function executeSuiRedeem({
   } catch (err) {
     throw new SuiRedeemError(
       "wallet_rejected",
-      err instanceof Error ? err.message : "Slush rejected the signature."
+      err instanceof Error
+        ? err.message
+        : `${connection.displayName} rejected the signature.`
     );
   }
 
@@ -399,7 +511,3 @@ export async function executeSuiRedeem({
 
   return digest;
 }
-
-export const __testables = {
-  SLUSH_WALLET_NAMES,
-};

--- a/packages/web/components/bridge/wormhole-sui.ts
+++ b/packages/web/components/bridge/wormhole-sui.ts
@@ -114,6 +114,7 @@ const SUI_WALLET_BY_ID: Record<SuiWalletId, SuiWalletDescriptor> =
 
 type SuiRedeemErrorCode =
   | "wallet_not_installed"
+  | "no_sui_account"
   | "unsupported_token"
   | "wallet_mismatch"
   | "wallet_rejected"
@@ -361,10 +362,16 @@ export function subscribeToAvailableSuiWallets(
 /**
  * Locate the requested Sui wallet via Wallet Standard and request a
  * connection. Throws `wallet_not_installed` if no compatible wallet
- * is registered for the given id.
+ * is registered for the given id, or `no_sui_account` if the wallet
+ * connected but has no Sui-mainnet accounts to choose from.
+ *
+ * `preferredAddress` (typically the VAA recipient) lets us pick the
+ * account that will actually be authorised to pay gas without forcing
+ * a wallet-side switch when the user has multiple Sui accounts.
  */
 export async function connectSuiWallet(
-  walletId: SuiWalletId
+  walletId: SuiWalletId,
+  preferredAddress?: string
 ): Promise<SuiWalletConnection> {
   if (typeof window === "undefined") {
     throw new SuiRedeemError(
@@ -411,19 +418,48 @@ export async function connectSuiWallet(
     );
   }
 
-  const account = wallet.accounts[0];
-  if (!account) {
+  if (wallet.accounts.length === 0) {
     throw new SuiRedeemError(
       "wallet_rejected",
       `${descriptor.displayName} returned no accounts. Unlock the wallet and try again.`
     );
   }
 
+  // Multi-chain wallets (notably Phantom) put their Solana / BTC / EVM
+  // accounts into the same Wallet Standard `accounts` array as Sui ones,
+  // and may list a non-Sui account at index 0. Picking that blindly and
+  // feeding it through `normalizeSuiAddress` produces a malformed
+  // "0x00…<base58-blob>" address and a confusing mismatch error. Filter
+  // by the per-account `chains` tag so we only ever pick a real Sui
+  // mainnet account.
+  const suiAccounts = wallet.accounts.filter((a) =>
+    a.chains.includes(SUI_MAINNET_CHAIN)
+  );
+  if (suiAccounts.length === 0) {
+    throw new SuiRedeemError(
+      "no_sui_account",
+      `${descriptor.displayName} is connected but does not expose a Sui mainnet account. Create or enable one in ${descriptor.displayName} and try again.`
+    );
+  }
+
+  // Prefer the account that matches the VAA recipient, so users with
+  // multiple Sui accounts don't have to manually switch in the wallet
+  // before the redeem succeeds.
+  const normalizedPreferred = preferredAddress
+    ? normalizeSuiAddress(preferredAddress)
+    : null;
+  const chosen =
+    (normalizedPreferred
+      ? suiAccounts.find(
+          (a) => normalizeSuiAddress(a.address) === normalizedPreferred
+        )
+      : undefined) ?? suiAccounts[0];
+
   return {
     id: descriptor.id,
     displayName: descriptor.displayName,
     wallet,
-    address: account.address,
+    address: chosen.address,
   };
 }
 
@@ -491,6 +527,16 @@ export async function executeSuiRedeem({
     throw new SuiRedeemError(
       "wallet_rejected",
       `The connected ${connection.displayName} account is no longer available. Reconnect and try again.`
+    );
+  }
+  // Defense-in-depth: even though we filter by chain at connect time,
+  // a multi-chain wallet could have swapped its `accounts` array since
+  // then. Signing on a non-Sui-tagged account would surface a
+  // confusing wallet-side error.
+  if (!account.chains.includes(SUI_MAINNET_CHAIN)) {
+    throw new SuiRedeemError(
+      "no_sui_account",
+      `The connected ${connection.displayName} account no longer advertises a Sui mainnet chain. Reconnect with a Sui account in ${connection.displayName} and try again.`
     );
   }
 

--- a/packages/web/components/bridge/wormhole-sui.ts
+++ b/packages/web/components/bridge/wormhole-sui.ts
@@ -305,13 +305,35 @@ export interface AvailableSuiWallet {
   wallet: WalletWithRequiredFeatures;
 }
 
+/**
+ * The single Wallet Standard feature we actually invoke from this
+ * module (via `signAndExecuteTransaction` in `@mysten/wallet-standard`).
+ * A registration that doesn't advertise this isn't a Sui wallet for
+ * our purposes — relevant when a multi-chain wallet like Phantom
+ * registers a Solana-only entry under the same `wallet.name`.
+ */
+const SUI_SIGN_FEATURE = "sui:signAndExecuteTransaction" as const;
+
+function isSuiCapableWallet(wallet: {
+  features: Record<string, unknown>;
+}): boolean {
+  return SUI_SIGN_FEATURE in wallet.features;
+}
+
+/** Sui addresses are unambiguously 32-byte `0x`-prefixed hex strings. */
+function isSuiHexAddress(address: string): boolean {
+  return /^0x[0-9a-f]{64}$/i.test(address);
+}
+
 function findWalletByDescriptor(
-  wallets: readonly { name: string }[],
+  wallets: readonly { name: string; features?: Record<string, unknown> }[],
   descriptor: SuiWalletDescriptor
 ): WalletWithRequiredFeatures | undefined {
-  return wallets.find((w) => descriptor.walletNames.has(w.name)) as
-    | WalletWithRequiredFeatures
-    | undefined;
+  return wallets.find(
+    (w) =>
+      descriptor.walletNames.has(w.name) &&
+      isSuiCapableWallet({ features: w.features ?? {} })
+  ) as WalletWithRequiredFeatures | undefined;
 }
 
 /**
@@ -429,11 +451,18 @@ export async function connectSuiWallet(
   // accounts into the same Wallet Standard `accounts` array as Sui ones,
   // and may list a non-Sui account at index 0. Picking that blindly and
   // feeding it through `normalizeSuiAddress` produces a malformed
-  // "0x00…<base58-blob>" address and a confusing mismatch error. Filter
-  // by the per-account `chains` tag so we only ever pick a real Sui
-  // mainnet account.
-  const suiAccounts = wallet.accounts.filter((a) =>
-    a.chains.includes(SUI_MAINNET_CHAIN)
+  // "0x00…<base58-blob>" address and a confusing mismatch error.
+  //
+  // We accept an account either if it advertises `sui:mainnet` in its
+  // `chains` tag (Slush's canonical behaviour) OR if the address itself
+  // is a 32-byte `0x`-prefixed hex string. Phantom doesn't populate the
+  // per-account `chains` array for its Sui account in some builds, but
+  // its Sui address is still the unambiguous discriminator: Solana
+  // (base58), Bitcoin (bech32) and Ethereum (20-byte hex) addresses
+  // never match the 64-hex-char Sui shape. See live repro tx
+  // D70648F68D1DC6A8E663D3A0841A7037D9D786AEE755F89735ACD04E5F576562.
+  const suiAccounts = wallet.accounts.filter(
+    (a) => a.chains.includes(SUI_MAINNET_CHAIN) || isSuiHexAddress(a.address)
   );
   if (suiAccounts.length === 0) {
     throw new SuiRedeemError(
@@ -529,14 +558,18 @@ export async function executeSuiRedeem({
       `The connected ${connection.displayName} account is no longer available. Reconnect and try again.`
     );
   }
-  // Defense-in-depth: even though we filter by chain at connect time,
-  // a multi-chain wallet could have swapped its `accounts` array since
-  // then. Signing on a non-Sui-tagged account would surface a
-  // confusing wallet-side error.
-  if (!account.chains.includes(SUI_MAINNET_CHAIN)) {
+  // Defense-in-depth: even though we filter at connect time, a
+  // multi-chain wallet could have swapped its `accounts` array since
+  // then. Mirror the same accept-either-chain-tag-or-Sui-hex-shape
+  // logic; signing on a non-Sui account would surface a confusing
+  // wallet-side error.
+  if (
+    !account.chains.includes(SUI_MAINNET_CHAIN) &&
+    !isSuiHexAddress(account.address)
+  ) {
     throw new SuiRedeemError(
       "no_sui_account",
-      `The connected ${connection.displayName} account no longer advertises a Sui mainnet chain. Reconnect with a Sui account in ${connection.displayName} and try again.`
+      `The connected ${connection.displayName} account no longer looks like a Sui account. Reconnect with a Sui account in ${connection.displayName} and try again.`
     );
   }
 

--- a/packages/web/components/bridge/wormhole-sui.ts
+++ b/packages/web/components/bridge/wormhole-sui.ts
@@ -1,0 +1,392 @@
+/**
+ * Native Sui redemption for Wormhole token-bridge transfers.
+ *
+ * We deliberately avoid pulling in `@wormhole-foundation/sdk-sui` or any
+ * dApp-kit dependencies so the attack surface stays small. The flow is
+ * the same five Move calls the official SDK builds:
+ *
+ *   1. wormhole::vaa::parse_and_verify
+ *   2. token_bridge::vaa::verify_only_once
+ *   3. token_bridge::complete_transfer::authorize_transfer<CoinType>
+ *   4. token_bridge::complete_transfer::redeem_relayer_payout<CoinType>
+ *   5. token_bridge::coin_utils::return_nonzero<CoinType>
+ *
+ * Package IDs are resolved dynamically from each state object's
+ * `upgrade_cap.fields.package`, so we don't have to redeploy this
+ * widget on Wormhole contract upgrades.
+ *
+ * Wallet integration is Slush-only via the Wallet Standard protocol
+ * (`@mysten/wallet-standard`). Slush is the rebrand of the Mysten Labs
+ * "Sui Wallet" extension; older builds still register under the legacy
+ * name so we accept both.
+ */
+
+import type { WalletWithRequiredFeatures } from "@mysten/wallet-standard";
+import { getWallets } from "@mysten/wallet-standard";
+
+export const SUI_RPC = "https://fullnode.mainnet.sui.io:443";
+export const SUI_MAINNET_CHAIN = "sui:mainnet" as const;
+export const SUI_CLOCK_OBJECT_ID = "0x6";
+
+/**
+ * Wormhole Sui mainnet state object IDs.
+ * Verified against https://wormhole.com/docs/products/reference/contract-addresses
+ * (Core Bridge & Token Bridge / Wrapped Token Transfers rows for Sui mainnet).
+ *
+ * Package IDs are read from these state objects at runtime so this
+ * widget keeps working across Wormhole contract upgrades.
+ */
+export const WORMHOLE_SUI_CORE_STATE =
+  "0xaeab97f96cf9877fee2883315d459552b2b921edc16d7ceac6eab944dd88919c";
+export const WORMHOLE_SUI_TOKEN_BRIDGE_STATE =
+  "0xc57508ee0d4595e5a8728974a4a93a787d38f339757230d441e895422c07aba9";
+
+/**
+ * Wormhole-canonical 32-byte representation of known native Sui coin
+ * types. The token bridge stores a mapping from these to the actual
+ * Move CoinType under a dynamic field on the bridge state, but the
+ * forward lookup requires a non-trivial RPC dance and is rarely needed:
+ * almost every Osmosis→Sui gateway transfer is unwrapping SUI itself.
+ *
+ * For other tokens we degrade gracefully: the user is told this widget
+ * only supports SUI native redemption and is sent back to the generic
+ * Wormholescan-link panel.
+ *
+ * To add a new token here, look up its `tokenAddress` in the
+ * Wormholescan operation payload and the matching Sui CoinType.
+ */
+export const KNOWN_SUI_COIN_TYPES: Record<string, string> = {
+  "0x9258181f5ceac8dbffb7030890243caed69a9599d2886d957a9cb7656af3bdb3":
+    "0x2::sui::SUI",
+};
+
+const SLUSH_WALLET_NAMES = new Set([
+  "Slush",
+  "Slush — A Sui wallet",
+  "Sui Wallet",
+]);
+
+export class SuiRedeemError extends Error {
+  /** Stable error code so the UI can branch without string-matching. */
+  readonly code:
+    | "slush_not_installed"
+    | "unsupported_token"
+    | "wallet_mismatch"
+    | "wallet_rejected"
+    | "rpc_error";
+
+  constructor(
+    code:
+      | "slush_not_installed"
+      | "unsupported_token"
+      | "wallet_mismatch"
+      | "wallet_rejected"
+      | "rpc_error",
+    message: string
+  ) {
+    super(message);
+    this.code = code;
+    this.name = "SuiRedeemError";
+  }
+}
+
+export interface SuiPackageIds {
+  corePackageId: string;
+  tokenBridgePackageId: string;
+}
+
+/**
+ * Minimal structural type so the tests can stub the Sui client without
+ * importing all of `@mysten/sui`. The real `SuiClient` satisfies this.
+ */
+export interface SuiClientLike {
+  getObject(input: {
+    id: string;
+    options: { showContent: true };
+  }): Promise<unknown>;
+  waitForTransaction(input: {
+    digest: string;
+    timeout?: number;
+  }): Promise<unknown>;
+}
+
+/**
+ * Read the current package IDs out of each Wormhole state object.
+ * On Sui, package upgrades produce a new package ID; the state's
+ * `upgrade_cap.fields.package` is the canonical pointer to the
+ * currently active version.
+ */
+export async function getSuiPackageIds(
+  client: Pick<SuiClientLike, "getObject">
+): Promise<SuiPackageIds> {
+  const [coreState, tokenBridgeState] = await Promise.all([
+    client.getObject({
+      id: WORMHOLE_SUI_CORE_STATE,
+      options: { showContent: true },
+    }),
+    client.getObject({
+      id: WORMHOLE_SUI_TOKEN_BRIDGE_STATE,
+      options: { showContent: true },
+    }),
+  ]);
+
+  const extract = (response: unknown, label: string): string => {
+    const data = (response as { data?: { content?: unknown } } | undefined)
+      ?.data;
+    const content = data?.content as
+      | {
+          dataType?: string;
+          fields?: { upgrade_cap?: { fields?: { package?: string } } };
+        }
+      | undefined;
+    if (content?.dataType !== "moveObject") {
+      throw new SuiRedeemError(
+        "rpc_error",
+        `Could not read ${label} state object (got dataType=${
+          content?.dataType ?? "undefined"
+        })`
+      );
+    }
+    const pkg = content.fields?.upgrade_cap?.fields?.package;
+    if (typeof pkg !== "string" || !pkg.startsWith("0x")) {
+      throw new SuiRedeemError(
+        "rpc_error",
+        `Could not read current ${label} package id from state object`
+      );
+    }
+    return pkg;
+  };
+
+  return {
+    corePackageId: extract(coreState, "core bridge"),
+    tokenBridgePackageId: extract(tokenBridgeState, "token bridge"),
+  };
+}
+
+/**
+ * Normalize a Sui 32-byte hex string to a `0x`-prefixed lowercase form,
+ * removing any leading zeros that Wormholescan sometimes strips.
+ */
+export function normalizeSuiAddress(hex: string): string {
+  const stripped = hex.toLowerCase().replace(/^0x/, "");
+  const padded = stripped.padStart(64, "0");
+  return `0x${padded}`;
+}
+
+/**
+ * Resolve the Sui Move CoinType for a Wormhole token (chain + 32-byte
+ * address). Currently only known native mappings are supported; for
+ * anything else we throw `unsupported_token` so the UI can fall back
+ * to the generic Wormholescan-link panel.
+ */
+export function getCoinTypeForSuiVAA(
+  tokenChain: number,
+  tokenAddressHex: string
+): string {
+  const normalized = normalizeSuiAddress(tokenAddressHex);
+  const coinType = KNOWN_SUI_COIN_TYPES[normalized];
+  if (coinType) return coinType;
+
+  throw new SuiRedeemError(
+    "unsupported_token",
+    `This widget can natively redeem SUI but not the token at ${normalized} (chain ${tokenChain}). Use Wormholescan / Portal Bridge for other tokens.`
+  );
+}
+
+/** Decode a base64-encoded VAA into raw bytes. */
+export function decodeBase64Vaa(vaaBase64: string): Uint8Array {
+  return Uint8Array.from(atob(vaaBase64), (c) => c.charCodeAt(0));
+}
+
+/**
+ * Build the Sui `Transaction` that completes a Wormhole token-bridge
+ * transfer. This mirrors `redeemOnSui` from the v1 Wormhole SDK
+ * (`@certusone/wormhole-sdk`) but uses the v2 `@mysten/sui` builder.
+ */
+export async function buildSuiRedeemTransaction({
+  vaaBase64,
+  coinType,
+  packageIds,
+}: {
+  vaaBase64: string;
+  coinType: string;
+  packageIds: SuiPackageIds;
+}): Promise<import("@mysten/sui/transactions").Transaction> {
+  const { Transaction } = await import("@mysten/sui/transactions");
+  const tx = new Transaction();
+  const vaaBytes = decodeBase64Vaa(vaaBase64);
+
+  const [verifiedVaa] = tx.moveCall({
+    target: `${packageIds.corePackageId}::vaa::parse_and_verify`,
+    arguments: [
+      tx.object(WORMHOLE_SUI_CORE_STATE),
+      tx.pure.vector("u8", vaaBytes),
+      tx.object(SUI_CLOCK_OBJECT_ID),
+    ],
+  });
+
+  const [tokenBridgeMessage] = tx.moveCall({
+    target: `${packageIds.tokenBridgePackageId}::vaa::verify_only_once`,
+    arguments: [tx.object(WORMHOLE_SUI_TOKEN_BRIDGE_STATE), verifiedVaa],
+  });
+
+  const [relayerReceipt] = tx.moveCall({
+    target: `${packageIds.tokenBridgePackageId}::complete_transfer::authorize_transfer`,
+    arguments: [tx.object(WORMHOLE_SUI_TOKEN_BRIDGE_STATE), tokenBridgeMessage],
+    typeArguments: [coinType],
+  });
+
+  const [coins] = tx.moveCall({
+    target: `${packageIds.tokenBridgePackageId}::complete_transfer::redeem_relayer_payout`,
+    arguments: [relayerReceipt],
+    typeArguments: [coinType],
+  });
+
+  tx.moveCall({
+    target: `${packageIds.tokenBridgePackageId}::coin_utils::return_nonzero`,
+    arguments: [coins],
+    typeArguments: [coinType],
+  });
+
+  return tx;
+}
+
+export interface SlushConnection {
+  wallet: WalletWithRequiredFeatures;
+  address: string;
+}
+
+/**
+ * Locate the Slush wallet (formerly "Sui Wallet") and request a
+ * connection. Throws `slush_not_installed` if the user has no
+ * compatible Sui wallet registered via Wallet Standard.
+ */
+export async function connectSlush(): Promise<SlushConnection> {
+  if (typeof window === "undefined") {
+    throw new SuiRedeemError(
+      "slush_not_installed",
+      "Slush wallet detection is only available in the browser."
+    );
+  }
+
+  const walletsApi = getWallets();
+  const allWallets = walletsApi.get();
+  const slush = allWallets.find((w) => SLUSH_WALLET_NAMES.has(w.name)) as
+    | WalletWithRequiredFeatures
+    | undefined;
+
+  if (!slush) {
+    throw new SuiRedeemError(
+      "slush_not_installed",
+      "Slush wallet was not detected. Install the Slush extension and refresh."
+    );
+  }
+
+  const connectFeature = slush.features["standard:connect"];
+  if (!connectFeature) {
+    throw new SuiRedeemError(
+      "slush_not_installed",
+      "Slush wallet is missing the standard:connect feature."
+    );
+  }
+
+  try {
+    await connectFeature.connect();
+  } catch (err) {
+    throw new SuiRedeemError(
+      "wallet_rejected",
+      err instanceof Error ? err.message : "Slush rejected the connection."
+    );
+  }
+
+  const account = slush.accounts[0];
+  if (!account) {
+    throw new SuiRedeemError(
+      "wallet_rejected",
+      "Slush returned no accounts. Unlock the wallet and try again."
+    );
+  }
+
+  return { wallet: slush, address: account.address };
+}
+
+/**
+ * End-to-end Sui redeem against Slush. Caller is expected to have
+ * already verified the connected wallet address matches the VAA
+ * recipient (we do it here too as a defensive check).
+ *
+ * Returns the Sui transaction digest on success.
+ */
+export async function executeSuiRedeem({
+  vaaBase64,
+  recipient,
+  tokenChain,
+  tokenAddressHex,
+  slush,
+  suiClient,
+}: {
+  vaaBase64: string;
+  recipient: string;
+  tokenChain: number;
+  tokenAddressHex: string;
+  slush: SlushConnection;
+  suiClient?: SuiClientLike;
+}): Promise<string> {
+  const normalizedRecipient = normalizeSuiAddress(recipient);
+  const normalizedSlush = normalizeSuiAddress(slush.address);
+  if (normalizedRecipient !== normalizedSlush) {
+    throw new SuiRedeemError(
+      "wallet_mismatch",
+      `Connected Slush account (${normalizedSlush}) is not the VAA recipient (${normalizedRecipient}). Redemption credits the recipient regardless, but Slush will refuse to pay gas for a stranger's claim. Switch accounts in Slush.`
+    );
+  }
+
+  const coinType = getCoinTypeForSuiVAA(tokenChain, tokenAddressHex);
+
+  // Lazy-load the Sui client only when we actually redeem.
+  let client: SuiClientLike;
+  if (suiClient) {
+    client = suiClient;
+  } else {
+    const { SuiClient } = await import("@mysten/sui/client");
+    client = new SuiClient({ url: SUI_RPC }) as SuiClientLike;
+  }
+
+  const packageIds = await getSuiPackageIds(client);
+  const tx = await buildSuiRedeemTransaction({
+    vaaBase64,
+    coinType,
+    packageIds,
+  });
+  tx.setSender(slush.address);
+
+  const { signAndExecuteTransaction } = await import("@mysten/wallet-standard");
+
+  let digest: string;
+  try {
+    const result = await signAndExecuteTransaction(slush.wallet, {
+      transaction: tx,
+      account: slush.wallet.accounts.find((a) => a.address === slush.address)!,
+      chain: SUI_MAINNET_CHAIN,
+    });
+    digest = result.digest;
+  } catch (err) {
+    throw new SuiRedeemError(
+      "wallet_rejected",
+      err instanceof Error ? err.message : "Slush rejected the signature."
+    );
+  }
+
+  try {
+    await client.waitForTransaction({ digest, timeout: 60_000 });
+  } catch {
+    // Confirmation failure isn't necessarily fatal — the digest is
+    // already on-chain at this point. Surface it but don't error.
+  }
+
+  return digest;
+}
+
+export const __testables = {
+  SLUSH_WALLET_NAMES,
+};

--- a/packages/web/components/bridge/wormhole-sui.ts
+++ b/packages/web/components/bridge/wormhole-sui.ts
@@ -1,6 +1,11 @@
 /**
  * Native Sui redemption for Wormhole token-bridge transfers.
  *
+ * We do this in-app rather than redirecting because the obvious external
+ * destinations (Wormholescan, Portal Bridge) do not support an Osmosis
+ * source hash or the Wormchain intermediary lookup — the user would be
+ * left holding a copyable VAA with no UI to consume it.
+ *
  * We deliberately avoid pulling in `@wormhole-foundation/sdk-sui` or any
  * dApp-kit dependencies so the attack surface stays small. The flow is
  * the same five Move calls the official SDK builds:
@@ -17,11 +22,9 @@
  *
  * Wallet integration speaks the Sui Wallet Standard protocol directly
  * (`@mysten/wallet-standard`) so we don't ship a dApp-kit dependency.
- * We allowlist by `wallet.name` rather than auto-connecting to anything
- * advertised on the page: a malicious extension could otherwise register
- * a Wallet Standard wallet with a misleading name. Supported wallets are
- * Slush (formerly "Sui Wallet") and Phantom (which has multi-chain Sui
- * support); both register via Wallet Standard.
+ * Supported wallets are Slush (formerly "Sui Wallet") and Phantom
+ * (whose multi-chain build registers as a Sui wallet via Wallet
+ * Standard); both register via Wallet Standard.
  */
 
 import type { WalletWithRequiredFeatures } from "@mysten/wallet-standard";
@@ -66,10 +69,16 @@ export const KNOWN_SUI_COIN_TYPES: Record<string, string> = {
 export type SuiWalletId = "slush" | "phantom";
 
 /**
- * Allowlisted Wallet Standard descriptors. Order matters: we render
- * connect buttons in this order, with Slush first because it is the
- * Mysten-native Sui wallet. Phantom is supported as a secondary option
- * for users who already have it installed for Solana.
+ * Allowlisted Wallet Standard descriptors. We allowlist by `wallet.name`
+ * and render one connect button per detected wallet rather than
+ * auto-connecting to anything advertised on the page: a malicious
+ * extension could otherwise register a Wallet Standard wallet with a
+ * misleading name and get silently selected.
+ *
+ * Order matters: we render connect buttons in this order, with Slush
+ * first because it is the Mysten-native Sui wallet. Phantom is supported
+ * as a secondary option for users who already have it installed for
+ * Solana.
  *
  * Each descriptor lists every `wallet.name` we accept. Slush has shipped
  * under multiple names during its rebrand; Phantom only registers as

--- a/packages/web/components/bridge/wormhole-sui.ts
+++ b/packages/web/components/bridge/wormhole-sui.ts
@@ -362,11 +362,24 @@ export async function executeSuiRedeem({
 
   const { signAndExecuteTransaction } = await import("@mysten/wallet-standard");
 
+  // The wallet may have switched accounts (or locked entirely) between
+  // `connectSlush()` and now, so re-resolve the account before signing
+  // instead of trusting the cached one with a non-null assertion.
+  const account = slush.wallet.accounts.find(
+    (a) => a.address === slush.address
+  );
+  if (!account) {
+    throw new SuiRedeemError(
+      "wallet_rejected",
+      "The connected Slush account is no longer available. Reconnect and try again."
+    );
+  }
+
   let digest: string;
   try {
     const result = await signAndExecuteTransaction(slush.wallet, {
       transaction: tx,
-      account: slush.wallet.accounts.find((a) => a.address === slush.address)!,
+      account,
       chain: SUI_MAINNET_CHAIN,
     });
     digest = result.digest;

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -43,6 +43,8 @@
     "@keplr-wallet/types": "0.10.24-ibc.go.v7.hot.fix",
     "@moonpay/moonpay-node": "^0.2.7",
     "@moonpay/moonpay-react": "^1.8.2",
+    "@mysten/sui": "^1",
+    "@mysten/wallet-standard": "^0",
     "@next/bundle-analyzer": "^14.2.35",
     "@osmosis-labs/bridge": "^1.0.0",
     "@osmosis-labs/keplr-hooks": "0.10.24-ibc.go.v7.hot.fix",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,19 @@
 # yarn lockfile v1
 
 
+"@0no-co/graphql.web@^1.0.5":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@0no-co/graphql.web/-/graphql.web-1.2.0.tgz#296d00581bfaaabfda1e976849d927824aaea81b"
+  integrity sha512-/1iHy9TTr63gE1YcR5idjx8UREz1s0kFhydf3bBLCXyqjhkIc6igAzTOx3zPifCwFR87tsh/4Pa9cNts6d2otw==
+
+"@0no-co/graphqlsp@^1.12.13":
+  version "1.15.4"
+  resolved "https://registry.yarnpkg.com/@0no-co/graphqlsp/-/graphqlsp-1.15.4.tgz#37d0855650866584c71273e1a3e2f031e5aa5209"
+  integrity sha512-Nt1DVHcZ08lKRKwhiU0amXH77fSdrO6DzyjLE0DkCxfbM/N1SAs32d76y1xtCzM5H9eT0iDS7SdksgRXWJu05g==
+  dependencies:
+    "@gql.tada/internal" "^1.0.0"
+    graphql "^15.5.0 || ^16.0.0 || ^17.0.0"
+
 "@0xsquid/sdk@^1.14.0":
   version "1.14.0"
   resolved "https://registry.yarnpkg.com/@0xsquid/sdk/-/sdk-1.14.0.tgz#167a580ec05caaf0f65cacc12010abce3f1c58ed"
@@ -3845,6 +3858,27 @@
   resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.4.tgz#1d459cee5031893a08a0e064c406ad2130cced7c"
   integrity sha512-dWO2pw8hhi+WrXq1YJy2yCuWoL20PddgGaqTgVe4cOS9Q6qklXCiA1tJEqX6BEwRNSCP84/afac9hd4MS+zEUA==
 
+"@gql.tada/cli-utils@1.7.3":
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/@gql.tada/cli-utils/-/cli-utils-1.7.3.tgz#06dcab8d646f805176393864414c314d4a77826c"
+  integrity sha512-3iQY5E/jvv3Lnh6D1Mh7zr+Bb9C/TGk1DHkm+lbIjQBnZAu2m+BcTcr1e3spUt6Aa6HG/xAN2XxpbWw9oZALEg==
+  dependencies:
+    "@0no-co/graphqlsp" "^1.12.13"
+    "@gql.tada/internal" "1.0.9"
+    graphql "^15.5.0 || ^16.0.0 || ^17.0.0"
+
+"@gql.tada/internal@1.0.9", "@gql.tada/internal@^1.0.0":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@gql.tada/internal/-/internal-1.0.9.tgz#15602e4d444741b11557d17b0dab7e0299b18030"
+  integrity sha512-Bp8yi+kLrzIJ3l5Dfxhz48H4OCH2LCX+pShaPcJgh+oiBt6clrjUKDYNDD3Z78aDQ3+Tyrxe4dd0MfLgpSLPPg==
+  dependencies:
+    "@0no-co/graphql.web" "^1.0.5"
+
+"@graphql-typed-document-node/core@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.2.0.tgz#5f3d96ec6b2354ad6d8a28bf216a1d97b5426861"
+  integrity sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==
+
 "@hapi/hoek@^9.0.0":
   version "9.2.1"
   resolved "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz"
@@ -4462,7 +4496,29 @@
     buffer "^6.0.3"
     delay "^4.4.0"
 
-"@keplr-wallet/cosmos@0.10.24-ibc.go.v7.hot.fix", "@keplr-wallet/cosmos@0.12.12", "@keplr-wallet/cosmos@0.12.28":
+"@keplr-wallet/common@0.12.12":
+  version "0.12.12"
+  resolved "https://registry.yarnpkg.com/@keplr-wallet/common/-/common-0.12.12.tgz#55030d985b729eac582c0d7203190e25ea2cb3ec"
+  integrity sha512-AxpwmXdqs083lMvA8j0/V30oTGyobsefNaCou+lP4rCyDdYuXSEux+x2+1AGL9xB3yZfN+4jvEEKJdMwHYEHcQ==
+  dependencies:
+    "@keplr-wallet/crypto" "0.12.12"
+    "@keplr-wallet/types" "0.12.12"
+    buffer "^6.0.3"
+    delay "^4.4.0"
+    mobx "^6.1.7"
+
+"@keplr-wallet/common@0.12.28":
+  version "0.12.28"
+  resolved "https://registry.yarnpkg.com/@keplr-wallet/common/-/common-0.12.28.tgz#1d5d985070aced31a34a6426c9ac4b775081acca"
+  integrity sha512-ESQorPZw8PRiUXhsrxED+E1FEWkAdc6Kwi3Az7ce204gMBQDI2j0XJtTd4uCUp+C24Em9fk0samdHzdoB4caIg==
+  dependencies:
+    "@keplr-wallet/crypto" "0.12.28"
+    "@keplr-wallet/types" "0.12.28"
+    buffer "^6.0.3"
+    delay "^4.4.0"
+    mobx "^6.1.7"
+
+"@keplr-wallet/cosmos@0.10.24-ibc.go.v7.hot.fix":
   version "0.10.24-ibc.go.v7.hot.fix"
   resolved "https://registry.npmjs.org/@keplr-wallet/cosmos/-/cosmos-0.10.24-ibc.go.v7.hot.fix.tgz"
   integrity sha512-/A/wHyYo5gQIW5YkAQYZadEv/12EcAuDclO0KboIb9ti4XFJW6S4VY8LnA16R7DZyBx1cnQknyDm101fUrJfJQ==
@@ -4474,6 +4530,40 @@
     "@keplr-wallet/types" "0.10.24-ibc.go.v7.hot.fix"
     "@keplr-wallet/unit" "0.10.24-ibc.go.v7.hot.fix"
     axios "^0.27.2"
+    bech32 "^1.1.4"
+    buffer "^6.0.3"
+    long "^4.0.0"
+    protobufjs "^6.11.2"
+
+"@keplr-wallet/cosmos@0.12.12":
+  version "0.12.12"
+  resolved "https://registry.yarnpkg.com/@keplr-wallet/cosmos/-/cosmos-0.12.12.tgz#72c0505d2327bbf2f5cb51502acaf399b88b4ae3"
+  integrity sha512-9TLsefUIAuDqqf1WHBt9Bk29rPlkezmLM8P1eEsXGUaHBfuqUrO+RwL3eLA3HGcgNvdy9s8e0p/4CMInH/LLLQ==
+  dependencies:
+    "@ethersproject/address" "^5.6.0"
+    "@keplr-wallet/common" "0.12.12"
+    "@keplr-wallet/crypto" "0.12.12"
+    "@keplr-wallet/proto-types" "0.12.12"
+    "@keplr-wallet/simple-fetch" "0.12.12"
+    "@keplr-wallet/types" "0.12.12"
+    "@keplr-wallet/unit" "0.12.12"
+    bech32 "^1.1.4"
+    buffer "^6.0.3"
+    long "^4.0.0"
+    protobufjs "^6.11.2"
+
+"@keplr-wallet/cosmos@0.12.28":
+  version "0.12.28"
+  resolved "https://registry.yarnpkg.com/@keplr-wallet/cosmos/-/cosmos-0.12.28.tgz#d56e73468256e7276a66bb41f145449dbf11efa1"
+  integrity sha512-IuqmSBgKgIeWBA0XGQKKs28IXFeFMCrfadCbtiZccNc7qnNr5Y/Cyyk01BPC8Dd1ZyEyAByoICgrxvtGN0GGvA==
+  dependencies:
+    "@ethersproject/address" "^5.6.0"
+    "@keplr-wallet/common" "0.12.28"
+    "@keplr-wallet/crypto" "0.12.28"
+    "@keplr-wallet/proto-types" "0.12.28"
+    "@keplr-wallet/simple-fetch" "0.12.28"
+    "@keplr-wallet/types" "0.12.28"
+    "@keplr-wallet/unit" "0.12.28"
     bech32 "^1.1.4"
     buffer "^6.0.3"
     long "^4.0.0"
@@ -4551,10 +4641,26 @@
   resolved "https://registry.npmjs.org/@keplr-wallet/popup/-/popup-0.10.24-ibc.go.v7.hot.fix.tgz"
   integrity sha512-Q/teyV6vdmpH3SySGd1xrNc/mVGK/tCP5vFEG2I3Y4FDCSV1yD7vcVgUy+tN19Z8EM3goR57V2QlarSOidtdjQ==
 
-"@keplr-wallet/proto-types@0.10.24-ibc.go.v7.hot.fix", "@keplr-wallet/proto-types@0.12.12":
+"@keplr-wallet/proto-types@0.10.24-ibc.go.v7.hot.fix":
   version "0.10.24-ibc.go.v7.hot.fix"
   resolved "https://registry.npmjs.org/@keplr-wallet/proto-types/-/proto-types-0.10.24-ibc.go.v7.hot.fix.tgz"
   integrity sha512-fLUJEtDadYJIMBzhMSZpEDTvXqk8wW68TwnUCRAcAooEQEtXPwY5gfo3hcekQEiCYtIu8XqzJ9fg01rp2Z4d3w==
+  dependencies:
+    long "^4.0.0"
+    protobufjs "^6.11.2"
+
+"@keplr-wallet/proto-types@0.12.12":
+  version "0.12.12"
+  resolved "https://registry.yarnpkg.com/@keplr-wallet/proto-types/-/proto-types-0.12.12.tgz#24e0530af7604a90f33a397a82fe500865c76154"
+  integrity sha512-iAqqNlJpxu/8j+SwOXEH2ymM4W0anfxn+eNeWuqz2c/0JxGTWeLURioxQmCtewtllfHdDHHcoQ7/S+NmXiaEgQ==
+  dependencies:
+    long "^4.0.0"
+    protobufjs "^6.11.2"
+
+"@keplr-wallet/proto-types@0.12.28":
+  version "0.12.28"
+  resolved "https://registry.yarnpkg.com/@keplr-wallet/proto-types/-/proto-types-0.12.28.tgz#2fb2c37749ce7db974f01d07387e966c9b99027d"
+  integrity sha512-ukti/eCTltPUP64jxtk5TjtwJogyfKPqlBIT3KGUCGzBLIPeYMsffL5w5aoHsMjINzOITjYqzXyEF8LTIK/fmw==
   dependencies:
     long "^4.0.0"
     protobufjs "^6.11.2"
@@ -4634,12 +4740,32 @@
     deepmerge "^4.2.2"
     long "^4.0.0"
 
-"@keplr-wallet/router@0.10.24-ibc.go.v7.hot.fix", "@keplr-wallet/router@0.12.12", "@keplr-wallet/router@0.12.96":
+"@keplr-wallet/router@0.10.24-ibc.go.v7.hot.fix":
   version "0.10.24-ibc.go.v7.hot.fix"
   resolved "https://registry.npmjs.org/@keplr-wallet/router/-/router-0.10.24-ibc.go.v7.hot.fix.tgz"
   integrity sha512-bt9weexlbhlh8KsOvbDrvHJ8jtUXrXgB2LX+hEAwjclHQt7PMUhx9a5z0Obd19/ive5G/1M7/ccdPIWxRBpKQw==
 
-"@keplr-wallet/types@0.10.24-ibc.go.v7.hot.fix", "@keplr-wallet/types@0.12.107", "@keplr-wallet/types@0.12.12", "@keplr-wallet/types@0.12.96", "@keplr-wallet/types@^0.12.95":
+"@keplr-wallet/router@0.12.12":
+  version "0.12.12"
+  resolved "https://registry.yarnpkg.com/@keplr-wallet/router/-/router-0.12.12.tgz#92a2c006aec6945ed313575af6b0801f8e84e315"
+  integrity sha512-Aa1TiVRIEPaqs1t27nCNs5Kz6Ty4CLarVdfqcRWlFQL6zFq33GT46s6K9U4Lz2swVCwdmerSXaq308K/GJHTlw==
+
+"@keplr-wallet/router@0.12.96":
+  version "0.12.96"
+  resolved "https://registry.yarnpkg.com/@keplr-wallet/router/-/router-0.12.96.tgz#6a20ed2c90ba3ed4f3fc43ed7513f72d7055482d"
+  integrity sha512-O8izj032ZKQIoTus96BFqem+w6NpYHU3j6NEnSaQBh6Zncj9fgjoOVs0CKK+jsuLYUsOHx2t86BxMSKESsR0Ug==
+
+"@keplr-wallet/simple-fetch@0.12.12":
+  version "0.12.12"
+  resolved "https://registry.yarnpkg.com/@keplr-wallet/simple-fetch/-/simple-fetch-0.12.12.tgz#aacc5c3f22b7ab2804b39e864725294a32f858fd"
+  integrity sha512-lCOsaI8upMpbusfwJqEK8VIEX77+QE8+8MJVRqoCYwjOTqKGdUH7D1ieZWh+pzvzOnVgedM3lxqdmCvdgU91qw==
+
+"@keplr-wallet/simple-fetch@0.12.28":
+  version "0.12.28"
+  resolved "https://registry.yarnpkg.com/@keplr-wallet/simple-fetch/-/simple-fetch-0.12.28.tgz#44225df5b329c823076280df1ec9930a21b1373e"
+  integrity sha512-T2CiKS2B5n0ZA7CWw0CA6qIAH0XYI1siE50MP+i+V0ZniCGBeL+BMcDw64vFJUcEH+1L5X4sDAzV37fQxGwllA==
+
+"@keplr-wallet/types@0.10.24-ibc.go.v7.hot.fix":
   version "0.10.24-ibc.go.v7.hot.fix"
   resolved "https://registry.npmjs.org/@keplr-wallet/types/-/types-0.10.24-ibc.go.v7.hot.fix.tgz"
   integrity sha512-3KUjDMUCscYkvKnC+JsJh9+X0NHlsvBgAghP/uy2p5OGtiULqPBAjWiO+hnBbhis3ZEkzGcCROnnBOoccKd3CQ==
@@ -4650,12 +4776,65 @@
     long "^4.0.0"
     secretjs "^0.17.0"
 
+"@keplr-wallet/types@0.12.107":
+  version "0.12.107"
+  resolved "https://registry.yarnpkg.com/@keplr-wallet/types/-/types-0.12.107.tgz#8d6726d86e17a79131b4b6f4f114052d6384aa58"
+  integrity sha512-jBpjJO+nNL8cgsJLjZYoq84n+7nXHDdztTgRMVnnomFb+Vy0FVIEI8VUl89ImmHDUImDd0562ywsvA496/0yCA==
+  dependencies:
+    long "^4.0.0"
+
+"@keplr-wallet/types@0.12.12":
+  version "0.12.12"
+  resolved "https://registry.yarnpkg.com/@keplr-wallet/types/-/types-0.12.12.tgz#f4bd9e710d5e53504f6b53330abb45bedd9c20ae"
+  integrity sha512-fo6b8j9EXnJukGvZorifJWEm1BPIrvaTLuu5PqaU5k1ANDasm/FL1NaUuaTBVvhRjINtvVXqYpW/rVUinA9MBA==
+  dependencies:
+    long "^4.0.0"
+
+"@keplr-wallet/types@0.12.28":
+  version "0.12.28"
+  resolved "https://registry.yarnpkg.com/@keplr-wallet/types/-/types-0.12.28.tgz#eac3c2c9d4560856c5c403a87e67925992a04fbf"
+  integrity sha512-EcM9d46hYDm3AO4lf4GUbTSLRySONtTmhKb7p88q56OQOgJN3MMjRacEo2p9jX9gpPe7gRIjMUalhAfUiFpZoQ==
+  dependencies:
+    long "^4.0.0"
+
+"@keplr-wallet/types@0.12.96":
+  version "0.12.96"
+  resolved "https://registry.yarnpkg.com/@keplr-wallet/types/-/types-0.12.96.tgz#a7735051b1f7cbcdf9b8c29010b1c3c45d195c19"
+  integrity sha512-tr4tPjMrJCsfRXXhhmqnpb9DqH9auJp3uuj8SvDB3pQTTaYJNxkdonLv1tYmXZZ6J9oWtk9WVEDTVgBQN/wisw==
+  dependencies:
+    long "^4.0.0"
+
+"@keplr-wallet/types@^0.12.95":
+  version "0.12.313"
+  resolved "https://registry.yarnpkg.com/@keplr-wallet/types/-/types-0.12.313.tgz#c104de1250eaa02109a7a0e7fd3e12c2f11ff383"
+  integrity sha512-of3e8ISp8h9skE6NXHvaj7yKoNLhVkSdbFgcjSKH6JGg584zSIRrlyawjbNg3JI1kqi3MiuuOrFQZ+SOztGK9Q==
+  dependencies:
+    long "^4.0.0"
+
 "@keplr-wallet/unit@0.10.24-ibc.go.v7.hot.fix":
   version "0.10.24-ibc.go.v7.hot.fix"
   resolved "https://registry.npmjs.org/@keplr-wallet/unit/-/unit-0.10.24-ibc.go.v7.hot.fix.tgz"
   integrity sha512-XiOGAQEiYtd6B11B5JHXZHc9HOA2BKE+wL8mNc7vPQ8h73WiKhMAU2CkoS8LHsXkDJJy/Sq18WnJbGlu225/Ag==
   dependencies:
     "@keplr-wallet/types" "0.10.24-ibc.go.v7.hot.fix"
+    big-integer "^1.6.48"
+    utility-types "^3.10.0"
+
+"@keplr-wallet/unit@0.12.12":
+  version "0.12.12"
+  resolved "https://registry.yarnpkg.com/@keplr-wallet/unit/-/unit-0.12.12.tgz#2d7f2e38df4e09c8123dcc0784ffc4b5f4166217"
+  integrity sha512-fayJcfXWKUnbDZiRJHyuA9GMVS9DymjRlCzlpAJ0+xV0c4Kun/f+9FajL9OQAdPPhnJ7A3KevMI4VHZsd9Yw+A==
+  dependencies:
+    "@keplr-wallet/types" "0.12.12"
+    big-integer "^1.6.48"
+    utility-types "^3.10.0"
+
+"@keplr-wallet/unit@0.12.28":
+  version "0.12.28"
+  resolved "https://registry.yarnpkg.com/@keplr-wallet/unit/-/unit-0.12.28.tgz#907c7fa0b49a729cda207fca14fc0a38871cc6c4"
+  integrity sha512-kpXigHDBJGOmhtPkv9hqsQid9zkFo7OQPeKgO2n8GUlOINIXW6kWG5LXYTi/Yg9Uiw1CQF69gFMuZCJ8IzVHlA==
+  dependencies:
+    "@keplr-wallet/types" "0.12.28"
     big-integer "^1.6.48"
     utility-types "^3.10.0"
 
@@ -5149,6 +5328,49 @@
     strict-event-emitter "^0.2.4"
     web-encoding "^1.1.5"
 
+"@mysten/bcs@1.9.2":
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/@mysten/bcs/-/bcs-1.9.2.tgz#3bf0e30f14595c9d9e5c142e94b5646ac1318da7"
+  integrity sha512-kBk5xrxV9OWR7i+JhL/plQrgQ2/KJhB2pB5gj+w6GXhbMQwS3DPpOvi/zN0Tj84jwPvHMllpEl0QHj6ywN7/eQ==
+  dependencies:
+    "@mysten/utils" "0.2.0"
+    "@scure/base" "^1.2.6"
+
+"@mysten/sui@^1":
+  version "1.45.2"
+  resolved "https://registry.yarnpkg.com/@mysten/sui/-/sui-1.45.2.tgz#cd5f06226e3db74eba163d1deb180e53f9ec147b"
+  integrity sha512-gftf7fNpFSiXyfXpbtP2afVEnhc7p2m/MEYc/SO5pov92dacGKOpQIF7etZsGDI1Wvhv+dpph+ulRNpnYSs7Bg==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.2.0"
+    "@mysten/bcs" "1.9.2"
+    "@mysten/utils" "0.2.0"
+    "@noble/curves" "=1.9.4"
+    "@noble/hashes" "^1.8.0"
+    "@protobuf-ts/grpcweb-transport" "^2.11.1"
+    "@protobuf-ts/runtime" "^2.11.1"
+    "@protobuf-ts/runtime-rpc" "^2.11.1"
+    "@scure/base" "^1.2.6"
+    "@scure/bip32" "^1.7.0"
+    "@scure/bip39" "^1.6.0"
+    gql.tada "^1.8.13"
+    graphql "^16.11.0"
+    poseidon-lite "0.2.1"
+    valibot "^1.2.0"
+
+"@mysten/utils@0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@mysten/utils/-/utils-0.2.0.tgz#8c4fa3858284de84c333bc7ae09510cf54d55a54"
+  integrity sha512-CM6kJcJHX365cK6aXfFRLBiuyXc5WSBHQ43t94jqlCAIRw8umgNcTb5EnEA9n31wPAQgLDGgbG/rCUISCTJ66w==
+  dependencies:
+    "@scure/base" "^1.2.6"
+
+"@mysten/wallet-standard@^0":
+  version "0.20.3"
+  resolved "https://registry.yarnpkg.com/@mysten/wallet-standard/-/wallet-standard-0.20.3.tgz#732036a0960a8ba974032251e3c1373dc8bf8ced"
+  integrity sha512-Kp1EpWaQAwANuMoTCJKVdZnEOaE9aJ5PPvIC7qg+J3u6Uf20VsVsQngZllyaS2OQHm+iLlJzcLXHff7ttvQJYw==
+  dependencies:
+    "@wallet-standard/core" "1.1.1"
+
 "@next/bundle-analyzer@^14.2.35":
   version "14.2.35"
   resolved "https://registry.yarnpkg.com/@next/bundle-analyzer/-/bundle-analyzer-14.2.35.tgz#83379ce18a60bd1a8e9b518014365d7d431ef886"
@@ -5244,7 +5466,14 @@
   dependencies:
     "@noble/hashes" "1.7.1"
 
-"@noble/curves@^1.4.2", "@noble/curves@^1.9.2":
+"@noble/curves@=1.9.4":
+  version "1.9.4"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.9.4.tgz#a748c6837ee7854a558cc3b951aedd87a5e7d6a5"
+  integrity sha512-2bKONnuM53lINoDrSmK8qP8W271ms7pygDhZt4SiLOoLwBtoHqeCFi6RG42V8zd3mLHuJFhU/Bmaqo4nX0/kBw==
+  dependencies:
+    "@noble/hashes" "1.8.0"
+
+"@noble/curves@^1.4.2", "@noble/curves@^1.9.2", "@noble/curves@~1.9.0":
   version "1.9.7"
   resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.9.7.tgz#79d04b4758a43e4bca2cbdc62e7771352fa6b951"
   integrity sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==
@@ -5266,7 +5495,7 @@
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.7.1.tgz#5738f6d765710921e7a751e00c20ae091ed8db0f"
   integrity sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==
 
-"@noble/hashes@1.8.0", "@noble/hashes@^1.8.0":
+"@noble/hashes@1.8.0", "@noble/hashes@^1.8.0", "@noble/hashes@~1.8.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.8.0.tgz#cee43d801fcef9644b11b8194857695acd5f815a"
   integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
@@ -6239,6 +6468,26 @@
   dependencies:
     "@opentelemetry/instrumentation" "^0.52.0 || ^0.53.0 || ^0.54.0 || ^0.55.0 || ^0.56.0 || ^0.57.0"
 
+"@protobuf-ts/grpcweb-transport@^2.11.1":
+  version "2.11.1"
+  resolved "https://registry.yarnpkg.com/@protobuf-ts/grpcweb-transport/-/grpcweb-transport-2.11.1.tgz#63a8a0d6043851fec14de4b091121377d2549683"
+  integrity sha512-1W4utDdvOB+RHMFQ0soL4JdnxjXV+ddeGIUg08DvZrA8Ms6k5NN6GBFU2oHZdTOcJVpPrDJ02RJlqtaoCMNBtw==
+  dependencies:
+    "@protobuf-ts/runtime" "^2.11.1"
+    "@protobuf-ts/runtime-rpc" "^2.11.1"
+
+"@protobuf-ts/runtime-rpc@^2.11.1":
+  version "2.11.1"
+  resolved "https://registry.yarnpkg.com/@protobuf-ts/runtime-rpc/-/runtime-rpc-2.11.1.tgz#a6eb2f384bceae8d23a01d0b0e37faf0af36c179"
+  integrity sha512-4CqqUmNA+/uMz00+d3CYKgElXO9VrEbucjnBFEjqI4GuDrEQ32MaI3q+9qPBvIGOlL4PmHXrzM32vBPWRhQKWQ==
+  dependencies:
+    "@protobuf-ts/runtime" "^2.11.1"
+
+"@protobuf-ts/runtime@^2.11.1":
+  version "2.11.1"
+  resolved "https://registry.yarnpkg.com/@protobuf-ts/runtime/-/runtime-2.11.1.tgz#ee2bf2fac6e2d8deac0ca63471a77481548e5553"
+  integrity sha512-KuDaT1IfHkugM2pyz+FwiY80ejWrkH1pAtOBOZFuR6SXEFTsnb/jiQWQ1rCIrcKx2BtyxnxW6BWwsVSA/Ie+WQ==
+
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
   resolved "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz"
@@ -6778,6 +7027,11 @@
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.6.tgz#8ce5d304b436e4c84f896e0550c83e4d88cb917d"
   integrity sha512-ok9AWwhcgYuGG3Zfhyqg+zwl+Wn5uE+dwC0NV/2qQkx4dABbb/bx96vWu8NSj+BNjjSjno+JRYRjle1jV08k3g==
 
+"@scure/base@^1.2.6", "@scure/base@~1.2.5":
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.2.6.tgz#ca917184b8231394dd8847509c67a0be522e59f6"
+  integrity sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==
+
 "@scure/base@~1.1.7", "@scure/base@~1.1.8":
   version "1.1.9"
   resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.9.tgz#e5e142fbbfe251091f9c5f1dd4c834ac04c3dbd1"
@@ -6815,6 +7069,15 @@
     "@noble/hashes" "~1.7.1"
     "@scure/base" "~1.2.2"
 
+"@scure/bip32@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.7.0.tgz#b8683bab172369f988f1589640e53c4606984219"
+  integrity sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==
+  dependencies:
+    "@noble/curves" "~1.9.0"
+    "@noble/hashes" "~1.8.0"
+    "@scure/base" "~1.2.5"
+
 "@scure/bip39@1.2.2":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.2.2.tgz#f3426813f4ced11a47489cbcf7294aa963966527"
@@ -6838,6 +7101,14 @@
   dependencies:
     "@noble/hashes" "~1.7.1"
     "@scure/base" "~1.2.4"
+
+"@scure/bip39@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.6.0.tgz#475970ace440d7be87a6086cbee77cb8f1a684f9"
+  integrity sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==
+  dependencies:
+    "@noble/hashes" "~1.8.0"
+    "@scure/base" "~1.2.5"
 
 "@sentry/core@9.5.0", "@sentry/core@^9.5.0":
   version "9.5.0"
@@ -8482,6 +8753,51 @@
     eventemitter3 "5.0.1"
     mipd "0.0.7"
     zustand "4.4.1"
+
+"@wallet-standard/app@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@wallet-standard/app/-/app-1.1.0.tgz#2ca32e4675536224ebe55a00ad533b7923d7380a"
+  integrity sha512-3CijvrO9utx598kjr45hTbbeeykQrQfKmSnxeWOgU25TOEpvcipD/bYDQWIqUv1Oc6KK4YStokSMu/FBNecGUQ==
+  dependencies:
+    "@wallet-standard/base" "^1.1.0"
+
+"@wallet-standard/base@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@wallet-standard/base/-/base-1.1.0.tgz#214093c0597a1e724ee6dbacd84191dfec62bb33"
+  integrity sha512-DJDQhjKmSNVLKWItoKThJS+CsJQjR9AOBOirBVT1F9YpRyC9oYHE+ZnSf8y8bxUphtKqdQMPVQ2mHohYdRvDVQ==
+
+"@wallet-standard/core@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@wallet-standard/core/-/core-1.1.1.tgz#432e10420dc8892a63224d4863f8304fa01b4ea1"
+  integrity sha512-5Xmjc6+Oe0hcPfVc5n8F77NVLwx1JVAoCVgQpLyv/43/bhtIif+Gx3WUrDlaSDoM8i2kA2xd6YoFbHCxs+e0zA==
+  dependencies:
+    "@wallet-standard/app" "^1.1.0"
+    "@wallet-standard/base" "^1.1.0"
+    "@wallet-standard/errors" "^0.1.1"
+    "@wallet-standard/features" "^1.1.0"
+    "@wallet-standard/wallet" "^1.1.0"
+
+"@wallet-standard/errors@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@wallet-standard/errors/-/errors-0.1.1.tgz#e745c5925276c0ac6d02f0d489888c171f5e4680"
+  integrity sha512-V8Ju1Wvol8i/VDyQOHhjhxmMVwmKiwyxUZBnHhtiPZJTWY0U/Shb2iEWyGngYEbAkp2sGTmEeNX1tVyGR7PqNw==
+  dependencies:
+    chalk "^5.4.1"
+    commander "^13.1.0"
+
+"@wallet-standard/features@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@wallet-standard/features/-/features-1.1.0.tgz#f256d7b18940c8d134f66164330db358a8f5200e"
+  integrity sha512-hiEivWNztx73s+7iLxsuD1sOJ28xtRix58W7Xnz4XzzA/pF0+aicnWgjOdA10doVDEDZdUuZCIIqG96SFNlDUg==
+  dependencies:
+    "@wallet-standard/base" "^1.1.0"
+
+"@wallet-standard/wallet@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@wallet-standard/wallet/-/wallet-1.1.0.tgz#a1e46a3f1b2d06a0206058562169b1f0e9652d0f"
+  integrity sha512-Gt8TnSlDZpAl+RWOOAB/kuvC7RpcdWAlFbHNoi4gsXsfaWa1QCT6LBcfIYTPdOZC9OVZUDwqGuGAcqZejDmHjg==
+  dependencies:
+    "@wallet-standard/base" "^1.1.0"
 
 "@walletconnect/core@2.11.3":
   version "2.11.3"
@@ -10938,6 +11254,11 @@ comma-separated-tokens@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz#4e89c9458acb61bc8fef19f4529973b2392839ee"
   integrity sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==
+
+commander@^13.1.0:
+  version "13.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-13.1.0.tgz#776167db68c78f38dcce1f9b8d7b8b9a488abf46"
+  integrity sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==
 
 commander@^14.0.0:
   version "14.0.3"
@@ -13964,6 +14285,16 @@ gopd@^1.2.0:
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
   integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
 
+gql.tada@^1.8.13:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/gql.tada/-/gql.tada-1.9.2.tgz#9ceb5e4fe614c821a09e6e27075fe7bdfbbe4af1"
+  integrity sha512-QxRHVpxtrOVdYXz6oavq0lBM+Zdp0swapLGJcD4SLpXDcsD337BHDFrzqqjfkbepv0sSAiO0LGabu1kI5D5Gyg==
+  dependencies:
+    "@0no-co/graphql.web" "^1.0.5"
+    "@0no-co/graphqlsp" "^1.12.13"
+    "@gql.tada/cli-utils" "1.7.3"
+    "@gql.tada/internal" "1.0.9"
+
 graceful-fs@4.2.11, graceful-fs@^4.1.10, graceful-fs@^4.2.11, graceful-fs@^4.2.4, graceful-fs@^4.2.6:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
@@ -13978,6 +14309,11 @@ graphemer@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
+
+"graphql@^15.5.0 || ^16.0.0 || ^17.0.0", graphql@^16.11.0:
+  version "16.14.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.14.0.tgz#f1128a74b16a34d1245c8436bb07b488d87b83e1"
+  integrity sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==
 
 graphql@^16.8.1:
   version "16.8.1"
@@ -18951,6 +19287,11 @@ pony-cause@^2.1.10:
   resolved "https://registry.yarnpkg.com/pony-cause/-/pony-cause-2.1.10.tgz#828457ad6f13be401a075dbf14107a9057945174"
   integrity sha512-3IKLNXclQgkU++2fSi93sQ6BznFuxSLB11HdvZQ6JW/spahf/P1pAHBQEahr20rs0htZW0UDkM1HmA+nZkXKsw==
 
+poseidon-lite@0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/poseidon-lite/-/poseidon-lite-0.2.1.tgz#7ad98e3a3aa5b91a1fd3a61a87460e9e46fd76d6"
+  integrity sha512-xIr+G6HeYfOhCuswdqcFpSX47SPhm0EpisWJ6h7fHlWwaVIvH3dLnejpatrtw6Xc6HaLrpq05y7VRfvDmDGIog==
+
 possible-typed-array-names@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz#89bb63c6fada2c3e90adc4a647beeeb39cc7bf8f"
@@ -22568,6 +22909,11 @@ valibot@^0.38.0:
   version "0.38.0"
   resolved "https://registry.yarnpkg.com/valibot/-/valibot-0.38.0.tgz#2d035d2a5bd36e8ea8b48b56d44552ace1a7616f"
   integrity sha512-RCJa0fetnzp+h+KN9BdgYOgtsMAG9bfoJ9JSjIhFHobKWVWyzM3jjaeNTdpFK9tQtf3q1sguXeERJ/LcmdFE7w==
+
+valibot@^1.2.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/valibot/-/valibot-1.4.0.tgz#a27e48893af13834ae9dcf4f7e4b05cc7821ef35"
+  integrity sha512-iC/x7fVcSyOwlm/VSt7RlHnzNGLGvR9GnxdifUeWoCJo0q4ZZvrVkIHC6faTlkxG47I2Y4UrFquPuVHCrOnrLg==
 
 validate-npm-package-license@3.0.4, validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
## Summary

Fix the `/wormhole` redeem widget so it works for Osmosis-originated transfers, and add native in-app redemption on Sui.

Wormholescan's `/operations?txHash=` indexes Osmosis → Sui (or any gateway) VAAs **only under the Wormchain receive-tx hash**, so pasting an Osmosis hash always returned `{"operations":[]}` and the widget was effectively unusable for the very transfers it was designed to recover.

### Linear

[MTN-74: Fix Wormhole recovery widget for Osmosis-originated transfers (incl. Sui destinations)](https://linear.app/osmosis/issue/MTN-74/fix-wormhole-recovery-widget-for-osmosis-originated-transfers-incl-sui)

## Changes

- Follow the IBC packet: Osmosis tx → `send_packet` event → Wormchain RPC `tx_search` for the matching `recv_packet` → Wormholescan with the resolved Wormchain hash. Multiple LCD/RPC fallbacks with per-request timeouts.
- Drop the Solana-only gate; branch the redeem UI on destination chain.
- Add native Sui redemption (new `wormhole-sui.ts`) — builds the five Wormhole Move calls directly, resolves package IDs dynamically from each state object's `upgrade_cap`. Wallet integration via Wallet Standard, allowlisting Slush and Phantom; one connect button per detected wallet.
- Generic Wormholescan-link fallback for everything we don't natively support (other EVM chains, Sui tokens outside the known mapping).

Rationale for the in-app Sui flow, the allowlist, and the per-wallet-button UX is in the module docstrings; please flag in review if anything is unclear and I'll expand.

### Update — Phantom multi-chain account selection

Live-tested against `D70648F68D1DC6A8E663D3A0841A7037D9D786AEE755F89735ACD04E5F576562` with Phantom: connecting picked Phantom's Solana account out of its multi-chain `accounts` array, fed it through `normalizeSuiAddress`, and produced a malformed `0x0000…<base58-blob>` address that failed the recipient-mismatch guard. Initially fixed by filtering `wallet.accounts` by per-account `chains` (`sui:mainnet`) and preferring the account matching the VAA recipient.

Follow-up: Phantom doesn't reliably populate the per-account `chains` field for its Sui account, so the strict tag filter still rejected real Sui accounts in some builds. The filter now accepts an account if either its `chains` array includes `sui:mainnet` **or** its address matches the unambiguous 32-byte `0x`-prefixed Sui hex shape; Solana / BTC / EVM addresses never match that shape. A wallet-level `sui:signAndExecuteTransaction` capability check prevents a Solana-only Phantom registration from being offered as a Sui option under the same `wallet.name`.

## Test plan

- `yarn jest components/bridge/__tests__/wormhole-redeem.spec.tsx components/bridge/__tests__/wormhole-sui.spec.ts` → 47/47 pass.
- `yarn prettier --check` / `yarn eslint` / `yarn tsc --noEmit -p packages/web` → clean for touched files.
- Verified end-to-end against three real Osmosis → Sui transfers (`76E2…BED4`, `21BF…29EE`, `D706…6562`); all resolved correctly to their Wormchain receive and Sui completion txs.

### Reviewer checklist

- [x] Paste an Osmosis hash → resolves to the Wormchain hash and shows the operation.
      `D70648F68D1DC6A8E663D3A0841A7037D9D786AEE755F89735ACD04E5F576562`
- [x] Paste a Wormchain hash directly → still works (backward compatible).
- [x] Stuck Osmosis → Sui transfer with Slush only / Phantom only (with a Sui account) / both / neither installed → renders the expected button(s) / install links.
- [x] Phantom installed for Solana only (no Sui account) → connect shows the "create a Sui account in Phantom" error rather than the dual install-link banner.
