### PR TITLE
chore(security): scaffold dep-security-gate config (MTN-34, Phase 01)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# GitHub CODEOWNERS for osmosis-frontend
+#
+# Lines later in the file take precedence over earlier ones. See
+# https://docs.github.com/en/repositories/managing-your-repositories-settings-and-customization/customizing-your-repository/about-code-owners
+
+# Dependency Security Gate configuration, overrides, runbook, and (future)
+# detector scripts and workflow. Owned by merge-perms so any change to the
+# gate's behavior, override list, or operational docs is reviewed by a
+# trusted maintainer. See MTN-34 for the broader initiative.
+/.github/security/  @osmosis-labs/merge-perms

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,4 +7,14 @@
 # detector scripts and workflow. Owned by merge-perms so any change to the
 # gate's behavior, override list, or operational docs is reviewed by a
 # trusted maintainer. See MTN-34 for the broader initiative.
+#
+# NOTE: merge-perms is intentionally the v1 review team (broad scope, low
+# team-sprawl, lets the gate land fast). Plan to tighten to a scoped
+# @osmosis-labs/security-reviewers team after go-live if broader membership
+# proves too noisy or rubber-stamp-prone. Tracked in MTN-79.
 /.github/security/  @osmosis-labs/merge-perms
+
+# Self-protection: CODEOWNERS itself must be reviewed by the same team, so a
+# future PR cannot weaken or remove the rule above without merge-perms
+# approval. Without this line, the lock can unlock itself.
+/.github/CODEOWNERS  @osmosis-labs/merge-perms

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,17 +4,20 @@
 # https://docs.github.com/en/repositories/managing-your-repositories-settings-and-customization/customizing-your-repository/about-code-owners
 
 # Dependency Security Gate configuration, overrides, runbook, and (future)
-# detector scripts and workflow. Owned by merge-perms so any change to the
-# gate's behavior, override list, or operational docs is reviewed by a
-# trusted maintainer. See MTN-34 for the broader initiative.
+# detector scripts and workflow. Owned by security-reviewers so any change
+# to the gate's behavior, override list, or operational docs is reviewed by
+# a curated set of maintainers. See MTN-34 for the broader initiative.
 #
-# NOTE: merge-perms is intentionally the v1 review team (broad scope, low
-# team-sprawl, lets the gate land fast). Plan to tighten to a scoped
-# @osmosis-labs/security-reviewers team after go-live if broader membership
-# proves too noisy or rubber-stamp-prone. Tracked in MTN-79.
-/.github/security/  @osmosis-labs/merge-perms
+# NOTE: security-reviewers (created 28 May 2026, per MTN-79) is intentionally
+# a narrow, curated team rather than the broader org-wide reviewer pool. The
+# scope is just override approvals, gate-config changes, and the operational
+# docs in .github/security/. Tight membership exists so override approvals
+# carry the right level of scrutiny and so this PR queue does not blur into
+# the general review queue. See MTN-79 for the team's origin and acceptance
+# criteria.
+/.github/security/  @osmosis-labs/security-reviewers
 
 # Self-protection: CODEOWNERS itself must be reviewed by the same team, so a
-# future PR cannot weaken or remove the rule above without merge-perms
+# future PR cannot weaken or remove the rule above without security-reviewers
 # approval. Without this line, the lock can unlock itself.
-/.github/CODEOWNERS  @osmosis-labs/merge-perms
+/.github/CODEOWNERS  @osmosis-labs/security-reviewers

--- a/.github/security/RUNBOOK.md
+++ b/.github/security/RUNBOOK.md
@@ -16,10 +16,10 @@ Triage in order:
 2. **Is the underlying change actually intentional?**
    - If you accidentally bumped something or pulled in an unexpected transitive dep, fix the manifest / lockfile and push again. The gate re-runs automatically.
    - If the bump is intentional and the finding is real but low-risk for our use, you need an override.
-3. **Request an override** by opening a follow-up PR that adds an entry to [`.github/security/dep-overrides.yml`](./dep-overrides.yml). Required fields:
+3. **Request an override** from `@osmosis-labs/merge-perms`. The follow-up PR that adds an entry to [`.github/security/dep-overrides.yml`](./dep-overrides.yml) must be opened by, or contain an entry added by, an approving reviewer other than the PR author being unblocked. Required fields:
    - `package`, `version`, `integrity` (copy from `yarn.lock`).
    - `reason` - one-sentence justification; this is the audit trail.
