### PR TITLE
test(e2e): proxy-safe tx confirmation for EU/SG monitoring (MTN-98)

### DIFF
--- a/.github/workflows/monitoring-limit-geo-e2e-tests.yml
+++ b/.github/workflows/monitoring-limit-geo-e2e-tests.yml
@@ -462,177 +462,6 @@ jobs:
           name: sg-swap-test-results-${{ github.run_id }}
           path: packages/e2e/playwright-report
 
-  fe-trade-eu:
-    timeout-minutes: 20
-    needs: [preflight-eu, fe-swap-eu]
-    if: always() && needs.preflight-eu.outputs.outcome != 'fail'
-    name: prod-fe-trade-eu
-    runs-on: macos-14
-    outputs:
-      unexpected: ${{ steps.set-output.outputs.unexpected }}
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-        with:
-          sparse-checkout: |
-            packages/e2e
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22.x
-      - name: Cache dependencies
-        uses: actions/cache@v4
-        with:
-          path: "**/node_modules"
-          key: ${{ runner.OS }}-22.x-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.OS }}-22.x-
-      - name: Install Playwright
-        run: |
-          yarn --cwd packages/e2e install --frozen-lockfile && npx playwright install --with-deps chromium
-      - name: Run Trade tests in EU
-        env:
-          BASE_URL: "https://app.osmosis.zone"
-          TEST_PROXY: "http://138.68.112.16:8888"
-          TEST_PROXY_USERNAME: ${{ secrets.TEST_PROXY_USERNAME }}
-          TEST_PROXY_PASSWORD: ${{ secrets.TEST_PROXY_PASSWORD }}
-          PRIVATE_KEY: ${{ secrets.TEST_PRIVATE_KEY_EU }}
-          USE_TEST_PROXY: "use"
-          # Linux-headless mode (PR #4319) — disabled in favour of macos-14 above due to
-          # Keplr extension popup flakiness in headless Chromium on Linux. To retry the
-          # cheaper Linux runner, switch `runs-on:` to `ubuntu-latest` and uncomment:
-          # HEADLESS: "true"
-        run: |
-          cd packages/e2e
-          npx playwright test monitoring.market --timeout 180000
-      - name: set-output
-        if: always()
-        id: set-output
-        run: echo "unexpected=$(jq -r '.stats.unexpected' packages/e2e/playwright-report/test-results.json)" >> $GITHUB_OUTPUT
-      - name: upload monitoring test results
-        if: failure() || cancelled()
-        id: monitoring-test-results
-        uses: actions/upload-artifact@v4
-        with:
-          name: eu-trade-test-results-${{ github.run_id }}
-          path: packages/e2e/playwright-report
-
-  fe-limit-eu:
-    timeout-minutes: 15
-    needs: [preflight-eu, fe-trade-eu]
-    if: always() && needs.preflight-eu.outputs.outcome != 'fail'
-    name: prod-fe-limit-eu
-    runs-on: macos-14
-    outputs:
-      unexpected: ${{ steps.set-output.outputs.unexpected }}
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-        with:
-          sparse-checkout: |
-            packages/e2e
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22.x
-      - name: Cache dependencies
-        uses: actions/cache@v4
-        with:
-          path: "**/node_modules"
-          key: ${{ runner.OS }}-22.x-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.OS }}-22.x-
-      - name: Install Playwright
-        run: |
-          yarn --cwd packages/e2e install --frozen-lockfile && npx playwright install --with-deps chromium
-      - name: Cancel leftover open orders
-        continue-on-error: true
-        env:
-          PRIVATE_KEY: ${{ secrets.TEST_PRIVATE_KEY_EU }}
-          ACCOUNT_LABEL: "Monitoring EU (pre-test cleanup)"
-        run: npx tsx packages/e2e/scripts/cancel-all-orders.ts
-      - name: Run Limit tests in EU
-        env:
-          BASE_URL: "https://app.osmosis.zone"
-          TEST_PROXY: "http://138.68.112.16:8888"
-          TEST_PROXY_USERNAME: ${{ secrets.TEST_PROXY_USERNAME }}
-          TEST_PROXY_PASSWORD: ${{ secrets.TEST_PROXY_PASSWORD }}
-          PRIVATE_KEY: ${{ secrets.TEST_PRIVATE_KEY_EU }}
-          USE_TEST_PROXY: "use"
-          # Linux-headless mode (PR #4319) — disabled in favour of macos-14 above due to
-          # Keplr extension popup flakiness in headless Chromium on Linux. To retry the
-          # cheaper Linux runner, switch `runs-on:` to `ubuntu-latest` and uncomment:
-          # HEADLESS: "true"
-        run: |
-          cd packages/e2e
-          npx playwright test monitoring.limit --timeout 180000
-      - name: set-output
-        if: always()
-        id: set-output
-        run: echo "unexpected=$(jq -r '.stats.unexpected' packages/e2e/playwright-report/test-results.json)" >> $GITHUB_OUTPUT
-      - name: upload monitoring test results
-        if: failure() || cancelled()
-        id: monitoring-test-results
-        uses: actions/upload-artifact@v4
-        with:
-          name: eu-limit-test-results-${{ github.run_id }}
-          path: packages/e2e/playwright-report
-
-  fe-trade-sg:
-    timeout-minutes: 15
-    needs: [preflight-sg, fe-swap-sg]
-    if: always() && needs.preflight-sg.outputs.outcome != 'fail'
-    name: prod-fe-trade-sg
-    runs-on: macos-14
-    outputs:
-      unexpected: ${{ steps.set-output.outputs.unexpected }}
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-        with:
-          sparse-checkout: |
-            packages/e2e
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22.x
-      - name: Cache dependencies
-        uses: actions/cache@v4
-        with:
-          path: "**/node_modules"
-          key: ${{ runner.OS }}-22.x-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.OS }}-22.x-
-      - name: Install Playwright
-        run: |
-          yarn --cwd packages/e2e install --frozen-lockfile && npx playwright install --with-deps chromium
-      - name: Run Trade tests in SG
-        env:
-          BASE_URL: "https://app.osmosis.zone"
-          TEST_PROXY: "http://139.59.218.19:8888"
-          TEST_PROXY_USERNAME: ${{ secrets.TEST_PROXY_USERNAME }}
-          TEST_PROXY_PASSWORD: ${{ secrets.TEST_PROXY_PASSWORD }}
-          PRIVATE_KEY: ${{ secrets.TEST_PRIVATE_KEY_SG }}
-          USE_TEST_PROXY: "use"
-          # Linux-headless mode (PR #4319) — disabled in favour of macos-14 above due to
-          # Keplr extension popup flakiness in headless Chromium on Linux. To retry the
-          # cheaper Linux runner, switch `runs-on:` to `ubuntu-latest` and uncomment:
-          # HEADLESS: "true"
-        run: |
-          cd packages/e2e
-          npx playwright test monitoring.market --timeout 90000
-      - name: set-output
-        if: always()
-        id: set-output
-        run: echo "unexpected=$(jq -r '.stats.unexpected' packages/e2e/playwright-report/test-results.json)" >> $GITHUB_OUTPUT
-      - name: upload monitoring test results
-        if: failure() || cancelled()
-        id: monitoring-test-results
-        uses: actions/upload-artifact@v4
-        with:
-          name: sg-trade-test-results-${{ github.run_id }}
-          path: packages/e2e/playwright-report
-
   fe-trade-us:
     timeout-minutes: 10
     needs: [preflight-us, fe-swap-us]
