### PR TITLE
ci(e2e): dedup topup dispatches + remove preview-push source (MTN-97)

### DIFF
--- a/.github/workflows/e2e-topup-accounts.yml
+++ b/.github/workflows/e2e-topup-accounts.yml
@@ -8,6 +8,13 @@ name: "E2E: Topup Test Accounts"
 #
 # Defaults to dry run. Uncheck "Dry run" to broadcast real transactions.
 
+# The run-name encodes dry-run vs real so the auto-dispatch dedup guards
+# (in frontend-e2e / prod-frontend-e2e / monitoring-limit-geo) can exclude
+# dry runs via `gh run list --json displayTitle`. Without this, the run's
+# displayTitle would just be the workflow name and dry runs couldn't be told
+# apart from real top-ups.
+run-name: "${{ (inputs.dry_run == true || inputs.dry_run == 'true') && 'Dry run' || 'Topup' }} — E2E accounts (x${{ inputs.topup_multiplier }})"
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -98,33 +98,14 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.E2E_SLACK_WEBHOOK_BALANCE_ALERTS }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-      - name: Trigger automatic topup
-        if: steps.balance-check.outcome == 'failure'
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if [ -f packages/e2e/balance-report.json ]; then
-            OUTCOME=$(jq -r '.outcome // ""' packages/e2e/balance-report.json)
-            if [ "$OUTCOME" = "warn" ] || [ "$OUTCOME" = "fail" ]; then
-              PENDING=$(gh run list --workflow "E2E: Topup Test Accounts" --limit 50 --json status --jq '[.[] | select(.status == "queued" or .status == "in_progress")] | length')
-              if [ "$PENDING" -gt 0 ]; then
-                echo "Topup workflow already queued/in-progress — skipping dispatch."
-              else
-                gh workflow run "E2E: Topup Test Accounts" \
-                  --ref stage \
-                  -f dry_run=false \
-                  -f topup_multiplier=3.0 \
-                  -f reserve_osmo=5 \
-                  -f reserve_usdc=100
-                echo "Topup workflow dispatched (balance outcome: $OUTCOME)."
-              fi
-            else
-              echo "Skipping topup — balance outcome: $OUTCOME"
-            fi
-          else
-            echo "Skipping topup — no balance report found."
-          fi
+      # NOTE: This preview-push workflow intentionally does NOT auto-dispatch a
+      # topup (removed in Phase A of the E2E cleanup, MTN-97). The preview
+      # account is one of the four refilled by every topup run, and the hourly
+      # monitoring workflow (monitoring-limit-geo) already keeps it funded via
+      # its single, deduplicated topup-dispatch job. We keep the low-balance
+      # Slack alert above and the critical-fail gate below so pushes still
+      # surface and block on a depleted account, without adding another
+      # (bursty, per-push) dispatch source.
       - name: Fail if balance critically low
         if: always() && steps.balance-check.outcome == 'failure'
         run: |

--- a/.github/workflows/monitoring-limit-geo-e2e-tests.yml
+++ b/.github/workflows/monitoring-limit-geo-e2e-tests.yml
@@ -278,12 +278,16 @@ jobs:
           SG_OUTCOME: ${{ needs.preflight-sg.outputs.outcome }}
         run: |
           # Dedup guard (Phase A / MTN-97): skip if a topup is already in flight,
