### PR TITLE
feat(bridge): convert alloy to .wh variant on the wormhole page

### DIFF
--- a/packages/web/components/bridge/wormhole-alloy-convert.tsx
+++ b/packages/web/components/bridge/wormhole-alloy-convert.tsx
@@ -1,0 +1,146 @@
+import { CoinPretty } from "@osmosis-labs/unit";
+import { getAssetFromAssetList } from "@osmosis-labs/utils";
+import { observer } from "mobx-react-lite";
+import { FunctionComponent, useMemo } from "react";
+
+import { Icon } from "~/components/assets";
+import { SwapTool } from "~/components/swap-tool";
+import { AssetLists } from "~/config/generated/asset-lists";
+import { useTranslation } from "~/hooks";
+import { useStore } from "~/stores";
+import { api } from "~/utils/trpc";
+
+/**
+ * Wormhole Connect bridges a specific `.wh` variant (e.g. SOL.wh / SUI.wh /
+ * APT.wh), not the alloy denom (allSOL / allSUI / allAPT) the user holds. So a
+ * holder of the alloy would otherwise have to manually swap to the variant
+ * before bridging. For each supported destination we resolve the alloy↔variant
+ * pair from the asset list (the variant's `variantGroupKey` is the alloy's own
+ * coinMinimalDenom) and, when the user holds the alloy, embed the swap tool
+ * defaulted to alloy → variant (1:1 via the transmuter).
+ *
+ * Only the variant symbol and the destination network vary per asset; both
+ * denoms + decimals come from the asset list. When MTN-141's resolver lands
+ * this pairing should derive from it.
+ */
+const WORMHOLE_CONVERT_ASSETS = [
+  { whSymbol: "SOL.wh", toNetwork: "solana" },
+  { whSymbol: "SUI.wh", toNetwork: "sui" },
+  { whSymbol: "APT.wh", toNetwork: "aptos" },
+] as const;
+
+type ResolvedConvertAsset = {
+  toNetwork: string;
+  /** The page's `?token=` value this convert applies to (the base symbol, e.g.
+   *  "SOL"/"SUI"/"APT" — the variant symbol without the `.wh` suffix). Used so
+   *  the card only shows for the matching withdrawal, not every asset that
+   *  shares the destination network (e.g. PYTH → solana must not show it). */
+  pageToken: string;
+  variantMinimalDenom: string;
+  alloyMinimalDenom: string;
+};
+
+const resolvedConvertAssetsByNetwork: Record<string, ResolvedConvertAsset> =
+  WORMHOLE_CONVERT_ASSETS.reduce((acc, { whSymbol, toNetwork }) => {
+    const variant = getAssetFromAssetList({
+      symbol: whSymbol,
+      assetLists: AssetLists,
+    });
+    const variantMinimalDenom = variant?.coinMinimalDenom;
+    const alloyMinimalDenom = variant?.rawAsset.variantGroupKey;
+    const pageToken = whSymbol.replace(/\.wh$/, "");
+    if (variantMinimalDenom && alloyMinimalDenom) {
+      acc[toNetwork] = {
+        toNetwork,
+        pageToken,
+        variantMinimalDenom,
+        alloyMinimalDenom,
+      };
+    }
+    return acc;
+  }, {} as Record<string, ResolvedConvertAsset>);
+
+/**
+ * Pre-gate shown on the /wormhole page for an Osmosis → {Solana,Sui,Aptos}
+ * withdrawal: when the connected user holds the alloy that Wormhole can't bridge
+ * directly, embed the swap tool defaulted to alloy → `.wh` variant so they can
+ * convert before bridging. Renders nothing when the destination isn't supported
+ * or the user holds none of that alloy.
+ */
+export const WormholeAlloyConvert: FunctionComponent<{
+  toNetwork?: string;
+  token?: string;
+}> = observer(({ toNetwork, token }) => {
+  const { accountStore } = useStore();
+  const { t } = useTranslation();
+  const account = accountStore.getWallet(accountStore.osmosisChainId);
+
+  // Gate on both the destination network and the page's withdrawal token, so
+  // the card only shows for the alloy's own withdrawal (e.g. SOL → solana), not
+  // every other asset sharing that network (e.g. PYTH → solana).
+  const candidate = toNetwork
+    ? resolvedConvertAssetsByNetwork[toNetwork]
+    : undefined;
+  const convertAsset =
+    candidate && token === candidate.pageToken ? candidate : undefined;
+
+  // Use the full balance set (every denom), not the portfolio's top-N
+  // allocations — the alloy may be a long-tail holding for the user.
+  const { data: userBalances } = api.local.balances.getUserBalances.useQuery(
+    { bech32Address: account?.address ?? "" },
+    { enabled: !!account?.address }
+  );
+
+  const alloyBalance = useMemo<CoinPretty | undefined>(() => {
+    if (!convertAsset) return undefined;
+    const coin = userBalances?.find(
+      ({ denom }) => denom === convertAsset.alloyMinimalDenom
+    )?.coin;
+    // Only surface the convert card when the user actually holds the alloy.
+    return coin?.toDec().isPositive() ? coin : undefined;
+  }, [convertAsset, userBalances]);
+
+  // Unsupported destination, or the user holds none of this alloy.
+  if (!convertAsset || !alloyBalance) return null;
+
+  return (
+    <div className="flex flex-col gap-4 rounded-3xl border border-osmoverse-700 bg-osmoverse-850 p-5">
+      <h2 className="subtitle1 text-white-full">
+        {t("wormhole.convertAlloy.stepTitle", {
+          symbol: alloyBalance.currency.coinDenom,
+        })}
+      </h2>
+
+      <div className="flex items-start gap-3 rounded-2xl bg-osmoverse-800 p-4">
+        <Icon
+          id="alert-triangle"
+          className="h-5 w-5 shrink-0 text-wosmongton-300"
+        />
+        <p className="body2 text-osmoverse-200">
+          {t("wormhole.convertAlloy.description", {
+            balance: alloyBalance
+              .trim(true)
+              .maxDecimals(6)
+              .hideDenom(true)
+              .toString(),
+            symbol: alloyBalance.currency.coinDenom,
+          })}
+        </p>
+      </div>
+
+      {/*
+       * useQueryParams={false} is mandatory: the wormhole page uses ?from= and
+       * ?to= for the Connect widget's network defaults, and the swap tool reads
+       * the same query keys for its from/to denoms. Controlled mode keeps the
+       * swap state in local React state so it never writes those params.
+       */}
+      <SwapTool
+        useQueryParams={false}
+        useOtherCurrencies={false}
+        page="Wormhole Page"
+        initialSendTokenDenom={convertAsset.alloyMinimalDenom}
+        initialOutTokenDenom={convertAsset.variantMinimalDenom}
+      />
+    </div>
+  );
+});

