### PR TITLE
feat(positions): sort CL positions by status, then USD size desc

### DIFF
--- a/packages/server/src/queries/complex/concentrated-liquidity/index.ts
+++ b/packages/server/src/queries/complex/concentrated-liquidity/index.ts
@@ -550,37 +550,48 @@ export async function mapGetUserPositions({
   );
 
   // Fetch pools in batch via the sidecar so we can compute each position's
-  // status (in/near/out of range) for sorting and display. If the sidecar is
-  // unavailable, we'll fall back to direct chain RPC per missing pool below
-  // so status still gets computed.
+  // status (in/near/out of range) for sorting and display. If the sidecar
+  // call fails for a partial set we'll fall back to direct chain RPC per
+  // missing pool below; if it fails entirely we bail rather than fan out N
+  // chain queries.
   let poolItems: Pool[] = [];
+  let sidecarFailed = false;
   try {
     const pools = await getPools({ ...params, poolIds: uniquePoolIds });
     poolItems = pools.items;
-  } catch {
-    // sidecar unavailable; fall back to chain queries below
+  } catch (e) {
+    sidecarFailed = true;
+    console.warn(
+      "mapGetUserPositions: sidecar getPools failed, position status will be unranked",
+      e
+    );
   }
 
   const sqrtPriceFromChain = new Map<string, string>();
-  const missingPoolIds = uniquePoolIds.filter(
-    (id) => !poolItems.some((p) => p.id === id)
-  );
-  await Promise.all(
-    missingPoolIds.map(async (poolId) => {
-      try {
-        const { pool } = await queryPoolChain({
-          poolId,
-          chainList: params.chainList,
-        });
-        const concentrated = pool as ConcentratedPoolRawResponse;
-        if (concentrated?.current_sqrt_price) {
-          sqrtPriceFromChain.set(poolId, concentrated.current_sqrt_price);
+  if (!sidecarFailed) {
+    const missingPoolIds = uniquePoolIds.filter(
+      (id) => !poolItems.some((p) => p.id === id)
+    );
+    await Promise.all(
+      missingPoolIds.map(async (poolId) => {
+        try {
+          const { pool } = await queryPoolChain({
+            poolId,
+            chainList: params.chainList,
+          });
+          const concentrated = pool as ConcentratedPoolRawResponse;
+          if (concentrated?.current_sqrt_price) {
+            sqrtPriceFromChain.set(poolId, concentrated.current_sqrt_price);
+          }
+        } catch (e) {
+          console.warn(
+            `mapGetUserPositions: queryPoolChain failed for pool ${poolId}, status will be undefined`,
+            e
+          );
         }
-      } catch {
-        // skip; status will be undefined for this pool
-      }
-    })
-  );
+      })
+    );
+  }
 
   const userPositions = await Promise.all(
     filteredPositions.map(async (position_) => {
@@ -632,6 +643,9 @@ export async function mapGetUserPositions({
             lowerPrice: priceRange[0],
             upperPrice: priceRange[1],
             isFullRange,
+            // Unbonding and superfluid states don't apply to CL positions
+            // on this surface; passing false collapses calcPositionStatus
+            // to the in/near/out-of-range / fullRange outcomes we sort on.
             isSuperfluidStaked: false,
             isSuperfluidUnstaking: false,
             isUnbonding: false,

--- a/packages/server/src/queries/complex/concentrated-liquidity/index.ts
+++ b/packages/server/src/queries/complex/concentrated-liquidity/index.ts
@@ -18,14 +18,17 @@ import {
   getAsset,
   mapRawCoinToPretty,
 } from "../../../queries/complex/assets";
-import { getPools } from "../../../queries/complex/pools";
+import { getPools, Pool } from "../../../queries/complex/pools";
 import {
   getConcentratedRangePoolApr,
   getLockableDurations,
   getPoolIncentives,
 } from "../../../queries/complex/pools/incentives";
 import { getValidatorInfo } from "../../../queries/complex/staking/validator";
-import { ConcentratedPoolRawResponse } from "../../../queries/osmosis";
+import {
+  ConcentratedPoolRawResponse,
+  queryPoolChain,
+} from "../../../queries/osmosis";
 import {
   LiquidityPosition,
   queryAccountPositions,
@@ -538,61 +541,118 @@ export async function mapGetUserPositions({
 
   const positions = await positionsPromise;
 
+  const filteredPositions = positions.filter(
+    (position) => !forPoolId || position.position.pool_id === forPoolId
+  );
+
+  const uniquePoolIds = Array.from(
+    new Set(filteredPositions.map(({ position }) => position.pool_id))
+  );
+
+  // Fetch pools in batch via the sidecar so we can compute each position's
+  // status (in/near/out of range) for sorting and display. If the sidecar is
+  // unavailable, we'll fall back to direct chain RPC per missing pool below
+  // so status still gets computed.
+  let poolItems: Pool[] = [];
+  try {
+    const pools = await getPools({ ...params, poolIds: uniquePoolIds });
+    poolItems = pools.items;
+  } catch {
+    // sidecar unavailable; fall back to chain queries below
+  }
+
+  const sqrtPriceFromChain = new Map<string, string>();
+  const missingPoolIds = uniquePoolIds.filter(
+    (id) => !poolItems.some((p) => p.id === id)
+  );
+  await Promise.all(
+    missingPoolIds.map(async (poolId) => {
+      try {
+        const { pool } = await queryPoolChain({
+          poolId,
+          chainList: params.chainList,
+        });
+        const concentrated = pool as ConcentratedPoolRawResponse;
+        if (concentrated?.current_sqrt_price) {
+          sqrtPriceFromChain.set(poolId, concentrated.current_sqrt_price);
+        }
+      } catch {
+        // skip; status will be undefined for this pool
+      }
+    })
+  );
+
   const userPositions = await Promise.all(
-    positions
-      .filter((position) => {
-        if (Boolean(forPoolId) && position.position.pool_id !== forPoolId) {
-          return false;
-        }
-        return true;
-      })
-      .map(async (position_) => {
-        const { asset0, asset1, position } = position_;
+    filteredPositions.map(async (position_) => {
+      const { asset0, asset1, position } = position_;
 
-        const [baseCoin, quoteCoin] = mapRawCoinToPretty(params.assetLists, [
-          asset0,
-          asset1,
-        ]);
-        if (!baseCoin || !quoteCoin) {
-          throw new Error(
-            `Error finding assets for position ${position.position_id}`
-          );
-        }
-        const currentValue = new PricePretty(
-          DEFAULT_VS_CURRENCY,
-          await calcSumCoinsValue({ ...params, coins: [baseCoin, quoteCoin] })
+      const [baseCoin, quoteCoin] = mapRawCoinToPretty(params.assetLists, [
+        asset0,
+        asset1,
+      ]);
+      if (!baseCoin || !quoteCoin) {
+        throw new Error(
+          `Error finding assets for position ${position.position_id}`
         );
+      }
+      const currentValue = new PricePretty(
+        DEFAULT_VS_CURRENCY,
+        await calcSumCoinsValue({ ...params, coins: [baseCoin, quoteCoin] })
+      );
 
-        const lowerTick = new Int(position.lower_tick);
-        const upperTick = new Int(position.upper_tick);
-        const priceRange = await Promise.all([
-          getTickPrice({
-            tick: lowerTick,
-            baseCoin,
-            quoteCoin,
-          }),
-          getTickPrice({
-            tick: upperTick,
-            baseCoin,
-            quoteCoin,
-          }),
-        ]);
+      const lowerTick = new Int(position.lower_tick);
+      const upperTick = new Int(position.upper_tick);
+      const priceRange = await Promise.all([
+        getTickPrice({
+          tick: lowerTick,
+          baseCoin,
+          quoteCoin,
+        }),
+        getTickPrice({
+          tick: upperTick,
+          baseCoin,
+          quoteCoin,
+        }),
+      ]);
 
-        const isFullRange =
-          lowerTick.equals(minTick) && upperTick.equals(maxTick);
+      const isFullRange =
+        lowerTick.equals(minTick) && upperTick.equals(maxTick);
 
-        return {
-          id: position.position_id,
-          poolId: position.pool_id,
-          position: position_,
-          currentCoins: [baseCoin, quoteCoin],
-          currentValue,
-          isFullRange,
-          priceRange,
-          liquidity: new Dec(position.liquidity),
-          joinTime: new Date(position.join_time),
-        };
-      })
+      const pool = poolItems.find((p) => p.id === position.pool_id);
+      const sqrtPriceStr = pool
+        ? (pool.raw as ConcentratedPoolRawResponse).current_sqrt_price
+        : sqrtPriceFromChain.get(position.pool_id);
+      const status: PositionStatus | undefined = sqrtPriceStr
+        ? calcPositionStatus({
+            currentPrice: getPriceFromSqrtPrice({
+              sqrtPrice: new BigDec(sqrtPriceStr).toDec(),
+              baseCoin,
+              quoteCoin,
+            }),
+            lowerPrice: priceRange[0],
+            upperPrice: priceRange[1],
+            isFullRange,
+            isSuperfluidStaked: false,
+            isSuperfluidUnstaking: false,
+            isUnbonding: false,
+          })
+        : isFullRange
+        ? "fullRange"
+        : undefined;
+
+      return {
+        id: position.position_id,
+        poolId: position.pool_id,
+        position: position_,
+        currentCoins: [baseCoin, quoteCoin],
+        currentValue,
+        isFullRange,
+        priceRange,
+        liquidity: new Dec(position.liquidity),
+        joinTime: new Date(position.join_time),
+        status,
+      };
+    })
   );
 
   return userPositions.filter((p): p is NonNullable<typeof p> => !!p);

--- a/packages/trpc/src/__tests__/concentrated-liquidity.spec.ts
+++ b/packages/trpc/src/__tests__/concentrated-liquidity.spec.ts
@@ -1,0 +1,83 @@
+import { PositionStatus } from "@osmosis-labs/server";
+import { Dec, PricePretty } from "@osmosis-labs/unit";
+
+import { compareUserPositionsByStatusThenValue } from "../concentrated-liquidity";
+
+const usd = { currency: "usd", symbol: "$", maxDecimals: 2, locale: "en-US" };
+const price = (amount: number | string) =>
+  new PricePretty(usd, new Dec(amount));
+
+type SortInput = Parameters<typeof compareUserPositionsByStatusThenValue>[0];
+const pos = (
+  id: string,
+  status: PositionStatus | undefined,
+  value: number | string
+): SortInput => ({ id, status, currentValue: price(value) });
+
+describe("compareUserPositionsByStatusThenValue", () => {
+  it("orders status groups: out of range, near bounds, in range, full range", () => {
+    const positions = [
+      pos("p-full", "fullRange", 100),
+      pos("p-in", "inRange", 100),
+      pos("p-near", "nearBounds", 100),
+      pos("p-out", "outOfRange", 100),
+    ];
+    const sorted = [...positions].sort(compareUserPositionsByStatusThenValue);
+    expect(sorted.map((p) => p.id)).toEqual([
+      "p-out",
+      "p-near",
+      "p-in",
+      "p-full",
+    ]);
+  });
+
+  it("orders by USD value descending within a status group", () => {
+    const positions = [
+      pos("p-small", "inRange", 1),
+      pos("p-large", "inRange", 1000),
+      pos("p-medium", "inRange", 50),
+    ];
+    const sorted = [...positions].sort(compareUserPositionsByStatusThenValue);
+    expect(sorted.map((p) => p.id)).toEqual(["p-large", "p-medium", "p-small"]);
+  });
+
+  it("buckets unknown statuses after all known ones, before tiebreaker on id", () => {
+    const positions = [
+      pos("p-unknown-2", undefined, 100),
+      pos("p-in", "inRange", 0),
+      pos("p-unknown-1", undefined, 100),
+    ];
+    const sorted = [...positions].sort(compareUserPositionsByStatusThenValue);
+    expect(sorted.map((p) => p.id)).toEqual([
+      "p-in",
+      "p-unknown-1",
+      "p-unknown-2",
+    ]);
+  });
+
+  it("buckets unbonding and superfluid statuses with unknowns (not ranked here)", () => {
+    const positions = [
+      pos("p-unbonding", "unbonding", 100),
+      pos("p-in", "inRange", 0),
+      pos("p-superfluid", "superfluidStaked", 100),
+    ];
+    const sorted = [...positions].sort(compareUserPositionsByStatusThenValue);
+    // inRange has a known order (2), the others fall to UNKNOWN_STATUS_ORDER (99);
+    // tiebreaker on id within the unknown bucket.
+    expect(sorted.map((p) => p.id)).toEqual([
+      "p-in",
+      "p-superfluid",
+      "p-unbonding",
+    ]);
+  });
+
+  it("falls back to position id when both status and value are equal", () => {
+    const positions = [
+      pos("p-z", "inRange", 0),
+      pos("p-a", "inRange", 0),
+      pos("p-m", "inRange", 0),
+    ];
+    const sorted = [...positions].sort(compareUserPositionsByStatusThenValue);
+    expect(sorted.map((p) => p.id)).toEqual(["p-a", "p-m", "p-z"]);
+  });
+});

--- a/packages/trpc/src/concentrated-liquidity.ts
+++ b/packages/trpc/src/concentrated-liquidity.ts
@@ -4,15 +4,29 @@ import {
   getPositionHistoricalPerformance,
   mapGetUserPositionDetails,
   mapGetUserPositions,
+  PositionStatus,
   queryClParams,
   queryPositionById,
 } from "@osmosis-labs/server";
 import { AppCurrency } from "@osmosis-labs/types";
-import { getAssetFromAssetList, sort } from "@osmosis-labs/utils";
+import { getAssetFromAssetList } from "@osmosis-labs/utils";
 import { z } from "zod";
 
 import { createTRPCRouter, publicProcedure } from "./api";
 import { UserOsmoAddressSchema } from "./parameter-types";
+
+// Status grouping order for the user-positions sort: surface positions that
+// need attention (out of range) first, then those approaching the boundary,
+// and bucket every other status together so they sort purely by USD size desc.
+const POSITION_STATUS_ORDER: Record<PositionStatus, number> = {
+  outOfRange: 0,
+  nearBounds: 1,
+  inRange: 2,
+  fullRange: 2,
+  unbonding: 2,
+  superfluidStaked: 2,
+  superfluidUnstaking: 2,
+};
 
 const LiquidityPositionSchema = z.object({
   position: z.object({
@@ -57,17 +71,27 @@ export const concentratedLiquidityRouter = createTRPCRouter({
     .input(
       z
         .object({
-          sortDirection: z.enum(["asc", "desc"]).default("desc"),
           forPoolId: z.string().optional(),
         })
         .merge(UserOsmoAddressSchema.required())
     )
-    .query(({ input: { userOsmoAddress, sortDirection, forPoolId }, ctx }) =>
+    .query(({ input: { userOsmoAddress, forPoolId }, ctx }) =>
       mapGetUserPositions({
         ...ctx,
         userOsmoAddress,
         forPoolId,
-      }).then((positions) => sort(positions, "joinTime", sortDirection))
+      }).then((positions) =>
+        [...positions].sort((a, b) => {
+          const aOrder = a.status ? POSITION_STATUS_ORDER[a.status] ?? 99 : 99;
+          const bOrder = b.status ? POSITION_STATUS_ORDER[b.status] ?? 99 : 99;
+          if (aOrder !== bOrder) return aOrder - bOrder;
+          // Within a status group, larger USD value first.
+          const sizeDiff = b.currentValue.toDec().sub(a.currentValue.toDec());
+          if (sizeDiff.isPositive()) return 1;
+          if (sizeDiff.isNegative()) return -1;
+          return 0;
+        })
+      )
     ),
   getPositionDetails: publicProcedure
     .input(

--- a/packages/trpc/src/concentrated-liquidity.ts
+++ b/packages/trpc/src/concentrated-liquidity.ts
@@ -8,6 +8,7 @@ import {
   queryClParams,
   queryPositionById,
 } from "@osmosis-labs/server";
+import { PricePretty } from "@osmosis-labs/unit";
 import { AppCurrency } from "@osmosis-labs/types";
 import { getAssetFromAssetList } from "@osmosis-labs/utils";
 import { z } from "zod";
@@ -17,16 +18,39 @@ import { UserOsmoAddressSchema } from "./parameter-types";
 
 // Status grouping order for the user-positions sort: surface positions that
 // need attention (out of range) first, then those approaching the boundary,
-// and bucket every other status together so they sort purely by USD size desc.
-const POSITION_STATUS_ORDER: Record<PositionStatus, number> = {
+// then everything else. Unbonding/superfluid statuses aren't ranked because
+// CL positions never enter those states in this surface.
+const POSITION_STATUS_ORDER: Partial<Record<PositionStatus, number>> = {
   outOfRange: 0,
   nearBounds: 1,
   inRange: 2,
-  fullRange: 2,
-  unbonding: 2,
-  superfluidStaked: 2,
-  superfluidUnstaking: 2,
+  fullRange: 3,
 };
+const UNKNOWN_STATUS_ORDER = 99;
+
+/**
+ * Compares two user positions for sort order, surfacing those needing
+ * attention first (out of range), then larger USD value within each status
+ * group, with a final tiebreaker on position id for deterministic ordering.
+ */
+export function compareUserPositionsByStatusThenValue(
+  a: { status?: PositionStatus; currentValue: PricePretty; id: string },
+  b: { status?: PositionStatus; currentValue: PricePretty; id: string }
+): number {
+  const aOrder =
+    (a.status && POSITION_STATUS_ORDER[a.status]) ?? UNKNOWN_STATUS_ORDER;
+  const bOrder =
+    (b.status && POSITION_STATUS_ORDER[b.status]) ?? UNKNOWN_STATUS_ORDER;
+  if (aOrder !== bOrder) return aOrder - bOrder;
+
+  const sizeDiff = b.currentValue.toDec().sub(a.currentValue.toDec());
+  if (sizeDiff.isPositive()) return 1;
+  if (sizeDiff.isNegative()) return -1;
+
+  // Final tiebreaker keeps order stable across refetches when status and
+  // value are identical (e.g. two zero-value positions).
+  return a.id.localeCompare(b.id);
+}
 
 const LiquidityPositionSchema = z.object({
   position: z.object({
@@ -81,16 +105,7 @@ export const concentratedLiquidityRouter = createTRPCRouter({
         userOsmoAddress,
         forPoolId,
       }).then((positions) =>
-        [...positions].sort((a, b) => {
-          const aOrder = a.status ? POSITION_STATUS_ORDER[a.status] ?? 99 : 99;
-          const bOrder = b.status ? POSITION_STATUS_ORDER[b.status] ?? 99 : 99;
-          if (aOrder !== bOrder) return aOrder - bOrder;
-          // Within a status group, larger USD value first.
-          const sizeDiff = b.currentValue.toDec().sub(a.currentValue.toDec());
-          if (sizeDiff.isPositive()) return 1;
-          if (sizeDiff.isNegative()) return -1;
-          return 0;
-        })
+        [...positions].sort(compareUserPositionsByStatusThenValue)
       )
     ),
   getPositionDetails: publicProcedure


### PR DESCRIPTION
Replaces the previous joinTime-desc default sort on the user-positions query with a status-aware grouping that surfaces positions needing attention first, then sorts everything else by USD size.

**Server:** `mapGetUserPositions` now derives a position status (in / near / out of range, full range) by computing `currentPrice` from the pool's `current_sqrt_price`. Pool data is fetched via the sidecar `getPools()` in batch; if that call fails entirely we log and bail out (no status, sort by value only) rather than fan out an N+1 chain-query herd. Missing-pool entries still fall back to per-pool `queryPoolChain` when the sidecar partially succeeded. Adds `Pool` type and `queryPoolChain` imports.

**tRPC:** drops the unused `sortDirection` input and replaces the joinTime sort with a named, tested comparator. Status order:

  `outOfRange (0)` → `nearBounds (1)` → `inRange (2)` → `fullRange (3)` → unknown / unbonding / superfluid (99)

Within each tier, positions sort by `currentValue` (USD) descending. Final tiebreaker on `position_id.localeCompare` keeps ordering deterministic across refetches when status and value are both equal.

**Breaking tRPC contract change:** removes `sortDirection` from the `getUserPositions` input schema. Verified zero current callers were passing it.

Affects `/pools` (Your Positions), `/portfolio`, and `/pool/[id]` (filtered).

## Tests

Adds `packages/trpc/src/__tests__/concentrated-liquidity.spec.ts` with 5 unit tests covering:
- Status group ordering (out, near, in, full)
- USD value descending within a status group
- Unknown statuses bucketing after known ones
- Unbonding / superfluid bucketed with unknowns (they don't apply to CL positions on this surface but the comparator handles them robustly)
- Position-id tiebreaker on full ties

## Testing and Verifying

- [x] Visit `/pools` with a wallet that has CL positions in mixed statuses; verify out-of-range positions appear first, then near-bounds, then in-range, then full-range.
- [x] Within each group, larger USD-value positions appear above smaller.
- [x] Refresh the page; ordering of any equal-value pairs stays identical (id tiebreaker).
- [x] Force-fail the sidecar `getPools` call in devtools; positions still render (sort falls back to value-only, no thundering chain RPC).
- [x] Pool detail page (`forPoolId` set): positions for that pool render in the same sorted order.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new pool lookups (sidecar batch with per-pool chain RPC fallback) to derive `PositionStatus`, which could affect latency and error handling for the user-positions endpoint, but does not touch funds-moving logic.
> 
> **Overview**
> **Updates CL user position listing to be status-aware and re-sorted.** `mapGetUserPositions` now derives a `status` (in/near/out/full range) per position by fetching pool `current_sqrt_price` (batch via `getPools`, with `queryPoolChain` fallback for missing/sidecar failures) and includes this `status` on each returned position.
> 
> **Changes the TRPC `getUserPositions` API contract and sorting behavior.** Removes the `sortDirection` input and replaces join-time sorting with a comparator that groups by `status` (`outOfRange` first, then `nearBounds`, then all others) and sorts within each group by `currentValue` (USD) descending.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ef0633b7490ad4b801bc47ac3c5347a45eea931. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
