### PR TITLE
fix(wormhole): swap rate-limited Helius RPC for publicnode

### DIFF
--- a/packages/web/pages/wormhole.tsx
+++ b/packages/web/pages/wormhole.tsx
@@ -264,8 +264,12 @@ const Wormhole: FunctionComponent = () => {
   let config: WormholeConnectConfig = {
     networks: ["solana", "osmosis", "sui", "aptos", "ethereum"],
     rpcs: {
-      solana:
-        "https://mainnet.helius-rpc.com/?api-key=f4713222-8bbc-4495-aace-5693e719712e",
+      // Was a hardcoded Helius URL with a shared public API key that
+      // routinely 429s; the widget interprets failed `getAccountInfo`
+      // lookups as "no ATA exists" and shows a misleading create-account
+      // banner. Use the same keyless endpoint the recovery widget below
+      // relies on (see SOLANA_RPC in components/bridge/wormhole-redeem.tsx).
+      solana: "https://solana-rpc.publicnode.com",
       wormchain: "https://wormchain-rpc.polkachu.com",
       ethereum: "https://ethereum-rpc.publicnode.com",
       osmosis: "https://rpc.osmosis.zone",


### PR DESCRIPTION
## What is the purpose of the change:

Fix a false-positive "No associated token account exists for your wallet on Solana. You must create it before proceeding." banner on the `/wormhole` deposit widget. The banner is triggered whenever the widget's Solana `getAccountInfo` call fails — it can't distinguish "RPC errored" from "ATA truly missing" — and our hardcoded Helius RPC is currently `429`-rate-limited because it shares one public API key across all visitors (user devtools repro: ~356/394 requests returning 429).

This is not a revert: the Helius URL has been there unchanged since April 2024; the shared key has simply been exhausted.

### Linear Task

n/a — small bugfix discovered from a user report; happy to open a ticket if reviewers prefer.

## Brief Changelog

- `packages/web/pages/wormhole.tsx`: swap the rate-limited `mainnet.helius-rpc.com` URL for `https://solana-rpc.publicnode.com`, the same keyless endpoint the recovery widget on the same page already uses (`SOLANA_RPC` in `packages/web/components/bridge/wormhole-redeem.tsx`).

## Testing and Verifying

Open DevTools network tab on `/wormhole`:

- Requests now hit `solana-rpc.publicnode.com` with `200`s instead of `mainnet.helius-rpc.com` with `429`s.
- For a wallet with an existing ATA: the create-account banner no longer appears.
- For a wallet without an ATA: the create-account banner still correctly appears.
- Recovery widget below continues to function unchanged.