-          # OR a real (non-dry-run) topup completed successfully within the
-          # ~45 min cooldown. 45 min is deliberately below the 60 min cron so a
-          # still-low account is still refilled on the next hourly tick; the
-          # window only collapses same-tick and cross-workflow bursts. Failed
-          # runs do NOT count (so a bad topup can be retried immediately); dry
-          # runs do NOT count (they move no funds).
+          # OR a real (non-dry-run) successful topup was *created* (`createdAt`,
+          # i.e. dispatched/queued) within the ~45 min cooldown. The window is
+          # keyed off createdAt (≈ dispatch time), not completion time, since the
+          # intent is to rate-limit how often we dispatch. 45 min is deliberately
+          # below the 60 min cron so a still-low account is still refilled on the
+          # next hourly tick; the window only collapses same-tick and
+          # cross-workflow bursts. Failed runs do NOT count (so a bad topup can be
+          # retried immediately); dry runs do NOT count (they move no funds).
+          # Best-effort, non-atomic: two dispatchers firing at the same instant
+          # can still both dispatch.
           COOLDOWN_SECONDS=2700
           RECENT=$(gh run list --workflow "E2E: Topup Test Accounts" --limit 50 \
             --json status,conclusion,displayTitle,createdAt \

--- a/.github/workflows/monitoring-limit-geo-e2e-tests.yml
+++ b/.github/workflows/monitoring-limit-geo-e2e-tests.yml
@@ -18,13 +18,19 @@ jobs:
   # every swap/trade/limit job. They:
   #   - check the monitoring wallet's balance,
   #   - send AT MOST one Slack alert if low,
-  #   - dispatch AT MOST one topup workflow if low,
   #   - export `outcome` (pass | warn | fail | error) so the test jobs can
   #     skip themselves when the wallet is critically low.
   #
   # Before this refactor each of fe-swap-*, fe-trade-*, fe-limit-* ran the
   # same five balance steps independently, producing up to 9 Slack alerts
   # and up to 3 topup-workflow dispatches per cron tick.
+  #
+  # Topup dispatch is NOT done per-preflight anymore (Phase A / MTN-97). The
+  # three preflights run in parallel and each used to hit `gh run list` in the
+  # same second, so all three saw "nothing in flight" and dispatched — 3 full
+  # top-ups per tick for work that a single run already covers (one topup run
+  # refills US/EU/SG/preview). Dispatch is now centralised in the single
+  # `topup-dispatch` job below, which `needs` all three preflights.
   # -------------------------------------------------------------------------
 
   preflight-us:
@@ -95,24 +101,6 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.E2E_SLACK_WEBHOOK_BALANCE_ALERTS }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-      - name: Trigger automatic topup
-        if: steps.balance-details.outputs.outcome == 'warn' || steps.balance-details.outputs.outcome == 'fail'
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PENDING=$(gh run list --workflow "E2E: Topup Test Accounts" --limit 50 --json status --jq '[.[] | select(.status == "queued" or .status == "in_progress")] | length')
-          if [ "$PENDING" -gt 0 ]; then
-            echo "Topup workflow already queued/in-progress — skipping dispatch."
-          else
-            gh workflow run "E2E: Topup Test Accounts" \
-              --ref stage \
-              -f dry_run=false \
-              -f topup_multiplier=3.0 \
-              -f reserve_osmo=5 \
-              -f reserve_usdc=100
-            echo "Topup workflow dispatched (balance outcome: ${{ steps.balance-details.outputs.outcome }})."
-          fi
 
   preflight-eu:
     name: preflight-eu-balance
@@ -182,24 +170,6 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.E2E_SLACK_WEBHOOK_BALANCE_ALERTS }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-      - name: Trigger automatic topup
-        if: steps.balance-details.outputs.outcome == 'warn' || steps.balance-details.outputs.outcome == 'fail'
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PENDING=$(gh run list --workflow "E2E: Topup Test Accounts" --limit 50 --json status --jq '[.[] | select(.status == "queued" or .status == "in_progress")] | length')
-          if [ "$PENDING" -gt 0 ]; then
-            echo "Topup workflow already queued/in-progress — skipping dispatch."
-          else
-            gh workflow run "E2E: Topup Test Accounts" \
-              --ref stage \
-              -f dry_run=false \
-              -f topup_multiplier=3.0 \
-              -f reserve_osmo=5 \
-              -f reserve_usdc=100
-            echo "Topup workflow dispatched (balance outcome: ${{ steps.balance-details.outputs.outcome }})."
-          fi
 
   preflight-sg:
     name: preflight-sg-balance
