### PR TITLE
fix(web): fix inverted REST endpoint allowlist in broadcast-transaction

### DIFF
--- a/packages/web/__tests__/broadcast-transaction.spec.ts
+++ b/packages/web/__tests__/broadcast-transaction.spec.ts
@@ -9,11 +9,31 @@ jest.mock("~/config/generated/chain-list", () => ({
   ChainList: [
     {
       apis: {
-        rest: [{ address: "https://fake-endpoint.com" }],
+        rest: [
+          { address: "https://fake-endpoint.com" },
+          { address: "https://lcd.osmosis.zone" },
+          { address: "https://rest.cosmos.directory/osmosis" },
+        ],
       },
     },
   ],
 }));
+
+const validTxBody = {
+  tx_bytes: "bytes",
+  mode: "sync",
+};
+
+async function expectInvalidRestEndpoint(restEndpoint: string) {
+  const req = {
+    method: "POST",
+    json: () => Promise.resolve({ restEndpoint, ...validTxBody }),
+  } as unknown as Request;
+
+  const result = await broadcastTransactionHandler(req);
+  expect(result.status).toBe(400);
+  expect(await result.json()).toEqual({ error: "Invalid rest endpoint" });
+}
 
 it("should return method not allowed if not a POST request", async () => {
   const req = { method: "GET" } as Request;
@@ -68,6 +88,49 @@ it("should successfully broadcast transaction", async () => {
   const result = await broadcastTransactionHandler(req);
   expect(result.status).toBe(200);
   expect(await result.json()).toEqual({ data: "someData" });
+});
+
+describe("SSRF bypass prevention", () => {
+  it("rejects an empty rest endpoint", async () => {
+    await expectInvalidRestEndpoint("");
+  });
+
+  it("rejects a bare https prefix", async () => {
+    await expectInvalidRestEndpoint("https://");
+  });
+
+  it("rejects allowlisted URL prefixes", async () => {
+    await expectInvalidRestEndpoint("https://l");
+  });
+
+  it("rejects subdomain suffix bypasses", async () => {
+    await expectInvalidRestEndpoint("https://fake-endpoint.com.evil.com");
+  });
+});
+
+it("should broadcast via path-prefixed REST endpoints", async () => {
+  const req = {
+    method: "POST",
+    json: () =>
+      Promise.resolve({
+        restEndpoint: "https://rest.cosmos.directory/osmosis",
+        tx_bytes: "bytes",
+        mode: "sync",
+      }),
+  } as unknown as Request;
+
+  server.use(
+    rest.post(
+      "https://rest.cosmos.directory/osmosis/cosmos/tx/v1beta1/txs",
+      (_req, res, ctx) => {
+        return res(ctx.json({ data: "pathPrefixedData" }));
+      }
+    )
+  );
+
+  const result = await broadcastTransactionHandler(req);
+  expect(result.status).toBe(200);
+  expect(await result.json()).toEqual({ data: "pathPrefixedData" });
 });
 
 it("should handle fetch errors gracefully", async () => {

--- a/packages/web/pages/api/broadcast-transaction.ts
+++ b/packages/web/pages/api/broadcast-transaction.ts
@@ -1,4 +1,5 @@
 import { ChainList } from "~/config/generated/chain-list";
+import { findAllowedRestEndpoint } from "~/utils/url";
 
 /**
  * Broadcasts a transaction to the chain.
@@ -19,11 +20,17 @@ export default async function broadcastTransactionHandler(req: Request) {
   }
 
   const body = await req.json();
-  const isEndpointInChainConfig = ChainList.some(({ apis }) =>
-    apis?.rest?.some(({ address }) => address.startsWith(body.restEndpoint))
+
+  const allowedRestAddresses = ChainList.flatMap(
+    ({ apis }) => apis?.rest?.map(({ address }) => address) ?? []
   );
 
-  if (!isEndpointInChainConfig) {
+  const matchedRestEndpoint =
+    typeof body.restEndpoint === "string"
+      ? findAllowedRestEndpoint(body.restEndpoint, allowedRestAddresses)
+      : null;
+
+  if (!matchedRestEndpoint) {
     return new Response(JSON.stringify({ error: "Invalid rest endpoint" }), {
       status: 400,
       headers: {
@@ -47,16 +54,19 @@ export default async function broadcastTransactionHandler(req: Request) {
   }
 
   try {
-    const response = await fetch(`${body.restEndpoint}/cosmos/tx/v1beta1/txs`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        tx_bytes: body.tx_bytes,
-        mode: body.mode,
-      }),
-    });
+    const response = await fetch(
+      `${matchedRestEndpoint}/cosmos/tx/v1beta1/txs`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          tx_bytes: body.tx_bytes,
+          mode: body.mode,
+        }),
+      }
+    );
 
     if (!response.ok) {
       throw new Error("Response is not ok");

--- a/packages/web/utils/__tests__/url.spec.ts
+++ b/packages/web/utils/__tests__/url.spec.ts
@@ -68,6 +68,13 @@ describe("findAllowedRestEndpoint", () => {
     ).toBe("https://fake-endpoint.com");
   });
 
+  it("returns the canonical allowlist value on match", () => {
+    const allowlisted = "https://FAKE-ENDPOINT.COM/";
+    expect(
+      findAllowedRestEndpoint("https://fake-endpoint.com", [allowlisted])
+    ).toBe(normalizeRestBaseUrl(allowlisted));
+  });
+
   it("matches path-prefixed endpoints", () => {
     expect(findAllowedRestEndpoint(cosmosDirectoryOsmosis, allowed)).toBe(
       cosmosDirectoryOsmosis

--- a/packages/web/utils/__tests__/url.spec.ts
+++ b/packages/web/utils/__tests__/url.spec.ts
@@ -1,0 +1,97 @@
+import { findAllowedRestEndpoint, normalizeRestBaseUrl } from "~/utils/url";
+
+const lcdOsmosis = "https://lcd.osmosis.zone";
+const cosmosDirectoryOsmosis = "https://rest.cosmos.directory/osmosis";
+
+describe("normalizeRestBaseUrl", () => {
+  it("normalizes a standard REST endpoint", () => {
+    expect(normalizeRestBaseUrl("https://fake-endpoint.com")).toBe(
+      "https://fake-endpoint.com"
+    );
+  });
+
+  it("strips trailing slash from pathname", () => {
+    expect(normalizeRestBaseUrl("https://fake-endpoint.com/")).toBe(
+      "https://fake-endpoint.com"
+    );
+  });
+
+  it("preserves path-prefixed REST endpoints", () => {
+    expect(normalizeRestBaseUrl(cosmosDirectoryOsmosis)).toBe(
+      cosmosDirectoryOsmosis
+    );
+  });
+
+  it("rejects empty strings", () => {
+    expect(() => normalizeRestBaseUrl("")).toThrow();
+  });
+
+  it("rejects incomplete URLs", () => {
+    expect(() => normalizeRestBaseUrl("https://")).toThrow();
+  });
+
+  it("rejects URLs with credentials", () => {
+    expect(() =>
+      normalizeRestBaseUrl("https://user:pass@lcd.osmosis.zone")
+    ).toThrow();
+  });
+
+  it("rejects URLs with query or hash", () => {
+    expect(() =>
+      normalizeRestBaseUrl("https://lcd.osmosis.zone?foo=bar")
+    ).toThrow();
+    expect(() =>
+      normalizeRestBaseUrl("https://lcd.osmosis.zone#fragment")
+    ).toThrow();
+  });
+});
+
+describe("findAllowedRestEndpoint", () => {
+  const allowed = [lcdOsmosis, cosmosDirectoryOsmosis];
+
+  it("matches an exact allowlisted endpoint", () => {
+    expect(findAllowedRestEndpoint("https://fake-endpoint.com", allowed)).toBe(
+      null
+    );
+    expect(
+      findAllowedRestEndpoint("https://fake-endpoint.com", [
+        "https://fake-endpoint.com",
+      ])
+    ).toBe("https://fake-endpoint.com");
+  });
+
+  it("matches trailing-slash variants", () => {
+    expect(
+      findAllowedRestEndpoint("https://fake-endpoint.com/", [
+        "https://fake-endpoint.com",
+      ])
+    ).toBe("https://fake-endpoint.com");
+  });
+
+  it("matches path-prefixed endpoints", () => {
+    expect(findAllowedRestEndpoint(cosmosDirectoryOsmosis, allowed)).toBe(
+      cosmosDirectoryOsmosis
+    );
+  });
+
+  it("rejects empty strings", () => {
+    expect(findAllowedRestEndpoint("", allowed)).toBe(null);
+  });
+
+  it("rejects URL prefixes", () => {
+    expect(findAllowedRestEndpoint("https://", allowed)).toBe(null);
+    expect(findAllowedRestEndpoint("https://l", allowed)).toBe(null);
+  });
+
+  it("rejects subdomain suffix bypasses", () => {
+    expect(
+      findAllowedRestEndpoint("https://lcd.osmosis.zone.evil.com", allowed)
+    ).toBe(null);
+  });
+
+  it("rejects partial path matches", () => {
+    expect(
+      findAllowedRestEndpoint("https://rest.cosmos.directory", allowed)
+    ).toBe(null);
+  });
+});

--- a/packages/web/utils/url.ts
+++ b/packages/web/utils/url.ts
@@ -30,8 +30,9 @@ export function findAllowedRestEndpoint(
 
   for (const address of allowedAddresses) {
     try {
-      if (normalizeRestBaseUrl(address) === normalizedEndpoint) {
-        return normalizedEndpoint;
+      const canonical = normalizeRestBaseUrl(address);
+      if (canonical === normalizedEndpoint) {
+        return canonical;
       }
     } catch {
       continue;

--- a/packages/web/utils/url.ts
+++ b/packages/web/utils/url.ts
@@ -1,3 +1,46 @@
+export function normalizeRestBaseUrl(urlString: string): string {
+  const url = new URL(urlString);
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("Invalid protocol");
+  }
+
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error("Invalid URL components");
+  }
+
+  let pathname = url.pathname;
+  if (pathname.length > 1 && pathname.endsWith("/")) {
+    pathname = pathname.slice(0, -1);
+  }
+
+  return pathname === "/" ? url.origin : `${url.origin}${pathname}`;
+}
+
+export function findAllowedRestEndpoint(
+  restEndpoint: string,
+  allowedAddresses: string[]
+): string | null {
+  let normalizedEndpoint: string;
+  try {
+    normalizedEndpoint = normalizeRestBaseUrl(restEndpoint);
+  } catch {
+    return null;
+  }
+
+  for (const address of allowedAddresses) {
+    try {
+      if (normalizeRestBaseUrl(address) === normalizedEndpoint) {
+        return normalizedEndpoint;
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}
+
 export function removeQueryParam(key: string) {
   if (!key) return;
   if (typeof window === "undefined") return;


### PR DESCRIPTION
## What is the purpose of the change:

The `/api/broadcast-transaction` endpoint proxies signed transaction broadcasts to chain REST nodes (needed because many nodes lack CORS). Its allowlist check was inverted: it tested whether each configured REST address **starts with** the user-supplied `restEndpoint`, instead of whether user input matches an allowlisted base URL.

That made the allowlist ineffective. Empty strings, bare `https://`, and short prefixes of real node URLs could pass validation. In practice, most prefix payloads (e.g. `https://l`) resolve to non-existent hosts and fail at fetch time; the empty-string case triggers a same-origin relative fetch. This is **not classic SSRF** — attackers could not point the server at arbitrary hosts like `https://evil.com` or internal metadata endpoints. The realistic impact is **low**: broken validation on an endpoint that is already an intentional, public, unauthenticated relay to known chain REST URLs.

This PR replaces the reversed `startsWith` check with strict normalized URL matching against `ChainList` REST addresses, and uses the canonical matched allowlist value (not raw user input) for the outbound fetch.

**Out of scope:** this does not remove or restrict the intentional open-proxy behavior. Anyone can still call the endpoint with a full allowlisted REST URL and a signed transaction. Addressing relay abuse (rate limiting, monitoring, etc.) would be a separate effort.

### Linear Task

N/A — security hardening

## Brief Changelog

- Add `normalizeRestBaseUrl` and `findAllowedRestEndpoint` helpers in `packages/web/utils/url.ts` for exact `origin + pathname` matching (supports path-prefixed endpoints like `https://rest.cosmos.directory/osmosis`)
- Reject invalid URLs: empty strings, incomplete URLs, credentials, query strings, and hash fragments
- Update `broadcast-transaction` handler to validate `restEndpoint` against the allowlist and fetch via the canonical matched address
- Add allowlist bypass regression tests (`""`, `https://`, `https://l`, subdomain suffix) and a path-prefixed happy-path test
- Add unit tests for URL normalization and allowlist matching edge cases

## Testing and Verifying

This change has been tested locally by rebuilding the website and verified content and links are expected

- [x] `cd packages/web && yarn test broadcast-transaction url` (allowlist bypass regression + existing handler tests + URL helper unit tests)
- [ ] Confirm `POST /api/broadcast-transaction` with `restEndpoint: ""` returns 400
- [ ] Confirm prefix payloads (`https://`, `https://l`) return 400
- [ ] Confirm legitimate broadcasts still succeed for full allowlisted REST URLs (including path-prefixed endpoints)