--- a/packages/web/components/bridge/wormhole-redeem.tsx
+++ b/packages/web/components/bridge/wormhole-redeem.tsx
@@ -1231,9 +1231,9 @@ export const WormholeRedeem: FunctionComponent = () => {
   ].includes(status);
 
   return (
-    <div className="mx-auto mt-6 max-w-2xl px-4 pb-40">
-      <div className="rounded-2xl border border-osmoverse-600 bg-osmoverse-800 p-6">
-        <h2 className="mb-4 text-lg font-semibold text-white-full">
+    <div>
+      <div className="rounded-3xl border border-osmoverse-700 bg-osmoverse-850 p-5">
+        <h2 className="subtitle1 mb-1 text-white-full">
           Redeem a stuck Wormhole transfer
         </h2>
         <p className="mb-4 text-sm text-osmoverse-300">

--- a/packages/web/config/analytics-events.ts
+++ b/packages/web/config/analytics-events.ts
@@ -9,7 +9,11 @@ export const OUTLIER_USD_VALUE_THRESHOLD = 1_500_000;
 
 export type AmountDefault = "half" | "max" | "input";
 
-export type EventPage = "Swap Page" | "Token Info Page" | "Pool Details Page";
+export type EventPage =
+  | "Swap Page"
+  | "Token Info Page"
+  | "Pool Details Page"
+  | "Wormhole Page";
 
 export type EventProperties = {
   fromToken: string;

--- a/packages/web/localizations/de.json
+++ b/packages/web/localizations/de.json
@@ -1399,6 +1399,12 @@
   "taprootAddressNotSupported": "Taproot-Adressen werden für Abhebungen nicht unterstützt",
   "wormhole": {
     "deprecationTitle": "Wormhole-Unterstützung wird eingestellt",
-    "deprecationSubtitle": "Wir empfehlen nicht, zusätzliche Assets über Wormhole zu Osmosis zu bridgen. Diese Seite hilft Ihnen, bestehende über Wormhole gebridgte Assets von Osmosis abzuheben."
+    "deprecationSubtitle": "Wir empfehlen nicht, zusätzliche Assets über Wormhole zu Osmosis zu bridgen. Diese Seite hilft Ihnen, bestehende über Wormhole gebridgte Assets von Osmosis abzuheben.",
+    "bridgeStepTitle": "Über Wormhole bridgen",
+    "refreshBalance": "Guthaben aktualisieren",
+    "convertAlloy": {
+      "stepTitle": "{symbol} in {symbol}.wh umwandeln",
+      "description": "Du hältst {balance} {symbol} als alloyierten Vermögenswert. Wormhole bridgt die {symbol}.wh-Variante, also wandle zuerst um und bridge dann unten."
+    }
   }
 }

--- a/packages/web/localizations/en.json
+++ b/packages/web/localizations/en.json
@@ -1399,6 +1399,12 @@
   "taprootAddressNotSupported": "Taproot addresses are not supported for withdrawals",
   "wormhole": {
     "deprecationTitle": "Wormhole support is being deprecated",
-    "deprecationSubtitle": "We do not recommend bridging additional assets to Osmosis via Wormhole. This page is available to help you withdraw existing Wormhole-bridged assets from Osmosis."
+    "deprecationSubtitle": "We do not recommend bridging additional assets to Osmosis via Wormhole. This page is available to help you withdraw existing Wormhole-bridged assets from Osmosis.",
+    "bridgeStepTitle": "Bridge via Wormhole",
+    "refreshBalance": "Refresh balance",
+    "convertAlloy": {
+      "stepTitle": "Convert {symbol} to {symbol}.wh",
+      "description": "You hold {balance} {symbol} as the alloyed asset. Wormhole bridges the {symbol}.wh variant, so convert first, then bridge below."
+    }
   }
 }

--- a/packages/web/localizations/es.json
+++ b/packages/web/localizations/es.json
@@ -1399,6 +1399,12 @@
   "taprootAddressNotSupported": "Las direcciones Taproot no son compatibles con los retiros",
   "wormhole": {
     "deprecationTitle": "La compatibilidad con Wormhole se está descontinuando",
-    "deprecationSubtitle": "No recomendamos enviar activos adicionales a Osmosis a través de Wormhole. Esta página está disponible para ayudarle a retirar activos existentes bridgeados mediante Wormhole de Osmosis."
+    "deprecationSubtitle": "No recomendamos enviar activos adicionales a Osmosis a través de Wormhole. Esta página está disponible para ayudarle a retirar activos existentes bridgeados mediante Wormhole de Osmosis.",
+    "bridgeStepTitle": "Usar el puente de Wormhole",
+    "refreshBalance": "Actualizar saldo",
+    "convertAlloy": {
+      "stepTitle": "Convertir {symbol} a {symbol}.wh",
+      "description": "Tienes {balance} {symbol} como activo aleado. Wormhole usa el puente con la variante {symbol}.wh, así que convierte primero y luego usa el puente abajo."
+    }
   }
 }

