### PR TITLE
chore(security): patch @babel/traverse CVE-2023-45133 (GHSA-67hx-6x53-jw92)

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@keplr-wallet/cosmos": "0.10.24-ibc.go.v7.hot.fix",
     "@keplr-wallet/proto-types": "0.10.24-ibc.go.v7.hot.fix",
     "@keplr-wallet/router": "0.10.24-ibc.go.v7.hot.fix",
-    "@keplr-wallet/types": "0.10.24-ibc.go.v7.hot.fix"
+    "@keplr-wallet/types": "0.10.24-ibc.go.v7.hot.fix",
+    "@babel/traverse": "^7.24.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -575,7 +575,7 @@
   dependencies:
     "@babel/types" "^7.18.6"
 
-"@babel/helper-split-export-declaration@^7.22.6", "@babel/helper-split-export-declaration@^7.24.5":
+"@babel/helper-split-export-declaration@^7.24.5":
   version "7.24.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.5.tgz#b9a67f06a46b0b339323617c8c6213b9055a78b6"
   integrity sha512-5CHncttXohrHk8GWOFCcCl4oRD9fKosWlIRgWm4ql9VYioKm52Mk2xsmoohvm7f3JoiLSM5ZgJuRaf5QZZYd3Q==
@@ -701,7 +701,7 @@
   resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.18.11.tgz"
   integrity sha512-9JKn5vN+hDt0Hdqn1PiJ2guflwP+B6Ga8qbDuoF0PzzVhrzsKIJo8yGqVk6CmMHiMei9w1C1Bp9IMJSIK+HPIQ==
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.18.10", "@babel/parser@^7.18.11", "@babel/parser@^7.20.7", "@babel/parser@^7.21.4":
+"@babel/parser@^7.1.0", "@babel/parser@^7.14.7", "@babel/parser@^7.18.10", "@babel/parser@^7.20.7", "@babel/parser@^7.21.4":
   version "7.21.4"
   resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.21.4.tgz"
   integrity sha512-alVJj7k7zIxqBZ7BTRhz0IqJFxW1VJbm6N8JbcYhQ186df9ZBPbZBmWSqAMXwHGsCJdYks7z/voa3ibiS5bCIw==
@@ -2015,55 +2015,7 @@
     "@babel/parser" "^7.24.0"
     "@babel/types" "^7.24.0"
 
-"@babel/traverse@7.18.11":
-  version "7.18.11"
-  resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.11.tgz"
-  integrity sha512-TG9PiM2R/cWCAy6BPJKeHzNbu4lPzOSZpeMfeNErskGpTJx6trEvFaVCbDvpcxwy49BKWmEPwiW8mrysNiDvIQ==
-  dependencies:
-    "@babel/code-frame" "^7.18.6"
-    "@babel/generator" "^7.18.10"
-    "@babel/helper-environment-visitor" "^7.18.9"
-    "@babel/helper-function-name" "^7.18.9"
-    "@babel/helper-hoist-variables" "^7.18.6"
-    "@babel/helper-split-export-declaration" "^7.18.6"
-    "@babel/parser" "^7.18.11"
-    "@babel/types" "^7.18.10"
-    debug "^4.1.0"
-    globals "^11.1.0"
-
-"@babel/traverse@7.23.6":
-  version "7.23.6"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.23.6.tgz#b53526a2367a0dd6edc423637f3d2d0f2521abc5"
-  integrity sha512-czastdK1e8YByZqezMPFiZ8ahwVMh/ESl9vPgvgdB9AmFMGP5jfpFax74AQgl5zj4XHzqeYAg2l8PuUeRS1MgQ==
-  dependencies:
-    "@babel/code-frame" "^7.23.5"
-    "@babel/generator" "^7.23.6"
-    "@babel/helper-environment-visitor" "^7.22.20"
-    "@babel/helper-function-name" "^7.23.0"
-    "@babel/helper-hoist-variables" "^7.22.5"
-    "@babel/helper-split-export-declaration" "^7.22.6"
-    "@babel/parser" "^7.23.6"
-    "@babel/types" "^7.23.6"
-    debug "^4.3.1"
-    globals "^11.1.0"
-
-"@babel/traverse@^7.18.10", "@babel/traverse@^7.20.5", "@babel/traverse@^7.20.7", "@babel/traverse@^7.21.0", "@babel/traverse@^7.21.2", "@babel/traverse@^7.21.4":
-  version "7.21.4"
-  resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.21.4.tgz"
-  integrity sha512-eyKrRHKdyZxqDm+fV1iqL9UAHMoIg0nDaGqfIOd8rKH17m5snv7Gn4qgjBoFfLz9APvjFU/ICT00NVCv1Epp8Q==
-  dependencies:
-    "@babel/code-frame" "^7.21.4"
-    "@babel/generator" "^7.21.4"
-    "@babel/helper-environment-visitor" "^7.18.9"
-    "@babel/helper-function-name" "^7.21.0"
-    "@babel/helper-hoist-variables" "^7.18.6"
-    "@babel/helper-split-export-declaration" "^7.18.6"
-    "@babel/parser" "^7.21.4"
-    "@babel/types" "^7.21.4"
-    debug "^4.1.0"
-    globals "^11.1.0"
-
-"@babel/traverse@^7.24.1", "@babel/traverse@^7.24.5":
+"@babel/traverse@7.18.11", "@babel/traverse@7.23.6", "@babel/traverse@^7.18.10", "@babel/traverse@^7.20.5", "@babel/traverse@^7.20.7", "@babel/traverse@^7.21.0", "@babel/traverse@^7.21.2", "@babel/traverse@^7.21.4", "@babel/traverse@^7.24.1", "@babel/traverse@^7.24.5":
   version "7.24.5"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.24.5.tgz#972aa0bc45f16983bf64aa1f877b2dd0eea7e6f8"
   integrity sha512-7aaBLeDQ4zYcUFDUD41lJc1fG8+5IU9DaNSJAgal866FGvmD5EbWQgnEC6kO1gGLsX0esNkfnJSndbTXA3r7UA==