-   - `added_by` - your GitHub username. Must not equal the PR author of the PR being unblocked.
+   - `added_by` - GitHub username of the approving reviewer who added the override entry. Must not equal the PR author of the PR being unblocked.
    - `added_at` / `expires_at` - ISO dates, max 90 days apart.
    - The override PR is reviewed by `@osmosis-labs/merge-perms` (enforced via CODEOWNERS).
 4. **After the override merges to your branch's base** (`stage`), rebase or merge `stage` into your PR. The gate re-runs and the override is applied; the sticky comment flips to APPROVED.

--- a/.github/security/RUNBOOK.md
+++ b/.github/security/RUNBOOK.md
@@ -1,0 +1,48 @@
+# Dependency Security Gate - RUNBOOK (v1)
+
+## TL;DR
+
+- A blocking CI check (`dep-security-gate`) scans every PR that touches `yarn.lock` or `package.json` for supply-chain risk.
+- A REJECTED verdict means the merge is blocked until either the underlying finding is resolved or an override is approved by `@osmosis-labs/merge-perms`.
+- Behavior (block vs advisory) and Slack verbosity are configured in [`.github/security/gate-config.yml`](./gate-config.yml).
+
+> This is the minimal v1 runbook. It will be expanded iteratively under MTN-64 (Phase 11) as real questions and incidents accumulate. Until then, escalate edge cases in `#security-gate-alerts`.
+
+## I just got a REJECTED comment on my PR - what now?
+
+Triage in order:
+
+1. **Read the sticky comment.** The aggregator names exactly which detector fired (`lockfile-diff`, `socket`, or `dep-review`), which package, and the kind of finding (e.g. `republish`, `install-script`, `new-bin`, known CVE, behavioral risk).
+2. **Is the underlying change actually intentional?**
+   - If you accidentally bumped something or pulled in an unexpected transitive dep, fix the manifest / lockfile and push again. The gate re-runs automatically.
+   - If the bump is intentional and the finding is real but low-risk for our use, you need an override.
+3. **Request an override** by opening a follow-up PR that adds an entry to [`.github/security/dep-overrides.yml`](./dep-overrides.yml). Required fields:
+   - `package`, `version`, `integrity` (copy from `yarn.lock`).
+   - `reason` - one-sentence justification; this is the audit trail.
+   - `added_by` - your GitHub username. Must not equal the PR author of the PR being unblocked.
+   - `added_at` / `expires_at` - ISO dates, max 90 days apart.
+   - The override PR is reviewed by `@osmosis-labs/merge-perms` (enforced via CODEOWNERS).
+4. **After the override merges to your branch's base** (`stage`), rebase or merge `stage` into your PR. The gate re-runs and the override is applied; the sticky comment flips to APPROVED.
+5. **If the finding looks like a real attack** (Shai-Hulud-class republish, install script reaching out to a suspicious host, etc.), do NOT override. Post in `#security-gate-alerts` and tag `@osmosis-labs/merge-perms` for incident handling.
+
+## How do I read the sticky comment?
+
+The aggregator (MTN-55 / Phase 02) emits a single sticky comment per PR with three sections:
+
+- **Verdict header** - one of `APPROVED`, `NEEDS_HUMAN_REVIEW`, or `REJECTED`, plus the reason.
+- **Summary table** - one row per detector with finding counts at each severity.
+- **Findings detail** - collapsed `<details>` blocks per finding with the kind, package, evidence, and a link back to this runbook.
+
+Always-on Slack alerts (REJECTED verdicts, override events, republish detections, Socket outages, workflow errors) post to `#security-gate-alerts` regardless of `slack_verbosity`.
+
+## How do I change the gate's mode or Slack verbosity?
+
+Open a PR that edits [`.github/security/gate-config.yml`](./gate-config.yml). The file is owned by `@osmosis-labs/merge-perms` via CODEOWNERS, so it forces a review.
+
+- `mode: gate` -> REJECTED verdicts block merges.
+- `mode: advisory` -> REJECTED verdicts still post the sticky comment and Slack alert, but the status check passes. Use this only for short windows (false-positive investigation, infrastructure recovery, etc.) and flip back as soon as possible.
+- `slack_verbosity: verbose | alerts | silent` - tune signal-to-noise in `#security-gate-alerts`. Always-on events (see above) bypass this setting.
+
+## Vercel residual-risk note
+
+The gate runs in GitHub Actions. Vercel builds the merged commit independently and does NOT run the gate. The mitigation is structural: because nothing reaches `stage` without passing the gate, Vercel only ever builds commits that have already been cleared. Runtime egress monitoring on the Vercel side is out of scope for this initiative (StepSecurity Harden-Runner is Linux-runner-only and is tracked separately under MTN-59 / Phase 06).

