### PR TITLE
fix: default bridge input unit to crypto instead of fiat

### DIFF
--- a/packages/web/components/bridge/amount-screen.tsx
+++ b/packages/web/components/bridge/amount-screen.tsx
@@ -185,7 +185,7 @@ export const AmountScreen = observer(
     const [pendingChainApproval, setPendingChainApproval] = useState(false);
     const [wishesToProceed, setWishesToProceed] = useState(false);
 
-    const [inputUnit, setInputUnit] = useState<"crypto" | "fiat">("fiat");
+    const [inputUnit, setInputUnit] = useState<"crypto" | "fiat">("crypto");
     const {
       isOpen: isBridgeWalletSelectOpen,
       onClose: onCloseBridgeWalletSelect,


### PR DESCRIPTION
When opening the deposit or withdraw bridge modal, the amount input
defaulted to fiat (USD). Changed the default to crypto so the user
sees the underlying token unit instead.
