### PR TITLE
ci: migrate GitHub Actions off deprecated Node 20 runtime (MTN-120)

### DIFF
--- a/.github/workflows/cancel-open-orders.yml
+++ b/.github/workflows/cancel-open-orders.yml
@@ -42,18 +42,19 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             packages/e2e
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: 22.x
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: "**/node_modules"
           key: ${{ runner.OS }}-22.x-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/check-balances.yml
+++ b/.github/workflows/check-balances.yml
@@ -24,13 +24,14 @@ jobs:
             key_id: us
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             packages/e2e
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: 22.x
       - name: Install dependencies
         run: yarn --cwd packages/e2e install --frozen-lockfile

--- a/.github/workflows/e2e-migrate-funds.yml
+++ b/.github/workflows/e2e-migrate-funds.yml
@@ -58,18 +58,19 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             packages/e2e
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: 22.x
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: "**/node_modules"
           key: ${{ runner.OS }}-22.x-${{ hashFiles('**/yarn.lock') }}
@@ -115,18 +116,19 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             packages/e2e
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: 22.x
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: "**/node_modules"
           key: ${{ runner.OS }}-22.x-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/e2e-topup-accounts.yml
+++ b/.github/workflows/e2e-topup-accounts.yml
@@ -50,18 +50,19 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             packages/e2e
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: 22.x
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: "**/node_modules"
           key: ${{ runner.OS }}-22.x-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -77,8 +77,10 @@ jobs:
       - name: Send low-balance Slack alert
         if: steps.balance-check.outcome == 'failure' && steps.balance-details.outputs.is_balance_issue == 'true'
         continue-on-error: true
-        uses: slackapi/slack-github-action@v1.26.0
+        uses: slackapi/slack-github-action@v3
         with:
+          webhook: ${{ secrets.E2E_SLACK_WEBHOOK_BALANCE_ALERTS }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "text": "${{ steps.balance-details.outputs.outcome == 'fail' && '🚨 E2E Critical Balance Alert' || '⚠️ E2E Low Balance Warning' }}",
@@ -96,9 +98,6 @@ jobs:
                 }
               ]
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.E2E_SLACK_WEBHOOK_BALANCE_ALERTS }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
       # Auto-dispatch a topup when the preview account is low (restored in
       # MTN-110). Phase A (MTN-97) removed this and delegated funding to the
       # hourly monitoring-limit-geo topup-dispatch job, but that job only gates

--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -16,7 +16,7 @@ jobs:
       environment_url: ${{steps.vercel.outputs.environment_url}}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - id: vercel
         env:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
@@ -37,13 +37,14 @@ jobs:
       contents: read
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             packages/e2e
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: 22.x
       - name: Install dependencies
         run: yarn --cwd packages/e2e install --frozen-lockfile
