### PR TITLE
docs(security): user guide + landing page (MTN-80)

### DIFF
--- a/.github/security/README.md
+++ b/.github/security/README.md
@@ -1,0 +1,38 @@
+# Security Gate (osmosis-frontend)
+
+A CI check that scans dependency changes for supply-chain risk before they reach `stage`. Built in phases under [MTN-34](https://linear.app/osmosis/issue/MTN-34).
+
+## Status
+
+The gate is not yet live as of this PR. See [`gate-config.yml`](./gate-config.yml) for the current `mode` (the source of truth):
+
+- `mode: gate` -> blocking; REJECTED verdicts prevent merge.
+- `mode: advisory` -> observe-only; verdicts post but never block.
+
+The workflow that consumes this config lands in MTN-56 (Phase 03). The mode is flipped to `gate` in MTN-57 (Phase 04). Until then, nothing in CI is actively gated.
+
+## Where to go
+
+| You... | Go here |
+|---|---|
+| ...got a REJECTED comment on your PR | [USER_GUIDE.md - Unblocking a REJECTED PR](./USER_GUIDE.md#unblocking-a-rejected-pr) |
+| ...want to understand what the sticky comment is telling you | [USER_GUIDE.md - Reading the sticky comment](./USER_GUIDE.md#reading-the-sticky-comment) |
+| ...are being asked to approve an override | [USER_GUIDE.md - Approving an override](./USER_GUIDE.md#approving-an-override) |
+| ...want to know if your dep bump will be blocked, before pushing | [USER_GUIDE.md - Previewing gate behavior](./USER_GUIDE.md#previewing-gate-behavior) |
+| ...think Socket is down, the workflow is erroring, or the gate is blocking valid PRs | [RUNBOOK.md](./RUNBOOK.md) |
+| ...want to change the gate's mode or verbosity | Open a PR against [`gate-config.yml`](./gate-config.yml); [CODEOWNERS](../CODEOWNERS) routes review |
+| ...want to add a recurring exemption | Open a PR against [`dep-overrides.yml`](./dep-overrides.yml); the override entry's `added_by` must name a reviewer, not the PR author being unblocked |
+
+## How these docs are organised
+
+| File | Role | When you read it |
+|---|---|---|
+| [README.md](./README.md) | This landing page | First touch / "which doc?" |
+| [USER_GUIDE.md](./USER_GUIDE.md) | Task playbook for PR authors and override reviewers | ~80% of reads |
+| [RUNBOOK.md](./RUNBOOK.md) | Incident response (Socket down, workflow errors, suspected attack) | ~10% of reads, usually under stress |
+
+Architecture lives inline in the gate's source code (comments on the aggregator and detector scripts in MTN-55, the workflow in MTN-56) plus the [Linear issue tree](https://linear.app/osmosis/issue/MTN-34).
+
+## Phased rollout
+
+Each phase under MTN-34 is its own Linear issue. Documentation content is added by the phase that introduces the user-facing behavior - see each phase's "Documentation deliverables" section in Linear. The doc *structure* (this directory) is established here in MTN-80.

--- a/.github/security/RUNBOOK.md
+++ b/.github/security/RUNBOOK.md
@@ -1,50 +1,83 @@
-# Dependency Security Gate - RUNBOOK (v1)
+# Security Gate - Runbook (incident response)
 
-## TL;DR
+> **Audience:** on-call / maintainer / anyone who reached this doc because something is broken or feels wrong. For day-to-day tasks (unblocking a REJECTED PR, approving an override), see [USER_GUIDE.md](./USER_GUIDE.md). For "which doc do I want?", see [README.md](./README.md).
 
-> **Status:** the gate is being built in phases under MTN-34. This file (MTN-54 / Phase 01) lands inert configuration scaffolding only - no workflow runs yet, and no PR is being scanned. The behaviour described below takes effect once the gate workflow lands in MTN-56 (Phase 03) and is flipped to `gate` mode in MTN-57 (Phase 04).
+> **Status:** the gate is being built in phases under [MTN-34](https://linear.app/osmosis/issue/MTN-34). The incident scenarios below assume the gate is live (post-MTN-57 / Phase 04). Each section is marked with the phase that populates it; until that phase ships, the section is a stub.
 
-- A blocking CI check (`dep-security-gate`) scans every PR that touches `yarn.lock` or `package.json` for supply-chain risk.
-- A REJECTED verdict means the merge is blocked until either the underlying finding is resolved or an override is approved by `@osmosis-labs/security-reviewers`.
-- Behavior (block vs advisory) and Slack verbosity are configured in [`.github/security/gate-config.yml`](./gate-config.yml).
+## When you reach for this doc
 
-> This is the minimal v1 runbook. It will be expanded iteratively under MTN-64 (Phase 11) as real questions and incidents accumulate. Until then, escalate edge cases in `#security-gate-alerts`.
+- Something is failing or blocking that shouldn't be: workflow error, Socket outage, gate REJECTing valid PRs.
+- A real attack is suspected and you need to know what to do *and not do* (do not override).
+- An override turned out, post-hoc, to have approved something bad.
 
-## I just got a REJECTED comment on my PR - what now?
+If none of the above, you probably want [USER_GUIDE.md](./USER_GUIDE.md) instead.
 
-Triage in order:
+## Socket outage
 
-1. **Read the sticky comment.** The aggregator names exactly which detector fired (`lockfile-diff`, `socket`, or `dep-review`), which package, and the kind of finding (e.g. `republish`, `install-script`, `new-bin`, known CVE, behavioral risk).
-2. **Is the underlying change actually intentional?**
-   - If you accidentally bumped something or pulled in an unexpected transitive dep, fix the manifest / lockfile and push again. The gate re-runs automatically.
-   - If the bump is intentional and the finding is real but low-risk for our use, you need an override.
-3. **Request an override** from `@osmosis-labs/security-reviewers`. The follow-up PR that adds an entry to [`.github/security/dep-overrides.yml`](./dep-overrides.yml) must be opened by, or contain an entry added by, an approving reviewer other than the PR author being unblocked. Required fields:
-   - `package`, `version`, `integrity` (copy from `yarn.lock`).
-   - `reason` - one-sentence justification; this is the audit trail.
-   - `added_by` - GitHub username of the approving reviewer who added the override entry. Must not equal the PR author of the PR being unblocked.
-   - `added_at` / `expires_at` - ISO dates, max 90 days apart.
-   - The override PR is reviewed by `@osmosis-labs/security-reviewers` (enforced via CODEOWNERS).
-4. **After the override merges to your branch's base** (`stage`), rebase or merge `stage` into your PR. The gate re-runs and the override is applied; the sticky comment flips to APPROVED.
-5. **If the finding looks like a real attack** (Shai-Hulud-class republish, install script reaching out to a suspicious host, etc.), do NOT override. Post in `#security-gate-alerts` and tag `@osmosis-labs/security-reviewers` for incident handling.
+> **Populated in MTN-56 (Phase 03 - Workflow).**
 
-## How do I read the sticky comment?
+This section will cover:
 
-The aggregator (MTN-55 / Phase 02) emits a single sticky comment per PR with three sections:
+- **Symptoms.** Socket-API calls in the workflow time out or 5xx; aggregator emits REJECTED verdicts with `reason: socket_unavailable`; sticky comments fire on every PR; #security-gate-alerts fills up.
+- **Expected behaviour.** The gate fails *closed* by design - Socket being missing is treated as a high-severity finding, so all PRs touching deps are REJECTED until Socket recovers. This is intentional; do not override around it.
+- **Diagnosis.** Check Socket's status page (`status.socket.dev` or the current equivalent) and the `socket` job logs in a recent failed workflow run.
+- **Escalation.** Notify `#security-gate-alerts` with the suspected duration.
+- **Temporary `advisory` flip.** If the outage is prolonged (>= 1 hour) and dev velocity is impacted, open a fast-track PR against [`gate-config.yml`](./gate-config.yml) flipping `mode: gate` to `mode: advisory`. CODEOWNERS reviews. **Always paired with a flip-back PR queued and a stated plan for when Socket recovers.** The flip itself posts an always-on Slack alert.
 
-- **Verdict header** - one of `APPROVED`, `NEEDS_HUMAN_REVIEW`, or `REJECTED`, plus the reason.
-- **Summary table** - one row per detector with finding counts at each severity.
-- **Findings detail** - collapsed `<details>` blocks per finding with the kind, package, evidence, and a link back to this runbook.
+## Workflow errors
 
-Always-on Slack alerts (REJECTED verdicts, override events, republish detections, Socket outages, workflow errors) post to `#security-gate-alerts` regardless of `slack_verbosity`.
+> **Populated in MTN-55 (Phase 02 - Detectors) and MTN-56 (Phase 03 - Workflow).**
 
-## How do I change the gate's mode or Slack verbosity?
+This section will cover aggregator-specific failure modes:
 
-Open a PR that edits [`.github/security/gate-config.yml`](./gate-config.yml). The file is owned by `@osmosis-labs/security-reviewers` via CODEOWNERS, so it forces a review.
+- Missing detector input (lockfile-diff or dep-review JSON not uploaded).
+- Malformed [`dep-overrides.yml`](./dep-overrides.yml) causing aggregator crash.
+- Socket-API transient timeout vs sustained outage (different escalation paths).
+- Workflow YAML syntax errors (caught in CI; re-running rarely helps).
+- Concurrency-cancelled run vs actual error.
 
-- `mode: gate` -> REJECTED verdicts block merges.
-- `mode: advisory` -> REJECTED verdicts still post the sticky comment and Slack alert, but the status check passes. Use this only for short windows (false-positive investigation, infrastructure recovery, etc.) and flip back as soon as possible.
-- `slack_verbosity: verbose | alerts | silent` - tune signal-to-noise in `#security-gate-alerts`. Always-on events (see above) bypass this setting.
+## Gate stuck blocking valid PRs
 
-## Vercel residual-risk note
+> **Populated in MTN-57 (Phase 04 - Go-live) and iteratively after.**
 
-The gate runs in GitHub Actions. Vercel builds the merged commit independently and does NOT run the gate. The mitigation is structural: because nothing reaches `stage` without passing the gate, Vercel only ever builds commits that have already been cleared. Runtime egress monitoring on the Vercel side is out of scope for this initiative (StepSecurity Harden-Runner is Linux-runner-only and is tracked separately under MTN-59 / Phase 06).
+This section will cover symptom -> diagnosis -> action for cases where the gate appears to misbehave:
+
+- Lockfile-diff false positive on a legitimate dep bump (e.g. a re-publish that's actually upstream-correct).
+- Over-aggressive Socket alert on a known-good package.
+- Override entry that looks valid but isn't being picked up by the aggregator (check `integrity`, `expires_at`, `added_by`).
+
+Bias is **override-and-document** rather than weakening detector calibration on a single example.
+
+## Republish detected (suspected real attack)
+
+> **Populated iteratively (MTN-64).**
+
+This section will cover incident response for Shai-Hulud-class events:
+
+- **Do not override.** A republish is the strongest signal we have of a maintainer-account compromise. Overriding propagates the compromise to `stage`.
+- Notify `#security-gate-alerts` and tag `@osmosis-labs/security-reviewers`.
+- Verification: pull integrity hashes from `yarn.lock` head vs base, cross-reference against the package's npm history.
+- If confirmed: full incident-response playbook (to be expanded in MTN-64 after the first real incident or near-miss).
+
+## Override granted that turned out to be unsafe
+
+> **Populated in MTN-58 (Phase 05 - Slash override).**
+
+This section will cover incident response when an override is granted in good faith but later proves to have approved a real vulnerability:
+
+- How to revoke (manifest path: edit `dep-overrides.yml`; slash-command path: re-emit failing status check + roll the change).
+- Audit-trail reading - who approved, when, with what reason. Slack always-on log + workflow artifacts.
+- Post-mortem template.
+
+---
+
+## Scope & limitations (residual risk)
+
+The gate runs in GitHub Actions. Vercel builds the merged commit independently and does NOT run the gate. The mitigation is structural: because nothing reaches `stage` without passing the gate, Vercel only ever builds commits that have already been cleared. Runtime egress monitoring on the Vercel side is out of scope for this initiative; StepSecurity Harden-Runner is Linux-runner-only and is tracked separately under MTN-59 (Phase 06).
+
+## See also
+
+- [README.md](./README.md) - landing page.
+- [USER_GUIDE.md](./USER_GUIDE.md) - day-to-day PR-author and reviewer tasks.
+- [`gate-config.yml`](./gate-config.yml) - live config (mode + verbosity).
+- [MTN-34](https://linear.app/osmosis/issue/MTN-34) - parent initiative.

--- a/.github/security/USER_GUIDE.md
+++ b/.github/security/USER_GUIDE.md
@@ -1,0 +1,162 @@
+# Security Gate - User Guide
+
+> **Audience:** PR authors and override reviewers - the two flows that interact with the security gate as users. For incidents (Socket outage, workflow errors), see [RUNBOOK.md](./RUNBOOK.md). For "which doc do I want?", see [README.md](./README.md).
+
+> **Status:** the gate is being built in phases under [MTN-34](https://linear.app/osmosis/issue/MTN-34). Sections below are marked with the phase that populates them. Until that phase lands, the section is a stub - the structure exists so the doc can grow without re-organisation.
+
+## Quick reference
+
+| I want to... | Go to |
+|---|---|
+| Understand a sticky comment | [Reading the sticky comment](#reading-the-sticky-comment) |
+| Find out what each finding kind means | [Finding kinds](#finding-kinds) |
+| Unblock my REJECTED PR | [Unblocking a REJECTED PR](#unblocking-a-rejected-pr) |
+| Check if my dep bump will be blocked before pushing | [Previewing gate behavior](#previewing-gate-behavior) |
+| Know what to do while waiting for an override | [Waiting for an override](#waiting-for-an-override) |
+| Approve an override (reviewer) | [Approving an override](#approving-an-override) |
+| Use the slash-command override | [Using the security-override command](#using-the-security-override-command) |
+| Tell what mode the gate is in | [Advisory mode vs gate mode](#advisory-mode-vs-gate-mode) |
+| Change the gate's mode or verbosity | [Changing the gate's config](#changing-the-gates-config) |
+
+---
+
+## For PR authors
+
+### Reading the sticky comment
+
+> **Populated in MTN-55 (Phase 02 - Detectors).** Until then, no sticky comment exists yet; the aggregator that emits it lands in that phase.
+
+This section will cover:
+
+- The three verdict types: `APPROVED`, `NEEDS_HUMAN_REVIEW`, `REJECTED` - what each means for your PR and what to do next.
+- The summary table - one row per detector with counts at each severity.
+- The per-finding `<details>` blocks - how to expand and interpret them.
+- Severity meaning: `high` blocks merge (in gate mode); `medium` triggers `NEEDS_HUMAN_REVIEW`; `low` is informational.
+
+### Finding kinds
+
+> **Populated in MTN-56 (Phase 03 - Workflow).** The detectors are built in MTN-55, but you only encounter finding kinds via the workflow that ships in MTN-56.
+
+This section will be a per-finding-kind reference, one row each, covering what it means / why it matters / default user action:
+
+- `republish` (lockfile-diff)
+- `new-transitive` (lockfile-diff)
+- `resolved-change` (lockfile-diff)
+- `new-bin` (lockfile-diff)
+- `install-script` (lockfile-diff)
+- `resolutions-change` (lockfile-diff)
+- Socket categories (separate rows per Socket alert type)
+- `dep-review` (license, known CVE, etc.)
+
+### Unblocking a REJECTED PR
+
+> **Populated in MTN-57 (Phase 04 - Go-live).** Before MTN-57 the gate is in advisory mode and REJECTED verdicts do not block merges, so this content lands when the verdict actually starts blocking.
+
+> **Hard go-live gate:** the mode flip from `advisory` to `gate` is blocked on a doc self-serve test - a teammate not previously involved with the gate must be able to take a REJECTED test PR through to APPROVED using only this section. See MTN-57 for details.
+
+This section will be a step-by-step decision tree with three branches:
+
+1. **The finding is real and you need an override.** Steps to open the override PR, who reviews it, what to put in [`dep-overrides.yml`](./dep-overrides.yml), how to get the override back onto your branch.
+2. **The finding is spurious - you accidentally pulled in an unexpected change.** Steps to fix the manifest / lockfile and re-push.
+3. **The finding is real and not overridable.** When to bail out and pick a different dep.
+
+Each branch ends in a concrete next action, not a "contact the team" dead end.
+
+### Previewing gate behavior
+
+> **Populated in MTN-56 (Phase 03 - Workflow).**
+
+This section will cover running the detectors locally on a candidate dep change before pushing, so you can verify a risky bump without bouncing off CI. Approximate shape (final commands land in MTN-55 / MTN-56):
+
+```bash
+node .github/security/scripts/lockfile-diff-guard.mjs --base origin/stage --head HEAD
+```
+
+(plus aggregator + Socket invocations).
+
+### Waiting for an override
+
+> **Populated in MTN-57 (Phase 04 - Go-live).**
+
+This section will cover what a PR author should do while a reviewer is preparing your override - including how to verify the override entry looks valid before it hits the gate again, so the re-run loop doesn't bounce twice.
+
+---
+
+## For override reviewers
+
+### Approving an override
+
+> **Populated in MTN-58 (Phase 05 - Slash override).**
+
+> **Highest-leverage section in this doc.** Reviewer rubber-stamping is the most plausible failure mode for the whole gate. The checklist here is the structural defence; if it gets habitually skipped, the gate becomes ceremony.
+
+This section will be a reviewer checklist, in order of how easy each item is to skip:
+
+- **Two-person rule enforced.** `added_by` must not equal the PR author being unblocked. The slash command (MTN-58) enforces this in code; for the manifest path, you the reviewer enforce it visually.
+- **Integrity hash verified.** The `integrity` field in the override matches the one in `yarn.lock`. A mismatched hash means the override applies to a *different* package version than what's actually being installed.
+- **Reason field documented.** >= 10 chars, specific to *this* finding. "Known CVE, low-risk for our use, transitive only" - good. "approve" - not good.
+- **Expiry sensible.** Max 90 days. Shorter if the underlying advisory is expected to be fixed upstream sooner.
+- **Security finding actually understood, not just dismissed.** If you cannot explain in one sentence what was being approved, do not approve. This is the one that catches you on a busy day.
+- For *recurring* exemptions (e.g. a transitive dep that always trips dep-review for an accepted license), prefer the manifest path; for *one-off* unblocks, the slash command (MTN-58) is fine.
+
+### Reviewing a gate-config or workflow change
+
+> **Stub - content carries forward iteratively as real gate-config changes arrive.**
+
+When a PR changes:
+
+- [`gate-config.yml`](./gate-config.yml) (`mode` or `slack_verbosity`) - is the mode change temporary, with a stated plan to flip back? Is the verbosity change reducing noise or hiding alerts?
+- [`dep-overrides.yml`](./dep-overrides.yml) - run each override through [Approving an override](#approving-an-override).
+- `.github/workflows/dep-security-gate.yml` (lands in MTN-56) - are detectors being weakened? Are permissions being broadened beyond least-privilege? Is the always-on Slack list being silenced?
+
+### Using the security-override command
+
+> **Populated in MTN-58 (Phase 05 - Slash override).**
+
+This section will cover the `/security-override <reason>` slash command: how to invoke, who can invoke (the override-granting team, not the PR author), what gets logged, and how to revoke.
+
+---
+
+## For everyone
+
+### Advisory mode vs gate mode
+
+> **Populated in MTN-57 (Phase 04 - Go-live).** The mode flip lands in that phase; until then the field exists in [`gate-config.yml`](./gate-config.yml) but the workflow that honours it does not yet ship.
+
+This section will cover:
+
+- How to tell which mode is active: read `mode:` in [`gate-config.yml`](./gate-config.yml).
+- What each mode means for your PR (`gate` = blocking; `advisory` = observe-only).
+- When reviewers might intentionally flip to `advisory`: Socket outage recovery, false-positive investigation. These flips should always be paired with a stated plan for flipping back.
+
+### Changing the gate's config
+
+Open a PR against [`gate-config.yml`](./gate-config.yml). The file is owned by `@osmosis-labs/security-reviewers` via [CODEOWNERS](../CODEOWNERS), so review is enforced. The same CODEOWNERS rule applies to:
+
+- [`dep-overrides.yml`](./dep-overrides.yml) - the exemption list.
+- [`RUNBOOK.md`](./RUNBOOK.md), [`USER_GUIDE.md`](./USER_GUIDE.md), [`README.md`](./README.md) - this directory's docs.
+- [`../CODEOWNERS`](../CODEOWNERS) itself, by self-protection (added in MTN-54).
+
+Field reference:
+
+- `mode: gate` -> REJECTED verdicts block merges.
+- `mode: advisory` -> REJECTED verdicts still post the sticky comment and Slack alert, but the status check passes. Use only for short windows (false-positive investigation, infrastructure recovery, etc.) and flip back as soon as possible.
+- `slack_verbosity: verbose | alerts | silent` - tune signal-to-noise in `#security-gate-alerts`. Always-on events bypass this setting.
+- **Always-on events** (post regardless of verbosity): REJECTED verdicts, override granted, republish detected, Socket outage, workflow error.
+
+### Glossary
+
+> **Populated iteratively (MTN-64).**
+
+Quick definitions for terms you'll see in the sticky comment, this guide, and the runbook: aggregator, dep-review, integrity, lockfile-diff, override (manifest vs slash), republish, Shai-Hulud, Socket, sticky comment, verdict.
+
+---
+
+## See also
+
+- [README.md](./README.md) - landing page for these docs.
+- [RUNBOOK.md](./RUNBOOK.md) - incident response (when the gate itself is broken or under attack).
+- [`gate-config.yml`](./gate-config.yml) - the live config (mode + verbosity).
+- [`dep-overrides.yml`](./dep-overrides.yml) - the exemption list.
+- [`../CODEOWNERS`](../CODEOWNERS) - who reviews changes to this directory.
+- [MTN-34](https://linear.app/osmosis/issue/MTN-34) - the parent initiative tracking the build-out.

--- a/.github/security/gate-config.yml
+++ b/.github/security/gate-config.yml
@@ -16,7 +16,8 @@
 #   silent   -> normal verdicts and override events are suppressed; only
 #               always-on events post (see below).
 #
-# Always-on events (post regardless of verbosity; canonical list and
+# Always-on events (post regardless of verbosity; canonical list lives in
+# ./USER_GUIDE.md under "Changing the gate's config", incident-handling
 # rationale in ./RUNBOOK.md): REJECTED verdicts, override granted,
 # republish detected, Socket outage, workflow error.
 


### PR DESCRIPTION
## Summary

Adds the security-gate documentation **structure** so each subsequent phase has a clear target file for its user-facing content. Operating procedures must precede technical knowledge - the gate cannot go live in MTN-57 with only a v1 RUNBOOK; the first wave of confused PR authors will hit it within days.

Three files in `.github/security/`:

- **`README.md`** (new) - landing page, scannable in 30s. Routing table: symptom -> destination doc. This is what the sticky comment will link to first.
- **`USER_GUIDE.md`** (new) - task playbook for PR authors + override reviewers. Sections organised by task, not by audience. Most sections are **stubs marked with the phase that populates them** (e.g. "Reading the sticky comment - populated in MTN-55"), so the structure communicates the plan even while content is sparse. The reviewer "Approving an override" checklist is flagged inline as the highest-leverage section in the whole initiative because rubber-stamping is the most plausible failure mode.
- **`RUNBOOK.md`** (restructured) - now incident-only. Day-to-day content extracted to `USER_GUIDE.md`. Keeps: Socket outage, workflow errors, gate-stuck-blocking-valid-PRs, suspected-real-attack, unsafe-override post-mortem, plus the Vercel residual-risk note.

Plus a one-line comment update:

- **`gate-config.yml`** - the "canonical list of always-on events" pointer now references `USER_GUIDE.md` (where the user-facing list lives) alongside `RUNBOOK.md` (where the incident-handling rationale lives).

**No semantic changes to the gate.** Docs and a one-line comment update only. Cross-links use `@osmosis-labs/security-reviewers` consistently, matching the CODEOWNERS routing established in the foundation PR (#4364).

## Why this PR exists separately

This was decided in the [Security gate docs plan (May 2026)](https://linear.app/osmosis/issue/MTN-80). The doc-cadence question was: separate phase at the end, or doc-as-we-go? The end-phase option would have the gate going live in MTN-57 with only the minimal v1 RUNBOOK - the worst possible time to be writing a user guide.

So: structure now, content added by each phase that introduces user-facing behavior, MTN-64 repurposed from "RUNBOOK expansion" to "post-go-live polish based on real feedback." Each of MTN-55..MTN-58 now has explicit doc-deliverable acceptance criteria, and MTN-57 has a **hard go-live gate**: the mode flip from `advisory` to `gate` is blocked on a doc self-serve test (a teammate not previously involved with the gate must self-serve a synthetic REJECTED PR using only `USER_GUIDE.md`).

## Stacked-PR note for reviewers

This PR is opened against `jason/mtn-54-security-gate-phase-01-foundation` (the Phase 01 / MTN-54 branch, currently #4364), not directly against `stage`. Reason: PR #4364 has not yet merged. A doc PR off `stage` would either need to skip the RUNBOOK restructure (the file doesn't exist on `stage` until #4364 lands) or duplicate the Phase 01 files (which would conflict at merge).

GitHub auto-retargets dependent PRs when the base branch is deleted (which happens when #4364 merges with delete-branch-after-merge), so this PR's base will flip to `stage` automatically. No manual rebase needed. The visible diff against `stage` after #4364 merges will be exactly the four files above.

This stacking respects the "do not expand #4364's scope" constraint from MTN-80's plan.

## Acceptance criteria

- [x] `.github/security/README.md` exists with the routing table.
- [x] `.github/security/USER_GUIDE.md` exists with all phase-marked section stubs.
- [x] `.github/security/RUNBOOK.md` restructured to incident-only.
- [x] All cross-links resolve (no dead anchors).
- [x] PR opened against `stage` (or, in this case, against the in-flight Phase 01 branch; auto-retargets to `stage` on #4364 merge).
- [x] Doc references to the override-approving team match the CODEOWNERS team installed in #4364.

## Linear

- [MTN-80](https://linear.app/osmosis/issue/MTN-80) - this issue (doc structure)
- [MTN-64](https://linear.app/osmosis/issue/MTN-64) - repurposed to "post-go-live doc polish + lessons learned"
- [MTN-55](https://linear.app/osmosis/issue/MTN-55), [MTN-56](https://linear.app/osmosis/issue/MTN-56), [MTN-57](https://linear.app/osmosis/issue/MTN-57), [MTN-58](https://linear.app/osmosis/issue/MTN-58) - each updated with explicit doc-deliverable acceptance criteria
- [MTN-34](https://linear.app/osmosis/issue/MTN-34) - parent initiative

## Test plan

- [x] YAML files still parse (`js-yaml` confirms `gate-config.yml` -> `{mode: gate, slack_verbosity: verbose}`, `dep-overrides.yml` -> `{overrides: []}`).
- [x] No linter errors.
- [x] Reviewer: spot-check the cross-links by clicking through README -> USER_GUIDE -> RUNBOOK (GitHub's web viewer renders the anchors; if any 404, that's a slug mismatch to flag).
- [x] Reviewer: confirm the "stub" framing reads cleanly. The phase markers (`> **Populated in MTN-XX**`) are intended as a feature, not a bug - they communicate plan to readers.

## Not in this PR

- Content for stubbed sections - lands in MTN-55..MTN-58 alongside the features that introduce the behavior being documented.
- `ARCHITECTURE.md` - inline code comments + Linear issue tree are enough until the gate is built. Revisit in MTN-64 if needed.
- Moving docs out of `.github/security/` to a hypothetical `docs/` directory - the repo's pattern is per-package READMEs; co-locating with `gate-config.yml` is the right home.
- The CODEOWNERS routing change (MTN-79) - originally folded into this PR, now consolidated into the foundation PR #4364 so the gate scaffolds with `security-reviewers` from day one rather than scaffolding with a placeholder team and immediately swapping.
