### PR TITLE
feat(bridge): pre-convert alloy to variant before third-party external-url hand-off

### DIFF
--- a/packages/web/components/bridge/external-url-convert.tsx
+++ b/packages/web/components/bridge/external-url-convert.tsx
@@ -15,7 +15,6 @@ import { api } from "~/utils/trpc";
  *  variantGroupKey family; see bridge-transfer.ts. */
 export interface ConvertToVariant {
   coinMinimalDenom: string;
-  decimals: number;
   symbol: string;
 }
 

--- a/packages/web/components/bridge/external-url-convert.tsx
+++ b/packages/web/components/bridge/external-url-convert.tsx
@@ -3,6 +3,7 @@ import { observer } from "mobx-react-lite";
 import { FunctionComponent, useCallback, useMemo, useState } from "react";
 
 import { SwapTool } from "~/components/swap-tool";
+import { Button } from "~/components/ui/button";
 import { useTranslation } from "~/hooks";
 import { ModalBase } from "~/modals";
 import { useStore } from "~/stores";
@@ -61,10 +62,20 @@ export const ExternalUrlConvertOption: FunctionComponent<{
     const account = accountStore.getWallet(accountStore.osmosisChainId);
 
     const [isConvertOpen, setIsConvertOpen] = useState(false);
+    // Set once the alloy -> variant convert has succeeded. We do NOT auto-open
+    // the third-party URL from onSwapSuccess: that runs after async wallet
+    // approval, outside the user-gesture chain, so browsers block the popup.
+    // Instead we surface a "Continue" button whose click is a fresh gesture.
+    const [convertSucceeded, setConvertSucceeded] = useState(false);
 
     const openUrl = useCallback(() => {
       window.open(url.toString(), "_blank", "noopener,noreferrer");
     }, [url]);
+
+    const closeModal = useCallback(() => {
+      setIsConvertOpen(false);
+      setConvertSucceeded(false);
+    }, []);
 
     // Use the full balance set (every denom), not the portfolio's top-N
     // allocations — the alloy/variant may be a long-tail holding.
@@ -129,54 +140,92 @@ export const ExternalUrlConvertOption: FunctionComponent<{
         {isConvertOpen && (
           <ModalBase
             isOpen={isConvertOpen}
-            onRequestClose={() => setIsConvertOpen(false)}
+            onRequestClose={closeModal}
             title={
               <div className="md:subtitle1 mx-auto text-h6 font-h6">
-                {t("transfer.moreBridgeOptions.convertBeforeWithdraw.title", {
-                  variant: convertToVariant.symbol,
-                  provider: providerName,
-                })}
+                {t(
+                  convertSucceeded
+                    ? "transfer.moreBridgeOptions.convertBeforeWithdraw.successTitle"
+                    : "transfer.moreBridgeOptions.convertBeforeWithdraw.title",
+                  { variant: convertToVariant.symbol, provider: providerName }
+                )}
               </div>
             }
             className="!max-w-[30rem]"
           >
-            <p className="body2 py-4 text-center text-osmoverse-300">
-              {t(
-                "transfer.moreBridgeOptions.convertBeforeWithdraw.description",
-                { variant: convertToVariant.symbol, provider: providerName }
-              )}
-            </p>
-            {variantBalance?.toDec().isPositive() && (
-              <div className="body2 flex items-center justify-center gap-1 pb-2 text-osmoverse-400">
-                <span>
+            {convertSucceeded ? (
+              // Post-convert hand-off. Opening the URL here is driven by the
+              // user's button click (a fresh gesture), so it isn't popup-blocked
+              // the way an auto-open from onSwapSuccess would be.
+              <div className="flex flex-col gap-4 py-4">
+                <p className="body2 text-center text-osmoverse-300">
                   {t(
-                    "transfer.moreBridgeOptions.convertBeforeWithdraw.currentVariantBalance",
-                    { variant: convertToVariant.symbol }
+                    "transfer.moreBridgeOptions.convertBeforeWithdraw.successDescription",
+                    { variant: convertToVariant.symbol, provider: providerName }
                   )}
-                </span>
-                <span className="text-osmoverse-200">
-                  {formatPretty(variantBalance)}
-                </span>
+                </p>
+                <Button
+                  onClick={() => {
+                    openUrl();
+                    closeModal();
+                  }}
+                >
+                  {t(
+                    "transfer.moreBridgeOptions.convertBeforeWithdraw.continueTo",
+                    { provider: providerName }
+                  )}
+                </Button>
               </div>
+            ) : (
+              <>
+                <p className="body2 py-4 text-center text-osmoverse-300">
+                  {t(
+                    "transfer.moreBridgeOptions.convertBeforeWithdraw.description",
+                    { variant: convertToVariant.symbol, provider: providerName }
+                  )}
+                </p>
+                {variantBalance?.toDec().isPositive() && (
+                  <div className="body2 flex items-center justify-center gap-1 pb-2 text-osmoverse-400">
+                    <span>
+                      {t(
+                        "transfer.moreBridgeOptions.convertBeforeWithdraw.currentVariantBalance",
+                        { variant: convertToVariant.symbol }
+                      )}
+                    </span>
+                    <span className="text-osmoverse-200">
+                      {formatPretty(variantBalance)}
+                    </span>
+                  </div>
+                )}
+                {/*
+                 * useQueryParams={false}: the bridge flow owns the page query
+                 * params; controlled mode keeps the swap state in local React
+                 * state so it never writes them.
+                 */}
+                <SwapTool
+                  useQueryParams={false}
+                  useOtherCurrencies={false}
+                  page="Bridge Page"
+                  initialSendTokenDenom={alloyMinimalDenom}
+                  initialOutTokenDenom={convertToVariant.coinMinimalDenom}
+                  onSwapSuccess={({ sendTokenDenom, outTokenDenom }) => {
+                    // Only hand off if the completed swap was actually
+                    // alloy -> variant. The swap tool still exposes the asset
+                    // switch, so a reversed swap must NOT trigger the
+                    // third-party hand-off this flow exists to gate.
+                    if (
+                      sendTokenDenom === alloyMinimalDenom &&
+                      outTokenDenom === convertToVariant.coinMinimalDenom
+                    ) {
+                      setConvertSucceeded(true);
+                    } else {
+                      // Wrong direction — just close; no hand-off.
+                      closeModal();
+                    }
+                  }}
+                />
+              </>
             )}
-            {/*
-             * useQueryParams={false}: the bridge flow owns the page query
-             * params; controlled mode keeps the swap state in local React state
-             * so it never writes them. The third-party URL opens only on a
-             * successful convert, so a failed/rejected/cap-blocked swap never
-             * redirects.
-             */}
-            <SwapTool
-              useQueryParams={false}
-              useOtherCurrencies={false}
-              page="Bridge Page"
-              initialSendTokenDenom={alloyMinimalDenom}
-              initialOutTokenDenom={convertToVariant.coinMinimalDenom}
-              onSwapSuccess={() => {
-                setIsConvertOpen(false);
-                openUrl();
-              }}
-            />
           </ModalBase>
         )}
       </>

--- a/packages/web/components/bridge/external-url-convert.tsx
+++ b/packages/web/components/bridge/external-url-convert.tsx
@@ -1,0 +1,129 @@
+import { CoinPretty } from "@osmosis-labs/unit";
+import { observer } from "mobx-react-lite";
+import { FunctionComponent, useCallback, useMemo, useState } from "react";
+
+import { SwapTool } from "~/components/swap-tool";
+import { useTranslation } from "~/hooks";
+import { ModalBase } from "~/modals";
+import { useStore } from "~/stores";
+import { api } from "~/utils/trpc";
+
+/** Variant a third-party external-interface site recognises in place of the
+ *  alloy. Resolved server-side in `getExternalUrls` from the alloy's
+ *  variantGroupKey family; see bridge-transfer.ts. */
+export interface ConvertToVariant {
+  coinMinimalDenom: string;
+  decimals: number;
+  symbol: string;
+}
+
+/**
+ * Hand-off for an alloy withdrawal whose external-interface site (e.g.
+ * Sologenic for allXRP, Picasso for allSOL) only recognises a bridge *variant*,
+ * not the alloy denom the user holds. Opening the URL directly would strand the
+ * user on a site that rejects the alloy.
+ *
+ * When the user holds the alloy (and not already the variant) this renders a
+ * convert step instead of a plain link: a modal embedding the swap tool
+ * defaulted to alloy → variant (1:1 via the transmuter). The third-party URL is
+ * opened only from `onSwapSuccess`, so a failed, rejected, or
+ * transmuter-cap-blocked convert never redirects (the swap tool surfaces the
+ * error in place). Once the user holds the variant the convert is skipped and
+ * the link opens directly.
+ */
+export const ExternalUrlConvertOption: FunctionComponent<{
+  url: URL;
+  providerName: string;
+  /** The alloy being withdrawn (the swap input). */
+  alloyMinimalDenom: string;
+  convertToVariant: ConvertToVariant;
+  /** Render prop for the clickable surface (splash CTA or list row). Receives
+   *  `href` when the link should open directly, or `onClick` when a convert
+   *  must run first. */
+  children: (props: { href?: string; onClick?: () => void }) => React.ReactNode;
+}> = observer(
+  ({ url, providerName, alloyMinimalDenom, convertToVariant, children }) => {
+    const { accountStore } = useStore();
+    const { t } = useTranslation();
+    const account = accountStore.getWallet(accountStore.osmosisChainId);
+
+    const [isConvertOpen, setIsConvertOpen] = useState(false);
+
+    const openUrl = useCallback(() => {
+      window.open(url.toString(), "_blank", "noopener,noreferrer");
+    }, [url]);
+
+    // Use the full balance set (every denom), not the portfolio's top-N
+    // allocations — the alloy/variant may be a long-tail holding.
+    const { data: userBalances } = api.local.balances.getUserBalances.useQuery(
+      { bech32Address: account?.address ?? "" },
+      { enabled: !!account?.address }
+    );
+
+    const holdsAlloy = useMemo(() => {
+      const coin = userBalances?.find(
+        ({ denom }) => denom === alloyMinimalDenom
+      )?.coin;
+      return Boolean(coin?.toDec().isPositive());
+    }, [userBalances, alloyMinimalDenom]);
+
+    const holdsVariant = useMemo(() => {
+      const coin = userBalances?.find(
+        ({ denom }) => denom === convertToVariant.coinMinimalDenom
+      )?.coin as CoinPretty | undefined;
+      return Boolean(coin?.toDec().isPositive());
+    }, [userBalances, convertToVariant.coinMinimalDenom]);
+
+    // Convert only when the user holds the alloy but not yet the variant the
+    // site accepts. Otherwise behave exactly like the plain link.
+    const needsConvert = holdsAlloy && !holdsVariant;
+
+    return (
+      <>
+        {needsConvert
+          ? children({ onClick: () => setIsConvertOpen(true) })
+          : children({ href: url.toString() })}
+        {needsConvert && (
+          <ModalBase
+            isOpen={isConvertOpen}
+            onRequestClose={() => setIsConvertOpen(false)}
+            title={
+              <div className="md:subtitle1 mx-auto text-h6 font-h6">
+                {t("transfer.moreBridgeOptions.convertBeforeWithdraw.title", {
+                  variant: convertToVariant.symbol,
+                  provider: providerName,
+                })}
+              </div>
+            }
+            className="!max-w-[30rem]"
+          >
+            <p className="body2 py-4 text-center text-osmoverse-300">
+              {t(
+                "transfer.moreBridgeOptions.convertBeforeWithdraw.description",
+                { variant: convertToVariant.symbol, provider: providerName }
+              )}
+            </p>
+            {/*
+             * useQueryParams={false}: the bridge flow owns the page query
+             * params; controlled mode keeps the swap state in local React state
+             * so it never writes them. The third-party URL opens only on a
+             * successful convert, so a failed/rejected/cap-blocked swap never
+             * redirects.
+             */}
+            <SwapTool
+              useQueryParams={false}
+              useOtherCurrencies={false}
+              page="Bridge Page"
+              initialSendTokenDenom={alloyMinimalDenom}
+              initialOutTokenDenom={convertToVariant.coinMinimalDenom}
+              onSwapSuccess={() => {
+                setIsConvertOpen(false);
+                openUrl();
+              }}
+            />
+          </ModalBase>
+        )}
+      </>
+    );
+  }
+);

--- a/packages/web/components/bridge/external-url-convert.tsx
+++ b/packages/web/components/bridge/external-url-convert.tsx
@@ -6,6 +6,7 @@ import { SwapTool } from "~/components/swap-tool";
 import { useTranslation } from "~/hooks";
 import { ModalBase } from "~/modals";
 import { useStore } from "~/stores";
+import { formatPretty } from "~/utils/formatter";
 import { api } from "~/utils/trpc";
 
 /** Variant a third-party external-interface site recognises in place of the
@@ -23,13 +24,19 @@ export interface ConvertToVariant {
  * not the alloy denom the user holds. Opening the URL directly would strand the
  * user on a site that rejects the alloy.
  *
- * When the user holds the alloy (and not already the variant) this renders a
- * convert step instead of a plain link: a modal embedding the swap tool
- * defaulted to alloy → variant (1:1 via the transmuter). The third-party URL is
- * opened only from `onSwapSuccess`, so a failed, rejected, or
- * transmuter-cap-blocked convert never redirects (the swap tool surfaces the
- * error in place). Once the user holds the variant the convert is skipped and
- * the link opens directly.
+ * When the user holds the alloy this renders a convert step instead of a plain
+ * link: a modal embedding the swap tool defaulted to alloy → variant (1:1 via
+ * the transmuter). The third-party URL is opened only from `onSwapSuccess`, so a
+ * failed, rejected, or transmuter-cap-blocked convert never redirects (the swap
+ * tool surfaces the error in place).
+ *
+ * The convert is offered whenever the user holds the alloy, even if they also
+ * already hold some of the variant: a dust/partial variant balance must not
+ * suppress the chance to convert the alloy they're trying to withdraw. The swap
+ * tool surfaces the alloy (input) balance but not the variant (output) balance,
+ * so the modal additionally shows the user's current variant balance to inform
+ * how much to convert. Only when the user holds no alloy at all does the link
+ * open directly.
  */
 export const ExternalUrlConvertOption: FunctionComponent<{
   url: URL;
@@ -55,10 +62,11 @@ export const ExternalUrlConvertOption: FunctionComponent<{
 
     // Use the full balance set (every denom), not the portfolio's top-N
     // allocations — the alloy/variant may be a long-tail holding.
-    const { data: userBalances } = api.local.balances.getUserBalances.useQuery(
-      { bech32Address: account?.address ?? "" },
-      { enabled: !!account?.address }
-    );
+    const { data: userBalances, isLoading: isLoadingBalances } =
+      api.local.balances.getUserBalances.useQuery(
+        { bech32Address: account?.address ?? "" },
+        { enabled: !!account?.address }
+      );
 
     const holdsAlloy = useMemo(() => {
       const coin = userBalances?.find(
@@ -67,20 +75,36 @@ export const ExternalUrlConvertOption: FunctionComponent<{
       return Boolean(coin?.toDec().isPositive());
     }, [userBalances, alloyMinimalDenom]);
 
-    const holdsVariant = useMemo(() => {
-      const coin = userBalances?.find(
-        ({ denom }) => denom === convertToVariant.coinMinimalDenom
-      )?.coin as CoinPretty | undefined;
-      return Boolean(coin?.toDec().isPositive());
-    }, [userBalances, convertToVariant.coinMinimalDenom]);
+    // The user's existing balance of the variant the site accepts. Shown in the
+    // convert modal so a user who already holds some (e.g. dust) can see it and
+    // decide how much more to convert — the swap tool itself does not surface
+    // the output-token balance.
+    const variantBalance = useMemo(
+      () =>
+        userBalances?.find(
+          ({ denom }) => denom === convertToVariant.coinMinimalDenom
+        )?.coin as CoinPretty | undefined,
+      [userBalances, convertToVariant.coinMinimalDenom]
+    );
 
-    // Convert only when the user holds the alloy but not yet the variant the
-    // site accepts. Otherwise behave exactly like the plain link.
-    const needsConvert = holdsAlloy && !holdsVariant;
+    // While a connected wallet's balances are still loading we cannot tell
+    // whether a convert is required, so we must NOT emit a direct href — a fast
+    // click would strand the user on a site that rejects the alloy. Render an
+    // inert surface until balances resolve.
+    const balancesPending =
+      !!account?.address && (isLoadingBalances || !userBalances);
+
+    // Offer the convert whenever the user holds the alloy. We deliberately do
+    // NOT also require "doesn't hold the variant": a dust/partial variant
+    // balance must not suppress converting the alloy. The swap modal shows both
+    // balances and lets the user choose the amount.
+    const needsConvert = holdsAlloy;
 
     return (
       <>
-        {needsConvert
+        {balancesPending
+          ? children({})
+          : needsConvert
           ? children({ onClick: () => setIsConvertOpen(true) })
           : children({ href: url.toString() })}
         {needsConvert && (
@@ -103,6 +127,19 @@ export const ExternalUrlConvertOption: FunctionComponent<{
                 { variant: convertToVariant.symbol, provider: providerName }
               )}
             </p>
+            {variantBalance?.toDec().isPositive() && (
+              <div className="body2 flex items-center justify-center gap-1 pb-2 text-osmoverse-400">
+                <span>
+                  {t(
+                    "transfer.moreBridgeOptions.convertBeforeWithdraw.currentVariantBalance",
+                    { variant: convertToVariant.symbol }
+                  )}
+                </span>
+                <span className="text-osmoverse-200">
+                  {formatPretty(variantBalance)}
+                </span>
+              </div>
+            )}
             {/*
              * useQueryParams={false}: the bridge flow owns the page query
              * params; controlled mode keeps the swap state in local React state

--- a/packages/web/components/bridge/external-url-convert.tsx
+++ b/packages/web/components/bridge/external-url-convert.tsx
@@ -35,8 +35,14 @@ export interface ConvertToVariant {
  * suppress the chance to convert the alloy they're trying to withdraw. The swap
  * tool surfaces the alloy (input) balance but not the variant (output) balance,
  * so the modal additionally shows the user's current variant balance to inform
- * how much to convert. Only when the user holds no alloy at all does the link
- * open directly.
+ * how much to convert.
+ *
+ * The plain direct link is used only when we can be sure no convert is needed:
+ * either no wallet is connected, or a connected wallet's balance query has
+ * confidently resolved (settled, no error) and shows no alloy. While balances
+ * are loading, refetching, or errored, the convert path is used instead — a
+ * stale or unknown balance must never produce a direct hand-off that could
+ * strand a holder on a site that rejects the alloy.
  */
 export const ExternalUrlConvertOption: FunctionComponent<{
   url: URL;
@@ -62,11 +68,14 @@ export const ExternalUrlConvertOption: FunctionComponent<{
 
     // Use the full balance set (every denom), not the portfolio's top-N
     // allocations — the alloy/variant may be a long-tail holding.
-    const { data: userBalances, isLoading: isLoadingBalances } =
-      api.local.balances.getUserBalances.useQuery(
-        { bech32Address: account?.address ?? "" },
-        { enabled: !!account?.address }
-      );
+    const {
+      data: userBalances,
+      isFetching: isFetchingBalances,
+      isError: isBalancesError,
+    } = api.local.balances.getUserBalances.useQuery(
+      { bech32Address: account?.address ?? "" },
+      { enabled: !!account?.address }
+    );
 
     const holdsAlloy = useMemo(() => {
       const coin = userBalances?.find(
@@ -87,26 +96,30 @@ export const ExternalUrlConvertOption: FunctionComponent<{
       [userBalances, convertToVariant.coinMinimalDenom]
     );
 
-    // While a connected wallet's balances are still loading we cannot tell
-    // whether a convert is required, so we must NOT emit a direct href — a fast
-    // click would strand the user on a site that rejects the alloy. Render an
-    // inert surface until balances resolve.
-    const balancesPending =
-      !!account?.address && (isLoadingBalances || !userBalances);
+    // The only unsafe outcome is emitting a direct href when the user actually
+    // holds the alloy — that strands them on a site that rejects the alloy
+    // denom. So among *connected* wallets we emit the direct link ONLY when the
+    // balance query has confidently resolved (settled, not fetching, no error)
+    // and shows no alloy. Every uncertain connected case — loading, a background
+    // refetch in flight (a stale "no alloy" snapshot must not clear the gate),
+    // or a query error — falls through to the convert path rather than the
+    // direct link; if the user turns out not to hold the alloy the modal's swap
+    // tool just shows a zero balance (mild friction), nobody is stranded.
+    //
+    // With no connected wallet there is nothing to convert and no balance to
+    // protect, so the plain link is correct (preserves middle-click / new-tab).
+    const isConnected = !!account?.address;
+    const balancesResolved =
+      isConnected && !isFetchingBalances && !isBalancesError;
 
-    // Offer the convert whenever the user holds the alloy. We deliberately do
-    // NOT also require "doesn't hold the variant": a dust/partial variant
-    // balance must not suppress converting the alloy. The swap modal shows both
-    // balances and lets the user choose the amount.
-    const needsConvert = holdsAlloy;
+    const offerDirectLink = !isConnected || (balancesResolved && !holdsAlloy);
+    const needsConvert = !offerDirectLink;
 
     return (
       <>
-        {balancesPending
-          ? children({})
-          : needsConvert
-          ? children({ onClick: () => setIsConvertOpen(true) })
-          : children({ href: url.toString() })}
+        {offerDirectLink
+          ? children({ href: url.toString() })
+          : children({ onClick: () => setIsConvertOpen(true) })}
         {needsConvert && (
           <ModalBase
             isOpen={isConvertOpen}

--- a/packages/web/components/bridge/external-url-convert.tsx
+++ b/packages/web/components/bridge/external-url-convert.tsx
@@ -113,14 +113,20 @@ export const ExternalUrlConvertOption: FunctionComponent<{
       isConnected && !isFetchingBalances && !isBalancesError;
 
     const offerDirectLink = !isConnected || (balancesResolved && !holdsAlloy);
-    const needsConvert = !offerDirectLink;
 
     return (
       <>
         {offerDirectLink
           ? children({ href: url.toString() })
           : children({ onClick: () => setIsConvertOpen(true) })}
-        {needsConvert && (
+        {/*
+         * Gate the modal on `isConvertOpen`, not the balance gate: once the user
+         * has opened the convert modal it must stay mounted until they close it
+         * or the swap succeeds. A background balance refetch can flip the gate to
+         * a direct link mid-interaction, and keying the modal on that would
+         * unmount it and drop in-progress SwapTool state.
+         */}
+        {isConvertOpen && (
           <ModalBase
             isOpen={isConvertOpen}
             onRequestClose={() => setIsConvertOpen(false)}

--- a/packages/web/components/bridge/more-bridge-options.tsx
+++ b/packages/web/components/bridge/more-bridge-options.tsx
@@ -4,11 +4,23 @@ import Link from "next/link";
 import React, { FunctionComponent } from "react";
 
 import { Icon } from "~/components/assets";
+import { ExternalUrlConvertOption } from "~/components/bridge/external-url-convert";
 import { SkeletonLoader } from "~/components/loaders";
 import { useTranslation } from "~/hooks";
 import { ModalBase, ModalBaseProps } from "~/modals";
 import type { BridgeChainWithDisplayInfo } from "~/server/api/routers/bridge-transfer";
 import { api } from "~/utils/trpc";
+
+type ExternalUrl = {
+  urlProviderName: string;
+  url: URL;
+  logo: string;
+  convertToVariant?: {
+    coinMinimalDenom: string;
+    decimals: number;
+    symbol: string;
+  };
+};
 
 interface MoreBridgeOptionsProps {
   direction: "deposit" | "withdraw";
@@ -72,13 +84,14 @@ function ExternalProviderList({
     );
   }
 
+  // On a withdrawal the source asset is the (possibly alloyed) asset being sent.
+  const withdrawAlloyMinimalDenom =
+    direction === "withdraw" ? fromAsset?.address : undefined;
+
   // Single provider: centered splash with large logo and primary CTA
   if (externalUrlsData?.externalUrls.length === 1) {
-    const {
-      urlProviderName: providerName,
-      url,
-      logo,
-    } = externalUrlsData.externalUrls[0];
+    const externalUrl = externalUrlsData.externalUrls[0];
+    const { urlProviderName: providerName, logo } = externalUrl;
     return (
       <div className="flex flex-col items-center gap-6 py-4">
         <Image
@@ -88,58 +101,115 @@ function ExternalProviderList({
           height={100}
           className="rounded-2xl"
         />
-        <a
-          href={url.toString()}
-          target="_blank"
-          rel="noreferrer"
-          className="subtitle1 flex w-full items-center justify-center gap-2 rounded-2xl bg-wosmongton-700 px-6 py-4 transition-colors duration-200 hover:bg-wosmongton-700/80"
+        <ExternalUrlOption
+          externalUrl={externalUrl}
+          direction={direction}
+          withdrawAlloyMinimalDenom={withdrawAlloyMinimalDenom}
         >
-          {t(
-            direction === "deposit"
-              ? "transfer.moreBridgeOptions.depositWith"
-              : "transfer.moreBridgeOptions.withdrawWith"
-          )}{" "}
-          {providerName}
-          <Icon id="arrow-up-right" className="text-white-full" />
-        </a>
+          {({ href, onClick }) => (
+            <a
+              href={href}
+              onClick={onClick}
+              {...(href ? { target: "_blank", rel: "noreferrer" } : {})}
+              className="subtitle1 flex w-full cursor-pointer items-center justify-center gap-2 rounded-2xl bg-wosmongton-700 px-6 py-4 transition-colors duration-200 hover:bg-wosmongton-700/80"
+            >
+              {t(
+                direction === "deposit"
+                  ? "transfer.moreBridgeOptions.depositWith"
+                  : "transfer.moreBridgeOptions.withdrawWith"
+              )}{" "}
+              {providerName}
+              <Icon id="arrow-up-right" className="text-white-full" />
+            </a>
+          )}
+        </ExternalUrlOption>
       </div>
     );
   }
 
   return (
     <>
-      {externalUrlsData?.externalUrls.map(
-        ({ urlProviderName: providerName, url, logo }) => (
-          <a
+      {externalUrlsData?.externalUrls.map((externalUrl) => {
+        const { urlProviderName: providerName, url, logo } = externalUrl;
+        return (
+          <ExternalUrlOption
             key={url.toString()}
-            href={url.toString()}
-            target="_blank"
-            rel="noreferrer"
-            className="subtitle1 md:caption flex items-center justify-between rounded-2xl bg-osmoverse-700 px-4 py-4 transition-colors duration-200 hover:bg-osmoverse-700/50 md:bg-transparent md:px-2 md:py-2"
+            externalUrl={externalUrl}
+            direction={direction}
+            withdrawAlloyMinimalDenom={withdrawAlloyMinimalDenom}
           >
-            <div className="flex items-center gap-3">
-              <Image
-                alt={`${providerName} logo`}
-                src={logo}
-                width={44}
-                height={42}
-              />
-              <span>
-                {t(
-                  direction === "deposit"
-                    ? "transfer.moreBridgeOptions.depositWith"
-                    : "transfer.moreBridgeOptions.withdrawWith"
-                )}{" "}
-                {providerName}
-              </span>
-            </div>
-            <Icon id="arrow-up-right" className="text-osmoverse-400" />
-          </a>
-        )
-      )}
+            {({ href, onClick }) => (
+              <a
+                href={href}
+                onClick={onClick}
+                {...(href ? { target: "_blank", rel: "noreferrer" } : {})}
+                className="subtitle1 md:caption flex w-full cursor-pointer items-center justify-between rounded-2xl bg-osmoverse-700 px-4 py-4 transition-colors duration-200 hover:bg-osmoverse-700/50 md:bg-transparent md:px-2 md:py-2"
+              >
+                <div className="flex items-center gap-3">
+                  <Image
+                    alt={`${providerName} logo`}
+                    src={logo}
+                    width={44}
+                    height={42}
+                  />
+                  <span>
+                    {t(
+                      direction === "deposit"
+                        ? "transfer.moreBridgeOptions.depositWith"
+                        : "transfer.moreBridgeOptions.withdrawWith"
+                    )}{" "}
+                    {providerName}
+                  </span>
+                </div>
+                <Icon id="arrow-up-right" className="text-osmoverse-400" />
+              </a>
+            )}
+          </ExternalUrlOption>
+        );
+      })}
     </>
   );
 }
+
+/**
+ * Renders one external-URL bridge option. When the option carries a
+ * `convertToVariant` (an alloy withdrawal whose third-party site only
+ * recognises a specific variant), it routes the click through the pre-convert
+ * flow; otherwise it opens the URL directly. Both the single-provider splash
+ * and the multi-provider list use this so the convert path is never bypassed.
+ */
+const ExternalUrlOption: FunctionComponent<{
+  externalUrl: ExternalUrl;
+  direction: "deposit" | "withdraw";
+  withdrawAlloyMinimalDenom?: string;
+  children: (props: { href?: string; onClick?: () => void }) => React.ReactNode;
+}> = ({ externalUrl, direction, withdrawAlloyMinimalDenom, children }) => {
+  const { url, urlProviderName, convertToVariant } = externalUrl;
+
+  // Pre-convert only applies to an alloy withdrawal whose site needs a variant.
+  // ExternalUrlConvertOption decides per-balance whether to actually intercept
+  // the click (convert) or fall through to opening the URL.
+  if (
+    direction === "withdraw" &&
+    withdrawAlloyMinimalDenom &&
+    convertToVariant
+  ) {
+    return (
+      <ExternalUrlConvertOption
+        url={url}
+        providerName={urlProviderName}
+        alloyMinimalDenom={withdrawAlloyMinimalDenom}
+        convertToVariant={convertToVariant}
+      >
+        {children}
+      </ExternalUrlConvertOption>
+    );
+  }
+
+  // No convert needed: render as a real link so middle-click / open-in-new-tab
+  // keep working.
+  return <>{children({ href: url.toString() })}</>;
+};
 
 /** Inline provider list for assets that only support external transfers (e.g. NAM). */
 export const ExternalOnlyProviderList: FunctionComponent<

--- a/packages/web/components/bridge/more-bridge-options.tsx
+++ b/packages/web/components/bridge/more-bridge-options.tsx
@@ -17,7 +17,6 @@ type ExternalUrl = {
   logo: string;
   convertToVariant?: {
     coinMinimalDenom: string;
-    decimals: number;
     symbol: string;
   };
 };

--- a/packages/web/config/analytics-events.ts
+++ b/packages/web/config/analytics-events.ts
@@ -13,7 +13,8 @@ export type EventPage =
   | "Swap Page"
   | "Token Info Page"
   | "Pool Details Page"
-  | "Wormhole Page";
+  | "Wormhole Page"
+  | "Bridge Page";
 
 export type EventProperties = {
   fromToken: string;

--- a/packages/web/localizations/de.json
+++ b/packages/web/localizations/de.json
@@ -876,7 +876,11 @@
       "chooseAnAlternativeProviderWithdraw": "Wählen Sie einen alternativen Anbieter zum Abheben {asset} von {fromChain} nach {toChain}",
       "depositWith": "Einzahlung mit",
       "withdrawWith": "Abheben mit",
-      "noAlternativesFound": "Keine alternativen Anbieter für diese Route gefunden."
+      "noAlternativesFound": "Keine alternativen Anbieter für diese Route gefunden.",
+      "convertBeforeWithdraw": {
+        "title": "Zuerst in {variant} umwandeln",
+        "description": "{provider} akzeptiert nur {variant}. Wandeln Sie Ihr Alloyed-Guthaben unten in {variant} um und fahren Sie dann mit {provider} fort, um Ihre Auszahlung abzuschließen."
+      }
     },
     "assetSelectScreen": {
       "titleDeposit": "Wählen Sie einen Vermögenswert zur Einzahlung aus",

--- a/packages/web/localizations/de.json
+++ b/packages/web/localizations/de.json
@@ -879,7 +879,8 @@
       "noAlternativesFound": "Keine alternativen Anbieter für diese Route gefunden.",
       "convertBeforeWithdraw": {
         "title": "Zuerst in {variant} umwandeln",
-        "description": "{provider} akzeptiert nur {variant}. Wandeln Sie Ihr Alloyed-Guthaben unten in {variant} um und fahren Sie dann mit {provider} fort, um Ihre Auszahlung abzuschließen."
+        "description": "{provider} akzeptiert nur {variant}. Wandeln Sie Ihr Alloyed-Guthaben unten in {variant} um und fahren Sie dann mit {provider} fort, um Ihre Auszahlung abzuschließen.",
+        "currentVariantBalance": "Aktuelles {variant}-Guthaben:"
       }
     },
     "assetSelectScreen": {

--- a/packages/web/localizations/de.json
+++ b/packages/web/localizations/de.json
@@ -880,7 +880,10 @@
       "convertBeforeWithdraw": {
         "title": "Zuerst in {variant} umwandeln",
         "description": "{provider} akzeptiert nur {variant}. Wandeln Sie Ihr Alloyed-Guthaben unten in {variant} um und fahren Sie dann mit {provider} fort, um Ihre Auszahlung abzuschließen.",
-        "currentVariantBalance": "Aktuelles {variant}-Guthaben:"
+        "currentVariantBalance": "Aktuelles {variant}-Guthaben:",
+        "successTitle": "In {variant} umgewandelt",
+        "successDescription": "Ihr {variant} ist bereit. Fahren Sie mit {provider} fort, um Ihre Auszahlung abzuschließen.",
+        "continueTo": "Weiter zu {provider}"
       }
     },
     "assetSelectScreen": {

--- a/packages/web/localizations/en.json
+++ b/packages/web/localizations/en.json
@@ -880,7 +880,10 @@
       "convertBeforeWithdraw": {
         "title": "Convert to {variant} first",
         "description": "{provider} only accepts {variant}. Convert your alloyed balance to {variant} below, then continue to {provider} to complete your withdrawal.",
-        "currentVariantBalance": "Current {variant} balance:"
+        "currentVariantBalance": "Current {variant} balance:",
+        "successTitle": "Converted to {variant}",
+        "successDescription": "Your {variant} is ready. Continue to {provider} to complete your withdrawal.",
+        "continueTo": "Continue to {provider}"
       }
     },
     "assetSelectScreen": {

--- a/packages/web/localizations/en.json
+++ b/packages/web/localizations/en.json
@@ -876,7 +876,11 @@
       "chooseAnAlternativeProviderWithdraw": "Choose an alternative provider to withdraw {asset} from {fromChain} to {toChain}",
       "depositWith": "Deposit with",
       "withdrawWith": "Withdraw with",
-      "noAlternativesFound": "No alternative providers found for this route."
+      "noAlternativesFound": "No alternative providers found for this route.",
+      "convertBeforeWithdraw": {
+        "title": "Convert to {variant} first",
+        "description": "{provider} only accepts {variant}. Convert your alloyed balance to {variant} below, then continue to {provider} to complete your withdrawal."
+      }
     },
     "assetSelectScreen": {
       "titleDeposit": "Select an asset to deposit",

--- a/packages/web/localizations/en.json
+++ b/packages/web/localizations/en.json
@@ -879,7 +879,8 @@
       "noAlternativesFound": "No alternative providers found for this route.",
       "convertBeforeWithdraw": {
         "title": "Convert to {variant} first",
-        "description": "{provider} only accepts {variant}. Convert your alloyed balance to {variant} below, then continue to {provider} to complete your withdrawal."
+        "description": "{provider} only accepts {variant}. Convert your alloyed balance to {variant} below, then continue to {provider} to complete your withdrawal.",
+        "currentVariantBalance": "Current {variant} balance:"
       }
     },
     "assetSelectScreen": {

--- a/packages/web/localizations/es.json
+++ b/packages/web/localizations/es.json
@@ -879,7 +879,8 @@
       "noAlternativesFound": "No se encontraron proveedores alternativos para esta ruta.",
       "convertBeforeWithdraw": {
         "title": "Convierte primero a {variant}",
-        "description": "{provider} solo acepta {variant}. Convierte tu saldo aleado a {variant} a continuación y luego continúa con {provider} para completar tu retiro."
+        "description": "{provider} solo acepta {variant}. Convierte tu saldo aleado a {variant} a continuación y luego continúa con {provider} para completar tu retiro.",
+        "currentVariantBalance": "Saldo actual de {variant}:"
       }
     },
     "assetSelectScreen": {

--- a/packages/web/localizations/es.json
+++ b/packages/web/localizations/es.json
@@ -880,7 +880,10 @@
       "convertBeforeWithdraw": {
         "title": "Convierte primero a {variant}",
         "description": "{provider} solo acepta {variant}. Convierte tu saldo aleado a {variant} a continuación y luego continúa con {provider} para completar tu retiro.",
-        "currentVariantBalance": "Saldo actual de {variant}:"
+        "currentVariantBalance": "Saldo actual de {variant}:",
+        "successTitle": "Convertido a {variant}",
+        "successDescription": "Tu {variant} está listo. Continúa a {provider} para completar tu retiro.",
+        "continueTo": "Continuar a {provider}"
       }
     },
     "assetSelectScreen": {

--- a/packages/web/localizations/es.json
+++ b/packages/web/localizations/es.json
@@ -876,7 +876,11 @@
       "chooseAnAlternativeProviderWithdraw": "Elija un proveedor alternativo para retirar {asset} de {fromChain} a {toChain}",
       "depositWith": "Depositar con",
       "withdrawWith": "Retirarse con",
-      "noAlternativesFound": "No se encontraron proveedores alternativos para esta ruta."
+      "noAlternativesFound": "No se encontraron proveedores alternativos para esta ruta.",
+      "convertBeforeWithdraw": {
+        "title": "Convierte primero a {variant}",
+        "description": "{provider} solo acepta {variant}. Convierte tu saldo aleado a {variant} a continuación y luego continúa con {provider} para completar tu retiro."
+      }
     },
     "assetSelectScreen": {
       "titleDeposit": "Seleccione un activo para depositar",

--- a/packages/web/localizations/fa.json
+++ b/packages/web/localizations/fa.json
@@ -879,7 +879,8 @@
       "noAlternativesFound": "هیچ ارائه‌دهنده جایگزینی برای این مسیر یافت نشد.",
       "convertBeforeWithdraw": {
         "title": "ابتدا به {variant} تبدیل کنید",
-        "description": "{provider} فقط {variant} را می‌پذیرد. موجودی آلوید خود را در زیر به {variant} تبدیل کنید، سپس برای تکمیل برداشت خود به {provider} ادامه دهید."
+        "description": "{provider} فقط {variant} را می‌پذیرد. موجودی آلوید خود را در زیر به {variant} تبدیل کنید، سپس برای تکمیل برداشت خود به {provider} ادامه دهید.",
+        "currentVariantBalance": "موجودی فعلی {variant}:"
       }
     },
     "assetSelectScreen": {

--- a/packages/web/localizations/fa.json
+++ b/packages/web/localizations/fa.json
@@ -876,7 +876,11 @@
       "chooseAnAlternativeProviderWithdraw": "یک ارائه‌دهنده جایگزین برای برداشتن {asset} از {fromChain} به {toChain} انتخاب کنید. {toChain}",
       "depositWith": "سپرده گذاری با",
       "withdrawWith": "برداشت با",
-      "noAlternativesFound": "هیچ ارائه‌دهنده جایگزینی برای این مسیر یافت نشد."
+      "noAlternativesFound": "هیچ ارائه‌دهنده جایگزینی برای این مسیر یافت نشد.",
+      "convertBeforeWithdraw": {
+        "title": "ابتدا به {variant} تبدیل کنید",
+        "description": "{provider} فقط {variant} را می‌پذیرد. موجودی آلوید خود را در زیر به {variant} تبدیل کنید، سپس برای تکمیل برداشت خود به {provider} ادامه دهید."
+      }
     },
     "assetSelectScreen": {
       "titleDeposit": "دارایی را برای سپرده گذاری انتخاب کنید",

--- a/packages/web/localizations/fa.json
+++ b/packages/web/localizations/fa.json
@@ -880,7 +880,10 @@
       "convertBeforeWithdraw": {
         "title": "ابتدا به {variant} تبدیل کنید",
         "description": "{provider} فقط {variant} را می‌پذیرد. موجودی آلوید خود را در زیر به {variant} تبدیل کنید، سپس برای تکمیل برداشت خود به {provider} ادامه دهید.",
-        "currentVariantBalance": "موجودی فعلی {variant}:"
+        "currentVariantBalance": "موجودی فعلی {variant}:",
+        "successTitle": "به {variant} تبدیل شد",
+        "successDescription": "{variant} شما آماده است. برای تکمیل برداشت به {provider} ادامه دهید.",
+        "continueTo": "ادامه به {provider}"
       }
     },
     "assetSelectScreen": {

--- a/packages/web/localizations/fr.json
+++ b/packages/web/localizations/fr.json
@@ -879,7 +879,8 @@
       "noAlternativesFound": "Aucun fournisseur alternatif trouvé pour cette route.",
       "convertBeforeWithdraw": {
         "title": "Convertissez d'abord en {variant}",
-        "description": "{provider} n'accepte que {variant}. Convertissez votre solde allié en {variant} ci-dessous, puis continuez avec {provider} pour finaliser votre retrait."
+        "description": "{provider} n'accepte que {variant}. Convertissez votre solde allié en {variant} ci-dessous, puis continuez avec {provider} pour finaliser votre retrait.",
+        "currentVariantBalance": "Solde actuel de {variant} :"
       }
     },
     "assetSelectScreen": {

--- a/packages/web/localizations/fr.json
+++ b/packages/web/localizations/fr.json
@@ -876,7 +876,11 @@
       "chooseAnAlternativeProviderWithdraw": "Choisissez un autre fournisseur pour retirer {asset} de {fromChain} à {toChain}",
       "depositWith": "Dépôt avec",
       "withdrawWith": "Retirer avec",
-      "noAlternativesFound": "Aucun fournisseur alternatif trouvé pour cette route."
+      "noAlternativesFound": "Aucun fournisseur alternatif trouvé pour cette route.",
+      "convertBeforeWithdraw": {
+        "title": "Convertissez d'abord en {variant}",
+        "description": "{provider} n'accepte que {variant}. Convertissez votre solde allié en {variant} ci-dessous, puis continuez avec {provider} pour finaliser votre retrait."
+      }
     },
     "assetSelectScreen": {
       "titleDeposit": "Sélectionnez un actif à déposer",

--- a/packages/web/localizations/fr.json
+++ b/packages/web/localizations/fr.json
@@ -880,7 +880,10 @@
       "convertBeforeWithdraw": {
         "title": "Convertissez d'abord en {variant}",
         "description": "{provider} n'accepte que {variant}. Convertissez votre solde allié en {variant} ci-dessous, puis continuez avec {provider} pour finaliser votre retrait.",
-        "currentVariantBalance": "Solde actuel de {variant} :"
+        "currentVariantBalance": "Solde actuel de {variant} :",
+        "successTitle": "Converti en {variant}",
+        "successDescription": "Votre {variant} est prêt. Continuez vers {provider} pour terminer votre retrait.",
+        "continueTo": "Continuer vers {provider}"
       }
     },
     "assetSelectScreen": {

--- a/packages/web/localizations/gu.json
+++ b/packages/web/localizations/gu.json
@@ -879,7 +879,8 @@
       "noAlternativesFound": "આ રૂટ માટે કોઈ વૈકલ્પિક પ્રદાતા મળ્યા નથી.",
       "convertBeforeWithdraw": {
         "title": "પહેલા {variant} માં રૂપાંતરિત કરો",
-        "description": "{provider} ફક્ત {variant} સ્વીકારે છે. તમારી alloyed બેલેન્સને નીચે {variant} માં રૂપાંતરિત કરો, પછી તમારી ઉપાડ પૂર્ણ કરવા માટે {provider} પર ચાલુ રાખો."
+        "description": "{provider} ફક્ત {variant} સ્વીકારે છે. તમારી alloyed બેલેન્સને નીચે {variant} માં રૂપાંતરિત કરો, પછી તમારી ઉપાડ પૂર્ણ કરવા માટે {provider} પર ચાલુ રાખો.",
+        "currentVariantBalance": "વર્તમાન {variant} બેલેન્સ:"
       }
     },
     "assetSelectScreen": {

--- a/packages/web/localizations/gu.json
+++ b/packages/web/localizations/gu.json
@@ -880,7 +880,10 @@
       "convertBeforeWithdraw": {
         "title": "પહેલા {variant} માં રૂપાંતરિત કરો",
         "description": "{provider} ફક્ત {variant} સ્વીકારે છે. તમારી alloyed બેલેન્સને નીચે {variant} માં રૂપાંતરિત કરો, પછી તમારી ઉપાડ પૂર્ણ કરવા માટે {provider} પર ચાલુ રાખો.",
-        "currentVariantBalance": "વર્તમાન {variant} બેલેન્સ:"
+        "currentVariantBalance": "વર્તમાન {variant} બેલેન્સ:",
+        "successTitle": "{variant} માં રૂપાંતરિત",
+        "successDescription": "તમારું {variant} તૈયાર છે. તમારી ઉપાડ પૂર્ણ કરવા {provider} પર ચાલુ રાખો.",
+        "continueTo": "{provider} પર ચાલુ રાખો"
       }
     },
     "assetSelectScreen": {

--- a/packages/web/localizations/gu.json
+++ b/packages/web/localizations/gu.json
@@ -876,7 +876,11 @@
       "chooseAnAlternativeProviderWithdraw": "{asset} {fromChain} થી {toChain}",
       "depositWith": "સાથે જમા",
       "withdrawWith": "સાથે પાછી ખેંચો",
-      "noAlternativesFound": "આ રૂટ માટે કોઈ વૈકલ્પિક પ્રદાતા મળ્યા નથી."
+      "noAlternativesFound": "આ રૂટ માટે કોઈ વૈકલ્પિક પ્રદાતા મળ્યા નથી.",
+      "convertBeforeWithdraw": {
+        "title": "પહેલા {variant} માં રૂપાંતરિત કરો",
+        "description": "{provider} ફક્ત {variant} સ્વીકારે છે. તમારી alloyed બેલેન્સને નીચે {variant} માં રૂપાંતરિત કરો, પછી તમારી ઉપાડ પૂર્ણ કરવા માટે {provider} પર ચાલુ રાખો."
+      }
     },
     "assetSelectScreen": {
       "titleDeposit": "જમા કરવા માટે સંપત્તિ પસંદ કરો",

--- a/packages/web/localizations/hi.json
+++ b/packages/web/localizations/hi.json
@@ -879,7 +879,8 @@
       "noAlternativesFound": "इस रूट के लिए कोई वैकल्पिक प्रदाता नहीं मिला।",
       "convertBeforeWithdraw": {
         "title": "पहले {variant} में बदलें",
-        "description": "{provider} केवल {variant} स्वीकार करता है। नीचे अपने अलॉयड बैलेंस को {variant} में बदलें, फिर अपनी निकासी पूरी करने के लिए {provider} पर जारी रखें।"
+        "description": "{provider} केवल {variant} स्वीकार करता है। नीचे अपने अलॉयड बैलेंस को {variant} में बदलें, फिर अपनी निकासी पूरी करने के लिए {provider} पर जारी रखें।",
+        "currentVariantBalance": "वर्तमान {variant} शेष:"
       }
     },
     "assetSelectScreen": {

--- a/packages/web/localizations/hi.json
+++ b/packages/web/localizations/hi.json
@@ -876,7 +876,11 @@
       "chooseAnAlternativeProviderWithdraw": "{asset} {fromChain} से {toChain}",
       "depositWith": "जमा करें",
       "withdrawWith": "साथ वापस लें",
-      "noAlternativesFound": "इस रूट के लिए कोई वैकल्पिक प्रदाता नहीं मिला।"
+      "noAlternativesFound": "इस रूट के लिए कोई वैकल्पिक प्रदाता नहीं मिला।",
+      "convertBeforeWithdraw": {
+        "title": "पहले {variant} में बदलें",
+        "description": "{provider} केवल {variant} स्वीकार करता है। नीचे अपने अलॉयड बैलेंस को {variant} में बदलें, फिर अपनी निकासी पूरी करने के लिए {provider} पर जारी रखें।"
+      }
     },
     "assetSelectScreen": {
       "titleDeposit": "जमा करने के लिए एक परिसंपत्ति का चयन करें",

--- a/packages/web/localizations/hi.json
+++ b/packages/web/localizations/hi.json
@@ -880,7 +880,10 @@
       "convertBeforeWithdraw": {
         "title": "पहले {variant} में बदलें",
         "description": "{provider} केवल {variant} स्वीकार करता है। नीचे अपने अलॉयड बैलेंस को {variant} में बदलें, फिर अपनी निकासी पूरी करने के लिए {provider} पर जारी रखें।",
-        "currentVariantBalance": "वर्तमान {variant} शेष:"
+        "currentVariantBalance": "वर्तमान {variant} शेष:",
+        "successTitle": "{variant} में परिवर्तित",
+        "successDescription": "आपका {variant} तैयार है। अपनी निकासी पूरी करने के लिए {provider} पर जारी रखें।",
+        "continueTo": "{provider} पर जारी रखें"
       }
     },
     "assetSelectScreen": {

--- a/packages/web/localizations/ja.json
+++ b/packages/web/localizations/ja.json
@@ -880,7 +880,10 @@
       "convertBeforeWithdraw": {
         "title": "まず{variant}に変換してください",
         "description": "{provider}は{variant}のみを受け付けます。以下でアロイ残高を{variant}に変換してから、{provider}に進んで引き出しを完了してください。",
-        "currentVariantBalance": "現在の{variant}残高："
+        "currentVariantBalance": "現在の{variant}残高：",
+        "successTitle": "{variant}に変換しました",
+        "successDescription": "{variant}の準備ができました。{provider}に進んで出金を完了してください。",
+        "continueTo": "{provider}に進む"
       }
     },
     "assetSelectScreen": {

--- a/packages/web/localizations/ja.json
+++ b/packages/web/localizations/ja.json
@@ -879,7 +879,8 @@
       "noAlternativesFound": "このルートに対する代替プロバイダーが見つかりませんでした。",
       "convertBeforeWithdraw": {
         "title": "まず{variant}に変換してください",
-        "description": "{provider}は{variant}のみを受け付けます。以下でアロイ残高を{variant}に変換してから、{provider}に進んで引き出しを完了してください。"
+        "description": "{provider}は{variant}のみを受け付けます。以下でアロイ残高を{variant}に変換してから、{provider}に進んで引き出しを完了してください。",
+        "currentVariantBalance": "現在の{variant}残高："
       }
     },
     "assetSelectScreen": {

--- a/packages/web/localizations/ja.json
+++ b/packages/web/localizations/ja.json
@@ -876,7 +876,11 @@
       "chooseAnAlternativeProviderWithdraw": "{asset} {fromChain}から{toChain}に引き出すには、別のプロバイダーを選択してください",
       "depositWith": "入金",
       "withdrawWith": "撤退する",
-      "noAlternativesFound": "このルートに対する代替プロバイダーが見つかりませんでした。"
+      "noAlternativesFound": "このルートに対する代替プロバイダーが見つかりませんでした。",
+      "convertBeforeWithdraw": {
+        "title": "まず{variant}に変換してください",
+        "description": "{provider}は{variant}のみを受け付けます。以下でアロイ残高を{variant}に変換してから、{provider}に進んで引き出しを完了してください。"
+      }
     },
     "assetSelectScreen": {
       "titleDeposit": "預ける資産を選択してください",

--- a/packages/web/localizations/ko.json
+++ b/packages/web/localizations/ko.json
@@ -876,7 +876,11 @@
       "chooseAnAlternativeProviderWithdraw": "{asset} {fromChain} \"asset\"}을(를 {toChain} 로 철회하려면 대체 공급자를 선택하세요. {toChain}",
       "depositWith": "다음으로 입금",
       "withdrawWith": "다음으로 인출",
-      "noAlternativesFound": "이 경로에 대한 대체 공급자를 찾을 수 없습니다."
+      "noAlternativesFound": "이 경로에 대한 대체 공급자를 찾을 수 없습니다.",
+      "convertBeforeWithdraw": {
+        "title": "먼저 {variant}(으)로 변환하세요",
+        "description": "{provider}은(는) {variant}만 허용합니다. 아래에서 합금(alloyed) 잔액을 {variant}(으)로 변환한 다음, {provider}(으)로 이동하여 인출을 완료하세요."
+      }
     },
     "assetSelectScreen": {
       "titleDeposit": "입금할 자산을 선택하세요",

--- a/packages/web/localizations/ko.json
+++ b/packages/web/localizations/ko.json
@@ -880,7 +880,10 @@
       "convertBeforeWithdraw": {
         "title": "먼저 {variant}(으)로 변환하세요",
         "description": "{provider}은(는) {variant}만 허용합니다. 아래에서 합금(alloyed) 잔액을 {variant}(으)로 변환한 다음, {provider}(으)로 이동하여 인출을 완료하세요.",
-        "currentVariantBalance": "현재 {variant} 잔액:"
+        "currentVariantBalance": "현재 {variant} 잔액:",
+        "successTitle": "{variant}로 변환됨",
+        "successDescription": "{variant}가 준비되었습니다. {provider}로 이동하여 출금을 완료하세요.",
+        "continueTo": "{provider}로 계속"
       }
     },
     "assetSelectScreen": {

--- a/packages/web/localizations/ko.json
+++ b/packages/web/localizations/ko.json
@@ -879,7 +879,8 @@
       "noAlternativesFound": "이 경로에 대한 대체 공급자를 찾을 수 없습니다.",
       "convertBeforeWithdraw": {
         "title": "먼저 {variant}(으)로 변환하세요",
-        "description": "{provider}은(는) {variant}만 허용합니다. 아래에서 합금(alloyed) 잔액을 {variant}(으)로 변환한 다음, {provider}(으)로 이동하여 인출을 완료하세요."
+        "description": "{provider}은(는) {variant}만 허용합니다. 아래에서 합금(alloyed) 잔액을 {variant}(으)로 변환한 다음, {provider}(으)로 이동하여 인출을 완료하세요.",
+        "currentVariantBalance": "현재 {variant} 잔액:"
       }
     },
     "assetSelectScreen": {

--- a/packages/web/localizations/pl.json
+++ b/packages/web/localizations/pl.json
@@ -876,7 +876,11 @@
       "chooseAnAlternativeProviderWithdraw": "Wybierz alternatywnego dostawcę, aby wycofać {asset} z {fromChain} do {toChain}",
       "depositWith": "Wpłać za pomocą",
       "withdrawWith": "Wycofaj się z",
-      "noAlternativesFound": "Nie znaleziono alternatywnych dostawców dla tej trasy."
+      "noAlternativesFound": "Nie znaleziono alternatywnych dostawców dla tej trasy.",
+      "convertBeforeWithdraw": {
+        "title": "Najpierw przekonwertuj na {variant}",
+        "description": "{provider} akceptuje tylko {variant}. Przekonwertuj swoje saldo alloyed na {variant} poniżej, a następnie przejdź do {provider}, aby zakończyć wypłatę."
+      }
     },
     "assetSelectScreen": {
       "titleDeposit": "Wybierz zasób do zdeponowania",

--- a/packages/web/localizations/pl.json
+++ b/packages/web/localizations/pl.json
@@ -880,7 +880,10 @@
       "convertBeforeWithdraw": {
         "title": "Najpierw przekonwertuj na {variant}",
         "description": "{provider} akceptuje tylko {variant}. Przekonwertuj swoje saldo alloyed na {variant} poniżej, a następnie przejdź do {provider}, aby zakończyć wypłatę.",
-        "currentVariantBalance": "Aktualne saldo {variant}:"
+        "currentVariantBalance": "Aktualne saldo {variant}:",
+        "successTitle": "Przekonwertowano na {variant}",
+        "successDescription": "Twój {variant} jest gotowy. Przejdź do {provider}, aby dokończyć wypłatę.",
+        "continueTo": "Przejdź do {provider}"
       }
     },
     "assetSelectScreen": {

--- a/packages/web/localizations/pl.json
+++ b/packages/web/localizations/pl.json
@@ -879,7 +879,8 @@
       "noAlternativesFound": "Nie znaleziono alternatywnych dostawców dla tej trasy.",
       "convertBeforeWithdraw": {
         "title": "Najpierw przekonwertuj na {variant}",
-        "description": "{provider} akceptuje tylko {variant}. Przekonwertuj swoje saldo alloyed na {variant} poniżej, a następnie przejdź do {provider}, aby zakończyć wypłatę."
+        "description": "{provider} akceptuje tylko {variant}. Przekonwertuj swoje saldo alloyed na {variant} poniżej, a następnie przejdź do {provider}, aby zakończyć wypłatę.",
+        "currentVariantBalance": "Aktualne saldo {variant}:"
       }
     },
     "assetSelectScreen": {

--- a/packages/web/localizations/pt-br.json
+++ b/packages/web/localizations/pt-br.json
@@ -876,7 +876,11 @@
       "chooseAnAlternativeProviderWithdraw": "Escolha um provedor alternativo para retirar {asset} de {fromChain} para {toChain}",
       "depositWith": "Deposite com",
       "withdrawWith": "Retirar com",
-      "noAlternativesFound": "Nenhum provedor alternativo encontrado para esta rota."
+      "noAlternativesFound": "Nenhum provedor alternativo encontrado para esta rota.",
+      "convertBeforeWithdraw": {
+        "title": "Converta primeiro para {variant}",
+        "description": "{provider} aceita apenas {variant}. Converta seu saldo alloyed para {variant} abaixo e, em seguida, continue para {provider} para concluir sua retirada."
+      }
     },
     "assetSelectScreen": {
       "titleDeposit": "Selecione um ativo para depositar",

--- a/packages/web/localizations/pt-br.json
+++ b/packages/web/localizations/pt-br.json
@@ -880,7 +880,10 @@
       "convertBeforeWithdraw": {
         "title": "Converta primeiro para {variant}",
         "description": "{provider} aceita apenas {variant}. Converta seu saldo alloyed para {variant} abaixo e, em seguida, continue para {provider} para concluir sua retirada.",
-        "currentVariantBalance": "Saldo atual de {variant}:"
+        "currentVariantBalance": "Saldo atual de {variant}:",
+        "successTitle": "Convertido para {variant}",
+        "successDescription": "Seu {variant} está pronto. Continue para {provider} para concluir seu saque.",
+        "continueTo": "Continuar para {provider}"
       }
     },
     "assetSelectScreen": {

--- a/packages/web/localizations/pt-br.json
+++ b/packages/web/localizations/pt-br.json
@@ -879,7 +879,8 @@
       "noAlternativesFound": "Nenhum provedor alternativo encontrado para esta rota.",
       "convertBeforeWithdraw": {
         "title": "Converta primeiro para {variant}",
-        "description": "{provider} aceita apenas {variant}. Converta seu saldo alloyed para {variant} abaixo e, em seguida, continue para {provider} para concluir sua retirada."
+        "description": "{provider} aceita apenas {variant}. Converta seu saldo alloyed para {variant} abaixo e, em seguida, continue para {provider} para concluir sua retirada.",
+        "currentVariantBalance": "Saldo atual de {variant}:"
       }
     },
     "assetSelectScreen": {

--- a/packages/web/localizations/ro.json
+++ b/packages/web/localizations/ro.json
@@ -880,7 +880,10 @@
       "convertBeforeWithdraw": {
         "title": "Convertiți mai întâi în {variant}",
         "description": "{provider} acceptă doar {variant}. Convertiți soldul dvs. aliat în {variant} mai jos, apoi continuați către {provider} pentru a finaliza retragerea.",
-        "currentVariantBalance": "Sold curent {variant}:"
+        "currentVariantBalance": "Sold curent {variant}:",
+        "successTitle": "Convertit în {variant}",
+        "successDescription": "{variant} este gata. Continuați la {provider} pentru a finaliza retragerea.",
+        "continueTo": "Continuați la {provider}"
       }
     },
     "assetSelectScreen": {

--- a/packages/web/localizations/ro.json
+++ b/packages/web/localizations/ro.json
@@ -879,7 +879,8 @@
       "noAlternativesFound": "Niciun furnizor alternativ găsit pentru această rută.",
       "convertBeforeWithdraw": {
         "title": "Convertiți mai întâi în {variant}",
-        "description": "{provider} acceptă doar {variant}. Convertiți soldul dvs. aliat în {variant} mai jos, apoi continuați către {provider} pentru a finaliza retragerea."
+        "description": "{provider} acceptă doar {variant}. Convertiți soldul dvs. aliat în {variant} mai jos, apoi continuați către {provider} pentru a finaliza retragerea.",
+        "currentVariantBalance": "Sold curent {variant}:"
       }
     },
     "assetSelectScreen": {

--- a/packages/web/localizations/ro.json
+++ b/packages/web/localizations/ro.json
@@ -876,7 +876,11 @@
       "chooseAnAlternativeProviderWithdraw": "Alegeți un furnizor alternativ pentru a retrage {asset} de la {fromChain} la {toChain}",
       "depositWith": "Depozit cu",
       "withdrawWith": "Retrage cu",
-      "noAlternativesFound": "Niciun furnizor alternativ găsit pentru această rută."
+      "noAlternativesFound": "Niciun furnizor alternativ găsit pentru această rută.",
+      "convertBeforeWithdraw": {
+        "title": "Convertiți mai întâi în {variant}",
+        "description": "{provider} acceptă doar {variant}. Convertiți soldul dvs. aliat în {variant} mai jos, apoi continuați către {provider} pentru a finaliza retragerea."
+      }
     },
     "assetSelectScreen": {
       "titleDeposit": "Selectați un activ de depus",

--- a/packages/web/localizations/ru.json
+++ b/packages/web/localizations/ru.json
@@ -876,7 +876,11 @@
       "chooseAnAlternativeProviderWithdraw": "Выберите альтернативного поставщика для вывода {asset} из {fromChain} в {toChain}",
       "depositWith": "Депозит с",
       "withdrawWith": "Вывод средств с помощью",
-      "noAlternativesFound": "Альтернативные поставщики для этого маршрута не найдены."
+      "noAlternativesFound": "Альтернативные поставщики для этого маршрута не найдены.",
+      "convertBeforeWithdraw": {
+        "title": "Сначала конвертируйте в {variant}",
+        "description": "{provider} принимает только {variant}. Конвертируйте ваш сплавленный баланс в {variant} ниже, затем перейдите к {provider}, чтобы завершить вывод средств."
+      }
     },
     "assetSelectScreen": {
       "titleDeposit": "Выберите актив для депозита",

--- a/packages/web/localizations/ru.json
+++ b/packages/web/localizations/ru.json
@@ -879,7 +879,8 @@
       "noAlternativesFound": "Альтернативные поставщики для этого маршрута не найдены.",
       "convertBeforeWithdraw": {
         "title": "Сначала конвертируйте в {variant}",
-        "description": "{provider} принимает только {variant}. Конвертируйте ваш сплавленный баланс в {variant} ниже, затем перейдите к {provider}, чтобы завершить вывод средств."
+        "description": "{provider} принимает только {variant}. Конвертируйте ваш сплавленный баланс в {variant} ниже, затем перейдите к {provider}, чтобы завершить вывод средств.",
+        "currentVariantBalance": "Текущий баланс {variant}:"
       }
     },
     "assetSelectScreen": {

--- a/packages/web/localizations/ru.json
+++ b/packages/web/localizations/ru.json
@@ -880,7 +880,10 @@
       "convertBeforeWithdraw": {
         "title": "Сначала конвертируйте в {variant}",
         "description": "{provider} принимает только {variant}. Конвертируйте ваш сплавленный баланс в {variant} ниже, затем перейдите к {provider}, чтобы завершить вывод средств.",
-        "currentVariantBalance": "Текущий баланс {variant}:"
+        "currentVariantBalance": "Текущий баланс {variant}:",
+        "successTitle": "Конвертировано в {variant}",
+        "successDescription": "Ваш {variant} готов. Перейдите к {provider}, чтобы завершить вывод.",
+        "continueTo": "Перейти к {provider}"
       }
     },
     "assetSelectScreen": {

--- a/packages/web/localizations/tr.json
+++ b/packages/web/localizations/tr.json
@@ -880,7 +880,10 @@
       "convertBeforeWithdraw": {
         "title": "Önce {variant} öğesine dönüştürün",
         "description": "{provider} yalnızca {variant} kabul eder. Alaşımlı bakiyenizi aşağıda {variant} öğesine dönüştürün, ardından çekme işleminizi tamamlamak için {provider} ile devam edin.",
-        "currentVariantBalance": "Mevcut {variant} bakiyesi:"
+        "currentVariantBalance": "Mevcut {variant} bakiyesi:",
+        "successTitle": "{variant} olarak dönüştürüldü",
+        "successDescription": "{variant} hazır. Çekiminizi tamamlamak için {provider} ile devam edin.",
+        "continueTo": "{provider} ile devam et"
       }
     },
     "assetSelectScreen": {

--- a/packages/web/localizations/tr.json
+++ b/packages/web/localizations/tr.json
@@ -879,7 +879,8 @@
       "noAlternativesFound": "Bu rota için alternatif sağlayıcı bulunamadı.",
       "convertBeforeWithdraw": {
         "title": "Önce {variant} öğesine dönüştürün",
-        "description": "{provider} yalnızca {variant} kabul eder. Alaşımlı bakiyenizi aşağıda {variant} öğesine dönüştürün, ardından çekme işleminizi tamamlamak için {provider} ile devam edin."
+        "description": "{provider} yalnızca {variant} kabul eder. Alaşımlı bakiyenizi aşağıda {variant} öğesine dönüştürün, ardından çekme işleminizi tamamlamak için {provider} ile devam edin.",
+        "currentVariantBalance": "Mevcut {variant} bakiyesi:"
       }
     },
     "assetSelectScreen": {

--- a/packages/web/localizations/tr.json
+++ b/packages/web/localizations/tr.json
@@ -876,7 +876,11 @@
       "chooseAnAlternativeProviderWithdraw": "{asset} yi {fromChain} den {toChain}",
       "depositWith": "Şununla para yatır:",
       "withdrawWith": "Şununla çekil:",
-      "noAlternativesFound": "Bu rota için alternatif sağlayıcı bulunamadı."
+      "noAlternativesFound": "Bu rota için alternatif sağlayıcı bulunamadı.",
+      "convertBeforeWithdraw": {
+        "title": "Önce {variant} öğesine dönüştürün",
+        "description": "{provider} yalnızca {variant} kabul eder. Alaşımlı bakiyenizi aşağıda {variant} öğesine dönüştürün, ardından çekme işleminizi tamamlamak için {provider} ile devam edin."
+      }
     },
     "assetSelectScreen": {
       "titleDeposit": "Yatırılacak bir varlık seçin",

--- a/packages/web/localizations/zh-cn.json
+++ b/packages/web/localizations/zh-cn.json
@@ -879,7 +879,8 @@
       "noAlternativesFound": "未找到此路线的替代提供商。",
       "convertBeforeWithdraw": {
         "title": "请先转换为 {variant}",
-        "description": "{provider} 仅接受 {variant}。请在下方将您的合金余额转换为 {variant}，然后继续前往 {provider} 完成提款。"
+        "description": "{provider} 仅接受 {variant}。请在下方将您的合金余额转换为 {variant}，然后继续前往 {provider} 完成提款。",
+        "currentVariantBalance": "当前 {variant} 余额："
       }
     },
     "assetSelectScreen": {

--- a/packages/web/localizations/zh-cn.json
+++ b/packages/web/localizations/zh-cn.json
@@ -876,7 +876,11 @@
       "chooseAnAlternativeProviderWithdraw": "选择替代提供商将{asset}从{fromChain}提取到{toChain}",
       "depositWith": "存款",
       "withdrawWith": "提款",
-      "noAlternativesFound": "未找到此路线的替代提供商。"
+      "noAlternativesFound": "未找到此路线的替代提供商。",
+      "convertBeforeWithdraw": {
+        "title": "请先转换为 {variant}",
+        "description": "{provider} 仅接受 {variant}。请在下方将您的合金余额转换为 {variant}，然后继续前往 {provider} 完成提款。"
+      }
     },
     "assetSelectScreen": {
       "titleDeposit": "选择要存入的资产",

--- a/packages/web/localizations/zh-cn.json
+++ b/packages/web/localizations/zh-cn.json
@@ -880,7 +880,10 @@
       "convertBeforeWithdraw": {
         "title": "请先转换为 {variant}",
         "description": "{provider} 仅接受 {variant}。请在下方将您的合金余额转换为 {variant}，然后继续前往 {provider} 完成提款。",
-        "currentVariantBalance": "当前 {variant} 余额："
+        "currentVariantBalance": "当前 {variant} 余额：",
+        "successTitle": "已转换为 {variant}",
+        "successDescription": "您的 {variant} 已就绪。继续前往 {provider} 完成提现。",
+        "continueTo": "继续前往 {provider}"
       }
     },
     "assetSelectScreen": {

--- a/packages/web/localizations/zh-hk.json
+++ b/packages/web/localizations/zh-hk.json
@@ -879,7 +879,8 @@
       "noAlternativesFound": "找不到此路線的替代提供者。",
       "convertBeforeWithdraw": {
         "title": "先轉換為 {variant}",
-        "description": "{provider} 只接受 {variant}。請在下方將你的合金結餘轉換為 {variant}，然後繼續前往 {provider} 完成提款。"
+        "description": "{provider} 只接受 {variant}。請在下方將你的合金結餘轉換為 {variant}，然後繼續前往 {provider} 完成提款。",
+        "currentVariantBalance": "目前 {variant} 餘額："
       }
     },
     "assetSelectScreen": {

--- a/packages/web/localizations/zh-hk.json
+++ b/packages/web/localizations/zh-hk.json
@@ -880,7 +880,10 @@
       "convertBeforeWithdraw": {
         "title": "先轉換為 {variant}",
         "description": "{provider} 只接受 {variant}。請在下方將你的合金結餘轉換為 {variant}，然後繼續前往 {provider} 完成提款。",
-        "currentVariantBalance": "目前 {variant} 餘額："
+        "currentVariantBalance": "目前 {variant} 餘額：",
+        "successTitle": "已轉換為 {variant}",
+        "successDescription": "您的 {variant} 已就緒。繼續前往 {provider} 完成提款。",
+        "continueTo": "繼續前往 {provider}"
       }
     },
     "assetSelectScreen": {

--- a/packages/web/localizations/zh-hk.json
+++ b/packages/web/localizations/zh-hk.json
@@ -876,7 +876,11 @@
       "chooseAnAlternativeProviderWithdraw": "選擇替代提供者將{asset}從{fromChain}撤回到{toChain}",
       "depositWith": "存款於",
       "withdrawWith": "撤回與",
-      "noAlternativesFound": "找不到此路線的替代提供者。"
+      "noAlternativesFound": "找不到此路線的替代提供者。",
+      "convertBeforeWithdraw": {
+        "title": "先轉換為 {variant}",
+        "description": "{provider} 只接受 {variant}。請在下方將你的合金結餘轉換為 {variant}，然後繼續前往 {provider} 完成提款。"
+      }
     },
     "assetSelectScreen": {
       "titleDeposit": "選擇要存入的資產",

--- a/packages/web/localizations/zh-tw.json
+++ b/packages/web/localizations/zh-tw.json
@@ -876,7 +876,11 @@
       "chooseAnAlternativeProviderWithdraw": "選擇替代提供者將{asset}從{fromChain}撤回到{toChain}",
       "depositWith": "存款於",
       "withdrawWith": "撤回與",
-      "noAlternativesFound": "找不到此路線的替代提供者。"
+      "noAlternativesFound": "找不到此路線的替代提供者。",
+      "convertBeforeWithdraw": {
+        "title": "請先轉換為 {variant}",
+        "description": "{provider} 僅接受 {variant}。請在下方將您的合金餘額轉換為 {variant}，然後繼續前往 {provider} 完成提款。"
+      }
     },
     "assetSelectScreen": {
       "titleDeposit": "選擇要存入的資產",

--- a/packages/web/localizations/zh-tw.json
+++ b/packages/web/localizations/zh-tw.json
@@ -879,7 +879,8 @@
       "noAlternativesFound": "找不到此路線的替代提供者。",
       "convertBeforeWithdraw": {
         "title": "請先轉換為 {variant}",
-        "description": "{provider} 僅接受 {variant}。請在下方將您的合金餘額轉換為 {variant}，然後繼續前往 {provider} 完成提款。"
+        "description": "{provider} 僅接受 {variant}。請在下方將您的合金餘額轉換為 {variant}，然後繼續前往 {provider} 完成提款。",
+        "currentVariantBalance": "目前 {variant} 餘額："
       }
     },
     "assetSelectScreen": {

--- a/packages/web/localizations/zh-tw.json
+++ b/packages/web/localizations/zh-tw.json
@@ -880,7 +880,10 @@
       "convertBeforeWithdraw": {
         "title": "請先轉換為 {variant}",
         "description": "{provider} 僅接受 {variant}。請在下方將您的合金餘額轉換為 {variant}，然後繼續前往 {provider} 完成提款。",
-        "currentVariantBalance": "目前 {variant} 餘額："
+        "currentVariantBalance": "目前 {variant} 餘額：",
+        "successTitle": "已轉換為 {variant}",
+        "successDescription": "您的 {variant} 已就緒。繼續前往 {provider} 完成提款。",
+        "continueTo": "繼續前往 {provider}"
       }
     },
     "assetSelectScreen": {

--- a/packages/web/server/api/routers/bridge-transfer.ts
+++ b/packages/web/server/api/routers/bridge-transfer.ts
@@ -20,7 +20,6 @@ import {
   UserOsmoAddressSchema,
 } from "@osmosis-labs/trpc";
 import { isInsufficientFeeError } from "@osmosis-labs/tx";
-import { TRPCError } from "@trpc/server";
 import { ExternalInterfaceBridgeTransferMethod } from "@osmosis-labs/types";
 import { CoinPretty, Dec, DecUtils, PricePretty } from "@osmosis-labs/unit";
 import {
@@ -39,11 +38,13 @@ import {
   TronChainInfo,
   XrplChainInfo,
 } from "@osmosis-labs/utils";
+import { TRPCError } from "@trpc/server";
 import { CacheEntry } from "cachified";
 import { LRUCache } from "lru-cache";
 import { z } from "zod";
 
 import { IS_TESTNET } from "~/config/env";
+import { resolveExternalUrlConvertVariant } from "~/server/api/routers/bridge/external-url-convert-variant";
 import { BridgeLogoUrls, ExternalBridgeLogoUrls } from "~/utils/bridge";
 import { INSUFFICIENT_FEE_TOKENS_OSMOSIS_MARKER } from "~/utils/error";
 
@@ -618,13 +619,15 @@ export const bridgeTransferRouter = createTRPCRouter({
         Boolean(externalUrl)
       );
 
+      const allAssetListAssets = ctx.assetLists.flatMap(({ assets }) => assets);
+
       // add external urls for external interfaces from asset list, as long as not already added
-      const assetListFromAsset = ctx.assetLists
-        .flatMap(({ assets }) => assets)
-        .find((asset) => asset.coinMinimalDenom === input.fromAsset?.address);
-      const assetListToAsset = ctx.assetLists
-        .flatMap(({ assets }) => assets)
-        .find((asset) => asset.coinMinimalDenom === input.toAsset?.address);
+      const assetListFromAsset = allAssetListAssets.find(
+        (asset) => asset.coinMinimalDenom === input.fromAsset?.address
+      );
+      const assetListToAsset = allAssetListAssets.find(
+        (asset) => asset.coinMinimalDenom === input.toAsset?.address
+      );
 
       const externalTransferMethods = (
         assetListFromAsset?.transferMethods.filter(
@@ -679,8 +682,29 @@ export const bridgeTransferRouter = createTRPCRouter({
         }
       );
 
+      // For an alloy withdrawal, a third-party external-interface site (e.g.
+      // Sologenic for allXRP, Picasso for allSOL) only recognises a specific
+      // bridge *variant* (XRP.coreum, SOL.pica), not the alloy denom the user
+      // holds. Resolve, per external URL, the sibling variant whose own
+      // `external_interface` carries the same provider name, so the client can
+      // convert alloy -> variant before opening the URL. Data-driven via the
+      // alloy's variantGroupKey; no per-site hardcoding.
+      const withdrawAlloy =
+        input.fromChain?.chainId === "osmosis-1"
+          ? assetListFromAsset ?? null
+          : null;
+
+      const externalUrlsWithConvert = externalUrls.map((externalUrl) => ({
+        ...externalUrl,
+        convertToVariant: resolveExternalUrlConvertVariant({
+          urlProviderName: externalUrl.urlProviderName,
+          alloy: withdrawAlloy,
+          assets: allAssetListAssets,
+        }),
+      }));
+
       return {
-        externalUrls,
+        externalUrls: externalUrlsWithConvert,
       };
     }),
 

--- a/packages/web/server/api/routers/bridge/__tests__/external-url-convert-variant.spec.ts
+++ b/packages/web/server/api/routers/bridge/__tests__/external-url-convert-variant.spec.ts
@@ -89,7 +89,6 @@ describe("resolveExternalUrlConvertVariant", () => {
       })
     ).toEqual({
       coinMinimalDenom: VARIANT_DENOM,
-      decimals: 6,
       symbol: "XRP.coreum",
     });
   });
@@ -133,22 +132,6 @@ describe("resolveExternalUrlConvertVariant", () => {
         assets: [alloyAsset],
       })
     ).toBeUndefined();
-  });
-
-  it("matches on the variant's own decimals, not the alloy's", () => {
-    const alloy9 = { ...alloyAsset, decimals: 9 };
-    const variant8 = { ...variantAsset, decimals: 8 };
-    expect(
-      resolveExternalUrlConvertVariant({
-        urlProviderName: SOLOGENIC,
-        alloy: alloy9,
-        assets: [alloy9, variant8],
-      })
-    ).toEqual({
-      coinMinimalDenom: VARIANT_DENOM,
-      decimals: 8,
-      symbol: "XRP.coreum",
-    });
   });
 
   it("ignores assets from a different variant group", () => {

--- a/packages/web/server/api/routers/bridge/__tests__/external-url-convert-variant.spec.ts
+++ b/packages/web/server/api/routers/bridge/__tests__/external-url-convert-variant.spec.ts
@@ -1,0 +1,175 @@
+import type { Asset } from "@osmosis-labs/types";
+
+import { resolveExternalUrlConvertVariant } from "../external-url-convert-variant";
+
+const ALLOY_DENOM =
+  "factory/osmo1qnglc04tmhg32uc4kxlxh55a5cmhj88cpa3rmtly484xqu82t79sfv94w0/alloyed/allXRP";
+const VARIANT_DENOM =
+  "ibc/63A7CA0B6838AD8CAD6B5103998FF9B9B6A6F06FBB9638BFF51E63E0142339F3";
+const SOLOGENIC = "Sologenic TX Bridge";
+
+/** Minimal Asset fixture; only the fields the resolver reads matter. */
+function asset(overrides: Partial<Asset>): Asset {
+  return {
+    chainName: "osmosis",
+    sourceDenom: overrides.coinMinimalDenom ?? "",
+    coinMinimalDenom: "",
+    symbol: "",
+    name: "",
+    decimals: 6,
+    isAlloyed: false,
+    verified: true,
+    preview: false,
+    unstable: false,
+    disabled: false,
+    categories: [],
+    transferMethods: [],
+    counterparty: [],
+    relative_image_url: "",
+    ...overrides,
+  } as Asset;
+}
+
+const alloyAsset = asset({
+  coinMinimalDenom: ALLOY_DENOM,
+  symbol: "XRP",
+  isAlloyed: true,
+  variantGroupKey: ALLOY_DENOM,
+  // The alloy entry itself carries the Sologenic external_interface.
+  transferMethods: [
+    {
+      name: SOLOGENIC,
+      type: "external_interface",
+      depositUrl: "https://sologenic.org/bridge/coreum-bridge",
+      withdrawUrl: "https://sologenic.org/bridge/coreum-bridge",
+    },
+  ],
+});
+
+const variantAsset = asset({
+  coinMinimalDenom: VARIANT_DENOM,
+  symbol: "XRP.coreum",
+  decimals: 6,
+  variantGroupKey: ALLOY_DENOM,
+  transferMethods: [
+    {
+      name: SOLOGENIC,
+      type: "external_interface",
+      depositUrl: "https://sologenic.org/bridge/coreum-bridge",
+      withdrawUrl: "https://sologenic.org/bridge/coreum-bridge",
+    },
+    {
+      name: "Osmosis IBC Transfer",
+      type: "ibc",
+      counterparty: {
+        chainName: "coreum",
+        chainId: "coreum-mainnet-1",
+        sourceDenom: "drop",
+        port: "transfer",
+        channelId: "channel-2",
+      },
+      chain: {
+        port: "transfer",
+        channelId: "channel-2188",
+        path: "transfer/channel-2188/drop",
+      },
+    },
+  ],
+});
+
+const assets = [alloyAsset, variantAsset];
+
+describe("resolveExternalUrlConvertVariant", () => {
+  it("resolves the sibling variant whose external_interface matches the provider", () => {
+    expect(
+      resolveExternalUrlConvertVariant({
+        urlProviderName: SOLOGENIC,
+        alloy: alloyAsset,
+        assets,
+      })
+    ).toEqual({
+      coinMinimalDenom: VARIANT_DENOM,
+      decimals: 6,
+      symbol: "XRP.coreum",
+    });
+  });
+
+  it("returns undefined when the from-asset is not an alloy", () => {
+    expect(
+      resolveExternalUrlConvertVariant({
+        urlProviderName: SOLOGENIC,
+        alloy: { ...variantAsset, isAlloyed: false },
+        assets,
+      })
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when from-asset is null (e.g. a deposit, no osmosis source)", () => {
+    expect(
+      resolveExternalUrlConvertVariant({
+        urlProviderName: SOLOGENIC,
+        alloy: null,
+        assets,
+      })
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when no sibling variant carries that provider's external_interface", () => {
+    expect(
+      resolveExternalUrlConvertVariant({
+        urlProviderName: "Some Other Bridge",
+        alloy: alloyAsset,
+        assets,
+      })
+    ).toBeUndefined();
+  });
+
+  it("does not match the alloy's own external_interface (must be a sibling variant)", () => {
+    // Only the alloy entry is present; its own Sologenic method must not match.
+    expect(
+      resolveExternalUrlConvertVariant({
+        urlProviderName: SOLOGENIC,
+        alloy: alloyAsset,
+        assets: [alloyAsset],
+      })
+    ).toBeUndefined();
+  });
+
+  it("matches on the variant's own decimals, not the alloy's", () => {
+    const alloy9 = { ...alloyAsset, decimals: 9 };
+    const variant8 = { ...variantAsset, decimals: 8 };
+    expect(
+      resolveExternalUrlConvertVariant({
+        urlProviderName: SOLOGENIC,
+        alloy: alloy9,
+        assets: [alloy9, variant8],
+      })
+    ).toEqual({
+      coinMinimalDenom: VARIANT_DENOM,
+      decimals: 8,
+      symbol: "XRP.coreum",
+    });
+  });
+
+  it("ignores assets from a different variant group", () => {
+    const otherGroupVariant = asset({
+      coinMinimalDenom: "ibc/OTHER",
+      symbol: "FOO.coreum",
+      variantGroupKey: "factory/.../alloyed/allFOO",
+      transferMethods: [
+        {
+          name: SOLOGENIC,
+          type: "external_interface",
+          withdrawUrl: "https://sologenic.org/bridge/coreum-bridge",
+        },
+      ],
+    });
+    expect(
+      resolveExternalUrlConvertVariant({
+        urlProviderName: SOLOGENIC,
+        alloy: alloyAsset,
+        assets: [alloyAsset, otherGroupVariant],
+      })
+    ).toBeUndefined();
+  });
+});

--- a/packages/web/server/api/routers/bridge/external-url-convert-variant.ts
+++ b/packages/web/server/api/routers/bridge/external-url-convert-variant.ts
@@ -1,0 +1,61 @@
+import type { Asset } from "@osmosis-labs/types";
+
+/** The variant a third-party external-interface site recognises in place of the
+ *  alloy the user holds. */
+export interface ExternalUrlConvertVariant {
+  coinMinimalDenom: string;
+  decimals: number;
+  symbol: string;
+}
+
+/**
+ * For an alloy withdrawal, a third-party external-interface site (e.g.
+ * Sologenic for allXRP, Picasso for allSOL) only recognises a specific bridge
+ * *variant* (XRP.coreum, SOL.pica), not the alloy denom the user holds. Given
+ * the external URL's provider name and the alloy being withdrawn, resolve the
+ * sibling variant (same `variantGroupKey`) whose own `external_interface`
+ * carries the same provider name, so the caller can convert alloy -> variant
+ * before opening the URL.
+ *
+ * Returns `undefined` when:
+ * - the from-asset is not an alloy, or
+ * - no sibling variant carries an `external_interface` with that provider name.
+ *
+ * Purely data-driven via the alloy's variant group; no per-site hardcoding. The
+ * matched variant must not be the alloy itself.
+ */
+export function resolveExternalUrlConvertVariant({
+  urlProviderName,
+  alloy,
+  assets,
+}: {
+  urlProviderName: string;
+  /** The from-asset of the withdrawal (the alloy candidate). */
+  alloy: Pick<
+    Asset,
+    "coinMinimalDenom" | "variantGroupKey" | "isAlloyed"
+  > | null;
+  /** All asset-list assets (flattened). */
+  assets: Asset[];
+}): ExternalUrlConvertVariant | undefined {
+  if (!alloy?.isAlloyed || !alloy.variantGroupKey) return undefined;
+
+  const variant = assets.find(
+    (asset) =>
+      asset.variantGroupKey === alloy.variantGroupKey &&
+      asset.coinMinimalDenom !== alloy.coinMinimalDenom &&
+      asset.transferMethods.some(
+        (method) =>
+          method.type === "external_interface" &&
+          method.name === urlProviderName
+      )
+  );
+
+  if (!variant) return undefined;
+
+  return {
+    coinMinimalDenom: variant.coinMinimalDenom,
+    decimals: variant.decimals,
+    symbol: variant.symbol,
+  };
+}

--- a/packages/web/server/api/routers/bridge/external-url-convert-variant.ts
+++ b/packages/web/server/api/routers/bridge/external-url-convert-variant.ts
@@ -4,7 +4,6 @@ import type { Asset } from "@osmosis-labs/types";
  *  alloy the user holds. */
 export interface ExternalUrlConvertVariant {
   coinMinimalDenom: string;
-  decimals: number;
   symbol: string;
 }
 
@@ -55,7 +54,6 @@ export function resolveExternalUrlConvertVariant({
 
   return {
     coinMinimalDenom: variant.coinMinimalDenom,
-    decimals: variant.decimals,
     symbol: variant.symbol,
   };
 }


### PR DESCRIPTION
## What this PR does

When a user withdraws an alloyed asset (e.g. allXRP) through a third-party bridge link that only recognizes a specific variant (e.g. XRP.coreum), this intercepts the click and runs an in-app 1:1 alloy→variant convert **before** opening the external URL — so the user is never handed off to a bridge site holding an asset that site can't recognize.

- **Server** resolves, per external URL, the sibling variant whose own `external_interface` carries the same provider name, and attaches it as a `convertToVariant` hint (`resolveExternalUrlConvertVariant`, matched on `coinMinimalDenom` within the alloy's `variantGroupKey` family — never on symbol).
- **Client** intercepts the link: if the user holds the alloy, it opens a `SwapTool` convert modal (preset alloy→variant). On a successful convert it shows a **"Continue to {provider}"** button; the external URL opens from that click. If no convert is needed, the original `<a href>` link is preserved.

## What it does NOT do

- **Does NOT add, remove, or aggregate external links** — it only annotates links that already exist with a `convertToVariant` hint. Surfacing *constituent* fallback links (e.g. for an alloy whose own entry has no connector, like allBTC) is the stacked **#4386** (MTN-148).
- **Does NOT gate on pool membership.** It resolves the convert target from the `variantGroupKey` family only; the membership gate (so the target is a real transmuter-pool constituent) lands in **#4386** and is unified in **MTN-141**.
- **Withdraw only.** Deposit-side convert is out of scope (a deposit convert happens *after* the bridge delivers the variant).
- **One variant per provider name**, not a unified alloy→variant→bridge resolver (MTN-141).

## Changes

**Server — `bridge/external-url-convert-variant.ts` (new):** `resolveExternalUrlConvertVariant` — pure resolver, matches the URL's provider name to a sibling variant in the alloy's `variantGroupKey` family. Unit-tested.

**Server — `bridge-transfer.ts`:** `getExternalUrls` attaches `convertToVariant` per URL for an Osmosis alloy withdrawal.

**Client — `bridge/external-url-convert.tsx` (new):** `ExternalUrlConvertOption` — balance-gated convert flow. Reads full wallet balances (not portfolio top-N); offers the convert whenever the user holds the alloy (a dust/partial variant balance does **not** suppress it); shows the user's current variant balance in the modal; emits a direct link only when balances have confidently resolved with no alloy held (loading/refetch/error → convert path, never a stray direct hand-off); the modal stays mounted on its own `isConvertOpen` state; post-convert hand-off is a user-click "Continue" button (avoids browser popup-blocking of `window.open` after async tx); `onSwapSuccess` guards that the completed swap was actually alloy→variant before handing off.

**Client — `bridge/more-bridge-options.tsx`:** both anchor paths (single-provider splash + multi-provider list) routed through a render-prop `ExternalUrlOption` (`{ href?, onClick? }`); non-convert path keeps a real `<a href>` (middle-click / new-tab preserved).

**`config/analytics-events.ts`:** adds the `"Bridge Page"` event page. **Localisations:** `convertBeforeWithdraw.{title,description,currentVariantBalance,successTitle,successDescription,continueTo}` added to all 17 locales.

## Review status

- **claude osmosis-frontend reviewer: clean, no blocking findings.** Denom/decimal handling correct (always full denom, never symbol); convert gate and pair-direction guard never strand a holder or redirect on a failed/reversed swap; types clean (no `as any` in product code); locales fully translated.
- **Partial convert is intentional:** converting *part* of the alloy still shows "Continue" — the user holds the variant the site accepts; residual alloy stays (matches the dust/partial design).
- **External-URL dedup is safe:** the `getExternalUrls` host/name dedup runs before the resolver, but the external_interface bridges (Sologenic / Picasso / Thesis / Omnity) are not SQS quote providers, so their hosts never collide with provider-returned URLs — the variant-carrying entry is never dropped.
- Pre-existing `"osmosis-1"` hardcode (also at lines 126/657/663) left as a repo-wide pattern; env-aware chain ID is a separate cleanup (CodeRabbit dismissal accepted).

## Relationship to the sibling work

This is the **output-side** annotation of `getExternalUrls`; **#4386** (MTN-148) is the **input-side** aggregation and adds the pool-membership gate that applies to both helpers. #4386 is stacked on this branch — **merge this first.** Both share the `variantGroupKey` family-expansion primitive, which collapses into the unified resolver in **MTN-141**.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches withdraw UX and on-chain swaps before leaving Osmosis; balance-gating is conservative but wrong resolver data could mis-target a variant.
> 
> **Overview**
> Adds a **withdraw-only** guard so third-party bridge links in **More withdraw options** do not open while the user still holds an **alloy** the site cannot accept.
> 
> **Server:** `getExternalUrls` now attaches optional `convertToVariant` per link via `resolveExternalUrlConvertVariant` (sibling variant in the same `variantGroupKey` with a matching `external_interface` provider name).
> 
> **Client:** `ExternalUrlConvertOption` intercepts clicks when balances show alloy (or are still loading/refetching), opens a modal with `SwapTool` preset alloy→variant, then a **Continue to {provider}** button opens the external URL (avoids popup blocking). Direct `<a href>` is kept when no wallet is connected or balances confidently show no alloy.
> 
> **UI wiring:** `more-bridge-options.tsx` routes single- and multi-provider rows through `ExternalUrlOption`. Locales add `convertBeforeWithdraw.*`; analytics adds `"Bridge Page"` for embedded swaps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03b330ca4d7106ff1002c20464c58652d0997bdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->




---

## Test matrix

Preview deploy root: **https://osmosis-frontend-git-johnnywyles-mtn-146-pre-convert-all-efc399.vercel.dev-osmosis.zone**

### What to check

1. **Unit + type:** `cd packages/web && node ../../node_modules/jest/bin/jest.js external-url-convert-variant` (resolver, 6/6); typecheck + lint clean on touched files.
2. **Trigger (hold the alloy):** withdraw an alloy whose connector surfaces (see table) → the **More withdraw options** row opens the **convert modal**, not a direct jump. Convert succeeds → a **"Continue to {provider}"** button appears → clicking it opens the third-party site in a new tab (not popup-blocked).
3. **Dust:** hold the alloy **and** a dust amount of the variant → the convert is **still** offered, and the modal shows your **current variant balance**.
4. **Direction guard:** inside the modal, flip the swap direction and complete it → it does **NOT** hand off to the external site (modal just closes).
5. **Failed/cancelled convert** → no redirect.
6. **No-trigger (see table):** variant-only holder (no alloy), native quote routes (Int3face/Nomic), `/wormhole` (allSOL), and Skip-only alloys (allETH/allUSDT) → **no convert modal**; direct link / native route as appropriate. Middle-click / open-in-new-tab on a direct link still works.

> Assumes the deploy is built against the current assetlist (allTON carries the **Thesis** connector, the **int3** connectors are removed from allTON and allXRP). Connector presence is generated at build time, so if a row's connector doesn't match, the deploy hasn't rebuilt against the latest assetlist yet.

The convert popup fires only when **all** hold: (1) you hold the alloy; (2) the link is a third-party `external_interface` withdraw URL in **More withdraw options**; (3) the provider name matches a sibling variant. Native quote bridges (Int3face, Nomic) and the internal `/wormhole` page never trigger it. Constituent aggregation + pool-membership gating land in the stacked **#4386** — on this branch (**#4385**) only an alloy that carries the connector on **its own** entry surfaces it.

### Convert popup — should appear (hold the alloy)

| Withdraw | What you should see | Asset page |
| -- | -- | -- |
| **allXRP** | "Withdraw with Sologenic TX Bridge" in More options → clicking opens the **convert modal** (allXRP → XRP.coreum), not a direct jump. **No** Int3face external link (removed). | [allXRP](https://osmosis-frontend-git-johnnywyles-mtn-146-pre-convert-all-efc399.vercel.dev-osmosis.zone/assets/factory%2Fosmo1qnglc04tmhg32uc4kxlxh55a5cmhj88cpa3rmtly484xqu82t79sfv94w0%2Falloyed%2FallXRP) |
| **allTON** | "Withdraw with Thesis" in More options → convert modal (allTON → TON.orai). **No** Int3face external link (removed). | [allTON](https://osmosis-frontend-git-johnnywyles-mtn-146-pre-convert-all-efc399.vercel.dev-osmosis.zone/assets/factory%2Fosmo12lnwf54yd30p6amzaged2atln8k0l32n7ncxf04ctg7u7ymnsy7qkqgsw4%2Falloyed%2FallTON) |
| **allDOGE** | "Withdraw with Omnity Bridge" → convert modal (allDOGE → ckDOGE). allDOGE carries its own Omnity connector. *Pool may hold ~0 ckDOGE, so the swap can have nothing to draw.* | [allDOGE](https://osmosis-frontend-git-johnnywyles-mtn-146-pre-convert-all-efc399.vercel.dev-osmosis.zone/assets/factory%2Fosmo10pk4crey8fpdyqd62rsau0y02e3rk055w5u005ah6ly7k849k5tsf72x40%2Falloyed%2FallDOGE) |

### Convert popup — dust / loading (the fix in this PR)

| Scenario | What you should see |
| -- | -- |
| Hold allXRP **and dust XRP.coreum** | Popup still appears (gate is `holdsAlloy`, not `holdsAlloy && !holdsVariant`); modal shows **Current XRP.coreum balance** so you choose the amount. |
| Balances still loading, click fast | The link is inert (no navigation) until balances resolve — no bypass to the third-party site. |

### Should NOT show a convert popup (by design)

| Withdraw / scenario | What you should see | Asset page |
| -- | -- | -- |
| Hold only the variant (e.g. XRP.coreum), not the alloy | Direct link, no modal (nothing to convert). | [allXRP](https://osmosis-frontend-git-johnnywyles-mtn-146-pre-convert-all-efc399.vercel.dev-osmosis.zone/assets/factory%2Fosmo1qnglc04tmhg32uc4kxlxh55a5cmhj88cpa3rmtly484xqu82t79sfv94w0%2Falloyed%2FallXRP) |
| **allBTC** | ckBTC/Omnity does **not** appear here (allBTC alloy entry carries no own connector; needs **#4386** aggregation). Int3face/Nomic show as native quote routes, not external links. | [allBTC](https://osmosis-frontend-git-johnnywyles-mtn-146-pre-convert-all-efc399.vercel.dev-osmosis.zone/assets/factory%2Fosmo1z6r6qdknhgsc0zeracktgpcxf43j6sekq07nw8sxduc9lg0qjjlqfu25e3%2Falloyed%2FallBTC) |
| **allSOL** | Only Wormhole surfaces → goes to the internal `/wormhole` page (its own convert, MTN-145). No external-url popup. SOL.wh is the only allSOL pool member. | [allSOL](https://osmosis-frontend-git-johnnywyles-mtn-146-pre-convert-all-efc399.vercel.dev-osmosis.zone/assets/factory%2Fosmo1n3n75av8awcnw4jl62n3l48e6e4sxqmaf97w5ua6ddu4s475q5qq9udvx4%2Falloyed%2FallSOL) |
| **allETH** | Only Skip (generic quote router); no third-party external-url variant → no popup. | [allETH](https://osmosis-frontend-git-johnnywyles-mtn-146-pre-convert-all-efc399.vercel.dev-osmosis.zone/assets/factory%2Fosmo1k6c8jln7ejuqwtqmay3yvzrg3kueaczl96pk067ldg8u835w0yhsw27twm%2Falloyed%2FallETH) |
| **allUSDT** | Only Skip surfaces; no external-url popup. | [allUSDT](https://osmosis-frontend-git-johnnywyles-mtn-146-pre-convert-all-efc399.vercel.dev-osmosis.zone/assets/factory%2Fosmo1em6xs47hd82806f5cxgyufguxrrc7l0aqx7nzzptjuqgswczk8csavdxek%2Falloyed%2FallUSDT) |

> **Int3face on allXRP/allTON:** removing the assetlist connector clears the external-url *link*. Int3face may still appear as a native *quote route* for these alloys (hardcoded `allTokenMinimalDenom` in the frontend Int3face provider) — that route-hiding is tracked in MTN-141, not this PR.

