### PR TITLE
feat(rewards): surface daily-epoch countdown on stake + pool detail

### DIFF
--- a/packages/web/components/cards/bond-card.tsx
+++ b/packages/web/components/cards/bond-card.tsx
@@ -11,7 +11,7 @@ import { FallbackImg, Icon } from "~/components/assets";
 import { RightArrowIcon } from "~/components/assets/right-arrow-icon";
 import { UnlockIcon } from "~/components/assets/unlock-icon";
 import { EventName } from "~/config";
-import { useTranslation } from "~/hooks";
+import { useDailyEpochCountdown, useTranslation } from "~/hooks";
 import { useAmplitudeAnalytics } from "~/hooks";
 import { formatPretty } from "~/utils/formatter";
 
@@ -189,6 +189,7 @@ const Drawer: FunctionComponent<{
   toggleDetailsVisible,
 }) => {
   const { t } = useTranslation();
+  const timeRemaining = useDailyEpochCountdown();
 
   return (
     <div
@@ -263,6 +264,7 @@ const Drawer: FunctionComponent<{
         </div>
         <span className="caption text-center text-osmoverse-400">
           {t("pool.rewardDistribution")}
+          {timeRemaining && ` · ${t("pool.nextRewardIn")} ${timeRemaining}`}
         </span>
       </div>
     </div>

--- a/packages/web/components/cards/bond-card.tsx
+++ b/packages/web/components/cards/bond-card.tsx
@@ -189,7 +189,6 @@ const Drawer: FunctionComponent<{
   toggleDetailsVisible,
 }) => {
   const { t } = useTranslation();
-  const timeRemaining = useDailyEpochCountdown();
 
   return (
     <div
@@ -262,12 +261,21 @@ const Drawer: FunctionComponent<{
           ))}
           <SwapFeeBreakdownRow swapFeeApr={swapFeeApr} />
         </div>
-        <span className="caption text-center text-osmoverse-400">
-          {t("pool.rewardDistribution")}
-          {timeRemaining && ` · ${t("pool.nextRewardIn")} ${timeRemaining}`}
-        </span>
+        <DrawerRewardCaption />
       </div>
     </div>
+  );
+};
+
+const DrawerRewardCaption = () => {
+  const { t } = useTranslation();
+  const timeRemaining = useDailyEpochCountdown();
+
+  return (
+    <span className="caption text-center text-osmoverse-400">
+      {t("pool.rewardDistribution")}
+      {timeRemaining && ` · ${t("pool.nextRewardIn")} ${timeRemaining}`}
+    </span>
   );
 };
 

--- a/packages/web/components/cards/stake-dashboard.tsx
+++ b/packages/web/components/cards/stake-dashboard.tsx
@@ -11,7 +11,7 @@ import { GenericMainCard } from "~/components/cards/generic-main-card";
 import { RewardsCard } from "~/components/cards/rewards-card";
 import { ValidatorSquadCard } from "~/components/cards/validator-squad-card";
 import { EventName } from "~/config";
-import { useTranslation } from "~/hooks";
+import { useDailyEpochCountdown, useTranslation } from "~/hooks";
 import { useAmplitudeAnalytics } from "~/hooks";
 import { useStore } from "~/stores";
 