--- a/packages/web/localizations/fa.json
+++ b/packages/web/localizations/fa.json
@@ -1399,6 +1399,12 @@
   "taprootAddressNotSupported": "آدرس‌های Taproot برای برداشت وجه پشتیبانی نمی‌شوند.",
   "wormhole": {
     "deprecationTitle": "پشتیبانی Wormhole در حال منسوخ شدن است",
-    "deprecationSubtitle": "ما توصیه نمی‌کنیم دارایی‌های اضافی را از طریق Wormhole به Osmosis منتقل کنید. این صفحه برای کمک به شما در خروج دارایی‌های موجود Wormhole از Osmosis در دسترس است."
+    "deprecationSubtitle": "ما توصیه نمی‌کنیم دارایی‌های اضافی را از طریق Wormhole به Osmosis منتقل کنید. این صفحه برای کمک به شما در خروج دارایی‌های موجود Wormhole از Osmosis در دسترس است.",
+    "bridgeStepTitle": "پل زدن از طریق Wormhole",
+    "refreshBalance": "به‌روزرسانی موجودی",
+    "convertAlloy": {
+      "stepTitle": "تبدیل {symbol} به {symbol}.wh",
+      "description": "شما {balance} {symbol} به صورت دارایی آلویدشده دارید. Wormhole واریانت {symbol}.wh را پل می‌زند، پس ابتدا تبدیل کنید و سپس در پایین پل بزنید."
+    }
   }
 }

--- a/packages/web/localizations/fr.json
+++ b/packages/web/localizations/fr.json
@@ -1399,6 +1399,12 @@
   "taprootAddressNotSupported": "Les adresses de racine pivotante ne sont pas prises en charge pour les retraits",
   "wormhole": {
     "deprecationTitle": "Le support de Wormhole est en cours de dépréciation",
-    "deprecationSubtitle": "Nous ne recommandons pas de transférer des actifs supplémentaires vers Osmosis via Wormhole. Cette page est disponible pour vous aider à retirer les actifs existants bridgés par Wormhole depuis Osmosis."
+    "deprecationSubtitle": "Nous ne recommandons pas de transférer des actifs supplémentaires vers Osmosis via Wormhole. Cette page est disponible pour vous aider à retirer les actifs existants bridgés par Wormhole depuis Osmosis.",
+    "bridgeStepTitle": "Faire le pont via Wormhole",
+    "refreshBalance": "Actualiser le solde",
+    "convertAlloy": {
+      "stepTitle": "Convertir {symbol} en {symbol}.wh",
+      "description": "Vous détenez {balance} {symbol} en tant qu actif allié. Wormhole fait le pont avec la variante {symbol}.wh, convertissez d abord puis faites le pont ci-dessous."
+    }
   }
 }

--- a/packages/web/localizations/gu.json
+++ b/packages/web/localizations/gu.json
@@ -1399,6 +1399,12 @@
   "taprootAddressNotSupported": "ઉપાડ માટે ટેપરૂટ સરનામાંઓ સમર્થિત નથી.",
   "wormhole": {
     "deprecationTitle": "Wormhole સપોર્ટ બંધ કરવામાં આવી રહ્યો છે",
-    "deprecationSubtitle": "અમે Wormhole મારફતે Osmosis માં વધારાની સંપત્તિ બ્રિજ કરવાની ભલામણ કરતા નથી. આ પૃષ્ઠ Osmosis માંથી હાલની Wormhole-બ્રિજ કરેલી સંપત્તિ ઉપાડવામાં તમને સહાય કરવા માટે ઉપલબ્ધ છે."
+    "deprecationSubtitle": "અમે Wormhole મારફતે Osmosis માં વધારાની સંપત્તિ બ્રિજ કરવાની ભલામણ કરતા નથી. આ પૃષ્ઠ Osmosis માંથી હાલની Wormhole-બ્રિજ કરેલી સંપત્તિ ઉપાડવામાં તમને સહાય કરવા માટે ઉપલબ્ધ છે.",
+    "bridgeStepTitle": "Wormhole દ્વારા બ્રિજ કરો",
+    "refreshBalance": "બેલેન્સ રિફ્રેશ કરો",
+    "convertAlloy": {
+      "stepTitle": "{symbol} ને {symbol}.wh માં કન્વર્ટ કરો",
+      "description": "તમારી પાસે {balance} {symbol} એલોય્ડ એસેટ તરીકે છે. Wormhole {symbol}.wh વેરિઅન્ટ બ્રિજ કરે છે, તેથી પહેલા કન્વર્ટ કરો, પછી નીચે બ્રિજ કરો."
+    }
   }
 }

--- a/packages/web/localizations/hi.json
+++ b/packages/web/localizations/hi.json
@@ -1399,6 +1399,12 @@
   "taprootAddressNotSupported": "निकासी के लिए टैपरूट पते समर्थित नहीं हैं",
   "wormhole": {
     "deprecationTitle": "Wormhole सहायता बंद की जा रही है",
-    "deprecationSubtitle": "हम Wormhole के माध्यम से Osmosis में अतिरिक्त संपत्ति ब्रिज करने की सिफारिश नहीं करते हैं। यह पृष्ठ आपको Osmosis से मौजूदा Wormhole-ब्रिज की गई संपत्ति निकालने में सहायता के लिए उपलब्ध है।"
+    "deprecationSubtitle": "हम Wormhole के माध्यम से Osmosis में अतिरिक्त संपत्ति ब्रिज करने की सिफारिश नहीं करते हैं। यह पृष्ठ आपको Osmosis से मौजूदा Wormhole-ब्रिज की गई संपत्ति निकालने में सहायता के लिए उपलब्ध है।",
+    "bridgeStepTitle": "Wormhole के माध्यम से ब्रिज करें",
+    "refreshBalance": "बैलेंस रिफ़्रेश करें",
+    "convertAlloy": {
+      "stepTitle": "{symbol} को {symbol}.wh में बदलें",
+      "description": "आपके पास एलॉयड एसेट के रूप में {balance} {symbol} है। Wormhole {symbol}.wh वैरिएंट को ब्रिज करता है, इसलिए पहले कन्वर्ट करें, फिर नीचे ब्रिज करें।"
+    }
   }
 }