--- a/.github/security/RUNBOOK.md
+++ b/.github/security/RUNBOOK.md
@@ -5,7 +5,7 @@
 > **Status:** the gate is being built in phases under MTN-34. This file (MTN-54 / Phase 01) lands inert configuration scaffolding only - no workflow runs yet, and no PR is being scanned. The behaviour described below takes effect once the gate workflow lands in MTN-56 (Phase 03) and is flipped to `gate` mode in MTN-57 (Phase 04).
 
 - A blocking CI check (`dep-security-gate`) scans every PR that touches `yarn.lock` or `package.json` for supply-chain risk.
-- A REJECTED verdict means the merge is blocked until either the underlying finding is resolved or an override is approved by `@osmosis-labs/merge-perms`.
+- A REJECTED verdict means the merge is blocked until either the underlying finding is resolved or an override is approved by `@osmosis-labs/security-reviewers`.
 - Behavior (block vs advisory) and Slack verbosity are configured in [`.github/security/gate-config.yml`](./gate-config.yml).
 
 > This is the minimal v1 runbook. It will be expanded iteratively under MTN-64 (Phase 11) as real questions and incidents accumulate. Until then, escalate edge cases in `#security-gate-alerts`.
@@ -18,14 +18,14 @@ Triage in order:
 2. **Is the underlying change actually intentional?**
    - If you accidentally bumped something or pulled in an unexpected transitive dep, fix the manifest / lockfile and push again. The gate re-runs automatically.
    - If the bump is intentional and the finding is real but low-risk for our use, you need an override.
-3. **Request an override** from `@osmosis-labs/merge-perms`. The follow-up PR that adds an entry to [`.github/security/dep-overrides.yml`](./dep-overrides.yml) must be opened by, or contain an entry added by, an approving reviewer other than the PR author being unblocked. Required fields:
+3. **Request an override** from `@osmosis-labs/security-reviewers`. The follow-up PR that adds an entry to [`.github/security/dep-overrides.yml`](./dep-overrides.yml) must be opened by, or contain an entry added by, an approving reviewer other than the PR author being unblocked. Required fields:
    - `package`, `version`, `integrity` (copy from `yarn.lock`).
    - `reason` - one-sentence justification; this is the audit trail.
    - `added_by` - GitHub username of the approving reviewer who added the override entry. Must not equal the PR author of the PR being unblocked.
    - `added_at` / `expires_at` - ISO dates, max 90 days apart.
-   - The override PR is reviewed by `@osmosis-labs/merge-perms` (enforced via CODEOWNERS).
+   - The override PR is reviewed by `@osmosis-labs/security-reviewers` (enforced via CODEOWNERS).
 4. **After the override merges to your branch's base** (`stage`), rebase or merge `stage` into your PR. The gate re-runs and the override is applied; the sticky comment flips to APPROVED.
-5. **If the finding looks like a real attack** (Shai-Hulud-class republish, install script reaching out to a suspicious host, etc.), do NOT override. Post in `#security-gate-alerts` and tag `@osmosis-labs/merge-perms` for incident handling.
+5. **If the finding looks like a real attack** (Shai-Hulud-class republish, install script reaching out to a suspicious host, etc.), do NOT override. Post in `#security-gate-alerts` and tag `@osmosis-labs/security-reviewers` for incident handling.
 
 ## How do I read the sticky comment?
 