@@ -136,7 +136,7 @@ export const StakeDashboard: React.FC<{
         titleIcon={LearnMoreIconText}
         titleIconAction={() => setShowStakeLearnMoreModal(true)}
       >
-        <div className="flex w-full flex-row gap-2 py-10 sm:flex-col sm:gap-6 sm:py-4">
+        <div className="flex w-full flex-row gap-2 py-10 xl:flex-col xl:gap-6 xl:py-4">
           <StakeBalances
             title={t("stake.stakeBalanceTitle")}
             dollarAmount={fiatBalance}
@@ -147,6 +147,7 @@ export const StakeDashboard: React.FC<{
             dollarAmount={fiatRewards}
             osmoAmount={summedStakeRewards}
           />
+          {balance.toDec().isPositive() && <NextRewardCountdown />}
         </div>
         <ValidatorSquadCard
           hasInsufficientBalance={hasInsufficientBalance}
@@ -185,6 +186,24 @@ export const StakeDashboard: React.FC<{
   }
 );
 
+const NextRewardCountdown: React.FC = () => {
+  const { t } = useTranslation();
+  const timeRemaining = useDailyEpochCountdown();
+
+  if (!timeRemaining) return null;
+
+  return (
+    <div className="flex w-[13rem] shrink-0 flex-col items-start justify-start gap-1 text-left xl:w-full xl:items-center">
+      <span className="caption text-sm text-osmoverse-200 md:text-xs">
+        {t("pool.nextRewardIn")}
+      </span>
+      <h3 className="whitespace-nowrap bg-superfluid bg-clip-text text-h3 tabular-nums text-transparent xl:text-h4 lg:text-h5">
+        {timeRemaining}
+      </h3>
+    </div>
+  );
+};
+
 const StakeBalances: React.FC<{
   title: string;
   dollarAmount?: PricePretty;
@@ -214,7 +233,7 @@ const StakeBalances: React.FC<{
       </span>
       <h3
         className={classNames(
-          "whitespace-nowrap",
+          "whitespace-nowrap text-h3 xl:text-h4 lg:text-h5",
           flashDollar ? "animate-flash" : ""
         )}
       >

--- a/packages/web/components/overview/pools.tsx
+++ b/packages/web/components/overview/pools.tsx
@@ -1,18 +1,15 @@
 import classNames from "classnames";
-import dayjs from "dayjs";
 import Image from "next/image";
-import { FunctionComponent, useEffect, useState } from "react";
+import { FunctionComponent } from "react";
 
 import { CustomClasses } from "~/components/types";
 import { Button } from "~/components/ui/button";
-import { Breakpoint, useTranslation } from "~/hooks";
+import { Breakpoint, useDailyEpochCountdown, useTranslation } from "~/hooks";
 import { useWindowSize } from "~/hooks";
 import { formatPretty } from "~/utils/formatter";
 import { api } from "~/utils/trpc";
 
 import { SkeletonLoader } from "../loaders/skeleton-loader";
-
-const REWARD_EPOCH_IDENTIFIER = "day";
 
 export const PoolsOverview: FunctionComponent<
   { setIsCreatingPool: () => void } & CustomClasses
@@ -23,37 +20,7 @@ export const PoolsOverview: FunctionComponent<
   const { data: osmo, isFetched } = api.edge.assets.getMarketAsset.useQuery({
     findMinDenomOrSymbol: "OSMO",
   });
-  const { data: epochs } = api.local.params.getEpochs.useQuery();
-
-  // update time every second
-  const [timeRemaining, setTimeRemaining] = useState<string | null>(null);
-  useEffect(() => {
-    const updateTimeRemaining = () => {
-      if (!epochs) return;
-      const epoch = epochs.find(
-        (e) => e.identifier === REWARD_EPOCH_IDENTIFIER
-      );
-      if (!epoch) return;
-      const now = new Date();
-      const epochRemainingTime = dayjs.duration(
-        dayjs(epoch.endTime).diff(dayjs(now), "second"),
-        "second"
-      );
-      const epochRemainingTimeString =
-        epochRemainingTime.asSeconds() <= 0
-          ? dayjs.duration(0, "seconds").format("HH-mm-ss")
-          : epochRemainingTime.format("HH-mm-ss");
-      const [epochRemainingHour, epochRemainingMinute, epochRemainingSeconds] =
-        epochRemainingTimeString.split("-");
-      setTimeRemaining(
-        `${epochRemainingHour}:${epochRemainingMinute}:${epochRemainingSeconds}`
-      );
-    };
-    const intervalId = setInterval(updateTimeRemaining, 1000);
-    updateTimeRemaining();
-
-    return () => clearInterval(intervalId);
-  }, [epochs]);
+  const timeRemaining = useDailyEpochCountdown();
 
   return (
     <div

--- a/packages/web/components/pool-detail/share.tsx
+++ b/packages/web/components/pool-detail/share.tsx
@@ -31,6 +31,7 @@ import { Button } from "~/components/ui/button";
 import { EventName } from "~/config";
 import {
   useAmplitudeAnalytics,
+  useDailyEpochCountdown,
   useLockTokenConfig,
   useSuperfluidPool,
   useTranslation,
@@ -555,6 +556,9 @@ export const SharePool: FunctionComponent<{ pool: Pool }> = observer(
                       },
                     ]}
                   />
+                  {userSharePool.lockedValue.toDec().isPositive() && (
+                    <NextRewardLine />
+                  )}
                 </div>
               </div>
             </div>
@@ -836,6 +840,24 @@ const LevelBadge: FunctionComponent<{ level: number } & Disableable> = ({
       <h5 className="md:text-h6 md:font-h6">
         {t("pool.level", { level: level.toString() })}
       </h5>
+    </div>
+  );
+};
+
+const NextRewardLine: FunctionComponent = () => {
+  const { t } = useTranslation();
+  const timeRemaining = useDailyEpochCountdown();
+
+  if (!timeRemaining) return null;
+
+  return (
+    <div className="flex items-baseline justify-between border-t border-osmoverse-700 pt-3">
+      <span className="caption text-osmoverse-300">
+        {t("pool.nextRewardIn")}
+      </span>
+      <span className="subtitle1 whitespace-nowrap bg-superfluid bg-clip-text tabular-nums text-transparent">
+        {timeRemaining}
+      </span>
     </div>
   );
 };

--- a/packages/web/hooks/index.ts
+++ b/packages/web/hooks/index.ts
@@ -7,6 +7,7 @@ export * from "./use-amplitude-analytics";
 export * from "./use-asset-variants-toast";
 export * from "./use-boolean-with-window-event";
 export * from "./use-connect-wallet-modal-redirect";
+export * from "./use-daily-epoch-countdown";
 export * from "./use-dimension";
 export * from "./use-disclosure";
 export * from "./use-feature-flags";

--- a/packages/web/hooks/use-daily-epoch-countdown.ts
+++ b/packages/web/hooks/use-daily-epoch-countdown.ts
@@ -1,0 +1,43 @@
+import dayjs from "dayjs";
+import { useEffect, useState } from "react";
+
+import { api } from "~/utils/trpc";
+
+const REWARD_EPOCH_IDENTIFIER = "day";
+
+/**
+ * Returns the time remaining until the next daily-epoch reward distribution,
+ * formatted as `HH:mm:ss`. Updates every second.
+ *
+ * Returns null until the epoch query resolves or if the daily epoch isn't found.
+ */
+export function useDailyEpochCountdown(): string | null {
+  const { data: epochs } = api.local.params.getEpochs.useQuery();
+
+  const [timeRemaining, setTimeRemaining] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!epochs) return;
+    const epoch = epochs.find((e) => e.identifier === REWARD_EPOCH_IDENTIFIER);
+    if (!epoch) return;
+
+    const update = () => {
+      const remaining = dayjs.duration(
+        dayjs(epoch.endTime).diff(dayjs(), "second"),
+        "second"
+      );
+      const formatted =
+        remaining.asSeconds() <= 0
+          ? dayjs.duration(0, "seconds").format("HH-mm-ss")
+          : remaining.format("HH-mm-ss");
+      const [h, m, s] = formatted.split("-");
+      setTimeRemaining(`${h}:${m}:${s}`);
+    };
+
+    update();
+    const id = setInterval(update, 1000);
+    return () => clearInterval(id);
+  }, [epochs]);
+
+  return timeRemaining;
+}