@@ -747,15 +576,8 @@ jobs:
 
   fe-bot-alert:
     runs-on: ubuntu-latest
-    needs:
-      [
-        fe-trade-eu,
-        fe-trade-us,
-        fe-trade-sg,
-        fe-limit-us,
-        fe-limit-eu,
-      ]
-    if: failure() && github.run_attempt == 2 && (needs.fe-trade-eu.outputs.unexpected > 1 || needs.fe-trade-us.outputs.unexpected > 1 || needs.fe-trade-sg.outputs.unexpected > 1 || needs.fe-limit-eu.outputs.unexpected > 1 || needs.fe-limit-us.outputs.unexpected > 1)
+    needs: [fe-trade-us, fe-limit-us]
+    if: failure() && github.run_attempt == 2 && (needs.fe-trade-us.outputs.unexpected > 1 || needs.fe-limit-us.outputs.unexpected > 1)
     # Send alert only if something failed and unexpected failures are more than 1
     steps:
       - name: Install Datadog CI
@@ -784,10 +606,7 @@ jobs:
 
           # Add tags for unexpected failure counts by region
           datadog-ci tag --level pipeline \
-            --tags "fe_trade_eu_unexpected:${{ needs.fe-trade-eu.outputs.unexpected }}" \
             --tags "fe_trade_us_unexpected:${{ needs.fe-trade-us.outputs.unexpected }}" \
-            --tags "fe_trade_sg_unexpected:${{ needs.fe-trade-sg.outputs.unexpected }}" \
-            --tags "fe_limit_eu_unexpected:${{ needs.fe-limit-eu.outputs.unexpected }}" \
             --tags "fe_limit_us_unexpected:${{ needs.fe-limit-us.outputs.unexpected }}"
 
           echo "✅ Metrics sent to Datadog successfully"
@@ -797,12 +616,12 @@ jobs:
     if: always()
     needs:
       [
-        fe-trade-eu,
+        fe-swap-us,
+        fe-swap-eu,
+        fe-swap-sg,
         fe-trade-us,
-        fe-trade-sg,
-        fe-bot-alert,
         fe-limit-us,
-        fe-limit-eu,
+        fe-bot-alert,
       ]
     steps:
       - name: Delete Previous deployments

