### PR TITLE
ci: replace dependabot relay's invalid trigger with scheduled REST poller (MTN-112)

### DIFF
--- a/.github/workflows/dependabot-slack-relay.yml
+++ b/.github/workflows/dependabot-slack-relay.yml
@@ -19,10 +19,17 @@ name: Dependabot Alerts -> Slack
 # CI), mirroring the missing-webhook guard.
 #
 # Dedup: stateless time window. Each run posts open alerts whose `updated_at`
-# is within the lookback window (cron interval + buffer). `updated_at` bumps on
-# create, reopen and reintroduce, so all three desired transitions are caught.
-# The buffer favours never missing an alert at the cost of a rare duplicate if
-# a scheduled run is delayed beyond the buffer.
+# is within the lookback window. `updated_at` bumps on create, reopen and
+# reintroduce, so all three desired transitions are caught.
+#
+# The window (75m) is deliberately wider than the cron interval (60m), so
+# consecutive runs ALWAYS overlap by ~15m. This is intentional: it guarantees we
+# never miss an alert even if a scheduled run starts late (GitHub's scheduler is
+# best-effort and can lag several minutes). The cost is that an alert updated
+# inside the overlap is posted by both runs, so the occasional duplicate in
+# #dependabot-alerts is expected — we favour never-miss over never-duplicate.
+# (The relay is stateless by design; true cross-run dedup would need persisted
+# state, which isn't worth the complexity for low-volume security alerts.)
 
 on:
   schedule:
@@ -86,10 +93,15 @@ jobs:
           fi
 
           # --paginate concatenates one JSON array per page; slurp + add merges
-          # them, then keep alerts updated within the window.
-          jq -s --arg since "$SINCE" -c \
+          # them, then keep alerts updated within the window. A parse failure
+          # (e.g. unexpected API response shape) warns and exits 0 rather than
+          # failing the job under `set -e` — a scheduled relay should not fail CI.
+          if ! jq -s --arg since "$SINCE" -c \
             'add | map(select(.updated_at >= $since)) | .[]' \
-            alerts_raw.json > alerts.ndjson
+            alerts_raw.json > alerts.ndjson 2> jq_err.txt; then
+            echo "::warning::Failed to parse Dependabot alerts response: $(cat jq_err.txt)"
+            exit 0
+          fi
 
           COUNT=$(wc -l < alerts.ndjson | tr -d ' ')
           echo "Found ${COUNT} alert(s) in window."
@@ -115,8 +127,13 @@ jobs:
               --arg ghsa "$GHSA" \
               --arg url "$URL" \
               '{text: ":warning: Dependabot alert *\($action)*\n*\($pkg)* (\($eco)) - *\($sev)*\n\($summary) \($ghsa)\n\($url)"}')
-            curl -sS --fail-with-body -X POST \
+            # Non-blocking: a Slack failure (non-2xx via --fail-with-body) only
+            # warns so the loop keeps relaying the remaining alerts and the job
+            # does not go red under `set -e`.
+            if ! curl -sS --fail-with-body -X POST \
               -H 'Content-type: application/json' \
               --data "$payload" \
-              "$WEBHOOK"
+              "$WEBHOOK"; then
+              echo "::warning::Slack POST failed for alert: ${GHSA:-$URL}"
+            fi
           done < alerts.ndjson

--- a/.github/workflows/dependabot-slack-relay.yml
+++ b/.github/workflows/dependabot-slack-relay.yml
@@ -1,58 +1,122 @@
 name: Dependabot Alerts -> Slack
 
-# Routes GitHub's Dependabot alert events to #dependabot-alerts via a
+# Polls the Dependabot alerts REST API on a schedule and relays newly
+# created / reopened / reintroduced alerts to #dependabot-alerts via the
 # pre-provisioned Slack incoming webhook (SLACK_WEBHOOK_DEPENDABOT_ALERTS).
 #
-# Why a custom relay: GitHub's official Slack integration's
-# `/github subscribe ... dependabot_alerts` was deprecated alongside the
-# legacy `repository_vulnerability_alert` webhook and never re-implemented
-# for the newer `dependabot_alert` event. See MTN-53 for the resolved
-# decision (Option A - relay workflow) and MTN-34 for the broader gate
-# initiative this supports.
+# Why a poller (not `on: dependabot_alert`): GitHub Actions does NOT support
+# `dependabot_alert` as a workflow trigger — it exists only as a GitHub App
+# *webhook* event, so `on: dependabot_alert` fails the push-time workflow
+# validator on every branch. The previous relay (MTN-53, PR #4365) used that
+# invalid trigger and therefore never ran. See MTN-112. The supported
+# alternatives are a webhook->repository_dispatch bridge (needs a hosted app)
+# or this scheduled REST poller (no external infra) — we use the poller.
 #