--- a/packages/web/hooks/use-daily-epoch-countdown.ts
+++ b/packages/web/hooks/use-daily-epoch-countdown.ts
@@ -12,32 +12,48 @@ const REWARD_EPOCH_IDENTIFIER = "day";
  * Returns null until the epoch query resolves or if the daily epoch isn't found.
  */
 export function useDailyEpochCountdown(): string | null {
-  const { data: epochs } = api.local.params.getEpochs.useQuery();
+  const { data: epochs, refetch } = api.local.params.getEpochs.useQuery();
 
   const [timeRemaining, setTimeRemaining] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!epochs) return;
+    if (!epochs) {
+      setTimeRemaining(null);
+      return;
+    }
     const epoch = epochs.find((e) => e.identifier === REWARD_EPOCH_IDENTIFIER);
-    if (!epoch) return;
+    if (!epoch) {
+      setTimeRemaining(null);
+      return;
+    }
 
+    // The cached epoch.endTime describes the epoch we're tracking; once it
+    // lapses, we need to refetch to get the next boundary. The chain may not
+    // have ticked the next epoch yet, so refetch immediately on first expiry
+    // and then poll every 30s until fresh data arrives.
+    const RETRY_REFETCH_EVERY_SECONDS = 30;
+    let secondsSinceLastRefetch = RETRY_REFETCH_EVERY_SECONDS;
     const update = () => {
-      const remaining = dayjs.duration(
-        dayjs(epoch.endTime).diff(dayjs(), "second"),
-        "second"
+      const remainingSeconds = dayjs(epoch.endTime).diff(dayjs(), "second");
+      setTimeRemaining(
+        dayjs
+          .duration(Math.max(0, remainingSeconds), "second")
+          .format("HH:mm:ss")
       );
-      const formatted =
-        remaining.asSeconds() <= 0
-          ? dayjs.duration(0, "seconds").format("HH-mm-ss")
-          : remaining.format("HH-mm-ss");
-      const [h, m, s] = formatted.split("-");
-      setTimeRemaining(`${h}:${m}:${s}`);
+
+      if (remainingSeconds <= 0) {
+        secondsSinceLastRefetch += 1;
+        if (secondsSinceLastRefetch >= RETRY_REFETCH_EVERY_SECONDS) {
+          secondsSinceLastRefetch = 0;
+          void refetch();
+        }
+      }
     };
 
     update();
     const id = setInterval(update, 1000);
     return () => clearInterval(id);
-  }, [epochs]);
+  }, [epochs, refetch]);
 
   return timeRemaining;
 }

