### PR TITLE
fix(assets): age out "New" category after 30 days

### DIFF
--- a/packages/server/src/queries/complex/assets/__tests__/assets.spec.ts
+++ b/packages/server/src/queries/complex/assets/__tests__/assets.spec.ts
@@ -65,6 +65,48 @@ describe("getAssets", () => {
       expect(assets.some((asset) => asset.coinDenom === "OSMO")).toBeTruthy();
       expect(assets.some((asset) => asset.coinDenom === "ION")).toBeFalsy();
     });
+
+    describe('"new" category 30-day window', () => {
+      // Anchor the clock so the 2024 fixture listing dates straddle the window:
+      // window start = 2024-01-26. WBTC (2024-01-29) is inside (new); sqTIA
+      // (2024-01-19) is outside (stale); OSMO has no listingDate.
+      beforeAll(() => {
+        jest
+          .useFakeTimers()
+          .setSystemTime(new Date("2024-02-25T00:00:00.000Z"));
+      });
+
+      afterAll(() => {
+        jest.useRealTimers();
+      });
+
+      it("should return an asset listed within the last 30 days", () => {
+        const assets = getAssets({
+          assetLists: MockAssetLists,
+          categories: ["new"],
+        });
+
+        expect(assets.some((asset) => asset.coinDenom === "WBTC")).toBeTruthy();
+      });
+
+      it("should not return an asset listed more than 30 days ago", () => {
+        const assets = getAssets({
+          assetLists: MockAssetLists,
+          categories: ["new"],
+        });
+
+        expect(assets.some((asset) => asset.coinDenom === "sqTIA")).toBeFalsy();
+      });
+
+      it("should not return an asset without a listing date", () => {
+        const assets = getAssets({
+          assetLists: MockAssetLists,
+          categories: ["new"],
+        });
+
+        expect(assets.some((asset) => asset.coinDenom === "OSMO")).toBeFalsy();
+      });
+    });
   });
 });
 

--- a/packages/server/src/queries/complex/assets/categories.ts
+++ b/packages/server/src/queries/complex/assets/categories.ts
@@ -5,12 +5,24 @@ import { LRUCache } from "lru-cache";
 import { DEFAULT_LRU_OPTIONS } from "../../../utils";
 import { queryUpcomingAssets } from "../../github";
 
