### PR TITLE
ci: relay GitHub Dependabot alerts to #dependabot-alerts (MTN-53)

### DIFF
--- a/.github/workflows/dependabot-slack-relay.yml
+++ b/.github/workflows/dependabot-slack-relay.yml
@@ -1,0 +1,57 @@
+name: Dependabot Alerts -> Slack
+
+# Routes GitHub's Dependabot alert events to #dependabot-alerts via a
+# pre-provisioned Slack incoming webhook (SLACK_WEBHOOK_DEPENDABOT_ALERTS).
+#
+# Why a custom relay: GitHub's official Slack integration's
+# `/github subscribe ... dependabot_alerts` was deprecated alongside the
+# legacy `repository_vulnerability_alert` webhook and never re-implemented
+# for the newer `dependabot_alert` event. See MTN-53 for the resolved
+# decision (Option A - relay workflow) and MTN-34 for the broader gate
+# initiative this supports.
+#
+# Trigger scope is deliberately narrow:
+#   - `created`       new vulnerability reported on a dep we use.
+#   - `reopened`      previously dismissed alert is back (e.g. dep
+#                     re-added).
+#   - `reintroduced`  a fix was reverted; vulnerability is live again.
+# Dismissals (`dismissed`, `fixed`, `auto_dismissed`) are intentionally
+# excluded so Slack doesn't get noisy on healthy churn.
+
+on:
+  dependabot_alert:
+    types: [created, reopened, reintroduced]
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post to Slack
+        env:
+          WEBHOOK: ${{ secrets.SLACK_WEBHOOK_DEPENDABOT_ALERTS }}
+          ACTION: ${{ github.event.action }}
+          PKG: ${{ github.event.alert.dependency.package.name }}
+          ECO: ${{ github.event.alert.dependency.package.ecosystem }}
+          SEV: ${{ github.event.alert.security_advisory.severity }}
+          SUMMARY: ${{ github.event.alert.security_advisory.summary }}
+          URL: ${{ github.event.alert.html_url }}
+        run: |
+          if [ -z "$WEBHOOK" ]; then
+            echo "::warning::SLACK_WEBHOOK_DEPENDABOT_ALERTS is not set; skipping"
+            exit 0
+          fi
+          payload=$(jq -nc \
+            --arg action "$ACTION" \
+            --arg pkg "$PKG" \
+            --arg eco "$ECO" \
+            --arg sev "$SEV" \
+            --arg summary "$SUMMARY" \
+            --arg url "$URL" \
+            '{text: ":warning: Dependabot alert *\($action)*\n*\($pkg)* (\($eco)) - *\($sev)*\n\($summary)\n\($url)"}')
+          curl -sS --fail-with-body -X POST \
+            -H 'Content-type: application/json' \
+            --data "$payload" \
+            "$WEBHOOK"

--- a/.github/workflows/dependabot-slack-relay.yml
+++ b/.github/workflows/dependabot-slack-relay.yml
@@ -22,8 +22,9 @@ on:
   dependabot_alert:
     types: [created, reopened, reintroduced]
 
-permissions:
-  contents: read
+# Workflow only POSTs to an external Slack webhook; it neither reads the repo
+# nor uses GITHUB_TOKEN, so grant no token permissions at all.
+permissions: {}
 
 jobs:
   notify:


### PR DESCRIPTION
## What is the purpose of the change

Small companion to [#4364](https://github.com/osmosis-labs/osmosis-frontend/pull/4364) (Phase 01 / MTN-54 - security gate scaffolding). Routes GitHub's Dependabot alert events into `#dependabot-alerts` via the pre-provisioned `SLACK_WEBHOOK_DEPENDABOT_ALERTS` secret.

### Why a custom relay

`/github subscribe <owner>/<repo> dependabot_alerts` was deprecated by GitHub for Slack alongside the legacy `repository_vulnerability_alert` webhook. The newer `dependabot_alert` event (richer payload, GHSA-aware) replaced it but the Slack app was never updated to consume it. The resolved decision is documented as "Option A - relay workflow" in [MTN-53](https://linear.app/osmosis/issue/MTN-53/security-gate-phase-00-prerequisites).

Shipping this separately from #4364 keeps the diff to ~50 lines of YAML so it's reviewable in well under five minutes, and it starts working as soon as it merges - independent of the rest of the gate machinery.

### Linear Task

[MTN-53 - Security Gate - Phase 00 - Prerequisites](https://linear.app/osmosis/issue/MTN-53/security-gate-phase-00-prerequisites) (parent: [MTN-34](https://linear.app/osmosis/issue/MTN-34/ai-security-gate-for-dependency-bumps))

## Brief Changelog

- `.github/workflows/dependabot-slack-relay.yml` (new) - triggers on `dependabot_alert` event types `[created, reopened, reintroduced]` (dismissals/fixes intentionally excluded to keep Slack quiet on healthy churn). Builds a JSON payload with `jq` containing severity, package, ecosystem, advisory summary, and link to the alert, then POSTs to the webhook. Skips gracefully with a workflow warning if the secret is missing (handles forks / disabled secret).

## Testing and Verifying

- YAML parses cleanly (`js-yaml`); workflow structure is the canonical GitHub Actions shape.
- The `SLACK_WEBHOOK_DEPENDABOT_ALERTS` repo secret is already set (confirmed during Phase 00 / [MTN-53](https://linear.app/osmosis/issue/MTN-53/security-gate-phase-00-prerequisites) live progress).
- Permissions block is least-privilege (`contents: read`); the workflow does not need to write to the repo.
- First firing of this workflow will only happen on the next `created/reopened/reintroduced` Dependabot alert; the existing 281-alert backlog is intentionally not backfilled (tracked separately under [MTN-52](https://linear.app/osmosis/issue/MTN-52/triage-dependabot-alert-backlog-on-osmosis-frontend-11-critical-108)).