--- a/packages/web/localizations/ja.json
+++ b/packages/web/localizations/ja.json
@@ -1399,6 +1399,12 @@
   "taprootAddressNotSupported": "Taprootアドレスは出金には対応していません",
   "wormhole": {
     "deprecationTitle": "Wormholeサポートは廃止予定です",
-    "deprecationSubtitle": "Wormholeを経由してOsmosisに追加のアセットをブリッジすることはお勧めしません。このページは、Osmosisから既存のWormholeブリッジ済みアセットを引き出すためにご利用いただけます。"
+    "deprecationSubtitle": "Wormholeを経由してOsmosisに追加のアセットをブリッジすることはお勧めしません。このページは、Osmosisから既存のWormholeブリッジ済みアセットを引き出すためにご利用いただけます。",
+    "bridgeStepTitle": "Wormholeでブリッジ",
+    "refreshBalance": "残高を更新",
+    "convertAlloy": {
+      "stepTitle": "{symbol}を{symbol}.whに変換",
+      "description": "アロイド資産として {balance} {symbol} を保有しています。Wormholeは{symbol}.whバリアントをブリッジするため、先に変換してから下でブリッジしてください。"
+    }
   }
 }

--- a/packages/web/localizations/ko.json
+++ b/packages/web/localizations/ko.json
@@ -1399,6 +1399,12 @@
   "taprootAddressNotSupported": "Taproot 주소는 출금에 지원되지 않습니다.",
   "wormhole": {
     "deprecationTitle": "Wormhole 지원이 중단될 예정입니다",
-    "deprecationSubtitle": "Wormhole을 통해 Osmosis로 추가 자산을 브리징하는 것을 권장하지 않습니다. 이 페이지는 Osmosis에서 기존 Wormhole 브리징 자산을 인출하는 데 도움을 드리기 위해 제공됩니다."
+    "deprecationSubtitle": "Wormhole을 통해 Osmosis로 추가 자산을 브리징하는 것을 권장하지 않습니다. 이 페이지는 Osmosis에서 기존 Wormhole 브리징 자산을 인출하는 데 도움을 드리기 위해 제공됩니다.",
+    "bridgeStepTitle": "Wormhole로 브리지",
+    "refreshBalance": "잔액 새로고침",
+    "convertAlloy": {
+      "stepTitle": "{symbol}을 {symbol}.wh로 변환",
+      "description": "합금 자산으로 {balance} {symbol}을 보유하고 있습니다. Wormhole은 {symbol}.wh 변형을 브리지하므로 먼저 변환한 다음 아래에서 브리지하세요."
+    }
   }
 }

--- a/packages/web/localizations/pl.json
+++ b/packages/web/localizations/pl.json
@@ -1399,6 +1399,12 @@
   "taprootAddressNotSupported": "Adresy Taproot nie są obsługiwane w przypadku wypłat",
   "wormhole": {
     "deprecationTitle": "Wsparcie dla Wormhole jest wycofywane",
-    "deprecationSubtitle": "Nie zalecamy przesyłania dodatkowych aktywów do Osmosis za pośrednictwem Wormhole. Ta strona jest dostępna, aby pomóc Ci wypłacić istniejące aktywa Wormhole z Osmosis."
+    "deprecationSubtitle": "Nie zalecamy przesyłania dodatkowych aktywów do Osmosis za pośrednictwem Wormhole. Ta strona jest dostępna, aby pomóc Ci wypłacić istniejące aktywa Wormhole z Osmosis.",
+    "bridgeStepTitle": "Zmostkuj przez Wormhole",
+    "refreshBalance": "Odśwież saldo",
+    "convertAlloy": {
+      "stepTitle": "Konwertuj {symbol} na {symbol}.wh",
+      "description": "Posiadasz {balance} {symbol} jako aktywo stopowe. Wormhole mostkuje wariant {symbol}.wh, więc najpierw skonwertuj, a potem zmostkuj poniżej."
+    }
   }
 }

--- a/packages/web/localizations/pt-br.json
+++ b/packages/web/localizations/pt-br.json
@@ -1399,6 +1399,12 @@
   "taprootAddressNotSupported": "Endereços Taproot não são suportados para retiradas",
   "wormhole": {
     "deprecationTitle": "O suporte ao Wormhole está sendo descontinuado",
-    "deprecationSubtitle": "Não recomendamos transferir ativos adicionais para Osmosis via Wormhole. Esta página está disponível para ajudá-lo a retirar ativos existentes bridgeados pelo Wormhole de Osmosis."
+    "deprecationSubtitle": "Não recomendamos transferir ativos adicionais para Osmosis via Wormhole. Esta página está disponível para ajudá-lo a retirar ativos existentes bridgeados pelo Wormhole de Osmosis.",
+    "bridgeStepTitle": "Fazer a ponte via Wormhole",
+    "refreshBalance": "Atualizar saldo",
+    "convertAlloy": {
+      "stepTitle": "Converter {symbol} para {symbol}.wh",
+      "description": "Você tem {balance} {symbol} como ativo alloyed. A Wormhole faz a ponte da variante {symbol}.wh, então converta primeiro e depois faça a ponte abaixo."
+    }
   }
 }

--- a/packages/web/localizations/ro.json
+++ b/packages/web/localizations/ro.json
@@ -1399,6 +1399,12 @@
   "taprootAddressNotSupported": "Adresele Taproot nu sunt acceptate pentru retrageri",
   "wormhole": {
     "deprecationTitle": "Suportul pentru Wormhole este în curs de retragere",
-    "deprecationSubtitle": "Nu recomandăm transferul de active suplimentare către Osmosis prin Wormhole. Această pagină este disponibilă pentru a vă ajuta să retrageți activele existente bridge-uite prin Wormhole din Osmosis."
+    "deprecationSubtitle": "Nu recomandăm transferul de active suplimentare către Osmosis prin Wormhole. Această pagină este disponibilă pentru a vă ajuta să retrageți activele existente bridge-uite prin Wormhole din Osmosis.",
+    "bridgeStepTitle": "Fă puntea prin Wormhole",
+    "refreshBalance": "Reîmprospătează soldul",
+    "convertAlloy": {
+      "stepTitle": "Convertește {symbol} în {symbol}.wh",
+      "description": "Deții {balance} {symbol} ca activ aliat. Wormhole face puntea variantei {symbol}.wh, așa că convertește mai întâi, apoi fă puntea mai jos."
+    }
   }
 }