@@ -39,7 +39,7 @@ Always-on Slack alerts (REJECTED verdicts, override events, republish detections
 
 ## How do I change the gate's mode or Slack verbosity?
 
-Open a PR that edits [`.github/security/gate-config.yml`](./gate-config.yml). The file is owned by `@osmosis-labs/merge-perms` via CODEOWNERS, so it forces a review.
+Open a PR that edits [`.github/security/gate-config.yml`](./gate-config.yml). The file is owned by `@osmosis-labs/security-reviewers` via CODEOWNERS, so it forces a review.
 
 - `mode: gate` -> REJECTED verdicts block merges.
 - `mode: advisory` -> REJECTED verdicts still post the sticky comment and Slack alert, but the status check passes. Use this only for short windows (false-positive investigation, infrastructure recovery, etc.) and flip back as soon as possible.

--- a/.github/security/RUNBOOK.md
+++ b/.github/security/RUNBOOK.md
@@ -2,6 +2,8 @@
 
 ## TL;DR
 
+> **Status:** the gate is being built in phases under MTN-34. This file (MTN-54 / Phase 01) lands inert configuration scaffolding only - no workflow runs yet, and no PR is being scanned. The behaviour described below takes effect once the gate workflow lands in MTN-56 (Phase 03) and is flipped to `gate` mode in MTN-57 (Phase 04).
+
 - A blocking CI check (`dep-security-gate`) scans every PR that touches `yarn.lock` or `package.json` for supply-chain risk.
 - A REJECTED verdict means the merge is blocked until either the underlying finding is resolved or an override is approved by `@osmosis-labs/merge-perms`.
 - Behavior (block vs advisory) and Slack verbosity are configured in [`.github/security/gate-config.yml`](./gate-config.yml).

--- a/.github/security/dep-overrides.yml
+++ b/.github/security/dep-overrides.yml
@@ -1,0 +1,23 @@
+# Permanent / recurring exemptions for the dep-security-gate.
+#
+# Adding an entry here exempts a specific (package, version, integrity) tuple
+# from the gate's REJECTED verdict. Edits to this file require CODEOWNERS
+# approval - see .github/CODEOWNERS - so every override has a reviewable
+# diff in git history.
+#
+# Rules enforced by the aggregator (MTN-55 / Phase 02):
+#   - integrity must match the entry in yarn.lock exactly.
+#   - expires_at must be in the future and at most 90 days out.
+#   - added_by must NOT equal the PR author (no self-overrides).
+#
+# Schema:
+# overrides:
+#   - package: "<name>"           # e.g. "lodash"
+#     version: "<exact-version>"  # no ranges
+#     integrity: "sha512-..."     # must match yarn.lock
+#     reason: "<why this is safe>"
+#     added_by: "<github-username>"
+#     added_at: "<ISO date, e.g. 2026-05-26>"
+#     expires_at: "<ISO date>"    # max 90 days from added_at
+
+overrides: []

--- a/.github/security/gate-config.yml
+++ b/.github/security/gate-config.yml
@@ -1,0 +1,19 @@
+# Controls behavior of the dep-security-gate workflow.
+#
+# This file is the single source of truth for whether the gate blocks merges
+# and how loud it is on Slack. Changes require CODEOWNERS approval - see
+# .github/CODEOWNERS. The workflow itself is not yet wired up; see
+# MTN-56 (Phase 03) for the workflow PR that first consumes this file.
+#
+# mode:
+#   gate      -> aggregator exits non-zero on REJECTED verdicts (blocks merge).
+#   advisory  -> aggregator always exits zero; sticky comment + Slack still post.
+#
+# slack_verbosity:
+#   verbose  -> every verdict posts to #security-gate-alerts.
+#   alerts   -> only REJECTED + override events post.
+#   silent   -> only always-on critical events post (REJECTED, override granted,
+#               republish detected, Socket outage, workflow error).
+
+mode: gate
+slack_verbosity: verbose

--- a/.github/security/gate-config.yml
+++ b/.github/security/gate-config.yml
@@ -11,9 +11,14 @@
 #
 # slack_verbosity:
 #   verbose  -> every verdict posts to #security-gate-alerts.
-#   alerts   -> only REJECTED + override events post.
-#   silent   -> only always-on critical events post (REJECTED, override granted,
-#               republish detected, Socket outage, workflow error).
+#   alerts   -> REJECTED + override events post; APPROVED and
+#               NEEDS_HUMAN_REVIEW are suppressed.
+#   silent   -> normal verdicts and override events are suppressed; only
+#               always-on events post (see below).
+#
+# Always-on events (post regardless of verbosity; canonical list and
+# rationale in ./RUNBOOK.md): REJECTED verdicts, override granted,
+# republish detected, Socket outage, workflow error.
 
 mode: gate
 slack_verbosity: verbose


### PR DESCRIPTION
## What is the purpose of the change

Lands the inert configuration scaffolding for the AI Security Gate initiative ([MTN-34](https://linear.app/osmosis/issue/MTN-34/ai-security-gate-for-dependency-bumps)). Zero behavior change in CI today; the gate workflow itself ships in [MTN-56](https://linear.app/osmosis/issue/MTN-56/security-gate-phase-03-workflow-advisory) (Phase 03). The point of merging this PR first is that after it lands, **any future edit to `/.github/security/` requires `@osmosis-labs/security-reviewers` review via CODEOWNERS**, so the gate's eventual mode flip, override list, and runbook all have a reviewable audit trail from day one.

This is Phase 01 of 11. See the parent issue for the full plan and architecture diagram.

### Linear Task

[MTN-54 - Security Gate - Phase 01 - Foundation](https://linear.app/osmosis/issue/MTN-54/security-gate-phase-01-foundation) (parent: [MTN-34](https://linear.app/osmosis/issue/MTN-34/ai-security-gate-for-dependency-bumps))

This PR uses `@osmosis-labs/security-reviewers` as the CODEOWNERS team for `/.github/security/` and the self-protection rule on `/.github/CODEOWNERS` itself. That team was created on 28 May 2026 specifically for dep-security-gate review; its scope is intentionally narrow (override approvals, gate-config changes, ops docs). Team origin and acceptance criteria are tracked in [MTN-79](https://linear.app/osmosis/issue/MTN-79).

## Brief Changelog

- `.github/security/gate-config.yml` (new) - `mode: gate` and `slack_verbosity: verbose`. The future workflow reads this file at runtime to decide whether to fail closed and how loud to be on Slack.
- `.github/security/dep-overrides.yml` (new) - empty `overrides: []` with the integrity-bound schema as a header comment. Future detector + aggregator scripts consume this to grant per-(package, version, integrity) exemptions; entries require CODEOWNERS review.
- `.github/security/RUNBOOK.md` (new) - minimal v1 runbook covering: TL;DR, "I got a REJECTED comment - what now?", reading the sticky comment, changing mode/verbosity, and the Vercel residual-risk note. Restructured to incident-only and extended in PR #4366 (stacked on this one).
- `.github/CODEOWNERS` (new file - did not previously exist) - two rules: `/.github/security/` and a self-protection rule for `/.github/CODEOWNERS` itself, both assigned to `@osmosis-labs/security-reviewers`. Self-protection is what prevents a future PR from quietly weakening or removing the gate's review requirements without the same team's approval.

## Testing and Verifying

- Both YAML files parse cleanly (`js-yaml`): `gate-config.yml` -> `{mode: gate, slack_verbosity: verbose}`, `dep-overrides.yml` -> `{overrides: []}`.
- No workflow files added or modified, so no behavior change in CI.
- CODEOWNERS rules only take effect once this PR merges; verifying that a no-op edit under `/.github/security/` auto-requests `@osmosis-labs/security-reviewers` is part of the smoke test in [MTN-57](https://linear.app/osmosis/issue/MTN-57/security-gate-phase-04-go-live) (Phase 04 - Go-live).
- `security-reviewers` is a four-member team (Jason, Alessandro, Johnny, Doge); all members have effective Write access or higher on osmosis-frontend, so CODEOWNERS resolves without per-user repo-permission setup. Confirmed against the org API at team-creation time.

## Companion PRs

- **#4365** (`ci: relay GitHub Dependabot alerts to #dependabot-alerts`) - the tiny `.github/workflows/dependabot-slack-relay.yml` workflow ships on `jason/mtn-53-dependabot-slack-relay` (per the resolved decision recorded in [MTN-53](https://linear.app/osmosis/issue/MTN-53/security-gate-phase-00-prerequisites)) so the Dependabot -> `#dependabot-alerts` Slack routing starts working before any of the gate machinery exists. Independent of this stack.
- **#4366** (`docs(security): user guide + landing page`) - stacked on this PR. Adds `README.md`, `USER_GUIDE.md`, and restructures the `RUNBOOK.md` introduced here to be incident-only. Auto-retargets to `stage` once this PR merges.
