### PR TITLE
ci(e2e): fix monitoring topup auto-dispatch missing repo context (follow-up MTN-97/MTN-110)

### DIFF
--- a/.github/workflows/monitoring-limit-geo-e2e-tests.yml
+++ b/.github/workflows/monitoring-limit-geo-e2e-tests.yml
@@ -270,9 +270,13 @@ jobs:
       contents: read
     steps:
       - name: Trigger automatic topup (deduplicated)
-        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # This job has no `actions/checkout`, so `gh` can't infer the repo
+          # from a local git remote (it would fail with "not a git repository").
+          # `GH_REPO` tells `gh` which repo to operate on for both the cooldown
+          # `gh run list` lookup and the `gh workflow run` dispatch below.
+          GH_REPO: ${{ github.repository }}
           US_OUTCOME: ${{ needs.preflight-us.outputs.outcome }}
           EU_OUTCOME: ${{ needs.preflight-eu.outputs.outcome }}
           SG_OUTCOME: ${{ needs.preflight-sg.outputs.outcome }}


### PR DESCRIPTION
## Summary

Follow-up to MTN-97 (#4369) / MTN-110 (#4371).

The consolidated `topup-dispatch` job introduced in #4369 (in `monitoring-limit-geo-e2e-tests.yml`) has **no `actions/checkout` step**. `gh` resolves its target repo from the local git remote, so with no checkout both `gh run list` (cooldown lookup) and `gh workflow run` (the actual dispatch) fail with:

```
failed to determine base repo: failed to run git: fatal: not a git repository
```

Because the step was `continue-on-error: true`, the job stayed green while **no topup was ever auto-dispatched**. Monitoring US/EU/SG were never refilled, so the hourly `🚨 E2E Critical Balance Alert` (e.g. Monitoring US USDC stuck at ~6.94 < min 7) kept firing every cron tick.

Verified from run [`27011568418`](https://github.com/osmosis-labs/osmosis-frontend/actions/runs/27011568418), job `topup-dispatch`: `US_OUTCOME: fail` → `failed to determine base repo` → `exit code 1` (swallowed). The only recent x3.0 topup was a manual dispatch, confirming the auto-path has never fired since #4369.

## Changes

- Add `GH_REPO: ${{ github.repository }}` to the `Trigger automatic topup (deduplicated)` step so `gh` targets the repo without needing a checkout — fixes both the cooldown lookup and the dispatch.
- Drop `continue-on-error: true` on that step so a future dispatch regression fails loudly instead of being silently masked (this masking is what hid the bug for the life of the feature). The job is independent of the test/deploy jobs, so failing it only affects dispatch visibility.

## Test plan

- [ ] After merge to `stage`, on the next hourly cron (or a manual `workflow_dispatch`) confirm the `topup-dispatch` job log shows `Topup workflow dispatched (US=... EU=... SG=...)` instead of the git error.
- [ ] Confirm a new `E2E: Topup Test Accounts` run (title `Topup — E2E accounts (x3.0)`) appears and Monitoring US USDC rises to ~warnAmount x 3 (≈ 25 USDC), stopping the recurring critical alert.