@@ -269,15 +239,62 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.E2E_SLACK_WEBHOOK_BALANCE_ALERTS }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-      - name: Trigger automatic topup
-        if: steps.balance-details.outputs.outcome == 'warn' || steps.balance-details.outputs.outcome == 'fail'
+
+  # -------------------------------------------------------------------------
+  # Single, deduplicated topup dispatcher (Phase A / MTN-97).
+  #
+  # `needs` all three preflights and dispatches AT MOST ONE topup per cron tick
+  # if any region reports a low balance (warn/fail). One topup run refills every
+  # account (US/EU/SG/preview), so a single dispatch covers all regions.
+  #
+  # Dedup model:
+  #   - Consolidation (this single job) removes the same-tick 3x race: the three
+  #     preflights used to each dispatch in parallel.
+  #   - The cooldown guard below removes cross-tick / cross-workflow repeats
+  #     (this job + prod-frontend-e2e all check the same workflow's recent runs).
+  # The per-region Slack alerts stay in each preflight, so a persistently low
+  # account still pages every tick even while dispatch is on cooldown.
+  # -------------------------------------------------------------------------
+  topup-dispatch:
+    name: topup-dispatch
+    runs-on: ubuntu-latest
+    needs: [preflight-us, preflight-eu, preflight-sg]
+    if: >-
+      always() && (
+        needs.preflight-us.outputs.outcome == 'warn' || needs.preflight-us.outputs.outcome == 'fail' ||
+        needs.preflight-eu.outputs.outcome == 'warn' || needs.preflight-eu.outputs.outcome == 'fail' ||
+        needs.preflight-sg.outputs.outcome == 'warn' || needs.preflight-sg.outputs.outcome == 'fail'
+      )
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Trigger automatic topup (deduplicated)
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          US_OUTCOME: ${{ needs.preflight-us.outputs.outcome }}
+          EU_OUTCOME: ${{ needs.preflight-eu.outputs.outcome }}
+          SG_OUTCOME: ${{ needs.preflight-sg.outputs.outcome }}
         run: |