-# Trigger scope is deliberately narrow:
-#   - `created`       new vulnerability reported on a dep we use.
-#   - `reopened`      previously dismissed alert is back (e.g. dep
-#                     re-added).
-#   - `reintroduced`  a fix was reverted; vulnerability is live again.
-# Dismissals (`dismissed`, `fixed`, `auto_dismissed`) are intentionally
-# excluded so Slack doesn't get noisy on healthy churn.
+# Auth: the built-in GITHUB_TOKEN CANNOT read Dependabot alerts. This needs a
+# token with "Dependabot alerts: read" (fine-grained PAT) or `security_events`
+# / `repo` (classic PAT), stored as the repo secret DEPENDABOT_ALERTS_READ_TOKEN.
+# Until that secret is added the job no-ops with a warning (so it never fails
+# CI), mirroring the missing-webhook guard.
+#
+# Dedup: stateless time window. Each run posts open alerts whose `updated_at`
+# is within the lookback window (cron interval + buffer). `updated_at` bumps on
+# create, reopen and reintroduce, so all three desired transitions are caught.
+# The buffer favours never missing an alert at the cost of a rare duplicate if
+# a scheduled run is delayed beyond the buffer.
 
 on:
-  dependabot_alert:
-    types: [created, reopened, reintroduced]
+  schedule:
+    # Hourly, offset off the top of the hour to dodge scheduler congestion.
+    - cron: "7 * * * *"
+  workflow_dispatch:
+    inputs:
+      lookback_minutes:
+        description: "How far back to scan for new/updated alerts (minutes)"
+        type: string
+        default: "75"
 
-# Workflow only POSTs to an external Slack webhook; it neither reads the repo
-# nor uses GITHUB_TOKEN, so grant no token permissions at all.
+# We authenticate with DEPENDABOT_ALERTS_READ_TOKEN (a PAT/App token), not the
+# Actions GITHUB_TOKEN, so no GITHUB_TOKEN permissions are needed.
 permissions: {}
 
+concurrency:
+  group: dependabot-slack-relay
+  cancel-in-progress: false
+
 jobs:
-  notify:
+  relay:
     runs-on: ubuntu-latest
     steps:
-      - name: Post to Slack
+      - name: Poll Dependabot alerts and relay new ones to Slack
         env:
+          GH_TOKEN: ${{ secrets.DEPENDABOT_ALERTS_READ_TOKEN }}
           WEBHOOK: ${{ secrets.SLACK_WEBHOOK_DEPENDABOT_ALERTS }}
-          ACTION: ${{ github.event.action }}
-          PKG: ${{ github.event.alert.dependency.package.name }}
-          ECO: ${{ github.event.alert.dependency.package.ecosystem }}
-          SEV: ${{ github.event.alert.security_advisory.severity }}
-          SUMMARY: ${{ github.event.alert.security_advisory.summary }}
-          URL: ${{ github.event.alert.html_url }}
+          REPO: ${{ github.repository }}
+          LOOKBACK_MINUTES: ${{ github.event.inputs.lookback_minutes || '75' }}
         run: |
-          if [ -z "$WEBHOOK" ]; then
-            echo "::warning::SLACK_WEBHOOK_DEPENDABOT_ALERTS is not set; skipping"
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::warning::DEPENDABOT_ALERTS_READ_TOKEN is not set; skipping (needs a token with 'Dependabot alerts: read')."
             exit 0
           fi