@@ -185,7 +186,7 @@ jobs:
       unexpected: ${{ steps.set-output.outputs.unexpected }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             packages/e2e
@@ -197,8 +198,9 @@ jobs:
           echo "$BASE_URL"
           echo "$BRANCH_NAME"
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: 22.x
       - name: Install Playwright
         run: |
@@ -224,7 +226,7 @@ jobs:
       - name: upload Swap test results
         if: failure() || success()
         id: swap-test-results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: osmo-swap-test-results
           path: packages/e2e/playwright-report
@@ -235,7 +237,7 @@ jobs:
     needs: [wait-for-deployment, preview-swap-osmo-tests, check-balances]
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             packages/e2e
@@ -247,11 +249,12 @@ jobs:
           echo "$BASE_URL"
           echo "$BRANCH_NAME"
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: 22.x
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: "**/node_modules"
           key: ${{ runner.OS }}-22.x-${{ hashFiles('**/yarn.lock') }}
@@ -275,7 +278,7 @@ jobs:
       - name: upload Swap test results
         if: failure() || success()
         id: swap-test-results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: usdc-swap-test-results
           path: packages/e2e/playwright-report
@@ -286,16 +289,17 @@ jobs:
     runs-on: macos-14
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             packages/e2e
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: 22.x
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: "**/node_modules"
           key: ${{ runner.OS }}-22.x-${{ hashFiles('**/yarn.lock') }}
@@ -318,7 +322,7 @@ jobs:
       - name: upload Portfolio and transactions test results
         if: failure()
         id: portfolio-test-results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: preview-portfolio-trx-test-results
           path: packages/e2e/playwright-report
@@ -329,16 +333,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             packages/e2e
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: 22.x
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: "**/node_modules"
           key: ${{ runner.OS }}-22.x-${{ hashFiles('**/yarn.lock') }}
@@ -356,7 +361,7 @@ jobs:
       - name: upload pools test results
         if: failure()
         id: pools-test-results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: preview-pools-test-results
           path: packages/e2e/playwright-report
@@ -368,16 +373,17 @@ jobs:
       [wait-for-deployment, preview-swap-osmo-tests, preview-swap-usdc-tests, check-balances]
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             packages/e2e
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: 22.x
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: "**/node_modules"
           key: ${{ runner.OS }}-22.x-${{ hashFiles('**/yarn.lock') }}
@@ -407,7 +413,7 @@ jobs:
       - name: upload Trade test results
         if: failure()
         id: preview-trade-test-results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: preview-trade-test-results
           path: packages/e2e/playwright-report
@@ -418,16 +424,17 @@ jobs:
     needs: [wait-for-deployment, check-balances]
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             packages/e2e
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: 22.x
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: "**/node_modules"
           key: ${{ runner.OS }}-22.x-${{ hashFiles('**/yarn.lock') }}
@@ -451,7 +458,7 @@ jobs:
       - name: upload Claim test results
         if: failure()
         id: claim-test-results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: preview-claim-test-results
           path: packages/e2e/playwright-report

--- a/.github/workflows/jest-tests.yml
+++ b/.github/workflows/jest-tests.yml
@@ -24,15 +24,16 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: ${{ matrix.node-version }}
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: "**/node_modules"
           key: ${{ runner.OS }}-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/lint-and-check-format.yml
+++ b/.github/workflows/lint-and-check-format.yml
@@ -7,15 +7,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: 22.x
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: "**/node_modules"
           key: ${{ runner.OS }}-22.x-${{ hashFiles('**/yarn.lock') }}
@@ -37,15 +38,16 @@ jobs:
 
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: ${{ matrix.node-version }}
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: "**/node_modules"
           key: ${{ runner.OS }}-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/monitoring-e2e-tests.yml
+++ b/.github/workflows/monitoring-e2e-tests.yml
@@ -36,9 +36,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: "**/node_modules"
-          key: ${{ runner.OS }}-20.x-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.OS }}-22.x-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.OS }}-20.x-
+            ${{ runner.OS }}-22.x-
 
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
@@ -107,9 +107,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: "**/node_modules"
-          key: ${{ runner.OS }}-20.x-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.OS }}-22.x-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.OS }}-20.x-
+            ${{ runner.OS }}-22.x-
       - name: Install Playwright
         run: |
           yarn --cwd packages/e2e install --frozen-lockfile && npx playwright install --with-deps chromium

--- a/.github/workflows/monitoring-e2e-tests.yml
+++ b/.github/workflows/monitoring-e2e-tests.yml
@@ -24,15 +24,16 @@ jobs:
       matrix: ${{fromJson(needs.setup-matrix.outputs.matrix)}}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: 22.x
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: "**/node_modules"
           key: ${{ runner.OS }}-20.x-${{ hashFiles('**/yarn.lock') }}
@@ -93,16 +94,17 @@ jobs:
       - name: Echo IP
         run: curl -L "https://ipinfo.io" -s
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             packages/e2e
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: 22.x
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: "**/node_modules"
           key: ${{ runner.OS }}-20.x-${{ hashFiles('**/yarn.lock') }}
@@ -120,7 +122,7 @@ jobs:
       - name: upload test results
         if: failure()
         id: e2e-test-results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.env }}-quote-test-results
           path: packages/e2e/playwright-report
@@ -131,7 +133,7 @@ jobs:
     needs: [server-e2e-tests, fe-quote-tests]
     steps:
       - name: Delete Previous deployments
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           debug: true
           script: |

--- a/.github/workflows/monitoring-limit-geo-e2e-tests.yml
+++ b/.github/workflows/monitoring-limit-geo-e2e-tests.yml
@@ -80,8 +80,10 @@ jobs:
       - name: Send low-balance Slack alert
         if: steps.balance-details.outputs.outcome == 'warn' || steps.balance-details.outputs.outcome == 'fail'
         continue-on-error: true