-          PENDING=$(gh run list --workflow "E2E: Topup Test Accounts" --limit 50 --json status --jq '[.[] | select(.status == "queued" or .status == "in_progress")] | length')
-          if [ "$PENDING" -gt 0 ]; then
-            echo "Topup workflow already queued/in-progress — skipping dispatch."
+          # Dedup guard (Phase A / MTN-97): skip if a topup is already in flight,
+          # OR a real (non-dry-run) topup completed successfully within the
+          # ~45 min cooldown. 45 min is deliberately below the 60 min cron so a
+          # still-low account is still refilled on the next hourly tick; the
+          # window only collapses same-tick and cross-workflow bursts. Failed
+          # runs do NOT count (so a bad topup can be retried immediately); dry
+          # runs do NOT count (they move no funds).
+          COOLDOWN_SECONDS=2700
+          RECENT=$(gh run list --workflow "E2E: Topup Test Accounts" --limit 50 \
+            --json status,conclusion,displayTitle,createdAt \
+            --jq "[.[]
+              | select((.displayTitle | startswith(\"Dry run\")) | not)
+              | select(
+                  .status == \"queued\" or .status == \"in_progress\"
+                  or (.conclusion == \"success\" and ((now - (.createdAt | fromdateiso8601)) < $COOLDOWN_SECONDS))
+                )] | length")
+          if [ "$RECENT" -gt 0 ]; then
+            echo "Recent successful or in-flight topup within cooldown — skipping dispatch."
           else
             gh workflow run "E2E: Topup Test Accounts" \
               --ref stage \
@@ -285,7 +302,7 @@ jobs:
               -f topup_multiplier=3.0 \
               -f reserve_osmo=5 \
               -f reserve_usdc=100
-            echo "Topup workflow dispatched (balance outcome: ${{ steps.balance-details.outputs.outcome }})."
+            echo "Topup workflow dispatched (US=$US_OUTCOME EU=$EU_OUTCOME SG=$SG_OUTCOME)."
           fi
 
   # -------------------------------------------------------------------------

--- a/.github/workflows/prod-frontend-e2e-tests.yml
+++ b/.github/workflows/prod-frontend-e2e-tests.yml
@@ -106,9 +106,24 @@ jobs:
           if [ -f packages/e2e/balance-report.json ]; then
             OUTCOME=$(jq -r '.outcome // ""' packages/e2e/balance-report.json)
             if [ "$OUTCOME" = "warn" ] || [ "$OUTCOME" = "fail" ]; then
-              PENDING=$(gh run list --workflow "E2E: Topup Test Accounts" --limit 50 --json status --jq '[.[] | select(.status == "queued" or .status == "in_progress")] | length')
-              if [ "$PENDING" -gt 0 ]; then
-                echo "Topup workflow already queued/in-progress — skipping dispatch."
+              # Dedup guard (Phase A / MTN-97): skip if a topup is already in
+              # flight, OR a real (non-dry-run) topup completed successfully
+              # within the ~45 min cooldown. 45 min is deliberately below the
+              # 60 min monitoring cron so a still-low account is still refilled
+              # on the next hourly tick; the window only collapses same-tick and
+              # cross-workflow bursts. Failed runs do NOT count (so a bad topup
+              # can be retried immediately); dry runs do NOT count (no funds move).
+              COOLDOWN_SECONDS=2700
+              RECENT=$(gh run list --workflow "E2E: Topup Test Accounts" --limit 50 \
+                --json status,conclusion,displayTitle,createdAt \
+                --jq "[.[]
+                  | select((.displayTitle | startswith(\"Dry run\")) | not)
+                  | select(
+                      .status == \"queued\" or .status == \"in_progress\"
+                      or (.conclusion == \"success\" and ((now - (.createdAt | fromdateiso8601)) < $COOLDOWN_SECONDS))
+                    )] | length")
+              if [ "$RECENT" -gt 0 ]; then
+                echo "Recent successful or in-flight topup within cooldown — skipping dispatch."
               else
                 gh workflow run "E2E: Topup Test Accounts" \
                   --ref stage \

--- a/.github/workflows/prod-frontend-e2e-tests.yml
+++ b/.github/workflows/prod-frontend-e2e-tests.yml
@@ -107,12 +107,17 @@ jobs:
             OUTCOME=$(jq -r '.outcome // ""' packages/e2e/balance-report.json)
             if [ "$OUTCOME" = "warn" ] || [ "$OUTCOME" = "fail" ]; then
               # Dedup guard (Phase A / MTN-97): skip if a topup is already in
-              # flight, OR a real (non-dry-run) topup completed successfully
-              # within the ~45 min cooldown. 45 min is deliberately below the
-              # 60 min monitoring cron so a still-low account is still refilled
-              # on the next hourly tick; the window only collapses same-tick and
-              # cross-workflow bursts. Failed runs do NOT count (so a bad topup
-              # can be retried immediately); dry runs do NOT count (no funds move).
+              # flight, OR a real (non-dry-run) successful topup was *created*
+              # (`createdAt`, i.e. dispatched/queued) within the ~45 min cooldown.
+              # The window is keyed off createdAt (≈ dispatch time), not the
+              # completion time, since the intent is to rate-limit how often we
+              # dispatch. 45 min is deliberately below the 60 min monitoring cron
+              # so a still-low account is still refilled on the next hourly tick;
+              # the window only collapses same-tick and cross-workflow bursts.
+              # Failed runs do NOT count (so a bad topup can be retried
+              # immediately); dry runs do NOT count (no funds move). Note this is
+              # a best-effort, non-atomic check — two dispatchers firing in the
+              # same instant can still both dispatch.
               COOLDOWN_SECONDS=2700
               RECENT=$(gh run list --workflow "E2E: Topup Test Accounts" --limit 50 \
                 --json status,conclusion,displayTitle,createdAt \

--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -8,6 +8,7 @@ as well as standalone utility scripts for on-chain operations (e.g. cancelling o
 - [Environment Variables](#environment-variables)
 - [Running Tests](#running-tests)
 - [Balance Checking](#balance-checking)
+  - [Topup dispatch model (dedup)](#topup-dispatch-model-dedup)
 - [Required Token Balances](#required-token-balances)
 - [Order Cleanup Scripts](#order-cleanup-scripts)
 - [Fund Management](#fund-management)
@@ -159,11 +160,44 @@ alert at most per workflow run (or per region, for the geo-monitoring workflow).
 | `monitoring-limit-geo-e2e-tests.yml` | `preflight-us` | `fe-swap-us`, `fe-trade-us`, `fe-limit-us` | Monitoring US (`TEST_PRIVATE_KEY_US`) |
 
 Each `preflight-*` job in the geo-monitoring workflow runs the balance pipeline
-(check → alert if low → dispatch topup if low → expose `outcome` output) **once**
-per region per cron tick. Test jobs use `if: needs.preflight-XX.outputs.outcome
-!= 'fail'` to skip cleanly when the wallet is critically low — preserving the
-original fail-stop safety net while reducing per-cron-tick noise from up to
-9 Slack alerts and 3 topup dispatches down to 1 + 1 per region.
+(check → alert if low → expose `outcome` output) **once** per region per cron
+tick. Test jobs use `if: needs.preflight-XX.outputs.outcome != 'fail'` to skip
+cleanly when the wallet is critically low — preserving the original fail-stop
+safety net while reducing per-cron-tick noise from up to 9 Slack alerts down to
+1 per region.
+
+### Topup dispatch model (dedup)
+
+Topup dispatch is decoupled from the per-region/per-push balance checks so the
+"E2E: Topup Test Accounts" workflow fires **at most once per low-balance
+episode** instead of once per push and once per region (which raced and produced
+same-second and minutes-apart duplicate dispatches). One topup run refills
+**all four accounts** (preview + US/EU/SG), so a single dispatch always covers
+everyone.
+
+| Workflow | Dispatches topup? | Notes |
+|----------|-------------------|-------|
+| `monitoring-limit-geo-e2e-tests.yml` | Yes — single `topup-dispatch` job | `needs` all 3 preflights; dispatches once if any region is `warn`/`fail`. This is the primary funding path (hourly cron) and keeps the preview account funded too. |
+| `prod-frontend-e2e-tests.yml` | Yes — `check-balances` job | Master-push path; same cooldown guard. |
+| `frontend-e2e-tests.yml` | **No** (Phase A / MTN-97) | Preview push keeps the low-balance Slack alert + critical-fail gate, but no longer dispatches — the hourly monitoring path already refills the preview account. |
+
+Two complementary mechanisms keep dispatch deduplicated:
+
+- **Consolidation** — the geo-monitoring workflow uses one `topup-dispatch` job
+  (`needs: [preflight-us, preflight-eu, preflight-sg]`) instead of three
+  independent per-preflight dispatches, which removes the same-tick race (the
+  three preflights ran in parallel and all saw "nothing in flight").
+- **Cooldown guard** — every dispatcher skips if a topup is already
+  `queued`/`in_progress`, **or** a real topup `conclusion == "success"` within
+  the last ~45 min (`COOLDOWN_SECONDS=2700`). This removes cross-tick and
+  cross-workflow repeats. 45 min is deliberately below the 60 min cron so a
+  still-low account is still refilled on the next hourly tick. **Failed** runs do
+  not count (so a bad/partial topup can be retried immediately), and **dry runs**
+  do not count (they move no funds — excluded via the topup workflow's
+  `run-name`, matched with `displayTitle | startswith("Dry run")`).
+
+The per-region Slack alerts remain independent of dispatch, so a persistently
+low account still pages every cron tick even while dispatch is on cooldown.
 
 ### Exit Codes
 
@@ -392,6 +426,12 @@ warning suggests lowering the relevant reserve input if it becomes persistent.
 1. Run with dry run → see per-account balances, targets, and deficits
 2. Run live → sends only the deficits
 3. If interrupted, re-run safely — already-topped-up accounts are skipped
+
+**Who dispatches this workflow automatically?** See
+[Topup dispatch model (dedup)](#topup-dispatch-model-dedup) above — the
+geo-monitoring `topup-dispatch` job and the prod-master `check-balances` job,
+both behind a shared in-flight + ~45 min success cooldown guard so only one
+auto-topup fires per low-balance episode.
 
 ---
 

--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -169,11 +169,14 @@ safety net while reducing per-cron-tick noise from up to 9 Slack alerts down to
 ### Topup dispatch model (dedup)
 
 Topup dispatch is decoupled from the per-region/per-push balance checks so the
-"E2E: Topup Test Accounts" workflow fires **at most once per low-balance
+"E2E: Topup Test Accounts" workflow normally fires **about once per low-balance
 episode** instead of once per push and once per region (which raced and produced
 same-second and minutes-apart duplicate dispatches). One topup run refills
 **all four accounts** (preview + US/EU/SG), so a single dispatch always covers
-everyone.
+everyone. Note the dedup is **best-effort, not a hard guarantee**: the guard is a
+non-atomic `gh run list` check, so two dispatchers firing in the same instant can
+still both dispatch (harmless — the second run finds accounts already funded and
+sends nothing).
 
 | Workflow | Dispatches topup? | Notes |
 |----------|-------------------|-------|
@@ -188,13 +191,15 @@ Two complementary mechanisms keep dispatch deduplicated:
   independent per-preflight dispatches, which removes the same-tick race (the
   three preflights ran in parallel and all saw "nothing in flight").
 - **Cooldown guard** — every dispatcher skips if a topup is already
-  `queued`/`in_progress`, **or** a real topup `conclusion == "success"` within
-  the last ~45 min (`COOLDOWN_SECONDS=2700`). This removes cross-tick and
-  cross-workflow repeats. 45 min is deliberately below the 60 min cron so a
-  still-low account is still refilled on the next hourly tick. **Failed** runs do
-  not count (so a bad/partial topup can be retried immediately), and **dry runs**
-  do not count (they move no funds — excluded via the topup workflow's
-  `run-name`, matched with `displayTitle | startswith("Dry run")`).
+  `queued`/`in_progress`, **or** a real successful topup (`conclusion == "success"`)
+  whose run was **created within the last ~45 min** (`COOLDOWN_SECONDS=2700`). The
+  window is keyed off the run's `createdAt` (≈ when it was dispatched/queued), not
+  its completion time, because the intent is to rate-limit how often we dispatch.
+  This removes cross-tick and cross-workflow repeats. 45 min is deliberately below
+  the 60 min cron so a still-low account is still refilled on the next hourly tick.
+  **Failed** runs do not count (so a bad/partial topup can be retried immediately),
+  and **dry runs** do not count (they move no funds — excluded via the topup
+  workflow's `run-name`, matched with `displayTitle | startswith("Dry run")`).
 
 The per-region Slack alerts remain independent of dispatch, so a persistently
 low account still pages every cron tick even while dispatch is on cooldown.


### PR DESCRIPTION
## What is the purpose of the change

Stop the noisy, bursty E2E topup dispatches so the "E2E: Topup Test Accounts" workflow fires at most once per low-balance episode. Phase A of a 3-phase E2E test cleanup.

### Linear Task

https://linear.app/osmosis/issue/MTN-97

## Brief Changelog

- Consolidate the 3 per-region topup dispatches in `monitoring-limit-geo-e2e-tests.yml` into a single `topup-dispatch` job (one topup run already refills all accounts).
- Add a cooldown to the dedup guard on the remaining dispatchers (monitoring + prod-master): skip if a topup is in flight or a real topup succeeded within ~45 min. Failed runs don't block a retry; dry runs are ignored.
- Remove auto-dispatch from the preview-push workflow (`frontend-e2e-tests.yml`); keep the low-balance Slack alert + critical-fail gate.
- Add a `run-name` to `e2e-topup-accounts.yml` so dry runs are distinguishable in `gh run list`.
- Document the dispatch dedup model in `packages/e2e/README.md`.

Rationale, race analysis, and edge cases: see MTN-97.

## Testing and Verifying

This change has not been tested locally because it's CI-workflow-only logic. Validated all four workflow YAML files parse, and the jq dedup filter logic by inspection. Will verify on the hourly monitoring cron that a single topup dispatch occurs per low-balance episode.