+/** An asset is considered "new" for this many ms after its listing date. */
+export const NEW_ASSET_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** Parses a raw listing date to epoch ms, or undefined if missing/unparseable. */
+function parseListingDate(listingDate: string | undefined): number | undefined {
+  if (!listingDate) return undefined;
+  const ms = new Date(listingDate).getTime();
+  return Number.isNaN(ms) ? undefined : ms;
+}
+
 /** Filters an asset for whether it is included in the given list of categories. */
 export function isAssetInCategories(asset: Asset, categories: string[]) {
   return categories.some((category) => {
-    // "new" category is an asset with a listing date.
+    // "new" category is an asset listed within the last NEW_ASSET_WINDOW_MS.
     if (category === "new") {
-      return Boolean(asset.listingDate);
+      const listed = parseListingDate(asset.listingDate);
+      if (listed === undefined) return false;
+      return Date.now() - listed <= NEW_ASSET_WINDOW_MS;
     }
 
     return asset.categories.includes(category);
@@ -26,11 +38,12 @@ export function getAssetListingDate({
 }): Date | undefined {
   const assets = assetLists.flatMap(({ assets }) => assets);
 
-  const date = assets.find(
-    (asset) => asset.coinMinimalDenom === coinMinimalDenom
-  )?.listingDate;
+  const listed = parseListingDate(
+    assets.find((asset) => asset.coinMinimalDenom === coinMinimalDenom)
+      ?.listingDate
+  );
 
-  if (date) return new Date(date);
+  if (listed !== undefined) return new Date(listed);
 }
 
 const upcomingAssetsCache = new LRUCache<string, CacheEntry>(

--- a/packages/web/components/assets/highlights-categories.tsx
+++ b/packages/web/components/assets/highlights-categories.tsx
@@ -113,12 +113,21 @@ const HighlightsGrid: FunctionComponent<HighlightsProps> = ({
   const visibleTileCount =
     1 + (hasNewAssets ? 1 : 0) + (hasQualifyingUpcomingAssets ? 1 : 0);
 
+  const isGainersOnly = visibleTileCount === 1;
+
   // Top Gainers row count by its own layout (New/Upcoming always fetch 3):
   //  - gainers-only: full width, 6 rows across two columns (3 per column)
   //  - large-tablet snap carousel: 6 in a single-column swipe card
   //  - desktop multi-tile single-column card: 3
-  const isGainersOnly = visibleTileCount === 1;
-  const topGainerCount = isGainersOnly || isLargeTablet ? 6 : 3;
+  //
+  // Only switch the count once New/Upcoming have settled. While they load,
+  // `isGainersOnly` is transiently true (their `has*` flags are false), and
+  // letting that drive `topN` would change the query key mid-load, discarding
+  // the cache hit and forcing a redundant refetch when data arrives.
+  const isHighlightLayoutSettled =
+    !isTopNewAssetsLoading && !isTopUpcomingAssetsLoading;
+  const topGainerCount =
+    isLargeTablet || (isHighlightLayoutSettled && isGainersOnly) ? 6 : 3;
   const { data: topGainerAssets, isLoading: isTopGainerAssetsLoading } =
     api.edge.assets.getTopGainerAssets.useQuery({
       topN: topGainerCount,

--- a/packages/web/components/assets/highlights-categories.tsx
+++ b/packages/web/components/assets/highlights-categories.tsx
@@ -92,10 +92,6 @@ const HighlightsGrid: FunctionComponent<HighlightsProps> = ({
     api.edge.assets.getTopNewAssets.useQuery({
       topN: isLargeTablet ? 3 : undefined,
     });
-  const { data: topGainerAssets, isLoading: isTopGainerAssetsLoading } =
-    api.edge.assets.getTopGainerAssets.useQuery({
-      topN: isLargeTablet ? 8 : undefined,
-    });
   const { data: topUpcomingAssets, isLoading: isTopUpcomingAssetsLoading } =
     api.edge.assets.getTopUpcomingAssets.useQuery({
       topN: isLargeTablet ? 3 : undefined,
@@ -116,6 +112,17 @@ const HighlightsGrid: FunctionComponent<HighlightsProps> = ({
   // freed space instead of leaving a gap.
   const visibleTileCount =
     1 + (hasNewAssets ? 1 : 0) + (hasQualifyingUpcomingAssets ? 1 : 0);
+
+  // Top Gainers row count by its own layout (New/Upcoming always fetch 3):
+  //  - gainers-only: full width, 6 rows across two columns (3 per column)
+  //  - large-tablet snap carousel: 6 in a single-column swipe card
+  //  - desktop multi-tile single-column card: 3
+  const isGainersOnly = visibleTileCount === 1;
+  const topGainerCount = isGainersOnly || isLargeTablet ? 6 : 3;
+  const { data: topGainerAssets, isLoading: isTopGainerAssetsLoading } =
+    api.edge.assets.getTopGainerAssets.useQuery({
+      topN: topGainerCount,
+    });
 
   return (
     <div
@@ -142,9 +149,13 @@ const HighlightsGrid: FunctionComponent<HighlightsProps> = ({
         />
       )}
       <AssetHighlights
-        className={classNames("lg:w-[80%] lg:shrink-0 lg:snap-center", {
-          // Only span 2 rows when there is a second row to share with.
+        className={classNames({
+          // Multi-tile: 80% width snap card; span 2 rows on xl to share the
+          // second row with New / Upcoming.
+          "lg:w-[80%] lg:shrink-0 lg:snap-center": !isGainersOnly,
           "xl:row-span-2 lg:row-auto": visibleTileCount > 1,
+          // Gainers-only: full width, rows flow into two columns.
+          "w-full": isGainersOnly,
         })}
         title={t("assets.highlights.topGainers")}
         subtitle="24h"
@@ -152,6 +163,7 @@ const HighlightsGrid: FunctionComponent<HighlightsProps> = ({
         assets={(topGainerAssets ?? []).map(highlightPrice24hChangeAsset)}
         onClickSeeAll={onSelectAllTopGainers}
         highlight="topGainers"
+        columns={isGainersOnly ? 2 : 1}
       />
       {hasQualifyingUpcomingAssets && (
         <AssetHighlights
@@ -252,6 +264,12 @@ export const AssetHighlights: FunctionComponent<
     disableLinking?: boolean;
     highlight: Highlight;
     onClickAsset?: (asset: HighlightAsset) => void;
+    /**
+     * Number of columns to flow the asset rows into. Defaults to 1. Use 2 when
+     * the tile occupies the full width on its own, so the rows fill the
+     * horizontal space instead of stretching into one long list.
+     */
+    columns?: 1 | 2;
   } & CustomClasses
 > = ({
   title,
@@ -262,8 +280,11 @@ export const AssetHighlights: FunctionComponent<
   className,
   highlight,
   onClickAsset,
+  columns = 1,
 }) => {
   const { t } = useTranslation();
+
+  const skeletonCount = columns === 2 ? 6 : 3;
 
   return (
     <div
@@ -285,10 +306,20 @@ export const AssetHighlights: FunctionComponent<
           </button>
         )}
       </div>
-      <div className={classNames("flex flex-col", { "gap-1": isLoading })}>
+      <div
+        className={classNames({
+          "flex flex-col": columns === 1,
+          // NOTE: this repo's Tailwind screens are max-width, so unprefixed is
+          // the desktop base and `md:` applies at narrow widths. Two columns on
+          // desktop (where the tile spans full width on its own), collapsing to
+          // one column on small screens so rows never cramp.
+          "grid grid-cols-2 gap-x-8 md:grid-cols-1": columns === 2,
+          "gap-1": isLoading,
+        })}
+      >
         {isLoading ? (
           <>
-            {new Array(3).fill(0).map((_, i) => (
+            {new Array(skeletonCount).fill(0).map((_, i) => (
               <SkeletonLoader className="h-12 w-full" key={i} />
             ))}
           </>

--- a/packages/web/components/assets/highlights-categories.tsx
+++ b/packages/web/components/assets/highlights-categories.tsx
@@ -323,7 +323,9 @@ export const AssetHighlights: FunctionComponent<
           // desktop (where the tile spans full width on its own), collapsing to
           // one column on small screens so rows never cramp.
           "grid grid-cols-2 gap-x-8 md:grid-cols-1": columns === 2,
-          "gap-1": isLoading,
+          // gap-y only: tighten vertical spacing during load without
+          // overriding the column gap (gap-1 shorthand would clobber gap-x-8).
+          "gap-y-1": isLoading,
         })}
       >
         {isLoading ? (

--- a/packages/web/components/assets/highlights-categories.tsx
+++ b/packages/web/components/assets/highlights-categories.tsx
@@ -101,6 +101,9 @@ const HighlightsGrid: FunctionComponent<HighlightsProps> = ({
       topN: isLargeTablet ? 3 : undefined,
     });
 
+  const hasNewAssets =
+    !isTopNewAssetsLoading && (topNewAssets ?? []).length > 0;
+
   // Filter upcoming assets to only include those with specific launch dates
   const qualifyingUpcomingAssets = (topUpcomingAssets ?? []).filter((asset) =>
     hasSpecificLaunchDate(asset.estimatedLaunchDateUtc)
@@ -108,29 +111,41 @@ const HighlightsGrid: FunctionComponent<HighlightsProps> = ({
   const hasQualifyingUpcomingAssets =
     !isTopUpcomingAssetsLoading && qualifyingUpcomingAssets.length > 0;
 
+  // Top Gainers always renders; New and Upcoming are conditional. Drive the
+  // grid layout off the count of visible tiles so the row reflows to fill the
+  // freed space instead of leaving a gap.
+  const visibleTileCount =
+    1 + (hasNewAssets ? 1 : 0) + (hasQualifyingUpcomingAssets ? 1 : 0);
+
   return (
     <div
       className={classNames(
         "lg:no-scrollbar grid gap-6 xl:gap-8 lg:flex lg:snap-x lg:snap-mandatory lg:overflow-x-scroll",
         {
-          // When Upcoming is hidden, use 2-column grid with Top Gainers spanning 2 rows
-          "grid-cols-2 xl:grid-rows-2": !hasQualifyingUpcomingAssets,
-          // When Upcoming is shown, use 3-column grid
-          "grid-cols-3 xl:grid-cols-2 xl:grid-rows-2":
-            hasQualifyingUpcomingAssets,
+          // Gainers-only: single column, no row span.
+          "grid-cols-1": visibleTileCount === 1,
+          // Two tiles: 2 columns, Top Gainers spans 2 rows on xl.
+          "grid-cols-2 xl:grid-rows-2": visibleTileCount === 2,
+          // Three tiles: 3 columns collapsing to 2x2 on xl.
+          "grid-cols-3 xl:grid-cols-2 xl:grid-rows-2": visibleTileCount === 3,
         },
         className
       )}
     >
+      {hasNewAssets && (
+        <AssetHighlights
+          className="lg:w-[80%] lg:shrink-0 lg:snap-center"
+          title={t("assets.highlights.new")}
+          isLoading={isTopNewAssetsLoading}
+          assets={(topNewAssets ?? []).map(highlightPrice24hChangeAsset)}
+          highlight="new"
+        />
+      )}
       <AssetHighlights
-        className="lg:w-[80%] lg:shrink-0 lg:snap-center"
-        title={t("assets.highlights.new")}
-        isLoading={isTopNewAssetsLoading}
-        assets={(topNewAssets ?? []).map(highlightPrice24hChangeAsset)}
-        highlight="new"
-      />
-      <AssetHighlights
-        className="xl:row-span-2 lg:row-auto lg:w-[80%] lg:shrink-0 lg:snap-center"
+        className={classNames("lg:w-[80%] lg:shrink-0 lg:snap-center", {
+          // Only span 2 rows when there is a second row to share with.
+          "xl:row-span-2 lg:row-auto": visibleTileCount > 1,
+        })}
         title={t("assets.highlights.topGainers")}
         subtitle="24h"
         isLoading={isTopGainerAssetsLoading}


### PR DESCRIPTION
## What

On the Assets page, the **New** highlights section showed assets that listed long ago, because an asset counted as "new" if it had *any* `listingDate` with no age limit.

- An asset is now "new" only within **30 days** of its `listingDate`.
- The cutoff lives in `isAssetInCategories`, the single definition of the "new" category, so the homepage **New** highlights and the main table's **New** filter chip stay consistent.
- When there are no qualifying new assets, the **New** highlights tile is hidden and the grid reflows (derived from a visible-tile count) so **Top gainers** and **Upcoming** fill the row, mirroring how **Upcoming** is already conditionally hidden.
- When **Top gainers** ends up as the only tile, it now lays out full width with its rows in **two columns** (one column on small screens) instead of stretching into a single long list. Row counts are tuned per layout: 6 when full-width or in the large-tablet carousel, 3 in the desktop multi-tile card.

## Why

The "New" assets were no longer new. They should fall off after about a month, and the section shouldn't render empty. With New (and possibly Upcoming) gone, a lone full-width Top gainers tile looked stretched, so it now uses the freed space.

## Changes

- `packages/server/src/queries/complex/assets/categories.ts` — add `NEW_ASSET_WINDOW_MS` (30 days) and a shared `parseListingDate` helper; apply the window in `isAssetInCategories` (inclusive boundary). `getAssetListingDate` reuses the same parser.
- `packages/web/components/assets/highlights-categories.tsx` — add `hasNewAssets`, conditionally render the New tile, and derive grid columns from `visibleTileCount` (1/2/3 tiles), keeping Top Gainers' `xl:row-span-2` only when a second row exists. `AssetHighlights` gains an optional `columns` prop (default 1); the gainers-only tile uses `columns={2}` + full width. Top gainers row count is layout-dependent (6 full-width / 6 large-tablet carousel / 3 desktop multi-tile).

## Tests

- `assets.spec.ts` — 3 added cases for the "new" category: recent listing returned, stale (>30d) excluded, no `listingDate` excluded. Deterministic via `jest.useFakeTimers().setSystemTime("2024-02-25")` against the existing 2024 fixtures (shared fixtures not mutated). 14/14 pass.
- Typecheck: server `tsc` clean; web file introduces no new type errors. Prettier + eslint clean on changed files.

No new or upcoming assets exist:
<img width="1409" height="398" alt="image" src="https://github.com/user-attachments/assets/b323e785-52a3-41ba-b657-d7a5fa843813" />

New assets exist:
<img width="1363" height="394" alt="image" src="https://github.com/user-attachments/assets/506e22c7-46c1-43ba-aa6f-e77868e28ea0" />

Upcoming assets exist:
<img width="1352" height="394" alt="image" src="https://github.com/user-attachments/assets/8399b3f9-f2f4-4243-a44e-273be51c3dc3" />

Both New and Upcoming exist:
<img width="1409" height="404" alt="image" src="https://github.com/user-attachments/assets/d37b9243-55d3-404c-be5b-15c21271cacf" />


## Notes

- "New" is server-clock evaluated. The table chip path has a 30s LRU; `getTopNewAssets` is uncached at the procedure level, so an asset crossing the 30-day boundary may appear in one surface up to one cache lifetime after the other. Cosmetic; aligning them via a short cachified TTL is a possible follow-up, out of scope here.
- This repo's Tailwind screens are max-width, so the 2-column gainers layout uses `grid-cols-2 md:grid-cols-1` (2 columns on desktop, 1 on small screens).

Closes MTN-140

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Category and UI layout changes only; no auth, payments, or data migration. Minor cosmetic risk if server clock vs short-lived caches disagree across surfaces.
> 
> **Overview**
> **"New"** now means listed within the last **30 days** (via `NEW_ASSET_WINDOW_MS` and shared `parseListingDate` in `isAssetInCategories`), not merely having a `listingDate`. That keeps the assets table **New** filter and server highlights aligned; `getAssetListingDate` uses the same parser.
> 
> On the homepage highlights row, the **New** tile is **hidden** when there are no qualifying assets, and the grid is driven by **visible tile count** (1–3) so **Top gainers** and **Upcoming** reflow without gaps. When only gainers show, the tile goes **full width** with a **two-column** asset list (`columns` on `AssetHighlights`) and **6** gainers (vs 3 in multi-tile desktop), with `topN` deferred until New/Upcoming finish loading to avoid query-key churn.
> 
> Tests add a fake-timer suite for the 30-day window (recent in, stale out, no date out).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8c47d1bb98187b43a64461c90bfebeb282623c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->