-        uses: slackapi/slack-github-action@v1.26.0
+        uses: slackapi/slack-github-action@v3
         with:
+          webhook: ${{ secrets.E2E_SLACK_WEBHOOK_BALANCE_ALERTS }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "text": "${{ steps.balance-details.outputs.outcome == 'fail' && '🚨 E2E Critical Balance Alert' || '⚠️ E2E Low Balance Warning' }}",
@@ -99,9 +101,6 @@ jobs:
                 }
               ]
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.E2E_SLACK_WEBHOOK_BALANCE_ALERTS }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
   preflight-eu:
     name: preflight-eu-balance
@@ -150,8 +149,10 @@ jobs:
       - name: Send low-balance Slack alert
         if: steps.balance-details.outputs.outcome == 'warn' || steps.balance-details.outputs.outcome == 'fail'
         continue-on-error: true
-        uses: slackapi/slack-github-action@v1.26.0
+        uses: slackapi/slack-github-action@v3
         with:
+          webhook: ${{ secrets.E2E_SLACK_WEBHOOK_BALANCE_ALERTS }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "text": "${{ steps.balance-details.outputs.outcome == 'fail' && '🚨 E2E Critical Balance Alert' || '⚠️ E2E Low Balance Warning' }}",
@@ -169,9 +170,6 @@ jobs:
                 }
               ]
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.E2E_SLACK_WEBHOOK_BALANCE_ALERTS }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
   preflight-sg:
     name: preflight-sg-balance
@@ -220,8 +218,10 @@ jobs:
       - name: Send low-balance Slack alert
         if: steps.balance-details.outputs.outcome == 'warn' || steps.balance-details.outputs.outcome == 'fail'
         continue-on-error: true
-        uses: slackapi/slack-github-action@v1.26.0
+        uses: slackapi/slack-github-action@v3
         with:
+          webhook: ${{ secrets.E2E_SLACK_WEBHOOK_BALANCE_ALERTS }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "text": "${{ steps.balance-details.outputs.outcome == 'fail' && '🚨 E2E Critical Balance Alert' || '⚠️ E2E Low Balance Warning' }}",
@@ -239,9 +239,6 @@ jobs:
                 }
               ]
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.E2E_SLACK_WEBHOOK_BALANCE_ALERTS }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
   # -------------------------------------------------------------------------
   # Single, deduplicated topup dispatcher (Phase A / MTN-97).