-          payload=$(jq -nc \
-            --arg action "$ACTION" \
-            --arg pkg "$PKG" \
-            --arg eco "$ECO" \
-            --arg sev "$SEV" \
-            --arg summary "$SUMMARY" \
-            --arg url "$URL" \
-            '{text: ":warning: Dependabot alert *\($action)*\n*\($pkg)* (\($eco)) - *\($sev)*\n\($summary)\n\($url)"}')
-          curl -sS --fail-with-body -X POST \
-            -H 'Content-type: application/json' \
-            --data "$payload" \
-            "$WEBHOOK"
+          if [ -z "$WEBHOOK" ]; then
+            echo "::warning::SLACK_WEBHOOK_DEPENDABOT_ALERTS is not set; skipping."
+            exit 0
+          fi
+
+          # Guard the lookback against bad manual input.
+          if ! [[ "$LOOKBACK_MINUTES" =~ ^[0-9]+$ ]]; then
+            echo "::warning::Invalid lookback_minutes '$LOOKBACK_MINUTES'; defaulting to 75."
+            LOOKBACK_MINUTES=75
+          fi
+
+          # Window start (UTC ISO-8601). Open alerts updated at/after this are
+          # candidates to relay.
+          SINCE=$(date -u -d "-${LOOKBACK_MINUTES} minutes" +%Y-%m-%dT%H:%M:%SZ)
+          echo "Scanning open Dependabot alerts updated since $SINCE"
+
+          # Fetch all open alerts (Link-header paginated). gh uses $GH_TOKEN.
+          # A failed fetch (auth/transient) warns and exits 0 — a scheduled
+          # relay should not fail CI noisily.
+          if ! gh api --paginate \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/$REPO/dependabot/alerts?state=open&per_page=100&sort=updated&direction=desc" \
+            > alerts_raw.json 2> gh_err.txt; then
+            echo "::warning::Failed to fetch Dependabot alerts: $(cat gh_err.txt)"
+            exit 0
+          fi
+
+          # --paginate concatenates one JSON array per page; slurp + add merges
+          # them, then keep alerts updated within the window.
+          jq -s --arg since "$SINCE" -c \
+            'add | map(select(.updated_at >= $since)) | .[]' \
+            alerts_raw.json > alerts.ndjson
+
+          COUNT=$(wc -l < alerts.ndjson | tr -d ' ')
+          echo "Found ${COUNT} alert(s) in window."
+          if [ "$COUNT" = "0" ]; then
+            exit 0
+          fi
+
+          while IFS= read -r alert; do
+            [ -z "$alert" ] && continue
+            ACTION=$(echo "$alert" | jq -r 'if .created_at == .updated_at then "created" else "reopened/updated" end')
+            PKG=$(echo "$alert" | jq -r '.dependency.package.name // "unknown"')
+            ECO=$(echo "$alert" | jq -r '.dependency.package.ecosystem // "unknown"')
+            SEV=$(echo "$alert" | jq -r '.security_advisory.severity // "unknown"')
+            SUMMARY=$(echo "$alert" | jq -r '.security_advisory.summary // ""')
+            GHSA=$(echo "$alert" | jq -r '.security_advisory.ghsa_id // ""')
+            URL=$(echo "$alert" | jq -r '.html_url // ""')
+            payload=$(jq -nc \
+              --arg action "$ACTION" \
+              --arg pkg "$PKG" \
+              --arg eco "$ECO" \
+              --arg sev "$SEV" \
+              --arg summary "$SUMMARY" \
+              --arg ghsa "$GHSA" \
+              --arg url "$URL" \
+              '{text: ":warning: Dependabot alert *\($action)*\n*\($pkg)* (\($eco)) - *\($sev)*\n\($summary) \($ghsa)\n\($url)"}')
+            curl -sS --fail-with-body -X POST \
+              -H 'Content-type: application/json' \
+              --data "$payload" \
+              "$WEBHOOK"
+          done < alerts.ndjson


### PR DESCRIPTION
## Summary

Replaces the broken Dependabot→Slack relay with a working scheduled poller.

`on: dependabot_alert` is **not** a valid GitHub Actions trigger (it's an App webhook event only), so the relay shipped under MTN-53 (PR #4365) never ran *and* failed the workflow validator on every push to every branch.

This rewrites `.github/workflows/dependabot-slack-relay.yml` as an **hourly `schedule` + `workflow_dispatch`** poller that:
- Lists open alerts via `GET /repos/{owner}/{repo}/dependabot/alerts` (paginated).
- Relays alerts whose `updated_at` falls within a lookback window (covers created / reopened / reintroduced) to `#dependabot-alerts` via the existing `SLACK_WEBHOOK_DEPENDABOT_ALERTS` webhook.
- No-ops with a warning (never fails CI) if its token or webhook secret is missing, or on a transient API error.

Fixing the invalid trigger also stops the per-push "invalid workflow file" noise on all branches.

Detail / context: [MTN-112](https://linear.app/osmosis/issue/MTN-112/fix-dependabot-slack-relay-uses-unsupported-dependabot-alert-actions)

## Required before this works (action item)

The Actions `GITHUB_TOKEN` **cannot** read Dependabot alerts. Add a repo secret **`DEPENDABOT_ALERTS_READ_TOKEN`** holding a token with `Dependabot alerts: read` (fine-grained PAT) or `security_events` / `repo` (classic PAT). Until then the job no-ops with a warning.

## Test plan

- [ ] Add `DEPENDABOT_ALERTS_READ_TOKEN`, then `workflow_dispatch` with a large `lookback_minutes` (e.g. `100000`) to backfill-verify it posts current open alerts to `#dependabot-alerts`.
- [ ] Confirm the hourly schedule run posts nothing when there are no recent alerts (empty window) and doesn't fail.
- [x] YAML validates; window-filter + created/reopened detection verified locally.