--- a/packages/web/localizations/ru.json
+++ b/packages/web/localizations/ru.json
@@ -1399,6 +1399,12 @@
   "taprootAddressNotSupported": "Адреса Taproot не поддерживаются для вывода средств.",
   "wormhole": {
     "deprecationTitle": "Поддержка Wormhole прекращается",
-    "deprecationSubtitle": "Мы не рекомендуем переводить дополнительные активы в Osmosis через Wormhole. Эта страница доступна для того, чтобы помочь вам вывести существующие активы, переведённые через Wormhole, из Osmosis."
+    "deprecationSubtitle": "Мы не рекомендуем переводить дополнительные активы в Osmosis через Wormhole. Эта страница доступна для того, чтобы помочь вам вывести существующие активы, переведённые через Wormhole, из Osmosis.",
+    "bridgeStepTitle": "Бридж через Wormhole",
+    "refreshBalance": "Обновить баланс",
+    "convertAlloy": {
+      "stepTitle": "Конвертировать {symbol} в {symbol}.wh",
+      "description": "У вас есть {balance} {symbol} в виде alloyed-актива. Wormhole делает бридж варианта {symbol}.wh, поэтому сначала конвертируйте, затем используйте бридж ниже."
+    }
   }
 }

--- a/packages/web/localizations/tr.json
+++ b/packages/web/localizations/tr.json
@@ -1399,6 +1399,12 @@
   "taprootAddressNotSupported": "Taproot adresleri çekimler için desteklenmiyor",
   "wormhole": {
     "deprecationTitle": "Wormhole desteği kaldırılıyor",
-    "deprecationSubtitle": "Wormhole aracılığıyla Osmosis'e ek varlık köprülenmesini önermiyoruz. Bu sayfa, mevcut Wormhole köprülenmiş varlıklarınızı Osmosis'ten çekmenize yardımcı olmak için kullanılabilir."
+    "deprecationSubtitle": "Wormhole aracılığıyla Osmosis'e ek varlık köprülenmesini önermiyoruz. Bu sayfa, mevcut Wormhole köprülenmiş varlıklarınızı Osmosis'ten çekmenize yardımcı olmak için kullanılabilir.",
+    "bridgeStepTitle": "Wormhole ile köprüle",
+    "refreshBalance": "Bakiyeyi yenile",
+    "convertAlloy": {
+      "stepTitle": "{symbol} ı {symbol}.wh ye dönüştür",
+      "description": "Alaşımlı varlık olarak {balance} {symbol} tutuyorsunuz. Wormhole {symbol}.wh varyantını köprüler, bu yüzden önce dönüştürün, sonra aşağıda köprüleyin."
+    }
   }
 }

--- a/packages/web/localizations/zh-cn.json
+++ b/packages/web/localizations/zh-cn.json
@@ -1399,6 +1399,12 @@
   "taprootAddressNotSupported": "Taproot 地址不支持提现",
   "wormhole": {
     "deprecationTitle": "Wormhole 支持正在被弃用",
-    "deprecationSubtitle": "我们不建议通过 Wormhole 向 Osmosis 桥接更多资产。此页面可帮助您从 Osmosis 提取现有的 Wormhole 桥接资产。"
+    "deprecationSubtitle": "我们不建议通过 Wormhole 向 Osmosis 桥接更多资产。此页面可帮助您从 Osmosis 提取现有的 Wormhole 桥接资产。",
+    "bridgeStepTitle": "通过 Wormhole 跨链",
+    "refreshBalance": "刷新余额",
+    "convertAlloy": {
+      "stepTitle": "将 {symbol} 转换为 {symbol}.wh",
+      "description": "您持有 {balance} {symbol} 作为合金资产。Wormhole 跨链的是 {symbol}.wh 变体，请先转换，然后在下方跨链。"
+    }
   }
 }

--- a/packages/web/localizations/zh-hk.json
+++ b/packages/web/localizations/zh-hk.json
@@ -1399,6 +1399,12 @@
   "taprootAddressNotSupported": "Taproot 位址不支援提現",
   "wormhole": {
     "deprecationTitle": "Wormhole 支援正在被棄用",
-    "deprecationSubtitle": "我哋唔建議通過 Wormhole 向 Osmosis 橋接更多資產。呢個頁面可以幫助你從 Osmosis 提取現有嘅 Wormhole 橋接資產。"
+    "deprecationSubtitle": "我哋唔建議通過 Wormhole 向 Osmosis 橋接更多資產。呢個頁面可以幫助你從 Osmosis 提取現有嘅 Wormhole 橋接資產。",
+    "bridgeStepTitle": "透過 Wormhole 跨鏈",
+    "refreshBalance": "重新整理餘額",
+    "convertAlloy": {
+      "stepTitle": "將 {symbol} 轉換為 {symbol}.wh",
+      "description": "您持有 {balance} {symbol} 作為合金資產。Wormhole 跨鏈的是 {symbol}.wh 變體，請先轉換，然後在下方跨鏈。"
+    }
   }
 }

--- a/packages/web/localizations/zh-tw.json
+++ b/packages/web/localizations/zh-tw.json
@@ -1399,6 +1399,12 @@
   "taprootAddressNotSupported": "Taproot 位址不支援提現",
   "wormhole": {
     "deprecationTitle": "Wormhole 支援正在被棄用",
-    "deprecationSubtitle": "我們不建議透過 Wormhole 向 Osmosis 橋接更多資產。此頁面可協助您從 Osmosis 提取現有的 Wormhole 橋接資產。"
+    "deprecationSubtitle": "我們不建議透過 Wormhole 向 Osmosis 橋接更多資產。此頁面可協助您從 Osmosis 提取現有的 Wormhole 橋接資產。",
+    "bridgeStepTitle": "透過 Wormhole 跨鏈",
+    "refreshBalance": "重新整理餘額",
+    "convertAlloy": {
+      "stepTitle": "將 {symbol} 轉換為 {symbol}.wh",
+      "description": "您持有 {balance} {symbol} 作為合金資產。Wormhole 跨鏈的是 {symbol}.wh 變體，請先轉換，然後在下方跨鏈。"
+    }
   }
 }

--- a/packages/web/pages/wormhole.tsx
+++ b/packages/web/pages/wormhole.tsx
@@ -16,6 +16,14 @@ const WormholeRedeem = dynamic(
   { ssr: false }
 );
 