--- a/.github/workflows/monitoring-limit-geo-e2e-tests.yml
+++ b/.github/workflows/monitoring-limit-geo-e2e-tests.yml
@@ -43,13 +43,14 @@ jobs:
       outcome: ${{ steps.balance-details.outputs.outcome }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             packages/e2e
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: 22.x
       - name: Install dependencies
         run: yarn --cwd packages/e2e install --frozen-lockfile
@@ -112,13 +113,14 @@ jobs:
       outcome: ${{ steps.balance-details.outputs.outcome }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             packages/e2e
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: 22.x
       - name: Install dependencies
         run: yarn --cwd packages/e2e install --frozen-lockfile
@@ -181,13 +183,14 @@ jobs:
       outcome: ${{ steps.balance-details.outputs.outcome }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             packages/e2e
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: 22.x
       - name: Install dependencies
         run: yarn --cwd packages/e2e install --frozen-lockfile
@@ -338,16 +341,17 @@ jobs:
     if: needs.preflight-us.outputs.outcome != 'fail'
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             packages/e2e
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: 22.x
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: "**/node_modules"
           key: ${{ runner.OS }}-22.x-${{ hashFiles('**/yarn.lock') }}
@@ -370,7 +374,7 @@ jobs:
       - name: upload test results
         if: failure()
         id: e2e-test-results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: us-swap-test-results-${{ github.run_id }}
           path: packages/e2e/playwright-report
@@ -383,16 +387,17 @@ jobs:
     if: needs.preflight-eu.outputs.outcome != 'fail'
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             packages/e2e
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: 22.x
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: "**/node_modules"
           key: ${{ runner.OS }}-22.x-${{ hashFiles('**/yarn.lock') }}
@@ -419,7 +424,7 @@ jobs:
       - name: upload test results
         if: failure()
         id: e2e-test-results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: eu-swap-test-results-${{ github.run_id }}
           path: packages/e2e/playwright-report
@@ -434,16 +439,17 @@ jobs:
       - name: Echo IP
         run: curl -L "https://ipinfo.io" -s
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             packages/e2e
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: 22.x
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: "**/node_modules"
           key: ${{ runner.OS }}-22.x-${{ hashFiles('**/yarn.lock') }}
@@ -470,7 +476,7 @@ jobs:
       - name: upload test results
         if: failure()
         id: e2e-test-results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: sg-swap-test-results-${{ github.run_id }}
           path: packages/e2e/playwright-report
@@ -485,16 +491,17 @@ jobs:
       unexpected: ${{ steps.set-output.outputs.unexpected }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             packages/e2e
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: 22.x
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: "**/node_modules"
           key: ${{ runner.OS }}-22.x-${{ hashFiles('**/yarn.lock') }}
@@ -522,7 +529,7 @@ jobs:
       - name: upload monitoring test results
         if: failure() || cancelled()
         id: monitoring-test-results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: us-trade-test-results-${{ github.run_id }}
           path: packages/e2e/playwright-report
@@ -537,16 +544,17 @@ jobs:
       unexpected: ${{ steps.set-output.outputs.unexpected }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             packages/e2e
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: 22.x
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: "**/node_modules"
           key: ${{ runner.OS }}-22.x-${{ hashFiles('**/yarn.lock') }}
@@ -582,7 +590,7 @@ jobs:
       - name: upload monitoring test results
         if: failure() || cancelled()
         id: monitoring-test-results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: us-limit-test-results-${{ github.run_id }}
           path: packages/e2e/playwright-report
@@ -638,7 +646,7 @@ jobs:
       ]
     steps:
       - name: Delete Previous deployments
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           debug: true
           script: |

--- a/.github/workflows/monitoring-quote-geo-e2e-tests.yml
+++ b/.github/workflows/monitoring-quote-geo-e2e-tests.yml
@@ -27,16 +27,17 @@ jobs:
       - name: Echo IP
         run: curl -L "https://ipinfo.io" -s
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             packages/e2e
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: 22.x
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: "**/node_modules"
           key: ${{ runner.OS }}-22.x-${{ hashFiles('**/yarn.lock') }}
@@ -58,7 +59,7 @@ jobs:
       - name: upload test results
         if: failure()
         id: e2e-test-results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.env }}-quote-test-results
           path: packages/e2e/playwright-report
@@ -101,7 +102,7 @@ jobs:
     needs: [fe-quote-tests, fe-bot-alert]
     steps:
       - name: Delete Previous deployments
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           debug: true
           script: |

--- a/.github/workflows/pr-notification.yml
+++ b/.github/workflows/pr-notification.yml
@@ -9,12 +9,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Slack Notification
-        uses: 8398a7/action-slack@v3
+        uses: slackapi/slack-github-action@v3
         with:
-          status: ${{ job.status }}
-          text: New PR opened to master branch
-          author_name: GitHub Action
-          fields: repo,message,commit,author,action,eventName,ref,workflow
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ANNOUNCEMENT_WEBHOOK_URL }}
+          webhook: ${{ secrets.SLACK_ANNOUNCEMENT_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          # PR title is escaped via toJSON so quotes/backslashes can't break the payload JSON.
+          payload: |
+            {
+              "text": ${{ toJSON(format('New PR opened to master branch: {0}', github.event.pull_request.title)) }},
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": { "type": "plain_text", "text": "New PR opened to master branch", "emoji": true }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ${{ toJSON(format('*<{0}|#{1}: {2}>*', github.event.pull_request.html_url, github.event.pull_request.number, github.event.pull_request.title)) }}
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    { "type": "mrkdwn", "text": ${{ toJSON(format('*Repository:* {0}', github.repository)) }} },
+                    { "type": "mrkdwn", "text": ${{ toJSON(format('*Author:* {0}', github.event.pull_request.user.login)) }} },
+                    { "type": "mrkdwn", "text": ${{ toJSON(format('*Branch:* {0} → {1}', github.event.pull_request.head.ref, github.event.pull_request.base.ref)) }} }
+                  ]
+                }
+              ]
+            }

