### PR TITLE
feat(bridge): surface Wormhole governor daily-limit delay in redeem widget

### DIFF
--- a/packages/web/components/bridge/__tests__/wormhole-redeem.spec.tsx
+++ b/packages/web/components/bridge/__tests__/wormhole-redeem.spec.tsx
@@ -49,7 +49,9 @@ jest.mock("@mysten/wallet-standard", () => ({
 
 import {
   checkIfRedeemed,
+  fetchGovernorDelay,
   findWormchainRecvTx,
+  formatGovernorReleaseCountdown,
   lookupOsmosisIbcPacket,
   resolveOperation,
   WormholeRedeem,
@@ -578,5 +580,191 @@ describe("resolveOperation", () => {
     await expect(resolveOperation(OSMOSIS_HASH)).rejects.toThrow(
       /Wormchain receive hash/i
     );
+  });
+});
+
+// Fixtures: a Wormchain-emitter operation with no VAA yet. Mirrors the
+// shape of `/api/v1/operations` while the chain governor is holding the
+// VAA (i.e. before `vaa.raw` is populated).
+const OPERATION_WITHOUT_VAA = {
+  ...OPERATION_SUI_COMPLETED,
+  vaa: { raw: "", guardianSetIndex: 0 },
+  targetChain: undefined,
+} as const;
+
+describe("fetchGovernorDelay", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  it("returns null when the operation already has a signed VAA", async () => {
+    const fetchSpy = jest.fn();
+    global.fetch = fetchSpy;
+
+    const result = await fetchGovernorDelay(OPERATION_SUI_COMPLETED as any);
+
+    expect(result).toBeNull();
+    // Skipping the governor lookups entirely keeps the happy path snappy.
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns kind=enqueued with releaseTime when the VAA is in the chain's queue", async () => {
+    const RELEASE_TIME = 1779540976; // matches enqueued_vaas.releaseTime
+
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ isEnqueued: true }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: [
+            {
+              sequence: "51994",
+              emitterAddress:
+                "0xaeb534c45c3049d380b9d9b966f9895f53abd4301bfaff407fa09dea8ae7a924",
+              chainId: 3104,
+              releaseTime: RELEASE_TIME,
+              txHash: "0xabc",
+            },
+          ],
+        }),
+      });
+
+    const result = await fetchGovernorDelay(OPERATION_WITHOUT_VAA as any);
+
+    expect(result).toEqual({
+      kind: "enqueued",
+      releaseTime: RELEASE_TIME,
+      usdAmount: Number(OPERATION_SUI_COMPLETED.data.usdAmount),
+    });
+  });
+
+  it("still returns kind=enqueued (without releaseTime) when the row isn't in the enqueued list yet", async () => {
+    // Wormholescan occasionally returns `isEnqueued: true` slightly
+    // before the enqueued list endpoint catches up. We must still show
+    // the badge — just without a countdown — rather than suppressing it.
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ isEnqueued: true }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: [] }),
+      });
+
+    const result = await fetchGovernorDelay(OPERATION_WITHOUT_VAA as any);
+
+    expect(result?.kind).toBe("enqueued");
+    expect(result?.releaseTime).toBeUndefined();
+  });
+
+  it("returns kind=likely-enqueued when the transfer value exceeds the best guardian's headroom", async () => {
+    // is_vaa_enqueued is `false` (propagation window). Fall back to
+    // comparing the transfer's USD value against the chain's
+    // max-available notional.
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ isEnqueued: false }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: { availableNotional: 10 } }),
+      });
+
+    const usdAmount = Number(OPERATION_SUI_COMPLETED.data.usdAmount);
+    const result = await fetchGovernorDelay(OPERATION_WITHOUT_VAA as any);
+
+    expect(result).toEqual({
+      kind: "likely-enqueued",
+      availableNotional: 10,
+      usdAmount,
+    });
+  });
+
+  it("returns null when the transfer fits within the available headroom", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ isEnqueued: false }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: { availableNotional: 1_000_000 } }),
+      });
+
+    const result = await fetchGovernorDelay(OPERATION_WITHOUT_VAA as any);
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the governor endpoints all fail", async () => {
+    // Governor lookups are best-effort. A flaky guardian endpoint must
+    // never block the user from at least seeing the existing
+    // "VAA not yet available" error.
+    global.fetch = jest.fn().mockRejectedValue(new Error("Network error"));
+
+    const result = await fetchGovernorDelay(OPERATION_WITHOUT_VAA as any);
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when usdAmount is not a finite number", async () => {
+    // Wormholescan occasionally returns a non-numeric placeholder for
+    // transfers the notional pricing service hasn't scored yet. Without
+    // a number we can't render the badge meaningfully, so we bail
+    // before even hitting the governor endpoints to avoid spurious
+    // "$NaN" copy.
+    const op = {
+      ...OPERATION_WITHOUT_VAA,
+      data: { ...OPERATION_WITHOUT_VAA.data, usdAmount: "n/a" },
+    };
+    const fetchSpy = jest.fn();
+    global.fetch = fetchSpy;
+
+    const result = await fetchGovernorDelay(op as any);
+
+    expect(result).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("formatGovernorReleaseCountdown", () => {
+  it("renders hours + minutes for long waits", () => {
+    const now = 1_000_000_000_000;
+    const releaseTime = Math.floor(now / 1000) + 3 * 3600 + 25 * 60;
+    expect(formatGovernorReleaseCountdown(releaseTime, now)).toBe(
+      "Releases in 3h 25m"
+    );
+  });
+
+  it("renders minutes only when less than an hour remains", () => {
+    const now = 1_000_000_000_000;
+    const releaseTime = Math.floor(now / 1000) + 7 * 60;
+    expect(formatGovernorReleaseCountdown(releaseTime, now)).toBe(
+      "Releases in 7m"
+    );
+  });
+
+  it("renders 'Releases shortly' for the last minute", () => {
+    const now = 1_000_000_000_000;
+    const releaseTime = Math.floor(now / 1000) + 30;
+    expect(formatGovernorReleaseCountdown(releaseTime, now)).toBe(
+      "Releases shortly"
+    );
+  });
+
+  it("falls back to the generic 24h string when releaseTime is missing", () => {
+    expect(formatGovernorReleaseCountdown(undefined)).toBe("Up to 24 hours");
   });
 });