+const WormholeAlloyConvert = dynamic(
+  () =>
+    import("~/components/bridge/wormhole-alloy-convert").then(
+      (mod) => mod.WormholeAlloyConvert
+    ),
+  { ssr: false }
+);
+
 type PaletteColor = {
   50: string;
   100: string;
@@ -85,7 +93,9 @@ type WormholeConnectPartialTheme = {
 const customTheme: WormholeConnectPartialTheme = {
   mode: "dark",
   background: {
-    default: theme.colors.osmoverse["900"],
+    // Match the bridge step box so the widget blends in rather than reading as
+    // a nested card-within-a-box.
+    default: theme.colors.osmoverse["850"],
   },
   primary: {
     "50": theme.colors.wosmongton["100"],
@@ -254,6 +264,11 @@ const Wormhole: FunctionComponent = () => {
   const router = useRouter();
   const { t } = useTranslation();
   const [scriptLoaded, setScriptLoaded] = useState(false);
+  // The Connect widget mounts once on script execution and exposes no balance
+  // refresh API, so after the user converts their alloy to the `.wh` variant it
+  // keeps showing the stale balance. Bumping this re-mounts the widget div and
+  // re-injects (cache-busted) the bundle so it re-reads balances from scratch.
+  const [reloadKey, setReloadKey] = useState(0);
 
   useAmplitudeAnalytics({ onLoadEvent: [EventName.Wormhole.pageViewed] });
 
@@ -384,15 +399,44 @@ const Wormhole: FunctionComponent = () => {
     bridgeDefaults.toNetwork = toNetwork as ChainName;
   }
   if (token) {
-    bridgeDefaults.token = token;
+    // Wormhole Connect keys native Solana SOL as "SOL" (no Osmosis foreign
+    // asset) and the Osmosis-side wrapped form as "WSOL" (the SOL.wh denom). An
+    // Osmosis→Solana withdrawal therefore has to use "WSOL" or Connect can't
+    // resolve the source asset and won't prefill the token. The asset list
+    // hands off with token=SOL, so translate it here for that direction.
+    bridgeDefaults.token =
+      token === "SOL" && bridgeDefaults.fromNetwork === "osmosis"
+        ? "WSOL"
+        : token;
   }
   config.bridgeDefaults = bridgeDefaults;
 
   useEffect(() => {
+    // The Connect bundle reads `data-config` once on init and never re-reads it.
+    // Wait for the router to be ready so `config.bridgeDefaults` (built from the
+    // from/to/token query params) is populated before the script loads —
+    // otherwise the widget initialises with empty defaults and the deep-linked
+    // direction/token are lost.
+    if (!router.isReady) return;
+
+    // Each reload needs the spinner back until the re-injected bundle re-mounts.
+    setScriptLoaded(false);
+
+    // Removing the <script> node on cleanup does not abort an in-flight load, so
+    // a superseded reload's onload could still fire and flip scriptLoaded for a
+    // bundle that is no longer mounted. Guard the callbacks against a stale run.
+    let cancelled = false;
+
     const script = document.createElement("script");
     script.type = "module";
-    script.src =
-      "https://www.unpkg.com/@wormhole-foundation/wormhole-connect@0.3.21/dist/main.js";
+    // The bundle mounts once on execution and finds #wormhole-connect by id.
+    // To force a re-mount (after a convert) we re-key the container div AND
+    // re-run the module — module scripts are cached by resolved URL, so a
+    // changing query string is what makes the browser execute it again. The SRI
+    // hash is content-addressed (unpkg serves identical bytes for the
+    // query-string variants), so it still matches across the cache-busted URLs.
+    const cacheBust = reloadKey > 0 ? `?reload=${reloadKey}` : "";
+    script.src = `https://www.unpkg.com/@wormhole-foundation/wormhole-connect@0.3.21/dist/main.js${cacheBust}`;
     script.defer = true;
     /**
      * On version bumps make sure to update the hash.
@@ -401,17 +445,26 @@ const Wormhole: FunctionComponent = () => {
     script.integrity =
       "sha384-zGJnnw0Y8umaoMLkKqntkswRCTpYwMyu960bF3J77xySwmusndSEX9d4xUN/JXCl";
     script.crossOrigin = "anonymous";
-    script.onload = () => setScriptLoaded(true);
+    script.onload = () => {
+      if (!cancelled) setScriptLoaded(true);
+    };
+    // A failed integrity check or network error would otherwise leave the
+    // spinner up and the refresh button disabled forever with no recovery.
+    // Surface the bridge again so the user can retry via the refresh button.
+    script.onerror = () => {
+      if (!cancelled) setScriptLoaded(true);
+    };
     document.body.appendChild(script);
 
     return () => {
+      cancelled = true;
       document.body.removeChild(script);
     };
-  }, []);
+  }, [router.isReady, reloadKey]);
 
   return (
     <div className="bg-osmoverse-900">
-      <div className="mx-auto max-w-2xl px-4 pt-8">
+      <div className="mx-auto flex max-w-2xl flex-col gap-3 px-4 pt-8 pb-16">
         <div className="flex gap-3 rounded-2xl border-2 border-rust-600 p-5">
           <Icon
             id="alert-triangle"
@@ -426,19 +479,66 @@ const Wormhole: FunctionComponent = () => {
             </p>
           </div>
         </div>
-      </div>
-      {!scriptLoaded && (
-        <div className="flex h-screen w-full items-center justify-center">
-          <Spinner />
+
+        {/* Step 1 (optional): convert the alloy → its Wormhole `.wh` variant
+         * (allSOL→SOL.wh, allSUI→SUI.wh, allAPT→APT.wh) before bridging. The
+         * component self-gates on the destination + whether the user holds the
+         * alloy. */}
+        <WormholeAlloyConvert toNetwork={toNetwork} token={token} />
+
+        {/* Bridge step: the embedded Wormhole Connect widget. The widget brings
+         * its own generous internal padding and now shares the box background,
+         * so the container is pulled tight with negative margins to absorb the
+         * widget's built-in whitespace. */}
+        <div className="flex flex-col gap-1 rounded-3xl border border-osmoverse-700 bg-osmoverse-850 px-5 pt-5 pb-1">
+          <div className="flex items-center justify-between">
+            <h2 className="subtitle1 text-white-full">
+              {t("wormhole.bridgeStepTitle")}
+            </h2>
+            {/* The widget reads balances once on mount with no refresh API, so
+             * after a convert it can show a stale balance. This re-mounts and
+             * re-injects the bundle to re-read it. */}
+            <button
+              type="button"
+              onClick={() => {
+                // Show the spinner on this same render — without it the re-keyed
+                // (empty) container would flash visible for a frame before the
+                // effect resets scriptLoaded.
+                setScriptLoaded(false);
+                setReloadKey((k) => k + 1);
+              }}
+              disabled={!scriptLoaded}
+              className="flex items-center gap-1.5 rounded-lg px-2 py-1 text-osmoverse-300 transition-colors hover:bg-osmoverse-800 hover:text-white-full disabled:opacity-50"
+            >
+              <Icon id="refresh-ccw" className="h-4 w-4" />
+              <span className="caption">{t("wormhole.refreshBalance")}</span>
+            </button>
+          </div>
+          {(!scriptLoaded || !router.isReady) && (
+            <div className="flex w-full items-center justify-center py-16">
+              <Spinner />
+            </div>
+          )}
+          {/* Internal widget spacing is tightened via #wormhole-connect rules
+           * in globals.css (its DOM is a third-party CDN bundle). The key forces
+           * a fresh container on reload so the re-injected bundle mounts into an
+           * empty element rather than one holding a stale React root. */}
+          {router.isReady && (
+            <div
+              key={reloadKey}
+              id="wormhole-connect"
+              data-config={JSON.stringify(config)}
+              data-theme={JSON.stringify(customTheme)}
+              style={{ display: scriptLoaded ? "block" : "none" }}
+            ></div>
+          )}
         </div>
-      )}
-      <div
-        id="wormhole-connect"
-        data-config={JSON.stringify(config)}
-        data-theme={JSON.stringify(customTheme)}
-        style={{ display: scriptLoaded ? "block" : "none" }}
-      ></div>
-      <WormholeRedeem />
+
+        {/* Optional recovery step for stuck/unredeemed transfers — a sibling
+         * box in the step column. */}
+        <WormholeRedeem />
+      </div>
+
       {/**
        * On version bumps make sure to update the hash.
        * @see https://www.srihash.org/ - to compute it

--- a/packages/web/styles/globals.css
+++ b/packages/web/styles/globals.css
@@ -344,3 +344,13 @@
 .breakspaces {
   white-space-collapse: break-spaces;
 }
+
+/*
+ * Trim the embedded Wormhole Connect widget's content margin so it sits flush
+ * inside our bridge step box. The widget is a third-party CDN bundle rendered
+ * into #wormhole-connect with hashed MUI/emotion class names, so we match the
+ * stable `-appContent` suffix rather than the changeable hash prefix.
+ */
+#wormhole-connect [class*="-appContent"] {
+  margin: 0 !important;
+}


### PR DESCRIPTION
The `/wormhole` page (kept for withdrawing Wormhole-bridged assets) embeds the self-contained Wormhole Connect widget, which only bridges the `.wh` variant (`SOL.wh` / `SUI.wh` / `APT.wh`), not the alloy denom (`allSOL` / `allSUI` / `allAPT`) a user typically holds. Previously, they had to manually swap before bridging, with no in-page guidance.

This adds an inline **convert step**: **when the user holds the alloy for the selected destination**, the page embeds the swap tool defaulted to `alloy â†’ .wh variant` (1:1 via the transmuter) so they can convert in place, then bridge in the widget below.

This is reachable from the withdrawal flow for each of these 3 alloyed assets.

While touching the wormhole page, two other changes were made:
- Restructured the page into boxes more similar to the Osmosis style
- Fixed the wormhole widget not pre-populating
- Added Refresh Balance button to cater for the post-swap refresh since the wormhole widget needs entirely reimporting to refresh

## Preview links

The Connect widget click-through navigates to the external Wormhole provider and loses the Vercel preview domain, so use these direct deep-links into this branch's build:

- [SOL withdrawal](https://osmosis-frontend-git-johnnywyles-mtn-145-wormhole-allsol-7ceb57.vercel.dev-osmosis.zone/wormhole?from=osmosis&to=solana&token=SOL)
- [SUI withdrawal](https://osmosis-frontend-git-johnnywyles-mtn-145-wormhole-allsol-7ceb57.vercel.dev-osmosis.zone/wormhole?from=osmosis&to=sui&token=SUI)
- [APT withdrawal](https://osmosis-frontend-git-johnnywyles-mtn-145-wormhole-allsol-7ceb57.vercel.dev-osmosis.zone/wormhole?from=osmosis&to=aptos&token=APT)

## Changes

- **`wormhole-alloy-convert.tsx`** (new): config-driven `WormholeAlloyConvert` covering SOL/SUI/APT. Resolves each alloyâ†”variant pair from the asset list (variant by symbol, alloy via `variantGroupKey`), reads the user's full balance, and self-gates on destination network plus whether they hold the alloy. Embeds `SwapTool` in controlled mode (`useQueryParams={false}` so it doesn't clobber the page's `?from/to` params).
- **`wormhole.tsx`**: restructured into stepped boxes (deprecation banner, convert, bridge widget, recovery). Fixed the Connect widget not prefilling from the URL by gating the script-load effect and the `#wormhole-connect` container on `router.isReady`, so `data-config` is populated before the widget reads it once on mount. Added a `token=SOL â†’ WSOL` map for the Osmosisâ†’Solana direction (Connect keys the Osmosis-side wrapped SOL as `WSOL`; SUI/APT use their symbols directly). Matched the widget theme background to the box.
- **`wormhole-redeem.tsx`**: 3-line class change. Recovery box styling unified with the step boxes, made full-width.
- **`analytics-events.ts`**: added `"Wormhole Page"` to the `EventPage` union.
- **`globals.css`**: one rule trimming the embedded widget's content margin (`#wormhole-connect [class*="-appContent"]`, matched by stable MUI suffix since the CDN subtree can't be reached from a CSS module).
- **17 locales**: `wormhole.convertAlloy.{stepTitle,description}` (parameterized with `{symbol}`) plus a generic `bridgeStepTitle`.

## Decimals / correctness

Both denoms and decimals (allSOL 9 / SOL.wh 8; SUI/APT 8/8) resolve from the asset list via the swap tool's asset-resolution path, nothing hardcoded. Balance matching is denom-keyed. The convert is the standard 1:1 transmuter route.

## By-design notes

- **SOL/WSOL asymmetry**: only SOL needs the remap; SUI/APT pass through with their own symbols (a Connect-side quirk, commented inline).
- **Global CSS rule**: scoped to the page-specific `#wormhole-connect` container id with `!important` to beat emotion's injected styles; a CSS module can't reach into the third-party CDN-rendered subtree.
- **Slippage**: the embedded swap tool uses default slippage (no exact-0 pin), intentional.
- **No unit test** for the resolver/mapping: Wormhole is deprecating and its symbols/denoms are effectively frozen, so the asset-list-regen regression risk this would guard is negligible.

- **Stale bridge balance after converting**: the embedded Connect widget reads balances once on mount and exposes no refresh API (and its transfer events are unreachable in the CDN + `data-config` setup), so after a convert it shows a stale `.wh` balance. The bridge box has a **Refresh balance** button that re-keys the `#wormhole-connect` container and re-injects the bundle with a cache-busted URL, forcing a clean re-mount and balance re-read. The SRI hash stays valid (content-addressed, identical bytes per URL).
- **Source wallet can't be pre-connected**: for an Osmosis withdrawal the widget's source (Keplr/cosmos-kit) wallet must be connected inside the widget UI; Connect 0.3.21 has no config to inject or reuse the host app's existing connection, so the user reconnects there. Auto-connect would require upgrading the embedded widget to Connect 1.x, out of scope for this deprecated page.

## Note on APT testing

The APT end-to-end and layout checks below will not pass on this preview build. The convert card renders, but the swap tool can't quote `allAPT → APT.wh`: the preview hits the stage SQS deployment, which returns "no candidate routes found" for that pair.

This is a stage-only SQS infra issue, not a problem with this PR. allAPT is a single-asset alloy backed only by APT.wh, so the route is a 1:1 transmuter unwrap and quotes fine against prod SQS. Stage is running an older SQS release tag that predates the alloy-transmuter liquidity-filter exemption (PR #682 in the sqs repo), so it drops the thin APT transmuter pool. SUI passes because its pool clears the liquidity threshold even without the exemption. The fix is to deploy an SQS build containing that exemption to stage; no frontend change is needed.

## Review

- [x] Check layout renders for [SOL withdrawal](https://osmosis-frontend-git-johnnywyles-mtn-145-wormhole-allsol-7ceb57.vercel.dev-osmosis.zone/wormhole?from=osmosis&to=solana&token=SOL)
- [x] Check layout renders for [SUI withdrawal](https://osmosis-frontend-git-johnnywyles-mtn-145-wormhole-allsol-7ceb57.vercel.dev-osmosis.zone/wormhole?from=osmosis&to=sui&token=SUI)
- [x] Check layout renders for [APT withdrawal](https://osmosis-frontend-git-johnnywyles-mtn-145-wormhole-allsol-7ceb57.vercel.dev-osmosis.zone/wormhole?from=osmosis&to=aptos&token=APT)
- [x] Check end to end flow for [SOL](https://osmosis-frontend-git-johnnywyles-mtn-145-wormhole-allsol-7ceb57.vercel.dev-osmosis.zone/wormhole?from=osmosis&to=solana&token=SOL)
- [x] Check end to end flow for [SUI](https://osmosis-frontend-git-johnnywyles-mtn-145-wormhole-allsol-7ceb57.vercel.dev-osmosis.zone/wormhole?from=osmosis&to=sui&token=SUI)
- X Check end to end flow for [APT](https://osmosis-frontend-git-johnnywyles-mtn-145-wormhole-allsol-7ceb57.vercel.dev-osmosis.zone/wormhole?from=osmosis&to=aptos&token=APT)
- [x] Check that swap tool does not render when wallet has 0 of the alloy
- [x] Check that the swap tool does not render when navigating to another wormhole asset such as [PYTH](https://osmosis-frontend-git-johnnywyles-mtn-145-wormhole-allsol-7ceb57.vercel.dev-osmosis.zone/wormhole?from=osmosis&to=solana&token=PYTH)
- [x] Check that the swap tool does not render on [deposit flows](https://osmosis-frontend-git-johnnywyles-mtn-145-wormhole-allsol-7ceb57.vercel.dev-osmosis.zone/wormhole?from=solana&to=osmosis&token=SOL)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches real swap/bridge UX and wallet balance queries on a deprecated page; script reload and token mapping mistakes could confuse withdrawals but scope is limited to wormhole flows.
> 
> **Overview**
> Adds an optional **convert step** on `/wormhole` for Osmosis→Solana/Sui/Aptos withdrawals: when the user holds the alloy (`allSOL` / `allSUI` / `allAPT`) and the URL matches that asset, the page shows an inline **`SwapTool`** preset to swap alloy → `.wh` (transmuter), gated by destination + `?token=` and positive balance. **`useQueryParams={false}`** avoids clashing with the page’s `?from`/`?to` query keys.
> 
> **`wormhole.tsx`** is reorganized into stepped boxes (deprecation, convert, bridge, redeem). Connect **prefill** waits on **`router.isReady`** before injecting the script/`data-config`; **`token=SOL`** maps to **`WSOL`** for Osmosis→Solana. A **Refresh balance** control re-keys `#wormhole-connect` and cache-busts the Connect bundle so balances update after a convert. Theme/CSS tweaks align the widget with the bridge box.
> 
> Also: **`Wormhole Page`** analytics page type, redeem box styling aligned with steps, and new **`wormhole.*`** strings across locales.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08eafac3cc126b5947eb32b87d3da7b5ee5dceb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->