--- a/.github/workflows/prod-frontend-e2e-tests.yml
+++ b/.github/workflows/prod-frontend-e2e-tests.yml
@@ -76,8 +76,10 @@ jobs:
       - name: Send low-balance Slack alert
         if: steps.balance-check.outcome == 'failure' && steps.balance-details.outputs.is_balance_issue == 'true'
         continue-on-error: true
-        uses: slackapi/slack-github-action@v1.26.0
+        uses: slackapi/slack-github-action@v3
         with:
+          webhook: ${{ secrets.E2E_SLACK_WEBHOOK_BALANCE_ALERTS }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "text": "${{ steps.balance-details.outputs.outcome == 'fail' && '🚨 E2E Critical Balance Alert' || '⚠️ E2E Low Balance Warning' }}",
@@ -95,9 +97,6 @@ jobs:
                 }
               ]
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.E2E_SLACK_WEBHOOK_BALANCE_ALERTS }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
       - name: Trigger automatic topup
         if: steps.balance-check.outcome == 'failure'
         continue-on-error: true
@@ -217,8 +216,10 @@ jobs:
       - name: Send Slack alert if test fails
         id: slack
         if: failure() && github.run_attempt == 1
-        uses: slackapi/slack-github-action@v1.26.0
+        uses: slackapi/slack-github-action@v3
         with:
+          webhook: ${{ secrets.E2E_SLACK_WEBHOOK_MONITOR_CHAIN_LOW }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "text": "🚨 FE E2E Tests Failure Alert 🚨",
@@ -246,9 +247,6 @@ jobs:
                 }
               ]
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.E2E_SLACK_WEBHOOK_MONITOR_CHAIN_LOW }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
   prod-pools-and-select-pair-tests:
     timeout-minutes: 10

--- a/.github/workflows/prod-frontend-e2e-tests.yml
+++ b/.github/workflows/prod-frontend-e2e-tests.yml
@@ -189,9 +189,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: "**/node_modules"
-          key: ${{ runner.OS }}-20.x-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.OS }}-22.x-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.OS }}-20.x-
+            ${{ runner.OS }}-22.x-
       - name: Install Playwright
         run: |
           yarn --cwd packages/e2e install --frozen-lockfile && npx playwright install --with-deps chromium
@@ -267,9 +267,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: "**/node_modules"
-          key: ${{ runner.OS }}-20.x-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.OS }}-22.x-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.OS }}-20.x-
+            ${{ runner.OS }}-22.x-
       - name: Install Playwright
         run: |
           yarn --cwd packages/e2e install --frozen-lockfile && npx playwright install --with-deps chromium

--- a/.github/workflows/prod-frontend-e2e-tests.yml
+++ b/.github/workflows/prod-frontend-e2e-tests.yml
@@ -13,7 +13,7 @@ jobs:
       environment_url: ${{steps.vercel.outputs.environment_url}}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - id: vercel
         env:
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
@@ -35,14 +35,15 @@ jobs:
       contents: read
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             packages/e2e
           ref: master
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: 22.x
       - name: Install dependencies
         run: yarn --cwd packages/e2e install --frozen-lockfile
@@ -175,17 +176,18 @@ jobs:
       name: prod_swap_test
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             packages/e2e
           ref: master
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: 22.x
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: "**/node_modules"
           key: ${{ runner.OS }}-20.x-${{ hashFiles('**/yarn.lock') }}
@@ -208,7 +210,7 @@ jobs:
       - name: upload test results
         if: always()
         id: e2e-test-results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: prod-e2e-test-results-${{ github.run_id }}
           path: packages/e2e/playwright-report
@@ -254,16 +256,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: |
             packages/e2e
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: 22.x
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: "**/node_modules"
           key: ${{ runner.OS }}-20.x-${{ hashFiles('**/yarn.lock') }}
@@ -281,7 +284,7 @@ jobs:
       - name: upload pools test results
         if: failure()
         id: pools-test-results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: prod-pools-test-results-${{ github.run_id }}
           path: packages/e2e/playwright-report

--- a/.github/workflows/push-docker-images.yaml
+++ b/.github/workflows/push-docker-images.yaml
@@ -28,7 +28,7 @@ jobs:
     steps:
       -
         name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       -
         name: Get Short SHA
         uses: benjlevesque/short-sha@v2.1

--- a/.github/workflows/push-docker-images.yaml
+++ b/.github/workflows/push-docker-images.yaml
@@ -31,16 +31,16 @@ jobs:
         uses: actions/checkout@v6
       -
         name: Get Short SHA