--- a/packages/web/components/bridge/__tests__/wormhole-redeem.spec.tsx
+++ b/packages/web/components/bridge/__tests__/wormhole-redeem.spec.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom";
 
 import { apiClient } from "@osmosis-labs/utils";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 
 const mockClaimKey = {
@@ -736,6 +736,55 @@ describe("fetchGovernorDelay", () => {
 
     expect(result).toBeNull();
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("WormholeRedeem governor_delayed render guard", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  it("does not mount a redeem panel for a Sui-destination op held by the governor", async () => {
+    // resolveOperation: direct Wormholescan hit returns a VAA-less,
+    // Sui-destination operation.
+    mockedApiClient.mockResolvedValueOnce({
+      operations: [OPERATION_WITHOUT_VAA],
+    });
+    // fetchGovernorDelay: the VAA is enqueued in the chain governor.
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ isEnqueued: true }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: [] }),
+      });
+
+    render(<WormholeRedeem />);
+
+    fireEvent.change(
+      screen.getByPlaceholderText("Osmosis transaction hash..."),
+      { target: { value: WORMCHAIN_HASH } }
+    );
+    fireEvent.click(screen.getByText("Lookup"));
+
+    // The governor delay badge renders for the queued transfer.
+    expect(await screen.findByText("Daily limit exceeded")).toBeInTheDocument();
+
+    // The Sui redeem panel must NOT mount: governor_delayed leaves
+    // `operation.vaa.raw === ""`, and the panel would otherwise invite the
+    // user to redeem an empty VAA. Both the native Sui panel and its
+    // generic Wormholescan fallback advertise "VAA is signed and ready",
+    // so its absence proves neither rendered.
+    expect(
+      screen.queryByText(/VAA is signed and ready/i)
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Redeem on Sui")).not.toBeInTheDocument();
   });
 });
 

