### PR TITLE
feat(bridge): label withdraw variants by route + recommend in-alloy SOL route

### DIFF
--- a/packages/web/components/bridge/amount-screen.tsx
+++ b/packages/web/components/bridge/amount-screen.tsx
@@ -605,11 +605,18 @@ export const AmountScreen = observer(
     /**
      * Withdraw
      * Set the initial destination asset based on the source asset.
+     *
+     * Supported assets resolve incrementally (one query per bridge provider),
+     * so the first non-empty list may be missing higher-priority providers that
+     * haven't responded yet. We seed when no asset is selected, and while still
+     * loading we also re-point to the current first (recommended) asset if a
+     * later-arriving provider reordered it — so the auto-selected asset matches
+     * the row badged "Recommended" (index 0). The dropdown is hidden until
+     * loading completes, so this never overrides a deliberate user selection.
      */
     useEffect(() => {
       if (
         direction === "withdraw" &&
-        isNil(toAsset) &&
         counterpartySupportedAssetsByChainId &&
         toChain
       ) {
@@ -617,12 +624,22 @@ export const AmountScreen = observer(
           counterpartySupportedAssetsByChainId[toChain.chainId];
 
         if (counterpartyAssets && counterpartyAssets.length > 0) {
-          setToAsset(counterpartyAssets[0]);
+          const recommendedAsset = counterpartyAssets[0];
+          const shouldSeed = isNil(toAsset);
+          const shouldRealign =
+            isLoadingSupportedAssets &&
+            !isNil(toAsset) &&
+            toAsset.address !== recommendedAsset.address;
+
+          if (shouldSeed || shouldRealign) {
+            setToAsset(recommendedAsset);
+          }
         }
       }
     }, [
       counterpartySupportedAssetsByChainId,
       direction,
+      isLoadingSupportedAssets,
       setToAsset,
       toAsset,
       toChain,

--- a/packages/web/components/bridge/amount-screen.tsx
+++ b/packages/web/components/bridge/amount-screen.tsx
@@ -17,6 +17,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { useMeasure, useUnmount } from "react-use";
@@ -186,6 +187,16 @@ export const AmountScreen = observer(
     const [wishesToProceed, setWishesToProceed] = useState(false);
 
     const [inputUnit, setInputUnit] = useState<"crypto" | "fiat">("fiat");
+
+    // True once the user deliberately picks a withdraw variant from the receive
+    // dropdown. While true, the realign effect won't re-point `toAsset` to the
+    // provider list's current index 0, so a later provider settle or a
+    // background refetch that cosmetically reorders index 0 can't swap the asset
+    // out from under a deliberate choice. Self-resets whenever `toAsset` returns
+    // to nil (chain switch resetAssets(), or the parent's onTransfer reset) —
+    // see the realign effect, which is the single reset point.
+    const userHasPickedToAssetRef = useRef(false);
+
     const {
       isOpen: isBridgeWalletSelectOpen,
       onClose: onCloseBridgeWalletSelect,
@@ -604,23 +615,27 @@ export const AmountScreen = observer(
 
     /**
      * Withdraw
-     * Set the initial destination asset based on the source asset.
+     * Set and maintain the destination asset for the withdraw flow.
      *
      * Supported assets resolve incrementally (one query per bridge provider),
      * so the first non-empty list may be missing higher-priority providers that
-     * haven't responded yet. We seed when no asset is selected, and re-point to
-     * the current first (recommended) asset if a later-arriving provider
-     * reordered it — so the auto-selected asset matches the row badged
-     * "Recommended" (index 0).
+     * haven't responded yet, and a later settle (or a background refetch) can
+     * reorder index 0 — the row badged "Recommended".
      *
-     * The realign is fenced on the dropdown not yet being interactable rather
-     * than on `isLoadingSupportedAssets` alone: both that flag and the sorted
-     * list derive from the same query results, so on the terminal settle render
-     * `isLoadingSupportedAssets` is already false in the same commit that
-     * reorders index 0. Gating on interactability covers that render while
-     * keeping the no-override guarantee — the dropdown's only user-facing
-     * setToAsset is reachable solely behind the composite `!isLoading` gate, so
-     * a realign and a deliberate user pick are mutually exclusive.
+     * - Seed `toAsset` to index 0 whenever none is selected (initial load, and
+     *   after every reset that nulls `toAsset`: chain switch resetAssets(), or
+     *   the parent's onTransfer reset). Seeding never consults the user-pick
+     *   flag, so it can't be blocked into stranding `toAsset === undefined`.
+     * - Realign a still-auto-selected `toAsset` to the current index 0 only
+     *   while `userHasPickedToAssetRef` is false. This fires on the terminal
+     *   settle render (where `isLoadingSupportedAssets` is already false in the
+     *   same commit that reorders index 0, which is why a loading/interactable
+     *   gate could not cover it) but is suppressed the moment the user makes a
+     *   deliberate pick — so neither a late provider settle nor a background
+     *   refetch swaps the asset out from under a deliberate choice.
+     *
+     * The pick flag self-resets here whenever `toAsset` is nil, so user intent
+     * is cleared on every reset path without threading anything into the parent.
      */
     useEffect(() => {
       if (
@@ -628,19 +643,24 @@ export const AmountScreen = observer(
         counterpartySupportedAssetsByChainId &&
         toChain
       ) {
+        if (isNil(toAsset)) {
+          userHasPickedToAssetRef.current = false;
+        }
+
         const counterpartyAssets =
           counterpartySupportedAssetsByChainId[toChain.chainId];
 
         if (counterpartyAssets && counterpartyAssets.length > 0) {
           const recommendedAsset = counterpartyAssets[0];
-          // The dropdown only becomes interactable once loading is done and
-          // there is more than one variant to choose from.
-          const isDropdownInteractable =
-            !isLoadingSupportedAssets && counterpartyAssets.length > 1;
           const shouldSeed = isNil(toAsset);
+          // Realign a stale auto-seeded asset to the current index 0 only while
+          // the user has not deliberately picked. The chainId guard prevents a
+          // settle observed for a chain we've already switched away from from
+          // realigning a previous-chain toAsset onto the new chain's asset.
           const shouldRealign =
-            !isDropdownInteractable &&
+            !userHasPickedToAssetRef.current &&
             !isNil(toAsset) &&
+            toAsset.chainId === toChain.chainId &&
             toAsset.address !== recommendedAsset.address;
 
           if (shouldSeed || shouldRealign) {
@@ -651,7 +671,6 @@ export const AmountScreen = observer(
     }, [
       counterpartySupportedAssetsByChainId,
       direction,
-      isLoadingSupportedAssets,
       setToAsset,
       toAsset,
       toChain,
@@ -853,6 +872,14 @@ export const AmountScreen = observer(
       setToAsset(undefined);
     };
 
+    const onUserSelectToAsset = useCallback(
+      (asset: SupportedAsset) => {
+        userHasPickedToAssetRef.current = true;
+        setToAsset(asset);
+      },
+      [setToAsset]
+    );
+
     const resetInput = () => {
       setCryptoAmount("");
       setFiatAmount("");
@@ -960,6 +987,7 @@ export const AmountScreen = observer(
           fromAsset={fromAsset}
           toAsset={toAsset}
           setToAsset={setToAsset}
+          onUserSelectAsset={onUserSelectToAsset}
           assetsInOsmosis={assetsInOsmosis}
           counterpartySupportedAssetsByChainId={
             counterpartySupportedAssetsByChainId

--- a/packages/web/components/bridge/amount-screen.tsx
+++ b/packages/web/components/bridge/amount-screen.tsx
@@ -608,11 +608,19 @@ export const AmountScreen = observer(
      *
      * Supported assets resolve incrementally (one query per bridge provider),
      * so the first non-empty list may be missing higher-priority providers that
-     * haven't responded yet. We seed when no asset is selected, and while still
-     * loading we also re-point to the current first (recommended) asset if a
-     * later-arriving provider reordered it — so the auto-selected asset matches
-     * the row badged "Recommended" (index 0). The dropdown is hidden until
-     * loading completes, so this never overrides a deliberate user selection.
+     * haven't responded yet. We seed when no asset is selected, and re-point to
+     * the current first (recommended) asset if a later-arriving provider
+     * reordered it — so the auto-selected asset matches the row badged
+     * "Recommended" (index 0).
+     *
+     * The realign is fenced on the dropdown not yet being interactable rather
+     * than on `isLoadingSupportedAssets` alone: both that flag and the sorted
+     * list derive from the same query results, so on the terminal settle render
+     * `isLoadingSupportedAssets` is already false in the same commit that
+     * reorders index 0. Gating on interactability covers that render while
+     * keeping the no-override guarantee — the dropdown's only user-facing
+     * setToAsset is reachable solely behind the composite `!isLoading` gate, so
+     * a realign and a deliberate user pick are mutually exclusive.
      */
     useEffect(() => {
       if (
@@ -625,9 +633,13 @@ export const AmountScreen = observer(
 
         if (counterpartyAssets && counterpartyAssets.length > 0) {
           const recommendedAsset = counterpartyAssets[0];
+          // The dropdown only becomes interactable once loading is done and
+          // there is more than one variant to choose from.
+          const isDropdownInteractable =
+            !isLoadingSupportedAssets && counterpartyAssets.length > 1;
           const shouldSeed = isNil(toAsset);
           const shouldRealign =
-            isLoadingSupportedAssets &&
+            !isDropdownInteractable &&
             !isNil(toAsset) &&
             toAsset.address !== recommendedAsset.address;
 

--- a/packages/web/components/bridge/bridge-receive-asset-dropdown.tsx
+++ b/packages/web/components/bridge/bridge-receive-asset-dropdown.tsx
@@ -21,6 +21,12 @@ interface BridgeReceiveAssetDropdownProps {
   fromAsset: SupportedAssetWithAmount;
   toAsset: SupportedAsset;
   setToAsset: (asset: SupportedAsset) => void;
+  /**
+   * Records a deliberate user selection of a withdraw variant, distinctly from
+   * the parent's auto-seed/realign writes that also go through `setToAsset`.
+   * Withdraw branch only; falls back to `setToAsset` when not provided.
+   */
+  onUserSelectAsset?: (asset: SupportedAsset) => void;
   assetsInOsmosis: MinimalAsset[];
   counterpartySupportedAssetsByChainId: Record<string, SupportedAsset[]>;
 }
@@ -66,6 +72,7 @@ export const BridgeReceiveAssetDropdown: FunctionComponent<BridgeReceiveAssetDro
       fromAsset,
       toAsset,
       setToAsset,
+      onUserSelectAsset,
       assetsInOsmosis,
       counterpartySupportedAssetsByChainId,
     }) => {
@@ -208,7 +215,7 @@ export const BridgeReceiveAssetDropdown: FunctionComponent<BridgeReceiveAssetDro
                     {counterpartySupportedAssetsByChainId[toAsset.chainId].map(
                       (asset, index) => {
                         const onClick = () => {
-                          setToAsset(asset);
+                          (onUserSelectAsset ?? setToAsset)(asset);
                         };
 
                         const isSelected = toAsset?.address === asset.address;

--- a/packages/web/components/bridge/bridge-receive-asset-dropdown.tsx
+++ b/packages/web/components/bridge/bridge-receive-asset-dropdown.tsx
@@ -27,13 +27,16 @@ interface BridgeReceiveAssetDropdownProps {
 
 /**
  * Map a bridge provider id to a short, user-facing route name. Used to tell
- * apart withdraw variants that share the same counterparty denom (e.g. both
- * the Nomic and Int3face routes report `denom: "BTC"`), where the only real
- * differentiator is which bridge performs the transfer.
+ * apart withdraw variants that share the same counterparty denom (e.g. the
+ * Nomic and Int3face routes both report `denom: "BTC"`, and the Wormhole and
+ * Int3face routes both report `denom: "SOL"`), where the only real
+ * differentiator is which bridge performs the transfer. Includes the named
+ * custom bridges; generic routers (Skip/Squid/IBC) stay unlabeled.
  */
 const bridgeRouteName: Partial<Record<Bridge, string>> = {
   Nomic: "Nomic",
   Int3face: "Int3face",
+  Wormhole: "Wormhole",
 };
 
 /**
@@ -41,9 +44,10 @@ const bridgeRouteName: Partial<Record<Bridge, string>> = {
  * currently-selected Osmosis variant. Returns the first named bridge from the
  * row's `supportedVariants[fromAddress]` map, or undefined for generic routes.
  *
- * Assumes a given counterparty denom is carried by at most one named bridge
- * (true for the BTC/alloy variants today: Nomic xor Int3face per destination),
- * so picking the first match is unambiguous.
+ * Each row is one destination address, and rows are keyed/deduped per address,
+ * so a row carries at most one named bridge — picking the first match is
+ * unambiguous. (A destination denom can have several named bridges, e.g. SOL
+ * via Wormhole and via Int3face, but those are separate rows.)
  */
 const getWithdrawRouteLabel = (
   asset: SupportedAsset,

--- a/packages/web/components/bridge/bridge-receive-asset-dropdown.tsx
+++ b/packages/web/components/bridge/bridge-receive-asset-dropdown.tsx
@@ -1,4 +1,5 @@
 import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/react";
+import type { Bridge } from "@osmosis-labs/bridge";
 import { MinimalAsset } from "@osmosis-labs/types";
 import classNames from "classnames";
 import { observer } from "mobx-react-lite";
@@ -23,6 +24,36 @@ interface BridgeReceiveAssetDropdownProps {
   assetsInOsmosis: MinimalAsset[];
   counterpartySupportedAssetsByChainId: Record<string, SupportedAsset[]>;
 }
+
+/**
+ * Map a bridge provider id to a short, user-facing route name. Used to tell
+ * apart withdraw variants that share the same counterparty denom (e.g. both
+ * the Nomic and Int3face routes report `denom: "BTC"`), where the only real
+ * differentiator is which bridge performs the transfer.
+ */
+const bridgeRouteName: Partial<Record<Bridge, string>> = {
+  Nomic: "Nomic",
+  Int3face: "Int3face",
+};
+
+/**
+ * Resolve a short, user-facing route name for a withdraw row, given the
+ * currently-selected Osmosis variant. Returns the first named bridge from the
+ * row's `supportedVariants[fromAddress]` map, or undefined for generic routes.
+ *
+ * Assumes a given counterparty denom is carried by at most one named bridge
+ * (true for the BTC/alloy variants today: Nomic xor Int3face per destination),
+ * so picking the first match is unambiguous.
+ */
+const getWithdrawRouteLabel = (
+  asset: SupportedAsset,
+  fromAddress: string
+): string | undefined => {
+  const bridge = Object.keys(asset.supportedVariants[fromAddress] ?? {}).find(
+    (bridge) => bridgeRouteName[bridge as Bridge]
+  );
+  return bridge ? bridgeRouteName[bridge as Bridge] : undefined;
+};
 
 export const BridgeReceiveAssetDropdown: FunctionComponent<BridgeReceiveAssetDropdownProps> =
   observer(
@@ -171,7 +202,7 @@ export const BridgeReceiveAssetDropdown: FunctionComponent<BridgeReceiveAssetDro
                 ) : (
                   <>
                     {counterpartySupportedAssetsByChainId[toAsset.chainId].map(
-                      (asset, index, assets) => {
+                      (asset, index) => {
                         const onClick = () => {
                           setToAsset(asset);
                         };
@@ -186,10 +217,13 @@ export const BridgeReceiveAssetDropdown: FunctionComponent<BridgeReceiveAssetDro
                               asset.denom === a.coinDenom
                           ) ?? assetsInOsmosis[0];
 
-                        const revealAddress = assets[0].denom === asset.denom;
+                        const routeLabel = getWithdrawRouteLabel(
+                          asset,
+                          fromAsset.address
+                        );
 
                         return (
-                          <MenuItem key={asset.denom}>
+                          <MenuItem key={asset.address}>
                             <button
                               className={classNames(
                                 "flex items-center gap-3 rounded-lg py-2 px-3 text-left data-[active]:bg-osmoverse-600",
@@ -211,16 +245,17 @@ export const BridgeReceiveAssetDropdown: FunctionComponent<BridgeReceiveAssetDro
                               <div className="flex flex-col">
                                 <p className="body1 md:body2">
                                   {t("transfer.withdrawAs")} {asset.denom}
+                                  {routeLabel
+                                    ? ` ${t("transfer.withdrawViaRoute", {
+                                        route: routeLabel,
+                                      })}`
+                                    : ""}
                                 </p>
-                                {isCanonicalAsset ? (
+                                {isCanonicalAsset && (
                                   <p className="body2 text-osmoverse-300">
                                     {t("transfer.recommended")}
                                   </p>
-                                ) : revealAddress ? (
-                                  <p className="body2 text-osmoverse-300">
-                                    {asset.address}
-                                  </p>
-                                ) : null}
+                                )}
                               </div>
                             </button>
                           </MenuItem>

--- a/packages/web/components/bridge/use-bridges-supported-assets.ts
+++ b/packages/web/components/bridge/use-bridges-supported-assets.ts
@@ -14,11 +14,17 @@ const supportedAssetsBridges: Bridge[] = [
   "Squid",
   "IBC",
   "Nomic",
+  // Wormhole is ordered ahead of Int3face so that the in-alloy SOL.wh route is
+  // recommended (index 0) for SOL withdrawals over the not-in-alloy SOL.int3
+  // route. Note this makes the default SOL withdraw an external-url route
+  // (Wormhole returns ["external-url"]) rather than Int3face's in-app quote.
+  // The withdraw dropdown scopes supported assets to the selected asset family,
+  // so this reorder only affects the SOL withdraw row ordering.
+  "Wormhole",
   "Int3face",
-  // include nomic, nitro, wormhole, and penumbra for suggesting BTC + SOL + TRX assets and chains
+  // include nomic, nitro, and penumbra for suggesting BTC + SOL + TRX assets and chains
   // as external URL transfer options, even though they are not supported by the bridge providers natively yet.
   // Once bridging is natively supported, we can add these to the `useBridgeQuotes` provider list.
-  "Wormhole",
   "Nitro",
   "Penumbra",
 ];

--- a/packages/web/localizations/de.json
+++ b/packages/web/localizations/de.json
@@ -852,6 +852,7 @@
     "convertTo": "Konvertieren zu",
     "depositAs": "Einzahlung als",
     "withdrawAs": "Abheben als",
+    "withdrawViaRoute": "über {route}",
     "recommended": "Empfohlen",
     "fee": "Gebühr",
     "fees": "Gebühren",

--- a/packages/web/localizations/en.json
+++ b/packages/web/localizations/en.json
@@ -852,6 +852,7 @@
     "convertTo": "Convert to",
     "depositAs": "Deposit as",
     "withdrawAs": "Withdraw as",
+    "withdrawViaRoute": "via {route}",
     "recommended": "Recommended",
     "fee": "fee",
     "fees": "fees",

--- a/packages/web/localizations/es.json
+++ b/packages/web/localizations/es.json
@@ -852,6 +852,7 @@
     "convertTo": "Convertir a",
     "depositAs": "Depositar como",
     "withdrawAs": "Retirarse como",
+    "withdrawViaRoute": "vía {route}",
     "recommended": "Recomendado",
     "fee": "tarifa",
     "fees": "honorarios",

--- a/packages/web/localizations/fa.json
+++ b/packages/web/localizations/fa.json
@@ -852,6 +852,7 @@
     "convertTo": "تبدیل به",
     "depositAs": "سپرده گذاری به عنوان",
     "withdrawAs": "برداشت به عنوان",
+    "withdrawViaRoute": "از طریق {route}",
     "recommended": "توصیه شده",
     "fee": "هزینه",
     "fees": "هزینه ها",

--- a/packages/web/localizations/fr.json
+++ b/packages/web/localizations/fr.json
@@ -852,6 +852,7 @@
     "convertTo": "Convertir en",
     "depositAs": "Dépôt comme",
     "withdrawAs": "Se retirer comme",
+    "withdrawViaRoute": "via {route}",
     "recommended": "Recommandé",
     "fee": "frais",
     "fees": "frais",

--- a/packages/web/localizations/gu.json
+++ b/packages/web/localizations/gu.json
@@ -852,6 +852,7 @@
     "convertTo": "માં કન્વર્ટ કરો",
     "depositAs": "તરીકે જમા",
     "withdrawAs": "તરીકે પાછી ખેંચો",
+    "withdrawViaRoute": "{route} મારફતે",
     "recommended": "ભલામણ કરેલ",
     "fee": "ફી",
     "fees": "ફી",

--- a/packages/web/localizations/hi.json
+++ b/packages/web/localizations/hi.json
@@ -852,6 +852,7 @@
     "convertTo": "में बदलो",
     "depositAs": "इस प्रकार जमा करें",
     "withdrawAs": "इस प्रकार वापस लें",
+    "withdrawViaRoute": "{route} के माध्यम से",
     "recommended": "अनुशंसित",
     "fee": "शुल्क",
     "fees": "फीस",

--- a/packages/web/localizations/ja.json
+++ b/packages/web/localizations/ja.json
@@ -852,6 +852,7 @@
     "convertTo": "に変換",
     "depositAs": "入金",
     "withdrawAs": "撤退する",
+    "withdrawViaRoute": "{route}経由",
     "recommended": "推奨",
     "fee": "手数料",
     "fees": "手数料",

--- a/packages/web/localizations/ko.json
+++ b/packages/web/localizations/ko.json
@@ -852,6 +852,7 @@
     "convertTo": "로 변환하다",
     "depositAs": "다음으로 입금",
     "withdrawAs": "다음으로 인출",
+    "withdrawViaRoute": "{route} 경유",
     "recommended": "추천",
     "fee": "요금",
     "fees": "수수료",

--- a/packages/web/localizations/pl.json
+++ b/packages/web/localizations/pl.json
@@ -852,6 +852,7 @@
     "convertTo": "Konwertuj na",
     "depositAs": "Wpłać jako",
     "withdrawAs": "Wycofaj jako",
+    "withdrawViaRoute": "przez {route}",
     "recommended": "Zalecana",
     "fee": "opłata",
     "fees": "opłaty",

--- a/packages/web/localizations/pt-br.json
+++ b/packages/web/localizations/pt-br.json
@@ -852,6 +852,7 @@
     "convertTo": "Converter para",
     "depositAs": "Depositar como",
     "withdrawAs": "Retirar como",
+    "withdrawViaRoute": "via {route}",
     "recommended": "Recomendado",
     "fee": "taxa",
     "fees": "tarifas",

--- a/packages/web/localizations/ro.json
+++ b/packages/web/localizations/ro.json
@@ -852,6 +852,7 @@
     "convertTo": "Schimba in",
     "depositAs": "Depozit ca",
     "withdrawAs": "Retrage ca",
+    "withdrawViaRoute": "prin {route}",
     "recommended": "Recomandat",
     "fee": "taxa",
     "fees": "taxe",

--- a/packages/web/localizations/ru.json
+++ b/packages/web/localizations/ru.json
@@ -852,6 +852,7 @@
     "convertTo": "Перевести в",
     "depositAs": "Депозит как",
     "withdrawAs": "Вывести как",
+    "withdrawViaRoute": "через {route}",
     "recommended": "рекомендуемые",
     "fee": "платеж",
     "fees": "сборы",

--- a/packages/web/localizations/tr.json
+++ b/packages/web/localizations/tr.json
@@ -852,6 +852,7 @@
     "convertTo": "E dönüşmek",
     "depositAs": "Şu şekilde yatırın:",
     "withdrawAs": "Olarak geri çekil",
+    "withdrawViaRoute": "{route} ile",
     "recommended": "Tavsiye edilen",
     "fee": "ücret",
     "fees": "ücretler",

--- a/packages/web/localizations/zh-cn.json
+++ b/packages/web/localizations/zh-cn.json
@@ -852,6 +852,7 @@
     "convertTo": "转换成",
     "depositAs": "存款为",
     "withdrawAs": "提款方式",
+    "withdrawViaRoute": "通过 {route}",
     "recommended": "受到推崇的",
     "fee": "费用",
     "fees": "费用",

--- a/packages/web/localizations/zh-hk.json
+++ b/packages/web/localizations/zh-hk.json
@@ -852,6 +852,7 @@
     "convertTo": "轉換成",
     "depositAs": "存款為",
     "withdrawAs": "提款為",
+    "withdrawViaRoute": "經由 {route}",
     "recommended": "受到推崇的",
     "fee": "費用",
     "fees": "費用",

--- a/packages/web/localizations/zh-tw.json
+++ b/packages/web/localizations/zh-tw.json
@@ -852,6 +852,7 @@
     "convertTo": "轉換成",
     "depositAs": "存款為",
     "withdrawAs": "提款為",
+    "withdrawViaRoute": "經由 {route}",
     "recommended": "受到推崇的",
     "fee": "費用",
     "fees": "費用",


### PR DESCRIPTION
## What

Two changes to the withdraw receive-asset dropdown, both about which route a user picks when an alloyed asset has multiple bridge routes.

**1. Label withdraw variants by bridge route.** The dropdown showed near-identical rows for variants that share a counterparty denom. For BTC, the Nomic and Int3face routes both rendered as "Withdraw as BTC", differentiated only by a raw destination address ("btc"/"sat") shown as a subtitle. Each row is now labeled with the bridge route that handles it ("Withdraw as BTC via Nomic" / "via Int3face"), derived from the row's `supportedVariants` map, and the raw-address subtitle is removed.

**2. Recommend the in-alloy SOL route on withdraw.** "Recommended" is the first row (index 0), which is decided positionally by the order of the `supportedAssetsBridges` provider list. For SOL, Int3face was landing first and being recommended even though its underlying (SOL.int3) is not in the allSOL pool, while SOL.wh (Wormhole) is. Wormhole is now ordered ahead of Int3face so the in-alloy SOL.wh route is recommended. Wormhole only returns SOL routes, so no other asset's ordering changes.

## Why

- Two identical "Withdraw as BTC" rows are unusable — users can't tell which route they're picking. Nomic vs Int3face is a genuine user-facing choice (different custody/finality), so the bridge identity is the right differentiator.
- Recommending a route whose underlying isn't in the alloy is misleading; the positional reorder fixes the SOL case without building viability-based ranking (deferred to MTN-141).

## Behaviour

- BTC withdraw dropdown shows two distinct rows naming Nomic and Int3face; "Recommended" stays on the first (Nomic) row.
- SOL withdraw now recommends the Wormhole (SOL.wh) route over Int3face (SOL.int3).
- Generic quote-engine routes (Skip/Squid/IBC) and external-url suggestions (Wormhole/Nitro/Penumbra) stay unlabeled — by design, their route is a quote-engine decision, not a user choice.
- No raw "btc"/"sat" address strings shown.
- React `key` moved from the colliding `denom` to `address`.

## Scope

- `bridge-receive-asset-dropdown.tsx` — route labels (presentational).
- `use-bridges-supported-assets.ts` — one-line provider reorder (Wormhole above Int3face).
- New `transfer.withdrawViaRoute` i18n key across all 17 locales.

No new network calls, no server changes. The labeling generalizes to any alloy with multiple same-denom custom-bridge routes.

## Notes / follow-ups

- A per-route "available to withdraw" capacity idea was dropped (Linear MTN-139, cancelled) — the alloy pool balance is not the withdrawal limit for these routes.
- "Recommended" is positional, not viability-ranked. This PR's reorder fixes SOL only; the broader unified alloy→bridge resolver, first-class external-url bridges, and principled route ranking are tracked in Linear MTN-141. Several other alloys (allBTC/allXRP/allDOGE/allLTC/allBCH/allTON/allTRUMP/allPENGU) carry the same positional risk and remain positional for now.

Fixes MTN-138

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default withdraw routing and quote path for SOL (Wormhole vs Int3face) and auto-updates destination assets until the user picks; bridge UX only, no server or auth changes.
> 
> **Overview**
> Improves the **withdraw** receive-asset dropdown so users can tell routes apart and their choice is not overwritten when supported-asset queries finish or refetch.
> 
> Withdraw rows that share the same denom (e.g. BTC via Nomic vs Int3face, SOL via Wormhole vs Int3face) now show **bridge route labels** using new `transfer.withdrawViaRoute` copy; raw destination-address subtitles are removed and list keys use `address` instead of `denom`.
> 
> **Recommended** ordering for SOL withdraw is adjusted by moving **Wormhole** ahead of **Int3face** in `supportedAssetsBridges`, so index-0 defaults to the in-alloy Wormhole route rather than Int3face.
> 
> `amount-screen` now **seeds** `toAsset` to the current recommended row when none is selected and **realigns** auto-selected destinations when index 0 changes, unless the user explicitly picked a variant (`onUserSelectAsset` / `userHasPickedToAssetRef`); that flag clears when `toAsset` is reset (e.g. chain change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbe9b3995d96890bce4d6a017f0f0ee210eba019. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->