--- a/packages/web/localizations/de.json
+++ b/packages/web/localizations/de.json
@@ -500,7 +500,8 @@
     "undelegating": "nichtdelegieren",
     "yourStats": "Ihr Pool-Guthaben",
     "onlyInRangePositions": "Nur für Positionen in Reichweite",
-    "custom": "Brauch"
+    "custom": "Brauch",
+    "nextRewardIn": "Nächste Belohnung in"
   },
   "pools": {
     "allPools": {

--- a/packages/web/localizations/en.json
+++ b/packages/web/localizations/en.json
@@ -500,7 +500,8 @@
     "undelegating": "undelegating",
     "yourStats": "Your pool balance",
     "onlyInRangePositions": "Only for positions in range",
-    "custom": "Custom"
+    "custom": "Custom",
+    "nextRewardIn": "Next reward in"
   },
   "pools": {
     "allPools": {

--- a/packages/web/localizations/es.json
+++ b/packages/web/localizations/es.json
@@ -500,7 +500,8 @@
     "undelegating": "desautorizando",
     "yourStats": "Su saldo de la piscina",
     "onlyInRangePositions": "Solo para posiciones en rango",
-    "custom": "Costumbre"
+    "custom": "Costumbre",
+    "nextRewardIn": "Próxima recompensa en"
   },
   "pools": {
     "allPools": {

--- a/packages/web/localizations/fa.json
+++ b/packages/web/localizations/fa.json
@@ -500,7 +500,8 @@
     "undelegating": "در حال خروج",
     "yourStats": "موجودی استخر شما",
     "onlyInRangePositions": "فقط برای موقعیت های در محدوده",
-    "custom": "سفارشی"
+    "custom": "سفارشی",
+    "nextRewardIn": "پاداش بعدی در"
   },
   "pools": {
     "allPools": {

--- a/packages/web/localizations/fr.json
+++ b/packages/web/localizations/fr.json
@@ -500,7 +500,8 @@
     "undelegating": "Désengager",
     "yourStats": "Le solde de votre piscine",
     "onlyInRangePositions": "Uniquement pour les positions dans la plage",
-    "custom": "Coutume"
+    "custom": "Coutume",
+    "nextRewardIn": "Prochaine récompense dans"
   },
   "pools": {
     "allPools": {

--- a/packages/web/localizations/gu.json
+++ b/packages/web/localizations/gu.json
@@ -500,7 +500,8 @@
     "undelegating": "સોંપણી",
     "yourStats": "તમારું પૂલ બેલેન્સ",
     "onlyInRangePositions": "માત્ર શ્રેણીમાં હોદ્દા માટે",
-    "custom": "કસ્ટમ"
+    "custom": "કસ્ટમ",
+    "nextRewardIn": "પછીનું પુરસ્કાર"
   },
   "pools": {
     "allPools": {

--- a/packages/web/localizations/hi.json
+++ b/packages/web/localizations/hi.json
@@ -500,7 +500,8 @@
     "undelegating": "प्रत्यायोजित न करना",
     "yourStats": "आपका पूल संतुलन",
     "onlyInRangePositions": "केवल रेंज में पदों के लिए",
-    "custom": "रिवाज़"
+    "custom": "रिवाज़",
+    "nextRewardIn": "अगला पुरस्कार"
   },
   "pools": {
     "allPools": {

--- a/packages/web/localizations/ja.json
+++ b/packages/web/localizations/ja.json
@@ -500,7 +500,8 @@
     "undelegating": "委任を解除する",
     "yourStats": "プール残高",
     "onlyInRangePositions": "範囲内の位置のみ",
-    "custom": "カスタム"
+    "custom": "カスタム",
+    "nextRewardIn": "次の報酬まで"
   },
   "pools": {
     "allPools": {

--- a/packages/web/localizations/ko.json
+++ b/packages/web/localizations/ko.json
@@ -500,7 +500,8 @@
     "undelegating": "위임 해제중",
     "yourStats": "내 잔액",
     "onlyInRangePositions": "범위 내 위치에만 해당",
-    "custom": "관습"
+    "custom": "관습",
+    "nextRewardIn": "다음 보상까지"
   },
   "pools": {
     "allPools": {

--- a/packages/web/localizations/pl.json
+++ b/packages/web/localizations/pl.json
@@ -500,7 +500,8 @@
     "undelegating": "oddelegowywane",
     "yourStats": "Twoje saldo puli",
     "onlyInRangePositions": "Tylko dla pozycji w zasięgu",
-    "custom": "Zwyczaj"
+    "custom": "Zwyczaj",
+    "nextRewardIn": "Następna nagroda za"
   },
   "pools": {
     "allPools": {

--- a/packages/web/localizations/pt-br.json
+++ b/packages/web/localizations/pt-br.json
@@ -500,7 +500,8 @@
     "undelegating": "removendo delegação",
     "yourStats": "O saldo da sua piscina",
     "onlyInRangePositions": "Apenas para posições no intervalo",
-    "custom": "Personalizado"
+    "custom": "Personalizado",
+    "nextRewardIn": "Próxima recompensa em"
   },
   "pools": {
     "allPools": {

--- a/packages/web/localizations/ro.json
+++ b/packages/web/localizations/ro.json
@@ -500,7 +500,8 @@
     "undelegating": "anulare delegare",
     "yourStats": "Statisticile tale",
     "onlyInRangePositions": "Doar pentru pozițiile din rază",
-    "custom": "Personalizat"
+    "custom": "Personalizat",
+    "nextRewardIn": "Următoarea recompensă în"
   },
   "pools": {
     "allPools": {

--- a/packages/web/localizations/ru.json
+++ b/packages/web/localizations/ru.json
@@ -500,7 +500,8 @@
     "undelegating": "отказ от делегирования",
     "yourStats": "Ваш баланс в пуле",
     "onlyInRangePositions": "Только для позиций в диапазоне",
-    "custom": "Обычай"
+    "custom": "Обычай",
+    "nextRewardIn": "Следующая награда через"
   },
   "pools": {
     "allPools": {

--- a/packages/web/localizations/tr.json
+++ b/packages/web/localizations/tr.json
@@ -500,7 +500,8 @@
     "undelegating": "delegasyonu bozulan",
     "yourStats": "Havuz bakiyeniz",
     "onlyInRangePositions": "Yalnızca menzil içindeki konumlar için",
-    "custom": "Gelenek"
+    "custom": "Gelenek",
+    "nextRewardIn": "Sonraki ödül"
   },
   "pools": {
     "allPools": {

--- a/packages/web/localizations/zh-cn.json
+++ b/packages/web/localizations/zh-cn.json
@@ -500,7 +500,8 @@
     "undelegating": "取消委托",
     "yourStats": "您的资金池余额",
     "onlyInRangePositions": "仅适用于范围内的位置",
-    "custom": "风俗"
+    "custom": "风俗",
+    "nextRewardIn": "下次奖励"
   },
   "pools": {
     "allPools": {

--- a/packages/web/localizations/zh-hk.json
+++ b/packages/web/localizations/zh-hk.json
@@ -500,7 +500,8 @@
     "undelegating": "解除質押中",
     "yourStats": "您嘅資金池餘額",
     "onlyInRangePositions": "僅適用於範圍內的位置",
-    "custom": "風俗"
+    "custom": "風俗",
+    "nextRewardIn": "下次獎勵"
   },
   "pools": {
     "allPools": {

--- a/packages/web/localizations/zh-tw.json
+++ b/packages/web/localizations/zh-tw.json
@@ -500,7 +500,8 @@
     "undelegating": "解除質押中",
     "yourStats": "您的資金池餘額",
     "onlyInRangePositions": "僅適用於範圍內的位置",
-    "custom": "風俗"
+    "custom": "風俗",
+    "nextRewardIn": "下次獎勵"
   },
   "pools": {
     "allPools": {


### PR DESCRIPTION
The "Reward distribution in HH:MM:SS" timer in the obsolete pools header is restored where it actually applies. A new useDailyEpochCountdown hook encapsulates the api.local.params.getEpochs query + 1-second tick. It's surfaced in three places, each in its own isolated subcomponent so only the timer text re-renders per second (parent cards / images / balances stay static):

  - /stake dashboard: a dedicated column to the right of the Unclaimed Rewards balance, with text size scaling at xl/lg breakpoints, pinned width to prevent layout shift, and stack-on-narrow at xl.
  - /pool/[id] "Your Stats" Bonded breakdown card: a small caption line beneath the chart, gated on a positive locked value.
  - Bond card drawer footer (pool detail): augments the existing "Rewards distributed to all liquidity providers" caption.
<img width="819" height="475" alt="image" src="https://github.com/user-attachments/assets/a937c2ca-85c2-4937-8b0a-01207a4307e9" />
<img width="325" height="888" alt="image" src="https://github.com/user-attachments/assets/35abd291-4a52-4e9c-85a6-f7154278f326" />
<img width="740" height="334" alt="image" src="https://github.com/user-attachments/assets/07f10d61-17af-4d22-9c44-e37f4bc77dac" />
<img width="837" height="448" alt="image" src="https://github.com/user-attachments/assets/b000d15e-41dd-43e9-bb37-5a84c1fbbc14" />


Adds pool.nextRewardIn ("Next reward in") to all 17 locale files with native translations.

## Testing and Verifying

This change has been tested locally by rebuilding the website and verified content and links are expected

- [x] [Stake Page](https://osmosis-frontend-kg3oaos96.vercel.dev-osmosis.zone/stake)
- [x] GAMM bonding page - Currently only bonded external incentives are against [2977](https://osmosis-frontend-kg3oaos96.vercel.dev-osmosis.zone/pool/2977)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new 1-second ticking countdown hook that triggers TRPC `getEpochs` refetching on epoch expiry; incorrect timer/refetch behavior could cause UI churn or extra network load. UI changes are localized but appear in several high-traffic pages (stake, pool detail, bond drawer, pools overview).
> 
> **Overview**
> Surfaces a live *daily epoch* countdown (`HH:mm:ss`) for reward distribution in multiple places: the stake dashboard (new countdown column when balance is positive), pool detail “Your Stats” breakdown (new gated line when bonded value is positive), and the bond card drawer footer (appends countdown to the existing reward caption).
> 
> Refactors the pools overview header to use the new `useDailyEpochCountdown` hook instead of its own `dayjs`/`setInterval` logic, and adds a new localized string `pool.nextRewardIn` across supported locales.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1261184a300ede18b5f620ea4842069c0b99f52b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->