--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -9,6 +9,7 @@ as well as standalone utility scripts for on-chain operations (e.g. cancelling o
 - [Running Tests](#running-tests)
 - [Balance Checking](#balance-checking)
   - [Topup dispatch model (dedup)](#topup-dispatch-model-dedup)
+- [Transaction Confirmation](#transaction-confirmation)
 - [Required Token Balances](#required-token-balances)
 - [Order Cleanup Scripts](#order-cleanup-scripts)
 - [Fund Management](#fund-management)
@@ -217,6 +218,37 @@ requirement is unavailable after retries — see "Price-Aware Checks" above.
 The Slack alert wording in that case calls out the cause ("price service
 unavailable — couldn't verify, dispatching topup as precaution") so it isn't
 mistaken for an actual shortage.
+
+## Transaction Confirmation
+
+Trade tests (swap / buy / sell) confirm a transaction succeeded using **two
+signals that race**, so a flaky WebSocket can't produce a false failure:
+
+1. **Primary — WebSocket toast.** The in-app "Transaction Successful" toast is
+   driven by the app's WebSocket `TxTracer` (`packages/tx/src/tracer.ts`). It's
+   fast and is what passes in non-proxied (US / preview / prod) runs.
+2. **Fallback — REST poll.** The EU/SG monitoring suites drive the browser
+   through an HTTP CONNECT proxy, over which long-lived WebSockets frequently
+   stall or disconnect — so the toast may never render even though the tx was
+   broadcast and included on-chain. To cover that, `TradePage.startTxConfirmation()`
+   also captures the broadcast tx hash from the app's `/api/broadcast-transaction`
+   response and polls the Osmosis LCD `GET /cosmos/tx/v1beta1/txs/{hash}` directly
+   from the Node test process (see `utils/tx-confirm.ts`). That fetch does **not**
+   go through the browser proxy, so it's reliable regardless of WebSocket health.
+
+Whichever signal confirms first wins (the loser is aborted); the test only fails
+if **both** time out, or if the REST poll sees the tx included with a non-zero
+code (a genuine on-chain failure). `getTransactionUrl()` likewise falls back to
+the captured hash (Mintscan URL) when the success-toast link is absent.
+
+The REST endpoint is `REST_ENDPOINT` (default `https://lcd.osmosis.zone`, see
+`utils/config.ts`). `TradePage.goto()` additionally retries with backoff so a
+proxy stall on initial page load surfaces as a recoverable retry rather than a
+hard `beforeAll` timeout.
+
+> Note: this is an E2E-layer safety net. A complementary product-side change —
+> making the app's own `broadcastMsgs` fall back to REST when `TxTracer`
+> exhausts its WebSocket endpoints — is tracked separately and ships as its own PR.
 
 ## Required Token Balances
 

--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -32,8 +32,8 @@ All you need to add is a private key for the wallet being used:
 | Secret | Label | Address |
 |--------|-------|---------|
 | `E2E_PRIVATE_KEY_PREVIEW` | E2E Test Account (preview + prod frontend tests) | `TBD` |
-| `TEST_PRIVATE_KEY_SG` | Monitoring SG region (swap, trade) | `TBD` |
-| `TEST_PRIVATE_KEY_EU` | Monitoring EU region (swap, trade, limit) | `TBD` |
+| `TEST_PRIVATE_KEY_SG` | Monitoring SG region (swap only — proxy) | `TBD` |
+| `TEST_PRIVATE_KEY_EU` | Monitoring EU region (swap only — proxy) | `TBD` |
 | `TEST_PRIVATE_KEY_US` | Monitoring US region (swap, trade, limit) | `TBD` |
 
 All wallet addresses are derived from the private key at runtime using `deriveAddress()` in `utils/wallet-utils.ts`.
@@ -156,8 +156,8 @@ alert at most per workflow run (or per region, for the geo-monitoring workflow).
 |----------|-----------|----------------|---------|
 | `frontend-e2e-tests.yml` | `check-balances` | `preview-swap-osmo-tests`, `preview-swap-usdc-tests`, `preview-trade-tests`, `preview-claim-tests` | E2E Test Account (`E2E_PRIVATE_KEY_PREVIEW`) |
 | `prod-frontend-e2e-tests.yml` | `check-balances` | `prod-e2e-tests` | E2E Test Account (`E2E_PRIVATE_KEY_PREVIEW`) |
-| `monitoring-limit-geo-e2e-tests.yml` | `preflight-sg` | `fe-swap-sg`, `fe-trade-sg` | Monitoring SG (`TEST_PRIVATE_KEY_SG`) |
-| `monitoring-limit-geo-e2e-tests.yml` | `preflight-eu` | `fe-swap-eu`, `fe-trade-eu`, `fe-limit-eu` | Monitoring EU (`TEST_PRIVATE_KEY_EU`) |
+| `monitoring-limit-geo-e2e-tests.yml` | `preflight-sg` | `fe-swap-sg` | Monitoring SG (`TEST_PRIVATE_KEY_SG`) |
+| `monitoring-limit-geo-e2e-tests.yml` | `preflight-eu` | `fe-swap-eu` | Monitoring EU (`TEST_PRIVATE_KEY_EU`) |
 | `monitoring-limit-geo-e2e-tests.yml` | `preflight-us` | `fe-swap-us`, `fe-trade-us`, `fe-limit-us` | Monitoring US (`TEST_PRIVATE_KEY_US`) |
 
 Each `preflight-*` job in the geo-monitoring workflow runs the balance pipeline
@@ -245,6 +245,22 @@ The REST endpoint is `REST_ENDPOINT` (default `https://lcd.osmosis.zone`, see
 `utils/config.ts`). `TradePage.goto()` additionally retries with backoff so a
 proxy stall on initial page load surfaces as a recoverable retry rather than a
 hard `beforeAll` timeout.
+
+### Why proxy regions (EU/SG) run swap-only
+
+Market and limit orders are intentionally **not** run over the EU/SG proxies —
+those regions run swaps only. Over the HTTP CONNECT proxy the
+estimate→broadcast window widens to tens of seconds, during which Osmosis's
+dynamic EIP base fee can drift past the app's fee buffer (`cur_eip_base_fee` ×
+`1.65`, frozen at estimate time). The market/limit txs are then rejected at
+`CheckTx` with `code 13` "insufficient fee" — they get a hash but are never
+included, so the LCD reports `tx not found`. This was a deterministic artifact
+of the proxy latency, not a product regression on the happy path: the same
+specs pass `code 0` on US-direct. Swap legs stay over the proxy because they
+validate the proxy path + WebSocket/REST confirmation cheaply with stable
+assets; market/limit run on US-direct where they're representative. See
+**MTN-98** for the full root-cause evidence and the deferred product-side fee
+fix.
 
 > Note: this is an E2E-layer safety net. A complementary product-side change —
 > making the app's own `broadcastMsgs` fall back to REST when `TxTracer`
@@ -368,7 +384,6 @@ The following CI workflows run `cancel-all-orders.ts` as a **prerequisite step**
 
 | Workflow | Job(s) | Account cleaned |
 |---|---|---|
-| `monitoring-limit-geo-e2e-tests.yml` | `fe-limit-eu` | `TEST_PRIVATE_KEY_EU` (Monitoring EU) |
 | `monitoring-limit-geo-e2e-tests.yml` | `fe-limit-us` | `TEST_PRIVATE_KEY_US` (Monitoring US) |
 | `frontend-e2e-tests.yml` | `preview-trade-tests` | `E2E_PRIVATE_KEY_PREVIEW` (E2E Test Account) |
 

--- a/packages/e2e/pages/trade-page.ts
+++ b/packages/e2e/pages/trade-page.ts
@@ -709,11 +709,38 @@ export class TradePage extends BasePage {
       { timeout }
     );
     const body = (await resp.json()) as {
-      tx_response?: { txhash?: string };
+      tx_response?: {
+        txhash?: string;
+        code?: number;
+        codespace?: string;
+        raw_log?: string;
+      };
+      code?: number;
+      message?: string;
     };
-    const hash = body?.tx_response?.txhash;
+    const txResponse = body?.tx_response;
+    const hash = txResponse?.txhash;
+
+    // Surface the broadcast result so a tx that is rejected at CheckTx (returns a
+    // hash but is never included → LCD "tx not found") is diagnosable from CI
+    // logs. `code === 0` means accepted into the mempool; a non-zero `code` +
+    // `raw_log`/`codespace` is the ante-handler rejection reason (sequence, fee,
+    // signature, etc.). Logged, not thrown, so the REST poll still runs.
+    console.log(
+      `Broadcast response: httpStatus=${resp.status()} ` +
+        `code=${txResponse?.code ?? body?.code ?? "?"} ` +
+        `codespace=${txResponse?.codespace ?? "-"} ` +
+        `txhash=${hash ?? "none"}` +
+        (txResponse?.raw_log ? ` raw_log=${txResponse.raw_log}` : "") +
+        (!txResponse && body?.message ? ` message=${body.message}` : "")
+    );
+
     if (!hash) {
-      throw new Error("broadcast response contained no txhash");
+      throw new Error(
+        `broadcast response contained no txhash (httpStatus=${resp.status()}, ` +
+          `code=${txResponse?.code ?? body?.code ?? "?"}, ` +
+          `message=${body?.message ?? txResponse?.raw_log ?? "none"})`
+      );
     }
     return String(hash).toLowerCase();
   }

--- a/packages/e2e/pages/trade-page.ts
+++ b/packages/e2e/pages/trade-page.ts
@@ -771,17 +771,35 @@ export class TradePage extends BasePage {
     // Clear any hash from a previous trade so getTransactionUrl can't reuse it.
     this.lastTxHash = undefined;
     const controller = new AbortController();
+    // Single overall budget shared by the hash-capture + REST-poll phases, so
+    // this can't run ~2x `timeout` (capture up to `timeout`, then poll for
+    // another full `timeout`).
+    const deadline = Date.now() + timeout;
 
-    const toastPromise = this.trxSuccessful
-      .waitFor({ state: "visible", timeout })
-      .then(() => "WebSocket toast" as const);
+    // Guard against a stale "Transaction Successful" toast from a previous trade
+    // (success toasts auto-close after ~7s): if one is already visible, wait for
+    // it to clear before arming the visible-wait, otherwise the race could
+    // resolve instantly on the old toast. Bounded + non-throwing, so it adds no
+    // latency or flake on the normal path (no toast present → proceeds at once).
+    const toastPromise = (async () => {
+      const stale = await this.trxSuccessful.isVisible().catch(() => false);
+      if (stale) {
+        await this.trxSuccessful
+          .waitFor({ state: "hidden", timeout: 8_000 })
+          .catch(() => {});
+      }
+      await this.trxSuccessful.waitFor({ state: "visible", timeout });
+      return "WebSocket toast" as const;
+    })();
 
     const restPromise = this.captureBroadcastHash(timeout).then((hash) => {
       this.lastTxHash = hash;
       console.log(`Captured broadcast tx hash: ${hash}`);
-      return pollTxOnChain(hash, { timeout, signal: controller.signal }).then(
-        () => "REST LCD poll" as const
-      );
+      const remaining = Math.max(0, deadline - Date.now());
+      return pollTxOnChain(hash, {
+        timeout: remaining,
+        signal: controller.signal,
+      }).then(() => "REST LCD poll" as const);
     });
 
     return Promise.any([toastPromise, restPromise])
@@ -851,7 +869,7 @@ export class TradePage extends BasePage {
    * - Waits for buy button to be enabled before proceeding
    * - Automatically approves transaction in Keplr if popup appears (10s event-driven timeout)
    * - Gracefully handles 1-click trading (no popup scenario)
-   * - Waits for blockchain confirmation (40s timeout, starts after confirm click, parallel with approval)
+   * - Confirms via WebSocket toast OR proxy-safe REST poll, armed before the confirm click (see startTxConfirmation)
    * - No retry logic - for retry support, use buyAndGetWalletMsg()
    */
   async buyAndApprove(
@@ -922,7 +940,7 @@ export class TradePage extends BasePage {
    * - Implements automatic retry logic with 1.5s delay for quote refresh race conditions
    * - Automatically approves transaction in Keplr if popup appears (10s event-driven timeout)
    * - Gracefully handles 1-click trading (no popup scenario)
-   * - Waits for blockchain confirmation (40s timeout, starts after confirm click, parallel with approval)
+   * - Confirms via WebSocket toast OR proxy-safe REST poll, armed before the confirm click (see startTxConfirmation)
    * - Retries only on swap button disabled errors; other errors fail immediately
    */
   async swapAndApprove(

--- a/packages/e2e/pages/trade-page.ts
+++ b/packages/e2e/pages/trade-page.ts
@@ -5,6 +5,7 @@ import {
   expect,
 } from "@playwright/test";
 
+import { buildExplorerTxUrl, pollTxOnChain } from "../utils/tx-confirm";
 import { BasePage } from "./base-page";
 import { getKeplrPopupPage, waitForKeplrApproval } from "./keplr-helper";
 
@@ -41,6 +42,8 @@ export class TradePage extends BasePage {
   readonly limitPrice: Locator;
   readonly slippageInput: Locator;
   readonly buySellTimeout = 30_000;
+  /** Hash of the most recently broadcast tx, captured for the REST fallback. */
+  private lastTxHash?: string;
 
   constructor(page: Page) {
     super(page);
@@ -72,16 +75,47 @@ export class TradePage extends BasePage {
       .first();
   }
 
-  async goto() {
-    const assetPromise = this.page.waitForRequest("**/assets.json");
-    await this.page.goto("/");
-    const request = await assetPromise;
-    expect(request).toBeTruthy();
-    // we expect that after 2 seconds tokens are loaded and any failure after this point should be considered a bug.
-    await this.page.waitForTimeout(2000);
-    const currentUrl = this.page.url();
-    console.log(`FE opened at: ${currentUrl}`);
-    await this.dismissVariantsPopupIfPresent();
+  /**
+   * Navigate to the app home and wait for tokens to load.
+   *
+   * Retries with backoff because the EU/SG monitoring suites load the app
+   * through an HTTP CONNECT proxy where the initial page load / `assets.json`
+   * fetch can intermittently stall — previously this surfaced as a hard
+   * `beforeAll` timeout (e.g. the 180s monitoring.limit hook on EU) instead of
+   * a recoverable retry.
+   */
+  async goto(retries = 2) {
+    let lastError: unknown;
+    for (let attempt = 0; attempt <= retries; attempt++) {
+      try {
+        if (attempt > 0) {
+          console.log(`🔄 Retry goto attempt ${attempt}/${retries}...`);
+        }
+        const assetPromise = this.page.waitForRequest("**/assets.json", {
+          timeout: 30_000,
+        });
+        await this.page.goto("/");
+        const request = await assetPromise;
+        expect(request).toBeTruthy();
+        // we expect that after 2 seconds tokens are loaded and any failure after this point should be considered a bug.
+        await this.page.waitForTimeout(2000);
+        const currentUrl = this.page.url();
+        console.log(`FE opened at: ${currentUrl}`);
+        await this.dismissVariantsPopupIfPresent();
+        return;
+      } catch (error: any) {
+        lastError = error;
+        console.warn(
+          `⚠️ goto attempt ${attempt + 1}/${retries + 1} failed: ${
+            error?.message ?? error
+          }`
+        );
+        if (attempt < retries) {
+          await this.page.waitForTimeout(2000 * (attempt + 1));
+        }
+      }
+    }
+    throw lastError;
   }
 
   async gotoOrdersHistory(timeout = 1) {
@@ -283,10 +317,28 @@ export class TradePage extends BasePage {
   }
 
   async getTransactionUrl() {
-    const trxUrl = await this.trxLink.getAttribute("href", { timeout: 10000 });
-    console.log(`Trx url: ${trxUrl}`);
-    await this.page.reload();
-    return trxUrl;
+    try {
+      const trxUrl = await this.trxLink.getAttribute("href", {
+        timeout: 10000,
+      });
+      console.log(`Trx url: ${trxUrl}`);
+      await this.page.reload();
+      return trxUrl;
+    } catch (error) {
+      // The "View explorer" link lives in the same success toast that the WS
+      // TxTracer drives; over the geo proxies it may never render even when the
+      // tx is confirmed on-chain (see startTxConfirmation). Fall back to the
+      // hash captured from the broadcast response so the test can still proceed.
+      if (this.lastTxHash) {
+        const fallbackUrl = buildExplorerTxUrl(this.lastTxHash);
+        console.log(
+          `Success-toast link absent; using captured tx hash: ${fallbackUrl}`
+        );
+        await this.page.reload();
+        return fallbackUrl;
+      }
+      throw error;
+    }
   }
 
   async isTransactionBroadcasted(delay = 5) {
@@ -645,6 +697,79 @@ export class TradePage extends BasePage {
   }
 
   /**
+   * Captures the broadcast tx hash from the app's `/api/broadcast-transaction`
+   * response. Must be armed BEFORE the Keplr approval click, since the broadcast
+   * only happens after approval. Resolves with the lowercase tx hash.
+   */
+  private async captureBroadcastHash(timeout: number): Promise<string> {
+    const resp = await this.page.waitForResponse(
+      (r) =>
+        r.url().includes("/api/broadcast-transaction") &&
+        r.request().method() === "POST",
+      { timeout }
+    );
+    const body = (await resp.json()) as {
+      tx_response?: { txhash?: string };
+    };
+    const hash = body?.tx_response?.txhash;
+    if (!hash) {
+      throw new Error("broadcast response contained no txhash");
+    }
+    return String(hash).toLowerCase();
+  }
+
+  /**
+   * Confirms a just-submitted transaction succeeded, resilient to WebSocket
+   * flakiness over the EU/SG geo proxies.
+   *
+   * Two signals race:
+   *   1. Primary (WebSocket): the in-app "Transaction Successful" toast, driven
+   *      by the app's WS `TxTracer`. Fast, but over the HTTP CONNECT proxy the
+   *      WebSocket often stalls/disconnects, so the toast may never render even
+   *      when the tx is included on-chain.
+   *   2. Fallback (REST): capture the broadcast tx hash and poll the Osmosis LCD
+   *      `GET /cosmos/tx/v1beta1/txs/{hash}` directly from Node (NOT through the
+   *      browser proxy), passing as soon as the tx is on-chain with code 0.
+   *
+   * Whichever confirms first wins; the loser is aborted. Only if BOTH fail does
+   * this reject. This must be armed before the Keplr approval click (mirroring
+   * the previous `expect(trxSuccessful).toBeVisible()` arm) so the broadcast
+   * response isn't missed.
+   */
+  startTxConfirmation(timeout = 40_000): Promise<void> {
+    // Clear any hash from a previous trade so getTransactionUrl can't reuse it.
+    this.lastTxHash = undefined;
+    const controller = new AbortController();
+
+    const toastPromise = this.trxSuccessful
+      .waitFor({ state: "visible", timeout })
+      .then(() => "WebSocket toast" as const);
+
+    const restPromise = this.captureBroadcastHash(timeout).then((hash) => {
+      this.lastTxHash = hash;
+      console.log(`Captured broadcast tx hash: ${hash}`);
+      return pollTxOnChain(hash, { timeout, signal: controller.signal }).then(
+        () => "REST LCD poll" as const
+      );
+    });
+
+    return Promise.any([toastPromise, restPromise])
+      .then((winner) => {
+        controller.abort();
+        console.log(`✓ Transaction confirmed via ${winner}.`);
+      })
+      .catch((err: any) => {
+        controller.abort();
+        const detail = err?.errors
+          ? err.errors.map((e: any) => e?.message ?? String(e)).join(" | ")
+          : (err?.message ?? String(err));
+        throw new Error(
+          `Transaction not confirmed via WebSocket toast or on-chain REST poll: ${detail}`
+        );
+      });
+  }
+
+  /**
    * Initiates a sell transaction with simplified approval flow.
    * Automatically waits for transaction confirmation on blockchain.
    *
@@ -656,7 +781,7 @@ export class TradePage extends BasePage {
    * - Waits for sell button to be enabled before proceeding
    * - Automatically approves transaction in Keplr if popup appears (10s event-driven timeout)
    * - Gracefully handles 1-click trading (no popup scenario)
-   * - Waits for blockchain confirmation (40s timeout, starts after confirm click, parallel with approval)
+   * - Confirms via WebSocket toast OR proxy-safe REST poll (see startTxConfirmation)
    * - No retry logic - for retry support, use sellAndGetWalletMsg()
    */
   async sellAndApprove(
@@ -678,11 +803,9 @@ export class TradePage extends BasePage {
     }
 
     await this.confirmSwapBtn.click();
-    const successPromise = expect(this.trxSuccessful).toBeVisible({
-      timeout: 40000,
-    });
+    const confirmation = this.startTxConfirmation();
     await this.justApproveIfNeeded(context);
-    await successPromise;
+    await confirmation;
   }
 
   /**
@@ -719,11 +842,9 @@ export class TradePage extends BasePage {
     }
 
     await this.confirmSwapBtn.click();
-    const successPromise = expect(this.trxSuccessful).toBeVisible({
-      timeout: 40000,
-    });
+    const confirmation = this.startTxConfirmation();
     await this.justApproveIfNeeded(context);
-    await successPromise;
+    await confirmation;
   }
 
   /**
@@ -800,9 +921,7 @@ export class TradePage extends BasePage {
         }
 
         await this.confirmSwapBtn.click({ timeout: 5000 });
-        const successPromise = expect(this.trxSuccessful).toBeVisible({
-          timeout: 40000,
-        });
+        const confirmation = this.startTxConfirmation();
         await this.justApproveIfNeeded(context);
 
         if (attempt > 0) {
@@ -811,7 +930,7 @@ export class TradePage extends BasePage {
           );
         }
 
-        await successPromise;
+        await confirmation;
 
         return;
       } catch (error: any) {

--- a/packages/e2e/pages/trade-page.ts
+++ b/packages/e2e/pages/trade-page.ts
@@ -91,12 +91,16 @@ export class TradePage extends BasePage {
         if (attempt > 0) {
           console.log(`🔄 Retry goto attempt ${attempt}/${retries}...`);
         }
-        const assetPromise = this.page.waitForRequest("**/assets.json", {
-          timeout: 30_000,
-        });
-        await this.page.goto("/");
-        const request = await assetPromise;
-        expect(request).toBeTruthy();
+        // Wait for the assets.json *response* (not just the request being
+        // issued) and assert it loaded successfully, so a stalled/failed load
+        // surfaces as a retryable error rather than a false "ready". Using
+        // Promise.all ties both promises together, so if goto() throws the
+        // waitForResponse promise is still handled (no unhandled rejection).
+        const [assetResponse] = await Promise.all([
+          this.page.waitForResponse("**/assets.json", { timeout: 30_000 }),
+          this.page.goto("/"),
+        ]);
+        expect(assetResponse.ok()).toBeTruthy();
         // we expect that after 2 seconds tokens are loaded and any failure after this point should be considered a bug.
         await this.page.waitForTimeout(2000);
         const currentUrl = this.page.url();
@@ -829,8 +833,8 @@ export class TradePage extends BasePage {
       await this.setSlippageTolerance(slippagePercent);
     }
 
-    await this.confirmSwapBtn.click();
     const confirmation = this.startTxConfirmation();
+    await this.confirmSwapBtn.click();
     await this.justApproveIfNeeded(context);
     await confirmation;
   }
@@ -868,8 +872,8 @@ export class TradePage extends BasePage {
       await this.setSlippageTolerance(slippagePercent);
     }
 
-    await this.confirmSwapBtn.click();
     const confirmation = this.startTxConfirmation();
+    await this.confirmSwapBtn.click();
     await this.justApproveIfNeeded(context);
     await confirmation;
   }
@@ -947,8 +951,8 @@ export class TradePage extends BasePage {
           await this.setSlippageTolerance(slippagePercent);
         }
 
-        await this.confirmSwapBtn.click({ timeout: 5000 });
         const confirmation = this.startTxConfirmation();
+        await this.confirmSwapBtn.click({ timeout: 5000 });
         await this.justApproveIfNeeded(context);
 
         if (attempt > 0) {

--- a/packages/e2e/utils/tx-confirm.ts
+++ b/packages/e2e/utils/tx-confirm.ts
@@ -101,7 +101,13 @@ export async function pollTxOnChain(
       signal?.removeEventListener("abort", onCallerAbort);
     }
 
-    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    // Cap the inter-poll sleep to the remaining budget so we don't overshoot
+    // the deadline by up to `intervalMs` on the final iteration.
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+    await new Promise((resolve) =>
+      setTimeout(resolve, Math.min(intervalMs, remaining))
+    );
   }
 
   throw new Error(`tx ${hash} not confirmed on-chain within ${timeout}ms`);

--- a/packages/e2e/utils/tx-confirm.ts
+++ b/packages/e2e/utils/tx-confirm.ts
@@ -1,0 +1,93 @@
+/**
+ * @file tx-confirm.ts
+ * @description Proxy-safe transaction confirmation helpers for the E2E layer.
+ *
+ * Why this exists:
+ * The in-app "Transaction Successful" toast is driven by the app's WebSocket
+ * `TxTracer` (see packages/tx/src/tracer.ts). The EU/SG monitoring suites run
+ * the browser through an HTTP CONNECT proxy, over which long-lived WebSockets
+ * frequently stall or disconnect. When that happens the toast never renders
+ * even though the transaction was broadcast and included on-chain — producing
+ * false test failures.
+ *
+ * These helpers let a test confirm a transaction by polling the Osmosis LCD
+ * REST API directly from the Node test process. That fetch does NOT go through
+ * the browser proxy, so it is reliable regardless of WebSocket health.
+ */
+
+import { REST_ENDPOINT } from "./config";
+
+/** Mintscan tx URL, matching the app's Osmosis `explorerUrlToTx` format. */
+export function buildExplorerTxUrl(hash: string): string {
+  return `https://www.mintscan.io/osmosis/txs/${hash}`;
+}
+
+export interface PollTxOptions {
+  /** Overall budget in ms before giving up. */
+  timeout?: number;
+  /** Delay between polls in ms. */
+  intervalMs?: number;
+  /** Abort early (e.g. when the WebSocket toast already confirmed success). */
+  signal?: AbortSignal;
+}
+
+/**
+ * Poll `GET {REST_ENDPOINT}/cosmos/tx/v1beta1/txs/{hash}` until the tx is
+ * indexed on-chain.
+ *
+ * Resolves with the `tx_response` when the tx is included with `code === 0`.
+ * Rejects if the tx is included but failed (`code !== 0`), if the abort signal
+ * fires, or if the timeout elapses before the tx is indexed.
+ *
+ * A not-yet-indexed tx returns 404/NotFound from the LCD; that is treated as
+ * "keep polling", as are transient network errors.
+ */
+export async function pollTxOnChain(
+  hash: string,
+  { timeout = 40_000, intervalMs = 2_000, signal }: PollTxOptions = {}
+): Promise<{ code: number; height?: string; raw_log?: string }> {
+  const url = `${REST_ENDPOINT.replace(/\/+$/, "")}/cosmos/tx/v1beta1/txs/${hash}`;
+  const deadline = Date.now() + timeout;
+
+  while (Date.now() < deadline) {
+    if (signal?.aborted) {
+      throw new Error("pollTxOnChain aborted");
+    }
+
+    try {
+      const res = await fetch(url, { signal });
+      if (res.ok) {
+        const json = (await res.json()) as {
+          tx_response?: { code?: number; height?: string; raw_log?: string };
+        };
+        const txResponse = json?.tx_response;
+        if (txResponse && typeof txResponse.code === "number") {
+          if (txResponse.code === 0) {
+            return {
+              code: 0,
+              height: txResponse.height,
+              raw_log: txResponse.raw_log,
+            };
+          }
+          throw new Error(
+            `tx ${hash} failed on-chain (code ${txResponse.code}): ${
+              txResponse.raw_log ?? "no log"
+            }`
+          );
+        }
+      }
+      // 404 / not indexed yet — keep polling until the deadline.
+    } catch (err) {
+      // Re-throw a genuine on-chain failure or an abort; swallow network blips.
+      if (signal?.aborted) throw err;
+      if (err instanceof Error && err.message.startsWith(`tx ${hash} failed`)) {
+        throw err;
+      }
+      // transient fetch error — keep polling
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+
+  throw new Error(`tx ${hash} not confirmed on-chain within ${timeout}ms`);
+}

--- a/packages/e2e/utils/tx-confirm.ts
+++ b/packages/e2e/utils/tx-confirm.ts
@@ -54,8 +54,19 @@ export async function pollTxOnChain(
       throw new Error("pollTxOnChain aborted");
     }
 
+    // WHATWG fetch has no default timeout, so a single hung request could
+    // block past `deadline` and never reach the throw below. Bound each attempt
+    // (capped at 10s, never beyond the remaining budget) with an
+    // AbortController, and also abort it if the caller's signal fires (e.g. the
+    // WS toast already confirmed success).
+    const attemptController = new AbortController();
+    const onCallerAbort = () => attemptController.abort();
+    const attemptMs = Math.max(0, Math.min(deadline - Date.now(), 10_000));
+    const attemptTimer = setTimeout(() => attemptController.abort(), attemptMs);
+    signal?.addEventListener("abort", onCallerAbort, { once: true });
+
     try {
-      const res = await fetch(url, { signal });
+      const res = await fetch(url, { signal: attemptController.signal });
       if (res.ok) {
         const json = (await res.json()) as {
           tx_response?: { code?: number; height?: string; raw_log?: string };
@@ -78,12 +89,16 @@ export async function pollTxOnChain(
       }
       // 404 / not indexed yet — keep polling until the deadline.
     } catch (err) {
-      // Re-throw a genuine on-chain failure or an abort; swallow network blips.
+      // Re-throw a genuine on-chain failure or a caller abort; swallow network
+      // blips and per-attempt timeouts (the loop re-checks the deadline next).
       if (signal?.aborted) throw err;
       if (err instanceof Error && err.message.startsWith(`tx ${hash} failed`)) {
         throw err;
       }
-      // transient fetch error — keep polling
+      // transient fetch error / per-attempt timeout — keep polling
+    } finally {
+      clearTimeout(attemptTimer);
+      signal?.removeEventListener("abort", onCallerAbort);
     }
 
     await new Promise((resolve) => setTimeout(resolve, intervalMs));

--- a/packages/e2e/utils/tx-confirm.ts
+++ b/packages/e2e/utils/tx-confirm.ts
@@ -19,7 +19,7 @@ import { REST_ENDPOINT } from "./config";
 
 /** Mintscan tx URL, matching the app's Osmosis `explorerUrlToTx` format. */
 export function buildExplorerTxUrl(hash: string): string {
-  return `https://www.mintscan.io/osmosis/txs/${hash}`;
+  return `https://www.mintscan.io/osmosis/txs/${hash.toUpperCase()}`;
 }
 
 export interface PollTxOptions {


### PR DESCRIPTION
## What is the purpose of the change

Restore green EU/SG geo-monitoring (Phase B of a 3-phase E2E cleanup). Two parts:

1. **Proxy-safe tx confirmation** so a flaky WebSocket over the geo proxies can't report an on-chain tx as a failure.
2. **Run swap-only over the EU/SG proxies** — instrumenting the broadcast response proved the remaining market/limit failures were not a confirmation problem but `code 13` "insufficient fee" rejections caused by EIP base-fee drift over the slow estimate→broadcast window. Those legs are removed from the proxy regions and kept on US-direct (no frontend/product changes).

Full root-cause evidence and the deferred product-side fee-fix options are on the Linear issue.

### Linear Task

https://linear.app/osmosis/issue/MTN-98

## Brief Changelog

- `trade-page.ts`: `*AndApprove` flows confirm via `startTxConfirmation()`, which races the WS success toast against capturing the broadcast hash (`/api/broadcast-transaction`) and polling the Osmosis LCD `GET /cosmos/tx/v1beta1/txs/{hash}` directly from Node (proxy-free). Passes on whichever wins; fails only if both time out or the tx lands with a non-zero code. Broadcast `code`/`codespace`/`raw_log` are logged for diagnosability.
- `getTransactionUrl()` falls back to the captured hash (Mintscan URL) when the toast link is absent; `TradePage.goto()` retries with backoff so a proxy stall on load is recoverable instead of a `beforeAll` timeout.
- `monitoring-limit-geo-e2e-tests.yml`: removed the proxy market/limit jobs (`fe-trade-eu`, `fe-limit-eu`, `fe-trade-sg`); kept proxy swaps + all US-direct jobs; fixed downstream `fe-bot-alert` / `delete-deployments` `needs:`/`if:`.
- Add `utils/tx-confirm.ts`; `packages/e2e/README.md` documents the WS-vs-REST model and why proxy regions run swap-only.
- Review hardening (Copilot/CodeRabbit): arm `startTxConfirmation()` before the confirm click so a fast broadcast can't be missed; bound each `pollTxOnChain` fetch with a per-attempt `AbortController` timeout so a hung LCD request can't block past the deadline; `goto()` waits for the `assets.json` response (asserts `ok()`) via `Promise.all` (no unhandled rejection on retry).

Scope note: proxy health verification and the product-side `base.ts` TxTracer WS→REST fallback are tracked separately; EU/SG wallet right-sizing (now swap-only) is Phase C.

## Testing and Verifying

Validated via a dispatched geo-monitoring run on this branch — **all green on the first attempt** (no retries): EU/SG swaps pass over the proxy (REST fallback covers WS stalls), and US-direct market + limit pass. The removed proxy market/limit jobs no longer run, and the `delete-deployments` / `fe-bot-alert` gating behaves correctly.

Run: https://github.com/osmosis-labs/osmosis-frontend/actions/runs/26906878265 (commit `8354345e5`) — `preflight-us/eu/sg`, `prod-fe-swap-us/eu/sg`, `prod-fe-trade-us`, `prod-fe-limit-us` all ✅; `fe-bot-alert` correctly skipped.