--- a/packages/web/components/bridge/wormhole-redeem.tsx
+++ b/packages/web/components/bridge/wormhole-redeem.tsx
@@ -1526,6 +1526,7 @@ export const WormholeRedeem: FunctionComponent = () => {
 
             {status !== "already_redeemed" &&
               status !== "success" &&
+              status !== "governor_delayed" &&
               operation.content.payload.toChain === CHAIN_ID.sui &&
               resolvedTxHash && (
                 <SuiRedeemPanel

--- a/packages/web/components/bridge/wormhole-redeem.tsx
+++ b/packages/web/components/bridge/wormhole-redeem.tsx
@@ -25,8 +25,21 @@ import {
 } from "./wormhole-sui";
 
 const WORMHOLESCAN_API = "https://api.wormholescan.io/api/v1";
+// The chain-governor `is_vaa_enqueued` lookup lives under the legacy
+// guardian-compatible namespace (`/v1`), not the wormholescan namespace.
+const WORMHOLESCAN_LEGACY_API = "https://api.wormholescan.io/v1";
 const WORMHOLESCAN_UI = "https://wormholescan.io";
 const SOLANA_RPC = "https://solana-rpc.publicnode.com";
+
+// Hard-coded by the Wormhole protocol: the chain governor enforces a sliding
+// 24-hour notional limit per chain. Used for the "up to 24 hours" copy in
+// the delay badge.
+const GOVERNOR_DELAY_HOURS = 24;
+// Learn-more link surfaced in the delay badge. Points at the protocol
+// blog post rather than the whitepaper because it's much shorter and
+// reader-friendly.
+const GOVERNOR_LEARN_MORE_URL =
+  "https://wormhole.com/blog/understanding-the-flow-canceling-governor-in-wormhole";
 
 // Wormhole gateway channel from Osmosis -> Wormchain (the IBC translator).
 // MsgTransfer's source_channel on Osmosis is `channel-2186`; on Wormchain
@@ -168,10 +181,57 @@ type RedeemStatus =
   | "already_redeemed"
   | "checking_solana"
   | "ready"
+  | "governor_delayed"
   | "signing"
   | "submitting"
   | "success"
   | "error";
+
+/**
+ * Outcome of inspecting the Wormhole chain governor for a given operation.
+ *
+ * `enqueued` means a `is_vaa_enqueued` response confirmed this specific
+ * VAA is being held; `releaseTime` is populated when we could also find
+ * the row in the chain's enqueued list.
+ *
+ * `likely-enqueued` is the heuristic fallback used during the propagation
+ * window where the operation is observable but the guardians have not yet
+ * marked the VAA as enqueued. We compare its USD value to the best
+ * available guardian headroom; if it doesn't fit, it almost certainly
+ * will be queued shortly.
+ */
+export interface GovernorDelay {
+  kind: "enqueued" | "likely-enqueued";
+  /** Unix seconds when the governor will release the VAA. Only present
+   *  for the `enqueued` kind, and only when the row was findable in the
+   *  per-chain enqueued list. */
+  releaseTime?: number;
+  /** USD notional value of the in-flight transfer. */
+  usdAmount: number;
+  /** Best per-guardian headroom remaining on the source chain, in USD.
+   *  Only present for the `likely-enqueued` kind. */
+  availableNotional?: number;
+}
+
+interface IsVaaEnqueuedResponse {
+  isEnqueued?: boolean;
+}
+
+interface EnqueuedVaasResponse {
+  data?: {
+    sequence: string | number;
+    emitterAddress?: string;
+    chainId?: number;
+    releaseTime?: number;
+    txHash?: string;
+  }[];
+}
+
+interface MaxAvailableResponse {
+  data?: {
+    availableNotional?: number;
+  };
+}
 
 const PHANTOM_DOWNLOAD_URL = "https://phantom.app/";
 
@@ -459,6 +519,132 @@ export async function resolveOperation(
   };
 }
 
+/**
+ * Inspect Wormhole's chain governor to determine whether an operation that
+ * has no VAA yet is being delayed by the daily-limit rate limiter.
+ *
+ * Returns `null` when the operation already has a signed VAA, when the
+ * governor isn't holding it and the value fits within available headroom,
+ * or when any of the governor endpoints are unreachable / malformed —
+ * the caller falls through to the existing "VAA not yet available" path
+ * in that case so a governor outage can never block a redeem.
+ *
+ * Lookup order mirrors what Wormholescan's UI does:
+ *  1. `/v1/governor/is_vaa_enqueued/{chain}/{emitter}/{seq}` — definitive
+ *     answer once the guardians have observed the VAA.
+ *  2. `/api/v1/governor/enqueued_vaas/{chain}` — populate `releaseTime`
+ *     so we can show a countdown.
+ *  3. Heuristic: during the propagation window between source-tx
+ *     confirmation and the guardians enqueueing the VAA, the operation
+ *     can already be observed via the operations endpoint while
+ *     `is_vaa_enqueued` is still `false`. In that window, comparing the
+ *     transfer's USD value against the best guardian's headroom from
+ *     `/api/v1/governor/notional/max_available/{chain}` lets us preempt
+ *     the badge with a "likely-enqueued" softer copy.
+ */
+export async function fetchGovernorDelay(
+  operation: OperationData
+): Promise<GovernorDelay | null> {
+  if (operation.vaa?.raw) {
+    return null;
+  }
+
+  const chain = operation.emitterChain;
+  const emitter = operation.emitterAddress.hex;
+  const sequence = operation.sequence;
+  const usdAmount = Number(operation.data?.usdAmount);
+  if (!Number.isFinite(usdAmount)) {
+    return null;
+  }
+
+  let isEnqueued = false;
+  try {
+    const res = await fetchWithTimeout(
+      `${WORMHOLESCAN_LEGACY_API}/governor/is_vaa_enqueued/${chain}/${encodeURIComponent(
+        emitter
+      )}/${encodeURIComponent(sequence)}`
+    );
+    if (res.ok) {
+      const json = (await res.json()) as IsVaaEnqueuedResponse;
+      isEnqueued = json.isEnqueued === true;
+    }
+  } catch {
+    // Governor endpoints are best-effort; fall through.
+  }
+
+  if (isEnqueued) {
+    let releaseTime: number | undefined;
+    try {
+      const res = await fetchWithTimeout(
+        `${WORMHOLESCAN_API}/governor/enqueued_vaas/${chain}?pageSize=1000`
+      );
+      if (res.ok) {
+        const json = (await res.json()) as EnqueuedVaasResponse;
+        const row = json.data?.find(
+          (v) =>
+            String(v.sequence) === String(sequence) &&
+            (!v.emitterAddress ||
+              v.emitterAddress.replace(/^0x/, "").toLowerCase() ===
+                emitter.toLowerCase())
+        );
+        if (row?.releaseTime && Number.isFinite(row.releaseTime)) {
+          releaseTime = row.releaseTime;
+        }
+      }
+    } catch {
+      // Missing `releaseTime` just means we render the generic "up to 24h"
+      // copy instead of a countdown; not a reason to suppress the badge.
+    }
+    return { kind: "enqueued", releaseTime, usdAmount };
+  }
+
+  // Heuristic fallback: pre-enqueue window.
+  try {
+    const res = await fetchWithTimeout(
+      `${WORMHOLESCAN_API}/governor/notional/max_available/${chain}`
+    );
+    if (!res.ok) return null;
+    const json = (await res.json()) as MaxAvailableResponse;
+    const available = Number(json.data?.availableNotional);
+    if (!Number.isFinite(available)) return null;
+    if (usdAmount > available) {
+      return {
+        kind: "likely-enqueued",
+        availableNotional: available,
+        usdAmount,
+      };
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
+/**
+ * Format a Unix release timestamp as a short countdown for the delay badge.
+ * Returns `"Releases shortly"` when ≤ 60 seconds remain so the copy doesn't
+ * jitter against the 1-minute ticker.
+ */
+export function formatGovernorReleaseCountdown(
+  releaseTime: number | undefined,
+  now: number = Date.now()
+): string {
+  if (!releaseTime) {
+    return `Up to ${GOVERNOR_DELAY_HOURS} hours`;
+  }
+  const remainingSeconds = Math.max(0, releaseTime - Math.floor(now / 1000));
+  if (remainingSeconds <= 60) {
+    return "Releases shortly";
+  }
+  const hours = Math.floor(remainingSeconds / 3600);
+  const minutes = Math.floor((remainingSeconds % 3600) / 60);
+  if (hours <= 0) {
+    return `Releases in ${minutes}m`;
+  }
+  return `Releases in ${hours}h ${minutes}m`;
+}
+
 function getDestinationExplorerUrl(
   toChain: number,
   hash: string
@@ -694,6 +880,13 @@ export const WormholeRedeem: FunctionComponent = () => {
   const [resolvedTxHash, setResolvedTxHash] = useState<string | null>(null);
   const [derivedFromOsmosis, setDerivedFromOsmosis] = useState(false);
   const [copyHint, setCopyHint] = useState<string | null>(null);
+  const [governorDelay, setGovernorDelay] = useState<GovernorDelay | null>(
+    null
+  );
+  // Forces the countdown to re-render every minute while in the delay
+  // state. Cheap and avoids a second `useEffect` boundary inside the
+  // render branch.
+  const [, setCountdownTick] = useState(0);
 
   const [phantom, setPhantom] = useState<any>(null);
   const [suiConnection, setSuiConnection] =
@@ -728,6 +921,16 @@ export const WormholeRedeem: FunctionComponent = () => {
   // load after this component mounts are picked up without a refresh.
   useEffect(() => subscribeToAvailableSuiWallets(setAvailableSuiWallets), []);
 
+  // Tick the governor countdown once a minute while the badge is shown.
+  // We deliberately avoid sub-minute granularity: the underlying release
+  // time has minute-level precision from the governor and a faster ticker
+  // would just thrash React.
+  useEffect(() => {
+    if (status !== "governor_delayed") return;
+    const interval = setInterval(() => setCountdownTick((t) => t + 1), 60_000);
+    return () => clearInterval(interval);
+  }, [status]);
+
   const lookupTransaction = useCallback(async () => {
     const hash = txHash.trim();
     if (!hash) return;
@@ -740,6 +943,7 @@ export const WormholeRedeem: FunctionComponent = () => {
     setLookedUpTxHash(hash);
     setResolvedTxHash(null);
     setDerivedFromOsmosis(false);
+    setGovernorDelay(null);
 
     try {
       const {
@@ -749,6 +953,18 @@ export const WormholeRedeem: FunctionComponent = () => {
       } = await resolveOperation(hash);
 
       if (!op.vaa?.raw) {
+        // Surface the chain-governor delay before falling back to the
+        // generic "not yet available" error so users on a queued VAA
+        // know to wait instead of retrying every few seconds.
+        const delay = await fetchGovernorDelay(op);
+        if (delay) {
+          setOperation(op);
+          setResolvedTxHash(wormHash);
+          setDerivedFromOsmosis(derived);
+          setGovernorDelay(delay);
+          setStatus("governor_delayed");
+          return;
+        }
         throw new Error(
           "VAA not yet available. The Wormhole guardians may still be processing this transaction."
         );
@@ -1166,6 +1382,61 @@ export const WormholeRedeem: FunctionComponent = () => {
               <div className="flex items-center gap-2 text-sm text-osmoverse-300">
                 <Spinner className="h-4 w-4" />
                 Checking Solana for redemption status...
+              </div>
+            )}
+
+            {status === "governor_delayed" && governorDelay && (
+              <div className="space-y-3">
+                <div className="rounded-lg border border-rust-600 bg-rust-600/10 p-3 text-sm text-rust-200">
+                  <div className="mb-1 font-semibold text-rust-200">
+                    Daily limit exceeded
+                  </div>
+                  <p className="text-rust-200/90">
+                    {governorDelay.kind === "enqueued"
+                      ? `This transfer will take up to ${GOVERNOR_DELAY_HOURS} hours to complete as Wormhole has reached the daily transfer limit for ${getChainLabel(
+                          operation.emitterChain
+                        )}. This is a normal and temporary security feature of the Wormhole network.`
+                      : `This transfer's value (~${formatPretty(
+                          new PricePretty(
+                            DEFAULT_VS_CURRENCY,
+                            new Dec(governorDelay.usdAmount.toString())
+                          )
+                        )}) exceeds the available headroom on ${getChainLabel(
+                          operation.emitterChain
+                        )} (~${formatPretty(
+                          new PricePretty(
+                            DEFAULT_VS_CURRENCY,
+                            new Dec(
+                              (governorDelay.availableNotional ?? 0).toString()
+                            )
+                          )
+                        )} remaining). The Wormhole guardians will likely queue it for up to ${GOVERNOR_DELAY_HOURS} hours.`}
+                  </p>
+                  <div className="mt-2 flex items-center justify-between">
+                    <span className="font-mono text-xs text-rust-200">
+                      {governorDelay.kind === "enqueued"
+                        ? formatGovernorReleaseCountdown(
+                            governorDelay.releaseTime
+                          )
+                        : `Up to ${GOVERNOR_DELAY_HOURS} hours`}
+                    </span>
+                    <a
+                      href={GOVERNOR_LEARN_MORE_URL}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-xs text-rust-200 underline"
+                    >
+                      Learn more
+                    </a>
+                  </div>
+                </div>
+                <button
+                  onClick={lookupTransaction}
+                  disabled={isLoading}
+                  className="w-full rounded-lg border border-osmoverse-600 bg-osmoverse-900 px-4 py-2 text-sm font-medium text-white-full transition-colors hover:bg-osmoverse-800 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  Check again
+                </button>
               </div>
             )}
 


### PR DESCRIPTION
## What is the purpose of the change:

Surfaces the Wormhole chain-governor "daily limit exceeded" status in the in-app redeem widget at `/wormhole`. Previously, when a user pasted a stuck-transfer hash whose VAA was being held by the Wormhole guardians' 24h rate limiter, the widget would just throw `"VAA not yet available. The Wormhole guardians may still be processing this transaction."` with no further explanation - so users typically assumed something was broken and either retried in a tight loop or gave up. Wormholescan shows a clear `DAILY LIMIT EXCEEDED` badge in this case; we now mirror that locally so users on Osmosis see the same context (with a countdown when available) without bouncing to wormholescan.io.

### Linear Task

## Brief Changelog

- Add `fetchGovernorDelay(operation)` helper in `packages/web/components/bridge/wormhole-redeem.tsx` that combines three Wormholescan endpoints to decide whether a VAA-less operation is being held by the chain governor:
  1. `/v1/governor/is_vaa_enqueued/{chain}/{emitter}/{seq}` - definitive per-VAA answer.
  2. `/api/v1/governor/enqueued_vaas/{chain}` - used to populate a `releaseTime` countdown when the row is available.
  3. `/api/v1/governor/notional/max_available/{chain}` - heuristic fallback for the propagation window where the operation has been observed but the guardians haven't enqueued the VAA yet (compares the transfer's USD value to the best guardian's remaining headroom).
- All governor lookups are wrapped in `fetchWithTimeout` and swallow failures - a flaky guardian endpoint can never block the existing redeem flow; we just fall through to the original "VAA not yet available" error.
- Add a new `governor_delayed` status, paint it with a rust-bordered warning card that uses the official Wormhole copy ("This transfer will take up to 24 hours to complete as Wormhole has reached the daily transfer limit for {chain}..."), and surface a "Check again" button so the user can re-poll without retyping the hash.
- Soft "likely-enqueued" variant during the propagation window includes the source chain's remaining headroom for transparency.
- Add `formatGovernorReleaseCountdown` + minute-granularity ticker so the badge shows "Releases in 3h 25m" / "Releases shortly" while the user is on the page.
- Tests: 11 new specs covering `fetchGovernorDelay` (enqueued / missing row / heuristic / fits-in-limit / endpoint failure / non-numeric USD) and `formatGovernorReleaseCountdown` (hours+minutes / minutes-only / sub-minute / no release time). Full suite passes locally (`32/32` in `wormhole-redeem.spec.tsx`).

## Testing and Verifying

This change has been tested locally by running the `wormhole-redeem.spec.tsx` Jest suite (`32/32` passing including the new specs), prettier and ESLint over the touched files (both clean), and reasoning through the render branches against real Wormholescan API responses (verified with chain 3104 / token-bridge emitter against `/v1/governor/is_vaa_enqueued`, `/api/v1/governor/enqueued_vaas/3104`, and `/api/v1/governor/notional/max_available/3104`).

End-to-end manual verification still wants a live VAA currently held by the governor - happy to walk through it with someone holding such a hash. In the meantime the new flow degrades cleanly: any governor-endpoint failure -> existing `"VAA not yet available"` error path, unchanged for users.