@@ -2106,7 +2058,7 @@
     "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
-"@babel/types@^7.18.6", "@babel/types@^7.23.6":
+"@babel/types@^7.18.6":
   version "7.24.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.24.0.tgz#3b951f435a92e7333eba05b7566fd297960ea1bf"
   integrity sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==


### PR DESCRIPTION
## Summary

Patches [GHSA-67hx-6x53-jw92](https://github.com/advisories/GHSA-67hx-6x53-jw92) / [CVE-2023-45133](https://nvd.nist.gov/vuln/detail/CVE-2023-45133) — _Babel arbitrary code execution when compiling specifically crafted malicious code_ (critical, CVSS 9.3).

Adds a single Yarn resolution to force `@babel/traverse` to `^7.24.5` (the version `@babel/core@^7.24.5` and `@babel/preset-env@^7.24.5` — already declared in this repo — pull in for the un-pinned ranges):

```jsonc
// package.json
"resolutions": {
  // ...
  "@babel/traverse": "^7.24.5"
}
```

## Why this is needed

Before this PR, `yarn.lock` contained two vulnerable copies (both `< 7.23.2`):

| Version    | Source                                                          |
| ---------- | --------------------------------------------------------------- |
| `7.18.11`  | exactly pinned by `@cosmwasm/ts-codegen@0.35.7`                 |
| `7.21.4`   | resolved from `^7.18.10` / `^7.20.x` / `^7.21.x` transitive ranges (e.g. `babel-plugin-istanbul`, `@babel/helper-module-transforms` consumers) |

The advisory's recommended remediation is to upgrade `@babel/traverse` to `>= 7.23.2`. A root-level Yarn `resolutions` entry is the simplest way to do this here without bumping unrelated dependency majors.

## Impact

- All `@babel/traverse` request strings — including the two exact pins from `@cosmwasm/ts-codegen@0.35.7` (`7.18.11`) and `@cosmology/telescope@1.10.0` (`7.23.6`) — now collapse onto the single patched `7.24.5`.
- `@cosmwasm/ts-codegen` and `@cosmology/telescope` are codegen tools (proto / TS generation). They consume stable `@babel/traverse` APIs and work fine on `7.24.x`.
- Babel compilation in this repo only runs against first-party / trusted source, so we weren't directly exposed in production, but the vulnerable code paths are now gone regardless.
- Net effect on `node_modules`: **one** copy of `@babel/traverse` instead of three.

## Diff

```
package.json |  3 ++-
yarn.lock    | 56 ++++----------------------------------------------------
2 files changed, 6 insertions(+), 53 deletions(-)
```

## Test plan

- [x] `yarn install` succeeds, lockfile updates as expected, only `@babel/traverse` entries (and two trivially-dedupeable transitive ranges) change in `yarn.lock`.
- [x] `grep '@babel/traverse@' yarn.lock` shows a single resolved entry at `7.24.5`; no `7.18.11` or `7.21.4` versions remain.
- [x] CI green (lint / build / test).
- [x] Spot-check that codegen-touching workflows (`@cosmwasm/ts-codegen`, `@cosmology/telescope`) still run cleanly during build, if exercised by CI.