-        uses: benjlevesque/short-sha@v2.1
+        uses: benjlevesque/short-sha@v4.0
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       -
         name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -50,7 +50,7 @@ jobs:
           echo "DATE=$(date +%s)" >> $GITHUB_ENV
       -
         name: Build and push (main)
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           file: ./docker/Dockerfile
           context: .
@@ -62,7 +62,7 @@ jobs:
             ${{ env.FRONTEND_DOCKER_REPOSITORY }}:latest
       -
         name: Build and push (testnet)
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           file: ./docker/Dockerfile.testnet
           context: .

--- a/.github/workflows/server-e2e-tests.yml
+++ b/.github/workflows/server-e2e-tests.yml
@@ -41,9 +41,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: "**/node_modules"
-          key: ${{ runner.OS }}-20.x-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.OS }}-22.x-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.OS }}-20.x-
+            ${{ runner.OS }}-22.x-
 
       - name: Install Dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/server-e2e-tests.yml
+++ b/.github/workflows/server-e2e-tests.yml
@@ -29,15 +29,16 @@ jobs:
       matrix: ${{fromJson(needs.setup-matrix.outputs.matrix)}}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
+          package-manager-cache: false
           node-version: 22.x
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: "**/node_modules"
           key: ${{ runner.OS }}-20.x-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
## Summary

Migrate this repo's GitHub Actions off the deprecated Node 20 runtime (GitHub forces JS actions onto Node 24 on 2026-06-16; Node 20 removed from runners in fall 2026).

- Bumped all affected `actions/*` to their Node 24 majors across 13 workflows: `checkout@v6`, `setup-node@v6`, `cache@v5`, `upload-artifact@v6`, `github-script@v8`.
- `upload-artifact` goes to **v6** intentionally — v5 still defaults to Node 20 and would not clear the warning.
- Added `package-manager-cache: false` to every `actions/setup-node` step. setup-node v5+ auto-enables yarn caching when a `packageManager` field is present (`yarn@1.22.22`); disabling it preserves the existing manual `actions/cache` behavior so this PR changes only the runtime, not caching.
- Part of the org-wide Node 20 migration umbrella **MTN-106**; this PR covers osmosis-frontend (**MTN-120**).

## Verification

Confirmed **zero** "Node.js 20 actions are deprecated" warnings across all triggered runs.

| Workflow | Safe to trigger-test w/o impact? | Result |
| --- | --- | --- |
| lint-and-check-format.yml | Yes (CI only) | Auto on push — PASS |
| jest-tests.yml | Yes (CI only) | Auto on push — PASS |
| server-e2e-tests.yml | Yes (CI only) | Auto on push — PASS |
| frontend-e2e-tests.yml | Partial (test-wallet funds) | 7/8 jobs PASS; `preview-trade-tests` failed on pre-existing insufficient-balance flake (out of scope) |
| monitoring-quote-geo-e2e-tests.yml | Yes (read-only quotes) | Dispatched on branch — PASS |
| check-balances.yml | Yes (read-only) | Dispatched on branch — PASS |
| prod-frontend-e2e-tests.yml | No (prod) | Not run on branch |
| monitoring-e2e-tests.yml | No (mainnet/funds) | Verify post-merge on schedule |
| monitoring-limit-geo-e2e-tests.yml | No (trades + auto-topup) | Verify post-merge on schedule |
| cancel-open-orders.yml | No (mutates orders; dry_run avail) | Dispatch w/ dry_run only |
| e2e-topup-accounts.yml | No (sends funds; dry_run avail) | Dispatch w/ dry_run only |
| e2e-migrate-funds.yml | No (moves funds) | Manual dispatch only |
| push-docker-images.yaml | No (publishes images) | Validates on stage merge (checkout-only change) |

## Test plan

- [x] Lint, Jest, Server E2E green on push with no Node 20 deprecation warning
- [x] `check-balances` and `monitoring-quote-geo` dispatched against the branch — both PASS
- [x] `upload-artifact@v6` confirmed uploading artifacts on a failed E2E run
- [ ] `push-docker-images` will get its first real run on the stage merge (checkout-only)

Out of scope: third-party actions (e.g. `8398a7/action-slack` in `pr-notification.yml`) and the pre-existing E2E test-wallet balance flakiness.
