### PR TITLE
feat(bridge): aggregate alloy constituents' external bridge links as fallbacks

### DIFF
--- a/packages/web/components/bridge/more-bridge-options.tsx
+++ b/packages/web/components/bridge/more-bridge-options.tsx
@@ -166,6 +166,12 @@ function ExternalProviderList({
           </ExternalUrlOption>
         );
       })}
+      {/* These open third-party sites; the links are tied to a specific
+          bridge/variant, not the route selected here, so the user confirms the
+          actual route on the provider's site. */}
+      <p className="caption pt-2 text-center text-osmoverse-400">
+        {t("transfer.moreBridgeOptions.externalSiteCaveat")}
+      </p>
     </>
   );
 }
@@ -279,24 +285,18 @@ export const MoreBridgeOptionsModal: FunctionComponent<
       className="!max-w-[30rem]"
       {...modalProps}
     >
+      {/* Route-neutral copy: these external providers are third-party sites and
+          their links are tied to a specific bridge/variant, not to the from/to
+          chain the user selected here. Stating a "from {x} to {y}" route would
+          overpromise — the user picks the actual route on the provider's site.
+          (`fromChain`/`toChain` retained in props for the underlying query.) */}
       <p className="body1 md:body2 py-4 text-center text-osmoverse-300 md:py-2">
-        {!fromChain || !toChain
-          ? t(
-              direction === "deposit"
-                ? "transfer.moreBridgeOptions.depositDescriptionUnknown"
-                : "transfer.moreBridgeOptions.withdrawDescriptionUnknown",
-              { denom }
-            )
-          : t(
-              direction === "deposit"
-                ? "transfer.moreBridgeOptions.chooseAnAlternativeProviderDeposit"
-                : "transfer.moreBridgeOptions.chooseAnAlternativeProviderWithdraw",
-              {
-                asset: denom,
-                fromChain: fromChain.prettyName,
-                toChain: toChain.prettyName,
-              }
-            )}
+        {t(
+          direction === "deposit"
+            ? "transfer.moreBridgeOptions.depositDescriptionUnknown"
+            : "transfer.moreBridgeOptions.withdrawDescriptionUnknown",
+          { denom }
+        )}
       </p>
       <div className="flex flex-col gap-1 pt-4 md:gap-0 md:pt-2">
         <ExternalProviderList

--- a/packages/web/components/bridge/more-bridge-options.tsx
+++ b/packages/web/components/bridge/more-bridge-options.tsx
@@ -122,6 +122,11 @@ function ExternalProviderList({
             </a>
           )}
         </ExternalUrlOption>
+        {/* Same caveat as the multi-provider list: this opens a third-party
+            site where the user confirms the actual route. */}
+        <p className="caption text-center text-osmoverse-400">
+          {t("transfer.moreBridgeOptions.externalSiteCaveat")}
+        </p>
       </div>
     );
   }

--- a/packages/web/localizations/de.json
+++ b/packages/web/localizations/de.json
@@ -872,11 +872,10 @@
       "titleWithdraw": "Weitere Auszahlungsoptionen",
       "depositDescriptionUnknown": "Um {denom} einzuzahlen, verwenden Sie bitte einen alternativen Anbieter.",
       "withdrawDescriptionUnknown": "Um {denom} abzuheben, verwenden Sie bitte einen alternativen Anbieter.",
-      "chooseAnAlternativeProviderDeposit": "Wählen Sie einen alternativen Anbieter zum Einzahlen {asset} von {fromChain} nach {toChain}",
-      "chooseAnAlternativeProviderWithdraw": "Wählen Sie einen alternativen Anbieter zum Abheben {asset} von {fromChain} nach {toChain}",
       "depositWith": "Einzahlung mit",
       "withdrawWith": "Abheben mit",
       "noAlternativesFound": "Keine alternativen Anbieter für diese Route gefunden.",
+      "externalSiteCaveat": "These open third-party bridge sites. Select your route there.",
       "convertBeforeWithdraw": {
         "title": "Zuerst in {variant} umwandeln",
         "description": "{provider} akzeptiert nur {variant}. Wandeln Sie Ihr Alloyed-Guthaben unten in {variant} um und fahren Sie dann mit {provider} fort, um Ihre Auszahlung abzuschließen.",

--- a/packages/web/localizations/de.json
+++ b/packages/web/localizations/de.json
@@ -875,7 +875,7 @@
       "depositWith": "Einzahlung mit",
       "withdrawWith": "Abheben mit",
       "noAlternativesFound": "Keine alternativen Anbieter für diese Route gefunden.",
-      "externalSiteCaveat": "These open third-party bridge sites. Select your route there.",
+      "externalSiteCaveat": "Diese öffnen Bridge-Websites von Drittanbietern. Wählen Sie dort Ihre Route.",
       "convertBeforeWithdraw": {
         "title": "Zuerst in {variant} umwandeln",
         "description": "{provider} akzeptiert nur {variant}. Wandeln Sie Ihr Alloyed-Guthaben unten in {variant} um und fahren Sie dann mit {provider} fort, um Ihre Auszahlung abzuschließen.",

--- a/packages/web/localizations/en.json
+++ b/packages/web/localizations/en.json
@@ -872,11 +872,10 @@
       "titleWithdraw": "More withdraw options",
       "depositDescriptionUnknown": "To deposit {denom}, please use an alternative provider.",
       "withdrawDescriptionUnknown": "To withdraw {denom}, please use an alternative provider.",
-      "chooseAnAlternativeProviderDeposit": "Choose an alternative provider to deposit {asset} from {fromChain} to {toChain}",
-      "chooseAnAlternativeProviderWithdraw": "Choose an alternative provider to withdraw {asset} from {fromChain} to {toChain}",
       "depositWith": "Deposit with",
       "withdrawWith": "Withdraw with",
       "noAlternativesFound": "No alternative providers found for this route.",
+      "externalSiteCaveat": "These open third-party bridge sites. Select your route there.",
       "convertBeforeWithdraw": {
         "title": "Convert to {variant} first",
         "description": "{provider} only accepts {variant}. Convert your alloyed balance to {variant} below, then continue to {provider} to complete your withdrawal.",

--- a/packages/web/localizations/es.json
+++ b/packages/web/localizations/es.json
@@ -875,7 +875,7 @@
       "depositWith": "Depositar con",
       "withdrawWith": "Retirarse con",
       "noAlternativesFound": "No se encontraron proveedores alternativos para esta ruta.",
-      "externalSiteCaveat": "These open third-party bridge sites. Select your route there.",
+      "externalSiteCaveat": "Estos abren sitios de puentes de terceros. Selecciona tu ruta allí.",
       "convertBeforeWithdraw": {
         "title": "Convierte primero a {variant}",
         "description": "{provider} solo acepta {variant}. Convierte tu saldo aleado a {variant} a continuación y luego continúa con {provider} para completar tu retiro.",

--- a/packages/web/localizations/es.json
+++ b/packages/web/localizations/es.json
@@ -872,11 +872,10 @@
       "titleWithdraw": "Más opciones de retiro",
       "depositDescriptionUnknown": "Para depositar {denom} , utilice un proveedor alternativo.",
       "withdrawDescriptionUnknown": "Para retirar {denom} , utilice un proveedor alternativo.",
-      "chooseAnAlternativeProviderDeposit": "Elija un proveedor alternativo para depositar {asset} de {fromChain} a {toChain}",
-      "chooseAnAlternativeProviderWithdraw": "Elija un proveedor alternativo para retirar {asset} de {fromChain} a {toChain}",
       "depositWith": "Depositar con",
       "withdrawWith": "Retirarse con",
       "noAlternativesFound": "No se encontraron proveedores alternativos para esta ruta.",
+      "externalSiteCaveat": "These open third-party bridge sites. Select your route there.",
       "convertBeforeWithdraw": {
         "title": "Convierte primero a {variant}",
         "description": "{provider} solo acepta {variant}. Convierte tu saldo aleado a {variant} a continuación y luego continúa con {provider} para completar tu retiro.",

--- a/packages/web/localizations/fa.json
+++ b/packages/web/localizations/fa.json
@@ -875,7 +875,7 @@
       "depositWith": "سپرده گذاری با",
       "withdrawWith": "برداشت با",
       "noAlternativesFound": "هیچ ارائه‌دهنده جایگزینی برای این مسیر یافت نشد.",
-      "externalSiteCaveat": "These open third-party bridge sites. Select your route there.",
+      "externalSiteCaveat": "این‌ها سایت‌های پل شخص ثالث را باز می‌کنند. مسیر خود را همان‌جا انتخاب کنید.",
       "convertBeforeWithdraw": {
         "title": "ابتدا به {variant} تبدیل کنید",
         "description": "{provider} فقط {variant} را می‌پذیرد. موجودی آلوید خود را در زیر به {variant} تبدیل کنید، سپس برای تکمیل برداشت خود به {provider} ادامه دهید.",

--- a/packages/web/localizations/fa.json
+++ b/packages/web/localizations/fa.json
@@ -872,11 +872,10 @@
       "titleWithdraw": "گزینه های برداشت بیشتر",
       "depositDescriptionUnknown": "برای واریز {denom} ، لطفاً از یک ارائه دهنده جایگزین استفاده کنید.",
       "withdrawDescriptionUnknown": "برای برداشتن {denom} ، لطفاً از یک ارائه دهنده جایگزین استفاده کنید.",
-      "chooseAnAlternativeProviderDeposit": "یک ارائه‌دهنده جایگزین برای واریز {asset} از {fromChain} به {toChain} انتخاب کنید. {toChain}",
-      "chooseAnAlternativeProviderWithdraw": "یک ارائه‌دهنده جایگزین برای برداشتن {asset} از {fromChain} به {toChain} انتخاب کنید. {toChain}",
       "depositWith": "سپرده گذاری با",
       "withdrawWith": "برداشت با",
       "noAlternativesFound": "هیچ ارائه‌دهنده جایگزینی برای این مسیر یافت نشد.",
+      "externalSiteCaveat": "These open third-party bridge sites. Select your route there.",
       "convertBeforeWithdraw": {
         "title": "ابتدا به {variant} تبدیل کنید",
         "description": "{provider} فقط {variant} را می‌پذیرد. موجودی آلوید خود را در زیر به {variant} تبدیل کنید، سپس برای تکمیل برداشت خود به {provider} ادامه دهید.",

--- a/packages/web/localizations/fr.json
+++ b/packages/web/localizations/fr.json
@@ -872,11 +872,10 @@
       "titleWithdraw": "Plus d'options de retrait",
       "depositDescriptionUnknown": "Pour déposer {denom} , veuillez utiliser un autre fournisseur.",
       "withdrawDescriptionUnknown": "Pour retirer {denom} , veuillez utiliser un autre fournisseur.",
-      "chooseAnAlternativeProviderDeposit": "Choisissez un autre fournisseur pour déposer {asset} de {fromChain} à {toChain}",
-      "chooseAnAlternativeProviderWithdraw": "Choisissez un autre fournisseur pour retirer {asset} de {fromChain} à {toChain}",
       "depositWith": "Dépôt avec",
       "withdrawWith": "Retirer avec",
       "noAlternativesFound": "Aucun fournisseur alternatif trouvé pour cette route.",
+      "externalSiteCaveat": "These open third-party bridge sites. Select your route there.",
       "convertBeforeWithdraw": {
         "title": "Convertissez d'abord en {variant}",
         "description": "{provider} n'accepte que {variant}. Convertissez votre solde allié en {variant} ci-dessous, puis continuez avec {provider} pour finaliser votre retrait.",

--- a/packages/web/localizations/fr.json
+++ b/packages/web/localizations/fr.json
@@ -875,7 +875,7 @@
       "depositWith": "Dépôt avec",
       "withdrawWith": "Retirer avec",
       "noAlternativesFound": "Aucun fournisseur alternatif trouvé pour cette route.",
-      "externalSiteCaveat": "These open third-party bridge sites. Select your route there.",
+      "externalSiteCaveat": "Ces liens ouvrent des sites de bridge tiers. Choisissez votre route sur le site.",
       "convertBeforeWithdraw": {
         "title": "Convertissez d'abord en {variant}",
         "description": "{provider} n'accepte que {variant}. Convertissez votre solde allié en {variant} ci-dessous, puis continuez avec {provider} pour finaliser votre retrait.",

--- a/packages/web/localizations/gu.json
+++ b/packages/web/localizations/gu.json
@@ -875,7 +875,7 @@
       "depositWith": "સાથે જમા",
       "withdrawWith": "સાથે પાછી ખેંચો",
       "noAlternativesFound": "આ રૂટ માટે કોઈ વૈકલ્પિક પ્રદાતા મળ્યા નથી.",
-      "externalSiteCaveat": "These open third-party bridge sites. Select your route there.",
+      "externalSiteCaveat": "આ ત્રીજા-પક્ષની બ્રિજ સાઇટ્સ ખોલે છે. ત્યાં તમારો રૂટ પસંદ કરો.",
       "convertBeforeWithdraw": {
         "title": "પહેલા {variant} માં રૂપાંતરિત કરો",
         "description": "{provider} ફક્ત {variant} સ્વીકારે છે. તમારી alloyed બેલેન્સને નીચે {variant} માં રૂપાંતરિત કરો, પછી તમારી ઉપાડ પૂર્ણ કરવા માટે {provider} પર ચાલુ રાખો.",

--- a/packages/web/localizations/gu.json
+++ b/packages/web/localizations/gu.json
@@ -872,11 +872,10 @@
       "titleWithdraw": "વધુ ઉપાડ વિકલ્પો",
       "depositDescriptionUnknown": "{denom} જમા કરાવવા માટે, કૃપા કરીને વૈકલ્પિક પ્રદાતાનો ઉપયોગ કરો.",
       "withdrawDescriptionUnknown": "{denom} પાછી ખેંચવા માટે, કૃપા કરીને વૈકલ્પિક પ્રદાતાનો ઉપયોગ કરો.",
-      "chooseAnAlternativeProviderDeposit": "{asset} {fromChain} થી {toChain}",
-      "chooseAnAlternativeProviderWithdraw": "{asset} {fromChain} થી {toChain}",
       "depositWith": "સાથે જમા",
       "withdrawWith": "સાથે પાછી ખેંચો",
       "noAlternativesFound": "આ રૂટ માટે કોઈ વૈકલ્પિક પ્રદાતા મળ્યા નથી.",
+      "externalSiteCaveat": "These open third-party bridge sites. Select your route there.",
       "convertBeforeWithdraw": {
         "title": "પહેલા {variant} માં રૂપાંતરિત કરો",
         "description": "{provider} ફક્ત {variant} સ્વીકારે છે. તમારી alloyed બેલેન્સને નીચે {variant} માં રૂપાંતરિત કરો, પછી તમારી ઉપાડ પૂર્ણ કરવા માટે {provider} પર ચાલુ રાખો.",

--- a/packages/web/localizations/hi.json
+++ b/packages/web/localizations/hi.json
@@ -872,11 +872,10 @@
       "titleWithdraw": "अधिक निकासी विकल्प",
       "depositDescriptionUnknown": "{denom} जमा करने के लिए कृपया वैकल्पिक प्रदाता का उपयोग करें।",
       "withdrawDescriptionUnknown": "{denom} वापस लेने के लिए, कृपया वैकल्पिक प्रदाता का उपयोग करें।",
-      "chooseAnAlternativeProviderDeposit": "{asset} {fromChain} से {toChain}",
-      "chooseAnAlternativeProviderWithdraw": "{asset} {fromChain} से {toChain}",
       "depositWith": "जमा करें",
       "withdrawWith": "साथ वापस लें",
       "noAlternativesFound": "इस रूट के लिए कोई वैकल्पिक प्रदाता नहीं मिला।",
+      "externalSiteCaveat": "These open third-party bridge sites. Select your route there.",
       "convertBeforeWithdraw": {
         "title": "पहले {variant} में बदलें",
         "description": "{provider} केवल {variant} स्वीकार करता है। नीचे अपने अलॉयड बैलेंस को {variant} में बदलें, फिर अपनी निकासी पूरी करने के लिए {provider} पर जारी रखें।",

--- a/packages/web/localizations/hi.json
+++ b/packages/web/localizations/hi.json
@@ -875,7 +875,7 @@
       "depositWith": "जमा करें",
       "withdrawWith": "साथ वापस लें",
       "noAlternativesFound": "इस रूट के लिए कोई वैकल्पिक प्रदाता नहीं मिला।",
-      "externalSiteCaveat": "These open third-party bridge sites. Select your route there.",
+      "externalSiteCaveat": "ये तृतीय-पक्ष ब्रिज साइट खोलते हैं। अपना रूट वहीं चुनें।",
       "convertBeforeWithdraw": {
         "title": "पहले {variant} में बदलें",
         "description": "{provider} केवल {variant} स्वीकार करता है। नीचे अपने अलॉयड बैलेंस को {variant} में बदलें, फिर अपनी निकासी पूरी करने के लिए {provider} पर जारी रखें।",

--- a/packages/web/localizations/ja.json
+++ b/packages/web/localizations/ja.json
@@ -875,7 +875,7 @@
       "depositWith": "入金",
       "withdrawWith": "撤退する",
       "noAlternativesFound": "このルートに対する代替プロバイダーが見つかりませんでした。",
-      "externalSiteCaveat": "These open third-party bridge sites. Select your route there.",
+      "externalSiteCaveat": "これらはサードパーティのブリッジサイトを開きます。ルートはそちらで選択してください。",
       "convertBeforeWithdraw": {
         "title": "まず{variant}に変換してください",
         "description": "{provider}は{variant}のみを受け付けます。以下でアロイ残高を{variant}に変換してから、{provider}に進んで引き出しを完了してください。",

--- a/packages/web/localizations/ja.json
+++ b/packages/web/localizations/ja.json
@@ -872,11 +872,10 @@
       "titleWithdraw": "引き出しオプションの追加",
       "depositDescriptionUnknown": "{denom}を入金するには、別のプロバイダーを使用してください。",
       "withdrawDescriptionUnknown": "{denom}を取り消すには、別のプロバイダーを使用してください。",
-      "chooseAnAlternativeProviderDeposit": "{asset} {fromChain}から{toChain}に預ける代替プロバイダーを選択してください",
-      "chooseAnAlternativeProviderWithdraw": "{asset} {fromChain}から{toChain}に引き出すには、別のプロバイダーを選択してください",
       "depositWith": "入金",
       "withdrawWith": "撤退する",
       "noAlternativesFound": "このルートに対する代替プロバイダーが見つかりませんでした。",
+      "externalSiteCaveat": "These open third-party bridge sites. Select your route there.",
       "convertBeforeWithdraw": {
         "title": "まず{variant}に変換してください",
         "description": "{provider}は{variant}のみを受け付けます。以下でアロイ残高を{variant}に変換してから、{provider}に進んで引き出しを完了してください。",

--- a/packages/web/localizations/ko.json
+++ b/packages/web/localizations/ko.json
@@ -872,11 +872,10 @@
       "titleWithdraw": "더 많은 인출 옵션",
       "depositDescriptionUnknown": "{denom} 을 입금하려면 대체 공급자를 이용하세요.",
       "withdrawDescriptionUnknown": "{denom} 철회하려면 대체 공급자를 이용하세요.",
-      "chooseAnAlternativeProviderDeposit": "{asset} {fromChain} 로 {toChain}",
-      "chooseAnAlternativeProviderWithdraw": "{asset} {fromChain} \"asset\"}을(를 {toChain} 로 철회하려면 대체 공급자를 선택하세요. {toChain}",
       "depositWith": "다음으로 입금",
       "withdrawWith": "다음으로 인출",
       "noAlternativesFound": "이 경로에 대한 대체 공급자를 찾을 수 없습니다.",
+      "externalSiteCaveat": "These open third-party bridge sites. Select your route there.",
       "convertBeforeWithdraw": {
         "title": "먼저 {variant}(으)로 변환하세요",
         "description": "{provider}은(는) {variant}만 허용합니다. 아래에서 합금(alloyed) 잔액을 {variant}(으)로 변환한 다음, {provider}(으)로 이동하여 인출을 완료하세요.",

--- a/packages/web/localizations/ko.json
+++ b/packages/web/localizations/ko.json
@@ -875,7 +875,7 @@
       "depositWith": "다음으로 입금",
       "withdrawWith": "다음으로 인출",
       "noAlternativesFound": "이 경로에 대한 대체 공급자를 찾을 수 없습니다.",
-      "externalSiteCaveat": "These open third-party bridge sites. Select your route there.",
+      "externalSiteCaveat": "타사 브리지 사이트로 이동합니다. 경로는 해당 사이트에서 선택하세요.",
       "convertBeforeWithdraw": {
         "title": "먼저 {variant}(으)로 변환하세요",
         "description": "{provider}은(는) {variant}만 허용합니다. 아래에서 합금(alloyed) 잔액을 {variant}(으)로 변환한 다음, {provider}(으)로 이동하여 인출을 완료하세요.",

--- a/packages/web/localizations/pl.json
+++ b/packages/web/localizations/pl.json
@@ -875,7 +875,7 @@
       "depositWith": "Wpłać za pomocą",
       "withdrawWith": "Wycofaj się z",
       "noAlternativesFound": "Nie znaleziono alternatywnych dostawców dla tej trasy.",
-      "externalSiteCaveat": "These open third-party bridge sites. Select your route there.",
+      "externalSiteCaveat": "Otwierają one zewnętrzne strony mostów. Wybierz tam swoją trasę.",
       "convertBeforeWithdraw": {
         "title": "Najpierw przekonwertuj na {variant}",
         "description": "{provider} akceptuje tylko {variant}. Przekonwertuj swoje saldo alloyed na {variant} poniżej, a następnie przejdź do {provider}, aby zakończyć wypłatę.",

--- a/packages/web/localizations/pl.json
+++ b/packages/web/localizations/pl.json
@@ -872,11 +872,10 @@
       "titleWithdraw": "Więcej opcji wypłat",
       "depositDescriptionUnknown": "Aby dokonać wpłaty {denom} , skorzystaj z alternatywnego dostawcy.",
       "withdrawDescriptionUnknown": "Aby wypłacić {denom} , skorzystaj z alternatywnego dostawcy.",
-      "chooseAnAlternativeProviderDeposit": "Wybierz alternatywnego dostawcę, aby wpłacić {asset} z {fromChain} do {toChain}",
-      "chooseAnAlternativeProviderWithdraw": "Wybierz alternatywnego dostawcę, aby wycofać {asset} z {fromChain} do {toChain}",
       "depositWith": "Wpłać za pomocą",
       "withdrawWith": "Wycofaj się z",
       "noAlternativesFound": "Nie znaleziono alternatywnych dostawców dla tej trasy.",
+      "externalSiteCaveat": "These open third-party bridge sites. Select your route there.",
       "convertBeforeWithdraw": {
         "title": "Najpierw przekonwertuj na {variant}",
         "description": "{provider} akceptuje tylko {variant}. Przekonwertuj swoje saldo alloyed na {variant} poniżej, a następnie przejdź do {provider}, aby zakończyć wypłatę.",

--- a/packages/web/localizations/pt-br.json
+++ b/packages/web/localizations/pt-br.json
@@ -875,7 +875,7 @@
       "depositWith": "Deposite com",
       "withdrawWith": "Retirar com",
       "noAlternativesFound": "Nenhum provedor alternativo encontrado para esta rota.",
-      "externalSiteCaveat": "These open third-party bridge sites. Select your route there.",
+      "externalSiteCaveat": "Estes abrem sites de ponte de terceiros. Selecione sua rota lá.",
       "convertBeforeWithdraw": {
         "title": "Converta primeiro para {variant}",
         "description": "{provider} aceita apenas {variant}. Converta seu saldo alloyed para {variant} abaixo e, em seguida, continue para {provider} para concluir sua retirada.",

--- a/packages/web/localizations/pt-br.json
+++ b/packages/web/localizations/pt-br.json
@@ -872,11 +872,10 @@
       "titleWithdraw": "Mais opções de retirada",
       "depositDescriptionUnknown": "Para depositar {denom} , use um provedor alternativo.",
       "withdrawDescriptionUnknown": "Para retirar {denom} , use um provedor alternativo.",
-      "chooseAnAlternativeProviderDeposit": "Escolha um provedor alternativo para depositar {asset} de {fromChain} para {toChain}",
-      "chooseAnAlternativeProviderWithdraw": "Escolha um provedor alternativo para retirar {asset} de {fromChain} para {toChain}",
       "depositWith": "Deposite com",
       "withdrawWith": "Retirar com",
       "noAlternativesFound": "Nenhum provedor alternativo encontrado para esta rota.",
+      "externalSiteCaveat": "These open third-party bridge sites. Select your route there.",
       "convertBeforeWithdraw": {
         "title": "Converta primeiro para {variant}",
         "description": "{provider} aceita apenas {variant}. Converta seu saldo alloyed para {variant} abaixo e, em seguida, continue para {provider} para concluir sua retirada.",

--- a/packages/web/localizations/ro.json
+++ b/packages/web/localizations/ro.json
@@ -875,7 +875,7 @@
       "depositWith": "Depozit cu",
       "withdrawWith": "Retrage cu",
       "noAlternativesFound": "Niciun furnizor alternativ găsit pentru această rută.",
-      "externalSiteCaveat": "These open third-party bridge sites. Select your route there.",
+      "externalSiteCaveat": "Acestea deschid site-uri de bridge terțe. Alege ruta acolo.",
       "convertBeforeWithdraw": {
         "title": "Convertiți mai întâi în {variant}",
         "description": "{provider} acceptă doar {variant}. Convertiți soldul dvs. aliat în {variant} mai jos, apoi continuați către {provider} pentru a finaliza retragerea.",

--- a/packages/web/localizations/ro.json
+++ b/packages/web/localizations/ro.json
@@ -872,11 +872,10 @@
       "titleWithdraw": "Mai multe opțiuni de retragere",
       "depositDescriptionUnknown": "Pentru a depune {denom} , vă rugăm să utilizați un furnizor alternativ.",
       "withdrawDescriptionUnknown": "Pentru a retrage {denom} , vă rugăm să utilizați un furnizor alternativ.",
-      "chooseAnAlternativeProviderDeposit": "Alegeți un furnizor alternativ pentru a depune {asset} de la {fromChain} la {toChain}",
-      "chooseAnAlternativeProviderWithdraw": "Alegeți un furnizor alternativ pentru a retrage {asset} de la {fromChain} la {toChain}",
       "depositWith": "Depozit cu",
       "withdrawWith": "Retrage cu",
       "noAlternativesFound": "Niciun furnizor alternativ găsit pentru această rută.",
+      "externalSiteCaveat": "These open third-party bridge sites. Select your route there.",
       "convertBeforeWithdraw": {
         "title": "Convertiți mai întâi în {variant}",
         "description": "{provider} acceptă doar {variant}. Convertiți soldul dvs. aliat în {variant} mai jos, apoi continuați către {provider} pentru a finaliza retragerea.",

--- a/packages/web/localizations/ru.json
+++ b/packages/web/localizations/ru.json
@@ -872,11 +872,10 @@
       "titleWithdraw": "Больше вариантов вывода",
       "depositDescriptionUnknown": "Чтобы внести {denom} , используйте альтернативного поставщика.",
       "withdrawDescriptionUnknown": "Чтобы вывести {denom} , используйте альтернативного поставщика.",
-      "chooseAnAlternativeProviderDeposit": "Выберите альтернативного поставщика для внесения {asset} из {fromChain} в {toChain}",
-      "chooseAnAlternativeProviderWithdraw": "Выберите альтернативного поставщика для вывода {asset} из {fromChain} в {toChain}",
       "depositWith": "Депозит с",
       "withdrawWith": "Вывод средств с помощью",
       "noAlternativesFound": "Альтернативные поставщики для этого маршрута не найдены.",
+      "externalSiteCaveat": "These open third-party bridge sites. Select your route there.",
       "convertBeforeWithdraw": {
         "title": "Сначала конвертируйте в {variant}",
         "description": "{provider} принимает только {variant}. Конвертируйте ваш сплавленный баланс в {variant} ниже, затем перейдите к {provider}, чтобы завершить вывод средств.",

--- a/packages/web/localizations/ru.json
+++ b/packages/web/localizations/ru.json
@@ -875,7 +875,7 @@
       "depositWith": "Депозит с",
       "withdrawWith": "Вывод средств с помощью",
       "noAlternativesFound": "Альтернативные поставщики для этого маршрута не найдены.",
-      "externalSiteCaveat": "These open third-party bridge sites. Select your route there.",
+      "externalSiteCaveat": "Откроются сторонние сайты мостов. Выберите маршрут там.",
       "convertBeforeWithdraw": {
         "title": "Сначала конвертируйте в {variant}",
         "description": "{provider} принимает только {variant}. Конвертируйте ваш сплавленный баланс в {variant} ниже, затем перейдите к {provider}, чтобы завершить вывод средств.",

--- a/packages/web/localizations/tr.json
+++ b/packages/web/localizations/tr.json
@@ -875,7 +875,7 @@
       "depositWith": "Şununla para yatır:",
       "withdrawWith": "Şununla çekil:",
       "noAlternativesFound": "Bu rota için alternatif sağlayıcı bulunamadı.",
-      "externalSiteCaveat": "These open third-party bridge sites. Select your route there.",
+      "externalSiteCaveat": "Bunlar üçüncü taraf köprü sitelerini açar. Rotanızı orada seçin.",
       "convertBeforeWithdraw": {
         "title": "Önce {variant} öğesine dönüştürün",
         "description": "{provider} yalnızca {variant} kabul eder. Alaşımlı bakiyenizi aşağıda {variant} öğesine dönüştürün, ardından çekme işleminizi tamamlamak için {provider} ile devam edin.",

--- a/packages/web/localizations/tr.json
+++ b/packages/web/localizations/tr.json
@@ -872,11 +872,10 @@
       "titleWithdraw": "Daha fazla para çekme seçeneği",
       "depositDescriptionUnknown": "{denom} yatırmak için lütfen alternatif bir sağlayıcı kullanın.",
       "withdrawDescriptionUnknown": "{denom} öğesini geri çekmek için lütfen alternatif bir sağlayıcı kullanın.",
-      "chooseAnAlternativeProviderDeposit": "{asset} yi {fromChain} den {toChain}",
-      "chooseAnAlternativeProviderWithdraw": "{asset} yi {fromChain} den {toChain}",
       "depositWith": "Şununla para yatır:",
       "withdrawWith": "Şununla çekil:",
       "noAlternativesFound": "Bu rota için alternatif sağlayıcı bulunamadı.",
+      "externalSiteCaveat": "These open third-party bridge sites. Select your route there.",
       "convertBeforeWithdraw": {
         "title": "Önce {variant} öğesine dönüştürün",
         "description": "{provider} yalnızca {variant} kabul eder. Alaşımlı bakiyenizi aşağıda {variant} öğesine dönüştürün, ardından çekme işleminizi tamamlamak için {provider} ile devam edin.",

--- a/packages/web/localizations/zh-cn.json
+++ b/packages/web/localizations/zh-cn.json
@@ -872,11 +872,10 @@
       "titleWithdraw": "更多提款选项",
       "depositDescriptionUnknown": "要存入{denom} ，请使用其他提供商。",
       "withdrawDescriptionUnknown": "要撤回{denom} ，请使用其他提供商。",
-      "chooseAnAlternativeProviderDeposit": "选择替代提供商将{asset}从{fromChain}存入{toChain}",
-      "chooseAnAlternativeProviderWithdraw": "选择替代提供商将{asset}从{fromChain}提取到{toChain}",
       "depositWith": "存款",
       "withdrawWith": "提款",
       "noAlternativesFound": "未找到此路线的替代提供商。",
+      "externalSiteCaveat": "These open third-party bridge sites. Select your route there.",
       "convertBeforeWithdraw": {
         "title": "请先转换为 {variant}",
         "description": "{provider} 仅接受 {variant}。请在下方将您的合金余额转换为 {variant}，然后继续前往 {provider} 完成提款。",

--- a/packages/web/localizations/zh-cn.json
+++ b/packages/web/localizations/zh-cn.json
@@ -875,7 +875,7 @@
       "depositWith": "存款",
       "withdrawWith": "提款",
       "noAlternativesFound": "未找到此路线的替代提供商。",
-      "externalSiteCaveat": "These open third-party bridge sites. Select your route there.",
+      "externalSiteCaveat": "这些链接将打开第三方跨链桥网站。请在该网站上选择您的路线。",
       "convertBeforeWithdraw": {
         "title": "请先转换为 {variant}",
         "description": "{provider} 仅接受 {variant}。请在下方将您的合金余额转换为 {variant}，然后继续前往 {provider} 完成提款。",

--- a/packages/web/localizations/zh-hk.json
+++ b/packages/web/localizations/zh-hk.json
@@ -872,11 +872,10 @@
       "titleWithdraw": "更多提款選項",
       "depositDescriptionUnknown": "若要存入{denom} ，請使用替代提供者。",
       "withdrawDescriptionUnknown": "若要撤回{denom} ，請使用替代提供者。",
-      "chooseAnAlternativeProviderDeposit": "選擇一個替代提供者將{asset}從{fromChain}存入{toChain}",
-      "chooseAnAlternativeProviderWithdraw": "選擇替代提供者將{asset}從{fromChain}撤回到{toChain}",
       "depositWith": "存款於",
       "withdrawWith": "撤回與",
       "noAlternativesFound": "找不到此路線的替代提供者。",
+      "externalSiteCaveat": "These open third-party bridge sites. Select your route there.",
       "convertBeforeWithdraw": {
         "title": "先轉換為 {variant}",
         "description": "{provider} 只接受 {variant}。請在下方將你的合金結餘轉換為 {variant}，然後繼續前往 {provider} 完成提款。",

--- a/packages/web/localizations/zh-hk.json
+++ b/packages/web/localizations/zh-hk.json
@@ -875,7 +875,7 @@
       "depositWith": "存款於",
       "withdrawWith": "撤回與",
       "noAlternativesFound": "找不到此路線的替代提供者。",
-      "externalSiteCaveat": "These open third-party bridge sites. Select your route there.",
+      "externalSiteCaveat": "這些連結會開啟第三方跨鏈橋網站。請在該網站上選擇您的路線。",
       "convertBeforeWithdraw": {
         "title": "先轉換為 {variant}",
         "description": "{provider} 只接受 {variant}。請在下方將你的合金結餘轉換為 {variant}，然後繼續前往 {provider} 完成提款。",

--- a/packages/web/localizations/zh-tw.json
+++ b/packages/web/localizations/zh-tw.json
@@ -875,7 +875,7 @@
       "depositWith": "存款於",
       "withdrawWith": "撤回與",
       "noAlternativesFound": "找不到此路線的替代提供者。",
-      "externalSiteCaveat": "These open third-party bridge sites. Select your route there.",
+      "externalSiteCaveat": "這些連結會開啟第三方跨鏈橋網站。請在該網站上選擇您的路線。",
       "convertBeforeWithdraw": {
         "title": "請先轉換為 {variant}",
         "description": "{provider} 僅接受 {variant}。請在下方將您的合金餘額轉換為 {variant}，然後繼續前往 {provider} 完成提款。",

--- a/packages/web/localizations/zh-tw.json
+++ b/packages/web/localizations/zh-tw.json
@@ -872,11 +872,10 @@
       "titleWithdraw": "更多提款選項",
       "depositDescriptionUnknown": "若要存入{denom} ，請使用替代提供者。",
       "withdrawDescriptionUnknown": "若要撤回{denom} ，請使用替代提供者。",
-      "chooseAnAlternativeProviderDeposit": "選擇一個替代提供者將{asset}從{fromChain}存入{toChain}",
-      "chooseAnAlternativeProviderWithdraw": "選擇替代提供者將{asset}從{fromChain}撤回到{toChain}",
       "depositWith": "存款於",
       "withdrawWith": "撤回與",
       "noAlternativesFound": "找不到此路線的替代提供者。",
+      "externalSiteCaveat": "These open third-party bridge sites. Select your route there.",
       "convertBeforeWithdraw": {
         "title": "請先轉換為 {variant}",
         "description": "{provider} 僅接受 {variant}。請在下方將您的合金餘額轉換為 {variant}，然後繼續前往 {provider} 完成提款。",

--- a/packages/web/server/api/routers/bridge-transfer.ts
+++ b/packages/web/server/api/routers/bridge-transfer.ts
@@ -11,6 +11,7 @@ import {
 import {
   DEFAULT_VS_CURRENCY,
   getAssetPrice,
+  getCachedTransmuterTotalPoolLiquidity,
   getChain,
   getTimeoutHeight,
 } from "@osmosis-labs/server";
@@ -630,26 +631,60 @@ export const bridgeTransferRouter = createTRPCRouter({
         (asset) => asset.coinMinimalDenom === input.toAsset?.address
       );
 
+      // Resolve the TRUE pool-member denom set for whichever side is an alloy.
+      // `variantGroupKey` only groups variants for display; it is NOT pool
+      // membership, so a grouped sibling (e.g. BTC.int3 for allBTC) can fail to
+      // be a real constituent the user can obtain from the alloy. We read the
+      // alloy's transmuter pool composition (`get_total_pool_liquidity` on its
+      // `contract`, cached 30s) and gate the family by it. Only fired when the
+      // side is actually an alloyed asset with a contract, so this stays on the
+      // fallback / convert path rather than every bridge view.
+      const resolveAlloyMemberDenoms = async (
+        alloyAsset: typeof assetListFromAsset
+      ): Promise<Set<string>> => {
+        if (!alloyAsset?.isAlloyed || !alloyAsset.contract) return new Set();
+        try {
+          const liquidity = await getCachedTransmuterTotalPoolLiquidity(
+            alloyAsset.contract,
+            ctx.chainList,
+            ctx.assetLists
+          );
+          return new Set(liquidity.map(({ asset }) => asset.coinMinimalDenom));
+        } catch {
+          // On a failed membership read, surface nothing rather than risk
+          // offering a non-constituent (dead) route.
+          return new Set();
+        }
+      };
+
+      const [fromAlloyMemberDenoms, toAlloyMemberDenoms] = await Promise.all([
+        resolveAlloyMemberDenoms(assetListFromAsset),
+        resolveAlloyMemberDenoms(assetListToAsset),
+      ]);
+
       // When the user transfers an alloy (the from-asset on a withdraw, the
       // to-asset on a deposit), aggregate the `external_interface` methods of
       // the alloy's constituent variants too, not just the alloy's own. An
       // alloy such as allBTC carries no transfer methods of its own, so without
       // this a down quote route leaves no external fallback even though the
-      // constituents carry usable bridge URLs. Constituents whose active
-      // direction is kill-switched are skipped inside the helper so dead links
-      // are not surfaced. Dedup by provider name / host is handled below, so
-      // constituent methods that collide with the alloy's own (e.g. Sologenic
-      // on both allXRP and XRP.coreum) are collapsed.
+      // constituents carry usable bridge URLs. The helper is gated by true pool
+      // membership (above), so non-constituent group siblings are never
+      // surfaced, and direction-halted constituents are skipped inside it. Dedup
+      // by provider name / host is handled below, so constituent methods that
+      // collide with the alloy's own (e.g. Sologenic on both allXRP and
+      // XRP.coreum) are collapsed.
       const constituentExternalMethods = [
         ...getAlloyConstituentExternalInterfaceMethods({
           alloy: assetListFromAsset,
           assets: allAssetListAssets,
           direction: "withdraw",
+          memberDenoms: fromAlloyMemberDenoms,
         }),
         ...getAlloyConstituentExternalInterfaceMethods({
           alloy: assetListToAsset,
           assets: allAssetListAssets,
           direction: "deposit",
+          memberDenoms: toAlloyMemberDenoms,
         }),
       ];
 
@@ -726,6 +761,9 @@ export const bridgeTransferRouter = createTRPCRouter({
           urlProviderName: externalUrl.urlProviderName,
           alloy: withdrawAlloy,
           assets: allAssetListAssets,
+          // The convert target must be a true pool member of the withdrawn
+          // alloy; a grouped non-constituent cannot be obtained from it.
+          memberDenoms: fromAlloyMemberDenoms,
         }),
       }));
 

--- a/packages/web/server/api/routers/bridge-transfer.ts
+++ b/packages/web/server/api/routers/bridge-transfer.ts
@@ -45,7 +45,10 @@ import { LRUCache } from "lru-cache";
 import { z } from "zod";
 
 import { IS_TESTNET } from "~/config/env";
-import { getAlloyConstituentExternalInterfaceMethods } from "~/server/api/routers/bridge/external-url-constituents";
+import {
+  getAlloyConstituentExternalInterfaceMethods,
+  getSuppressedAlloyExternalInterfaceNames,
+} from "~/server/api/routers/bridge/external-url-constituents";
 import { resolveExternalUrlConvertVariant } from "~/server/api/routers/bridge/external-url-convert-variant";
 import { BridgeLogoUrls, ExternalBridgeLogoUrls } from "~/utils/bridge";
 import { INSUFFICIENT_FEE_TOKENS_OSMOSIS_MARKER } from "~/utils/error";
@@ -688,14 +691,40 @@ export const bridgeTransferRouter = createTRPCRouter({
         }),
       ];
 
+      // An alloy can carry an `external_interface` of its own that is really a
+      // constituent connector by another name (e.g. allXRP's own Sologenic
+      // link). Those alloy-own methods have no halt flag or variant link, so the
+      // membership/halt gate above can't see them. Suppress an alloy-own method
+      // whose provider name belongs to a gated (non-member or halted) sibling
+      // and no reachable sibling — otherwise it would defeat the gate (and win
+      // the dedup over the dropped constituent copy).
+      const [fromSuppressedNames, toSuppressedNames] = [
+        getSuppressedAlloyExternalInterfaceNames({
+          alloy: assetListFromAsset,
+          assets: allAssetListAssets,
+          direction: "withdraw",
+          memberDenoms: fromAlloyMemberDenoms,
+        }),
+        getSuppressedAlloyExternalInterfaceNames({
+          alloy: assetListToAsset,
+          assets: allAssetListAssets,
+          direction: "deposit",
+          memberDenoms: toAlloyMemberDenoms,
+        }),
+      ];
+
       const externalTransferMethods = (
         (assetListFromAsset?.transferMethods.filter(
-          ({ type }) => type === "external_interface"
+          (method) =>
+            method.type === "external_interface" &&
+            !fromSuppressedNames.has(method.name)
         ) ?? []) as ExternalInterfaceBridgeTransferMethod[]
       )
         .concat(
           (assetListToAsset?.transferMethods.filter(
-            ({ type }) => type === "external_interface"
+            (method) =>
+              method.type === "external_interface" &&
+              !toSuppressedNames.has(method.name)
           ) ?? []) as ExternalInterfaceBridgeTransferMethod[]
         )
         .concat(constituentExternalMethods);

--- a/packages/web/server/api/routers/bridge-transfer.ts
+++ b/packages/web/server/api/routers/bridge-transfer.ts
@@ -44,6 +44,7 @@ import { LRUCache } from "lru-cache";
 import { z } from "zod";
 
 import { IS_TESTNET } from "~/config/env";
+import { getAlloyConstituentExternalInterfaceMethods } from "~/server/api/routers/bridge/external-url-constituents";
 import { resolveExternalUrlConvertVariant } from "~/server/api/routers/bridge/external-url-convert-variant";
 import { BridgeLogoUrls, ExternalBridgeLogoUrls } from "~/utils/bridge";
 import { INSUFFICIENT_FEE_TOKENS_OSMOSIS_MARKER } from "~/utils/error";
@@ -629,15 +630,40 @@ export const bridgeTransferRouter = createTRPCRouter({
         (asset) => asset.coinMinimalDenom === input.toAsset?.address
       );
 
+      // When the user transfers an alloy (the from-asset on a withdraw, the
+      // to-asset on a deposit), aggregate the `external_interface` methods of
+      // the alloy's constituent variants too, not just the alloy's own. An
+      // alloy such as allBTC carries no transfer methods of its own, so without
+      // this a down quote route leaves no external fallback even though the
+      // constituents carry usable bridge URLs. Constituents whose active
+      // direction is kill-switched are skipped inside the helper so dead links
+      // are not surfaced. Dedup by provider name / host is handled below, so
+      // constituent methods that collide with the alloy's own (e.g. Sologenic
+      // on both allXRP and XRP.coreum) are collapsed.
+      const constituentExternalMethods = [
+        ...getAlloyConstituentExternalInterfaceMethods({
+          alloy: assetListFromAsset,
+          assets: allAssetListAssets,
+          direction: "withdraw",
+        }),
+        ...getAlloyConstituentExternalInterfaceMethods({
+          alloy: assetListToAsset,
+          assets: allAssetListAssets,
+          direction: "deposit",
+        }),
+      ];
+
       const externalTransferMethods = (
-        assetListFromAsset?.transferMethods.filter(
+        (assetListFromAsset?.transferMethods.filter(
           ({ type }) => type === "external_interface"
-        ) ?? []
-      ).concat(
-        assetListToAsset?.transferMethods.filter(
-          ({ type }) => type === "external_interface"
-        ) ?? []
-      ) as ExternalInterfaceBridgeTransferMethod[];
+        ) ?? []) as ExternalInterfaceBridgeTransferMethod[]
+      )
+        .concat(
+          (assetListToAsset?.transferMethods.filter(
+            ({ type }) => type === "external_interface"
+          ) ?? []) as ExternalInterfaceBridgeTransferMethod[]
+        )
+        .concat(constituentExternalMethods);
 
       externalTransferMethods.forEach(
         ({ name, depositUrl: depositUrl_, withdrawUrl: withdrawUrl_ }) => {

--- a/packages/web/server/api/routers/bridge/__tests__/external-url-constituents.spec.ts
+++ b/packages/web/server/api/routers/bridge/__tests__/external-url-constituents.spec.ts
@@ -475,17 +475,45 @@ describe("getSuppressedAlloyExternalInterfaceNames", () => {
       variantGroupKey: ALL_XRP,
       transferMethods: [externalInterface("Sologenic TX Bridge")],
     });
-    const assets = [alloy, coreum];
+    // A different sibling IS a member, so membership is known (non-empty set)
+    // but coreum (the Sologenic-bearer) is not in it.
+    const otherMember = asset({
+      coinMinimalDenom: "ibc/XRP_OTHER",
+      isAlloyed: false,
+      variantGroupKey: ALL_XRP,
+      transferMethods: [externalInterface("Some Other Bridge")],
+    });
+    const assets = [alloy, coreum, otherMember];
 
     const suppressed = getSuppressedAlloyExternalInterfaceNames({
       alloy,
       assets,
       direction: "withdraw",
-      // coreum NOT a member → its route is unreachable from the alloy
-      memberDenoms: new Set(),
+      // membership is resolved (otherMember is in), but coreum is NOT
+      memberDenoms: new Set(["ibc/XRP_OTHER"]),
     });
 
     expect(suppressed.has("Sologenic TX Bridge")).toBe(true);
+  });
+
+  it("suppresses NOTHING when membership is unresolved (empty set = failed read / no contract)", () => {
+    // An empty memberDenoms means membership is UNKNOWN, not "no members".
+    // Must NOT strip the alloy-own Sologenic link on a transient pool-read
+    // failure — stage would still show it. (Cursor: "Failed pool read hides links".)
+    const coreum = asset({
+      coinMinimalDenom: "ibc/XRP_COREUM",
+      isAlloyed: false,
+      variantGroupKey: ALL_XRP,
+      transferMethods: [externalInterface("Sologenic TX Bridge")],
+    });
+    const suppressed = getSuppressedAlloyExternalInterfaceNames({
+      alloy,
+      assets: [alloy, coreum],
+      direction: "withdraw",
+      memberDenoms: new Set(),
+    });
+
+    expect(suppressed.size).toBe(0);
   });
 
   it("suppresses a name carried only by a withdrawal-halted member sibling", () => {

--- a/packages/web/server/api/routers/bridge/__tests__/external-url-constituents.spec.ts
+++ b/packages/web/server/api/routers/bridge/__tests__/external-url-constituents.spec.ts
@@ -1,0 +1,390 @@
+import type {
+  Asset,
+  ExternalInterfaceBridgeTransferMethod,
+} from "@osmosis-labs/types";
+
+import { getAlloyConstituentExternalInterfaceMethods } from "../external-url-constituents";
+
+/** Minimal Asset factory: only the fields the helper reads are meaningful. */
+function asset(
+  partial: Pick<
+    Asset,
+    "coinMinimalDenom" | "isAlloyed" | "variantGroupKey" | "transferMethods"
+  > &
+    Partial<
+      Pick<Asset, "haltWithdrawals" | "haltDeposits" | "disabled" | "unstable">
+    >
+): Asset {
+  return {
+    chainName: "test",
+    sourceDenom: partial.coinMinimalDenom,
+    symbol: "TEST",
+    name: "Test",
+    decimals: 6,
+    verified: true,
+    preview: false,
+    unstable: false,
+    disabled: false,
+    categories: [],
+    counterparty: [],
+    relative_image_url: "",
+    ...partial,
+  };
+}
+
+const externalInterface = (
+  name: string,
+  urls?: { depositUrl?: string; withdrawUrl?: string }
+): ExternalInterfaceBridgeTransferMethod => ({
+  name,
+  type: "external_interface",
+  ...urls,
+});
+
+const ibcMethod = {
+  type: "ibc" as const,
+  counterparty: {
+    chainName: "test",
+    chainId: "test-1",
+    sourceDenom: "utest",
+    port: "transfer",
+    channelId: "channel-0",
+  },
+  chain: { port: "transfer", channelId: "channel-1", path: "" },
+};
+
+// Real denoms from the asset list (allXRP family) so the test pins the actual
+// `variantGroupKey === alloy.coinMinimalDenom` relationship.
+const ALL_XRP =
+  "factory/osmo1qnglc04tmhg32uc4kxlxh55a5cmhj88cpa3rmtly484xqu82t79sfv94w0/alloyed/allXRP";
+const ALL_BTC =
+  "factory/osmo1z6r6qdknhgsc0zeracktgpcxf43j6sekq07nw8sxduc9lg0qjjlqfu25e3/alloyed/allBTC";
+
+describe("getAlloyConstituentExternalInterfaceMethods", () => {
+  it("collects external_interface methods from an alloy's constituents", () => {
+    const alloy = asset({
+      coinMinimalDenom: ALL_BTC,
+      isAlloyed: true,
+      variantGroupKey: ALL_BTC,
+      transferMethods: [], // allBTC carries no methods of its own
+    });
+    const assets: Asset[] = [
+      alloy,
+      asset({
+        coinMinimalDenom: "ibc/WBTC",
+        isAlloyed: false,
+        variantGroupKey: ALL_BTC,
+        transferMethods: [externalInterface("WBTC Bridge"), ibcMethod],
+      }),
+      asset({
+        coinMinimalDenom: "ibc/NBTC",
+        isAlloyed: false,
+        variantGroupKey: ALL_BTC,
+        transferMethods: [externalInterface("Nomic")],
+      }),
+    ];
+
+    const result = getAlloyConstituentExternalInterfaceMethods({
+      alloy,
+      assets,
+      direction: "withdraw",
+    });
+
+    // Order is incidental (asset-list iteration order); assert membership, not
+    // sequence, since the helper makes no ordering guarantee.
+    expect(result.map((m) => m.name).sort()).toEqual(["Nomic", "WBTC Bridge"]);
+    expect(result.every((m) => m.type === "external_interface")).toBe(true);
+  });
+
+  it("excludes a nested alloy constituent (only true variants contribute)", () => {
+    const alloy = asset({
+      coinMinimalDenom: ALL_BTC,
+      isAlloyed: true,
+      variantGroupKey: ALL_BTC,
+      transferMethods: [],
+    });
+    // A hypothetical nested alloy whose variantGroupKey points at the outer
+    // alloy. It must NOT be treated as a plain variant.
+    const nestedAlloy = asset({
+      coinMinimalDenom: "factory/osmo.../alloyed/allNestedBTC",
+      isAlloyed: true,
+      variantGroupKey: ALL_BTC,
+      transferMethods: [externalInterface("Should Not Appear")],
+    });
+    const realVariant = asset({
+      coinMinimalDenom: "ibc/WBTC",
+      isAlloyed: false,
+      variantGroupKey: ALL_BTC,
+      transferMethods: [externalInterface("WBTC Bridge")],
+    });
+
+    const result = getAlloyConstituentExternalInterfaceMethods({
+      alloy,
+      assets: [alloy, nestedAlloy, realVariant],
+      direction: "withdraw",
+    });
+
+    expect(result.map((m) => m.name)).toEqual(["WBTC Bridge"]);
+  });
+
+  it("excludes the alloy's own entry (variantGroupKey === own coinMinimalDenom)", () => {
+    // An alloy's variantGroupKey equals its own coinMinimalDenom, so a naive
+    // `variantGroupKey === alloyDenom` match would include the alloy itself.
+    const alloy = asset({
+      coinMinimalDenom: ALL_XRP,
+      isAlloyed: true,
+      variantGroupKey: ALL_XRP,
+      transferMethods: [externalInterface("Sologenic TX Bridge")],
+    });
+    const variant = asset({
+      coinMinimalDenom: "ibc/XRP_COREUM",
+      isAlloyed: false,
+      variantGroupKey: ALL_XRP,
+      transferMethods: [externalInterface("Sologenic TX Bridge")],
+    });
+
+    const result = getAlloyConstituentExternalInterfaceMethods({
+      alloy,
+      assets: [alloy, variant],
+      direction: "withdraw",
+    });
+
+    // Only the variant's method, not the alloy's own (caller adds the alloy's
+    // own separately).
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("Sologenic TX Bridge");
+  });
+
+  it("returns nothing when the asset is not an alloy", () => {
+    const variant = asset({
+      coinMinimalDenom: "ibc/XRP_COREUM",
+      isAlloyed: false,
+      variantGroupKey: ALL_XRP,
+      transferMethods: [externalInterface("Sologenic TX Bridge")],
+    });
+
+    expect(
+      getAlloyConstituentExternalInterfaceMethods({
+        alloy: variant,
+        assets: [variant],
+        direction: "withdraw",
+      })
+    ).toEqual([]);
+  });
+
+  it("returns nothing for null / undefined alloy", () => {
+    expect(
+      getAlloyConstituentExternalInterfaceMethods({
+        alloy: null,
+        assets: [],
+        direction: "withdraw",
+      })
+    ).toEqual([]);
+    expect(
+      getAlloyConstituentExternalInterfaceMethods({
+        alloy: undefined,
+        assets: [],
+        direction: "withdraw",
+      })
+    ).toEqual([]);
+  });
+
+  it("filters out non-external_interface transfer methods", () => {
+    const alloy = asset({
+      coinMinimalDenom: ALL_XRP,
+      isAlloyed: true,
+      variantGroupKey: ALL_XRP,
+      transferMethods: [],
+    });
+    const variant = asset({
+      coinMinimalDenom: "ibc/XRP_EVM",
+      isAlloyed: false,
+      variantGroupKey: ALL_XRP,
+      transferMethods: [ibcMethod], // IBC-only, no external_interface (XRP.xrplevm)
+    });
+
+    expect(
+      getAlloyConstituentExternalInterfaceMethods({
+        alloy,
+        assets: [alloy, variant],
+        direction: "withdraw",
+      })
+    ).toEqual([]);
+  });
+
+  it("does not cross variant-group boundaries", () => {
+    const alloy = asset({
+      coinMinimalDenom: ALL_XRP,
+      isAlloyed: true,
+      variantGroupKey: ALL_XRP,
+      transferMethods: [],
+    });
+    const xrpVariant = asset({
+      coinMinimalDenom: "ibc/XRP_COREUM",
+      isAlloyed: false,
+      variantGroupKey: ALL_XRP,
+      transferMethods: [externalInterface("Sologenic TX Bridge")],
+    });
+    // A BTC variant must not leak into the XRP alloy's result.
+    const btcVariant = asset({
+      coinMinimalDenom: "ibc/WBTC",
+      isAlloyed: false,
+      variantGroupKey: ALL_BTC,
+      transferMethods: [externalInterface("WBTC Bridge")],
+    });
+
+    const result = getAlloyConstituentExternalInterfaceMethods({
+      alloy,
+      assets: [alloy, xrpVariant, btcVariant],
+      direction: "withdraw",
+    });
+
+    expect(result.map((m) => m.name)).toEqual(["Sologenic TX Bridge"]);
+  });
+
+  it("preserves deposit and withdraw URLs verbatim for the caller to dedup", () => {
+    const alloy = asset({
+      coinMinimalDenom: ALL_XRP,
+      isAlloyed: true,
+      variantGroupKey: ALL_XRP,
+      transferMethods: [],
+    });
+    const variant = asset({
+      coinMinimalDenom: "ibc/XRP_INT3",
+      isAlloyed: false,
+      variantGroupKey: ALL_XRP,
+      transferMethods: [
+        externalInterface("Int3face Bridge", {
+          depositUrl:
+            "https://app.int3face.zone/bridge?fromChain=xrpl&toChain=osmosis&fromToken=XRP",
+          withdrawUrl:
+            "https://app.int3face.zone/bridge?fromChain=osmosis&toChain=xrpl&fromToken=XRP.int3",
+        }),
+      ],
+    });
+
+    const [method] = getAlloyConstituentExternalInterfaceMethods({
+      alloy,
+      assets: [alloy, variant],
+      direction: "withdraw",
+    });
+
+    expect(method.depositUrl).toBe(
+      "https://app.int3face.zone/bridge?fromChain=xrpl&toChain=osmosis&fromToken=XRP"
+    );
+    expect(method.withdrawUrl).toBe(
+      "https://app.int3face.zone/bridge?fromChain=osmosis&toChain=xrpl&fromToken=XRP.int3"
+    );
+  });
+
+  describe("halt awareness", () => {
+    const alloy = asset({
+      coinMinimalDenom: ALL_BTC,
+      isAlloyed: true,
+      variantGroupKey: ALL_BTC,
+      transferMethods: [],
+    });
+
+    it("skips a withdraw-halted constituent on a withdraw", () => {
+      const haltedVariant = asset({
+        coinMinimalDenom: "ibc/RBTC_RT",
+        isAlloyed: false,
+        variantGroupKey: ALL_BTC,
+        haltWithdrawals: true,
+        unstable: true,
+        transferMethods: [externalInterface("Nitro Router")],
+      });
+      const liveVariant = asset({
+        coinMinimalDenom: "ibc/CKBTC",
+        isAlloyed: false,
+        variantGroupKey: ALL_BTC,
+        transferMethods: [externalInterface("Omnity Bridge")],
+      });
+
+      const result = getAlloyConstituentExternalInterfaceMethods({
+        alloy,
+        assets: [alloy, haltedVariant, liveVariant],
+        direction: "withdraw",
+      });
+
+      expect(result.map((m) => m.name)).toEqual(["Omnity Bridge"]);
+    });
+
+    it("does not skip a withdraw-halted constituent on a deposit (only the active direction gates)", () => {
+      const withdrawHalted = asset({
+        coinMinimalDenom: "ibc/RBTC_RT",
+        isAlloyed: false,
+        variantGroupKey: ALL_BTC,
+        haltWithdrawals: true,
+        haltDeposits: false,
+        transferMethods: [
+          externalInterface("Nitro Router", {
+            depositUrl: "https://nitro.example/deposit",
+          }),
+        ],
+      });
+
+      const result = getAlloyConstituentExternalInterfaceMethods({
+        alloy,
+        assets: [alloy, withdrawHalted],
+        direction: "deposit",
+      });
+
+      expect(result.map((m) => m.name)).toEqual(["Nitro Router"]);
+    });
+
+    it("skips a deposit-halted constituent on a deposit", () => {
+      const depositHalted = asset({
+        coinMinimalDenom: "ibc/DEP_HALT",
+        isAlloyed: false,
+        variantGroupKey: ALL_BTC,
+        haltDeposits: true,
+        transferMethods: [externalInterface("Down Bridge")],
+      });
+
+      const result = getAlloyConstituentExternalInterfaceMethods({
+        alloy,
+        assets: [alloy, depositHalted],
+        direction: "deposit",
+      });
+
+      expect(result).toEqual([]);
+    });
+
+    it("keeps a disabled constituent (disabled often routes through the external flow)", () => {
+      const disabledVariant = asset({
+        coinMinimalDenom: "ibc/NBTC",
+        isAlloyed: false,
+        variantGroupKey: ALL_BTC,
+        disabled: true,
+        transferMethods: [externalInterface("Nomic")],
+      });
+
+      const result = getAlloyConstituentExternalInterfaceMethods({
+        alloy,
+        assets: [alloy, disabledVariant],
+        direction: "withdraw",
+      });
+
+      expect(result.map((m) => m.name)).toEqual(["Nomic"]);
+    });
+
+    it("keeps an unstable (warning-only) constituent", () => {
+      const unstableVariant = asset({
+        coinMinimalDenom: "ibc/BTC_INT3",
+        isAlloyed: false,
+        variantGroupKey: ALL_BTC,
+        unstable: true,
+        transferMethods: [externalInterface("Int3face Bridge")],
+      });
+
+      const result = getAlloyConstituentExternalInterfaceMethods({
+        alloy,
+        assets: [alloy, unstableVariant],
+        direction: "withdraw",
+      });
+
+      expect(result.map((m) => m.name)).toEqual(["Int3face Bridge"]);
+    });
+  });
+});

--- a/packages/web/server/api/routers/bridge/__tests__/external-url-constituents.spec.ts
+++ b/packages/web/server/api/routers/bridge/__tests__/external-url-constituents.spec.ts
@@ -3,7 +3,10 @@ import type {
   ExternalInterfaceBridgeTransferMethod,
 } from "@osmosis-labs/types";
 
-import { getAlloyConstituentExternalInterfaceMethods } from "../external-url-constituents";
+import {
+  getAlloyConstituentExternalInterfaceMethods,
+  getSuppressedAlloyExternalInterfaceNames,
+} from "../external-url-constituents";
 
 /** Minimal Asset factory: only the fields the helper reads are meaningful. */
 function asset(
@@ -453,5 +456,112 @@ describe("getAlloyConstituentExternalInterfaceMethods", () => {
 
       expect(result).toEqual([]);
     });
+  });
+});
+
+describe("getSuppressedAlloyExternalInterfaceNames", () => {
+  const alloy = asset({
+    coinMinimalDenom: ALL_XRP,
+    isAlloyed: true,
+    variantGroupKey: ALL_XRP,
+    // allXRP carries its OWN Sologenic link (a constituent connector by name).
+    transferMethods: [externalInterface("Sologenic TX Bridge")],
+  });
+
+  it("suppresses a name carried only by a non-member sibling", () => {
+    const coreum = asset({
+      coinMinimalDenom: "ibc/XRP_COREUM",
+      isAlloyed: false,
+      variantGroupKey: ALL_XRP,
+      transferMethods: [externalInterface("Sologenic TX Bridge")],
+    });
+    const assets = [alloy, coreum];
+
+    const suppressed = getSuppressedAlloyExternalInterfaceNames({
+      alloy,
+      assets,
+      direction: "withdraw",
+      // coreum NOT a member → its route is unreachable from the alloy
+      memberDenoms: new Set(),
+    });
+
+    expect(suppressed.has("Sologenic TX Bridge")).toBe(true);
+  });
+
+  it("suppresses a name carried only by a withdrawal-halted member sibling", () => {
+    const coreum = asset({
+      coinMinimalDenom: "ibc/XRP_COREUM",
+      isAlloyed: false,
+      variantGroupKey: ALL_XRP,
+      haltWithdrawals: true,
+      transferMethods: [externalInterface("Sologenic TX Bridge")],
+    });
+    const assets = [alloy, coreum];
+
+    const suppressed = getSuppressedAlloyExternalInterfaceNames({
+      alloy,
+      assets,
+      direction: "withdraw",
+      memberDenoms: allMembers(assets),
+    });
+
+    expect(suppressed.has("Sologenic TX Bridge")).toBe(true);
+  });
+
+  it("does NOT suppress a name still reachable via a good (member, non-halted) sibling", () => {
+    // Two siblings share the provider name; one is halted, one is live.
+    const halted = asset({
+      coinMinimalDenom: "ibc/XRP_HALTED",
+      isAlloyed: false,
+      variantGroupKey: ALL_XRP,
+      haltWithdrawals: true,
+      transferMethods: [externalInterface("Sologenic TX Bridge")],
+    });
+    const live = asset({
+      coinMinimalDenom: "ibc/XRP_LIVE",
+      isAlloyed: false,
+      variantGroupKey: ALL_XRP,
+      transferMethods: [externalInterface("Sologenic TX Bridge")],
+    });
+    const assets = [alloy, halted, live];
+
+    const suppressed = getSuppressedAlloyExternalInterfaceNames({
+      alloy,
+      assets,
+      direction: "withdraw",
+      memberDenoms: allMembers(assets),
+    });
+
+    expect(suppressed.has("Sologenic TX Bridge")).toBe(false);
+  });
+
+  it("does not suppress when the sibling route is reachable", () => {
+    const coreum = asset({
+      coinMinimalDenom: "ibc/XRP_COREUM",
+      isAlloyed: false,
+      variantGroupKey: ALL_XRP,
+      transferMethods: [externalInterface("Sologenic TX Bridge")],
+    });
+    const assets = [alloy, coreum];
+
+    const suppressed = getSuppressedAlloyExternalInterfaceNames({
+      alloy,
+      assets,
+      direction: "withdraw",
+      memberDenoms: allMembers(assets),
+    });
+
+    expect(suppressed.size).toBe(0);
+  });
+
+  it("returns an empty set for a non-alloy from-asset", () => {
+    expect(
+      getSuppressedAlloyExternalInterfaceNames({
+        alloy: { ...alloy, isAlloyed: false },
+        assets: [alloy],
+        direction: "withdraw",
+        memberDenoms: new Set(),
+      }).size
+    ).toBe(0);
   });
 });

--- a/packages/web/server/api/routers/bridge/__tests__/external-url-constituents.spec.ts
+++ b/packages/web/server/api/routers/bridge/__tests__/external-url-constituents.spec.ts
@@ -41,6 +41,11 @@ const externalInterface = (
   ...urls,
 });
 
+/** Default member set: treat every non-alloy asset as a true pool member.
+ *  Tests that exercise membership gating pass a restricted set explicitly. */
+const allMembers = (assets: Asset[]): Set<string> =>
+  new Set(assets.filter((a) => !a.isAlloyed).map((a) => a.coinMinimalDenom));
+
 const ibcMethod = {
   type: "ibc" as const,
   counterparty: {
@@ -88,6 +93,7 @@ describe("getAlloyConstituentExternalInterfaceMethods", () => {
       alloy,
       assets,
       direction: "withdraw",
+      memberDenoms: allMembers(assets),
     });
 
     // Order is incidental (asset-list iteration order); assert membership, not
@@ -122,6 +128,7 @@ describe("getAlloyConstituentExternalInterfaceMethods", () => {
       alloy,
       assets: [alloy, nestedAlloy, realVariant],
       direction: "withdraw",
+      memberDenoms: allMembers([alloy, nestedAlloy, realVariant]),
     });
 
     expect(result.map((m) => m.name)).toEqual(["WBTC Bridge"]);
@@ -147,6 +154,7 @@ describe("getAlloyConstituentExternalInterfaceMethods", () => {
       alloy,
       assets: [alloy, variant],
       direction: "withdraw",
+      memberDenoms: allMembers([alloy, variant]),
     });
 
     // Only the variant's method, not the alloy's own (caller adds the alloy's
@@ -168,6 +176,7 @@ describe("getAlloyConstituentExternalInterfaceMethods", () => {
         alloy: variant,
         assets: [variant],
         direction: "withdraw",
+        memberDenoms: allMembers([variant]),
       })
     ).toEqual([]);
   });
@@ -178,6 +187,7 @@ describe("getAlloyConstituentExternalInterfaceMethods", () => {
         alloy: null,
         assets: [],
         direction: "withdraw",
+        memberDenoms: new Set(),
       })
     ).toEqual([]);
     expect(
@@ -185,6 +195,7 @@ describe("getAlloyConstituentExternalInterfaceMethods", () => {
         alloy: undefined,
         assets: [],
         direction: "withdraw",
+        memberDenoms: new Set(),
       })
     ).toEqual([]);
   });
@@ -208,6 +219,7 @@ describe("getAlloyConstituentExternalInterfaceMethods", () => {
         alloy,
         assets: [alloy, variant],
         direction: "withdraw",
+        memberDenoms: allMembers([alloy, variant]),
       })
     ).toEqual([]);
   });
@@ -237,6 +249,7 @@ describe("getAlloyConstituentExternalInterfaceMethods", () => {
       alloy,
       assets: [alloy, xrpVariant, btcVariant],
       direction: "withdraw",
+      memberDenoms: allMembers([alloy, xrpVariant, btcVariant]),
     });
 
     expect(result.map((m) => m.name)).toEqual(["Sologenic TX Bridge"]);
@@ -267,6 +280,7 @@ describe("getAlloyConstituentExternalInterfaceMethods", () => {
       alloy,
       assets: [alloy, variant],
       direction: "withdraw",
+      memberDenoms: allMembers([alloy, variant]),
     });
 
     expect(method.depositUrl).toBe(
@@ -305,6 +319,7 @@ describe("getAlloyConstituentExternalInterfaceMethods", () => {
         alloy,
         assets: [alloy, haltedVariant, liveVariant],
         direction: "withdraw",
+        memberDenoms: allMembers([alloy, haltedVariant, liveVariant]),
       });
 
       expect(result.map((m) => m.name)).toEqual(["Omnity Bridge"]);
@@ -328,6 +343,7 @@ describe("getAlloyConstituentExternalInterfaceMethods", () => {
         alloy,
         assets: [alloy, withdrawHalted],
         direction: "deposit",
+        memberDenoms: allMembers([alloy, withdrawHalted]),
       });
 
       expect(result.map((m) => m.name)).toEqual(["Nitro Router"]);
@@ -346,6 +362,7 @@ describe("getAlloyConstituentExternalInterfaceMethods", () => {
         alloy,
         assets: [alloy, depositHalted],
         direction: "deposit",
+        memberDenoms: allMembers([alloy, depositHalted]),
       });
 
       expect(result).toEqual([]);
@@ -364,6 +381,7 @@ describe("getAlloyConstituentExternalInterfaceMethods", () => {
         alloy,
         assets: [alloy, disabledVariant],
         direction: "withdraw",
+        memberDenoms: allMembers([alloy, disabledVariant]),
       });
 
       expect(result.map((m) => m.name)).toEqual(["Nomic"]);
@@ -382,9 +400,58 @@ describe("getAlloyConstituentExternalInterfaceMethods", () => {
         alloy,
         assets: [alloy, unstableVariant],
         direction: "withdraw",
+        memberDenoms: allMembers([alloy, unstableVariant]),
       });
 
       expect(result.map((m) => m.name)).toEqual(["Int3face Bridge"]);
+    });
+  });
+
+  describe("pool membership gating", () => {
+    const alloy = asset({
+      coinMinimalDenom: ALL_BTC,
+      isAlloyed: true,
+      variantGroupKey: ALL_BTC,
+      transferMethods: [],
+    });
+    // A true pool constituent.
+    const ckBTC = asset({
+      coinMinimalDenom: "ibc/CKBTC",
+      isAlloyed: false,
+      variantGroupKey: ALL_BTC,
+      transferMethods: [externalInterface("Omnity Bridge")],
+    });
+    // Shares the allBTC variantGroupKey but is NOT in the allBTC pool (the
+    // real-world BTC.int3 case). Must never be surfaced to an allBTC holder.
+    const btcInt3 = asset({
+      coinMinimalDenom: "ibc/BTC_INT3",
+      isAlloyed: false,
+      variantGroupKey: ALL_BTC,
+      transferMethods: [externalInterface("Int3face Bridge")],
+    });
+    const assets = [alloy, ckBTC, btcInt3];
+
+    it("excludes a grouped variant that is not a pool member (BTC.int3 for allBTC)", () => {
+      const result = getAlloyConstituentExternalInterfaceMethods({
+        alloy,
+        assets,
+        direction: "withdraw",
+        // Only ckBTC is a real pool member; BTC.int3 is grouped but not pooled.
+        memberDenoms: new Set([ckBTC.coinMinimalDenom]),
+      });
+
+      expect(result.map((m) => m.name)).toEqual(["Omnity Bridge"]);
+    });
+
+    it("surfaces nothing when no grouped variant is a pool member", () => {
+      const result = getAlloyConstituentExternalInterfaceMethods({
+        alloy,
+        assets,
+        direction: "withdraw",
+        memberDenoms: new Set(),
+      });
+
+      expect(result).toEqual([]);
     });
   });
 });

--- a/packages/web/server/api/routers/bridge/__tests__/external-url-convert-variant.spec.ts
+++ b/packages/web/server/api/routers/bridge/__tests__/external-url-convert-variant.spec.ts
@@ -79,6 +79,11 @@ const variantAsset = asset({
 
 const assets = [alloyAsset, variantAsset];
 
+/** Default member set: every non-alloy asset is treated as a true pool member.
+ *  Membership-gating tests pass a restricted set explicitly. */
+const allMembers = (list: Asset[]): Set<string> =>
+  new Set(list.filter((a) => !a.isAlloyed).map((a) => a.coinMinimalDenom));
+
 describe("resolveExternalUrlConvertVariant", () => {
   it("resolves the sibling variant whose external_interface matches the provider", () => {
     expect(
@@ -86,6 +91,7 @@ describe("resolveExternalUrlConvertVariant", () => {
         urlProviderName: SOLOGENIC,
         alloy: alloyAsset,
         assets,
+        memberDenoms: allMembers(assets),
       })
     ).toEqual({
       coinMinimalDenom: VARIANT_DENOM,
@@ -99,6 +105,7 @@ describe("resolveExternalUrlConvertVariant", () => {
         urlProviderName: SOLOGENIC,
         alloy: { ...variantAsset, isAlloyed: false },
         assets,
+        memberDenoms: allMembers(assets),
       })
     ).toBeUndefined();
   });
@@ -109,6 +116,7 @@ describe("resolveExternalUrlConvertVariant", () => {
         urlProviderName: SOLOGENIC,
         alloy: null,
         assets,
+        memberDenoms: allMembers(assets),
       })
     ).toBeUndefined();
   });
@@ -119,6 +127,7 @@ describe("resolveExternalUrlConvertVariant", () => {
         urlProviderName: "Some Other Bridge",
         alloy: alloyAsset,
         assets,
+        memberDenoms: allMembers(assets),
       })
     ).toBeUndefined();
   });
@@ -130,6 +139,7 @@ describe("resolveExternalUrlConvertVariant", () => {
         urlProviderName: SOLOGENIC,
         alloy: alloyAsset,
         assets: [alloyAsset],
+        memberDenoms: allMembers([alloyAsset]),
       })
     ).toBeUndefined();
   });
@@ -152,6 +162,46 @@ describe("resolveExternalUrlConvertVariant", () => {
         urlProviderName: SOLOGENIC,
         alloy: alloyAsset,
         assets: [alloyAsset, otherGroupVariant],
+        memberDenoms: allMembers([alloyAsset, otherGroupVariant]),
+      })
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when the matching sibling is not a pool member", () => {
+    // The variant carries the matching provider AND shares the group key, but
+    // is NOT in the alloy's transmuter pool, so it is not a valid convert
+    // target (the alloy cannot be redeemed into it).
+    expect(
+      resolveExternalUrlConvertVariant({
+        urlProviderName: SOLOGENIC,
+        alloy: alloyAsset,
+        assets,
+        memberDenoms: new Set(), // variantAsset is not a member
+      })
+    ).toBeUndefined();
+  });
+
+  it("does not match a sibling that is itself an alloy", () => {
+    const nestedAlloy = asset({
+      coinMinimalDenom: "factory/.../alloyed/allNested",
+      symbol: "XRP.nested",
+      isAlloyed: true,
+      variantGroupKey: ALLOY_DENOM,
+      transferMethods: [
+        {
+          name: SOLOGENIC,
+          type: "external_interface",
+          withdrawUrl: "https://sologenic.org/bridge/coreum-bridge",
+        },
+      ],
+    });
+    expect(
+      resolveExternalUrlConvertVariant({
+        urlProviderName: SOLOGENIC,
+        alloy: alloyAsset,
+        assets: [alloyAsset, nestedAlloy],
+        // Even if (wrongly) listed as a member, the isAlloyed guard excludes it.
+        memberDenoms: new Set([nestedAlloy.coinMinimalDenom]),
       })
     ).toBeUndefined();
   });

--- a/packages/web/server/api/routers/bridge/__tests__/external-url-convert-variant.spec.ts
+++ b/packages/web/server/api/routers/bridge/__tests__/external-url-convert-variant.spec.ts
@@ -170,15 +170,34 @@ describe("resolveExternalUrlConvertVariant", () => {
   it("returns undefined when the matching sibling is not a pool member", () => {
     // The variant carries the matching provider AND shares the group key, but
     // is NOT in the alloy's transmuter pool, so it is not a valid convert
-    // target (the alloy cannot be redeemed into it).
+    // target (the alloy cannot be redeemed into it). Membership is RESOLVED
+    // (non-empty set with a different member), so the strict gate applies.
     expect(
       resolveExternalUrlConvertVariant({
         urlProviderName: SOLOGENIC,
         alloy: alloyAsset,
         assets,
-        memberDenoms: new Set(), // variantAsset is not a member
+        memberDenoms: new Set(["ibc/SOME_OTHER_MEMBER"]), // variantAsset not in it
       })
     ).toBeUndefined();
+  });
+
+  it("resolves best-effort from the group family when membership is UNKNOWN (empty set)", () => {
+    // Empty memberDenoms = unresolved membership (failed pool read / no
+    // contract), NOT "no members". The link degrades to best-effort, so the
+    // convert must too — otherwise the user opens the third-party site with an
+    // un-converted alloy (the strand MTN-146 prevents).
+    expect(
+      resolveExternalUrlConvertVariant({
+        urlProviderName: SOLOGENIC,
+        alloy: alloyAsset,
+        assets,
+        memberDenoms: new Set(),
+      })
+    ).toEqual({
+      coinMinimalDenom: VARIANT_DENOM,
+      symbol: "XRP.coreum",
+    });
   });
 
   it("does not match a sibling that is itself an alloy", () => {

--- a/packages/web/server/api/routers/bridge/__tests__/external-url-convert-variant.spec.ts
+++ b/packages/web/server/api/routers/bridge/__tests__/external-url-convert-variant.spec.ts
@@ -205,4 +205,46 @@ describe("resolveExternalUrlConvertVariant", () => {
       })
     ).toBeUndefined();
   });
+
+  it("does not target a withdrawal-halted member (convert precedes a withdraw)", () => {
+    const haltedVariant = { ...variantAsset, haltWithdrawals: true };
+    expect(
+      resolveExternalUrlConvertVariant({
+        urlProviderName: SOLOGENIC,
+        alloy: alloyAsset,
+        assets: [alloyAsset, haltedVariant],
+        memberDenoms: allMembers([alloyAsset, haltedVariant]),
+      })
+    ).toBeUndefined();
+  });
+
+  it("skips an earlier halted member sharing the provider name and picks the live one", () => {
+    // The exact divergence case: a halted and a live member share the provider
+    // name; the convert target must be the live one, not the first-listed halted
+    // one (which the surfaced link would never have come from).
+    const haltedVariant = {
+      ...variantAsset,
+      coinMinimalDenom: "ibc/HALTED_XRP_VARIANT",
+      symbol: "XRP.halted",
+      haltWithdrawals: true,
+    };
+    const liveVariant = {
+      ...variantAsset,
+      coinMinimalDenom: "ibc/LIVE_XRP_VARIANT",
+      symbol: "XRP.live",
+      haltWithdrawals: false,
+    };
+    expect(
+      resolveExternalUrlConvertVariant({
+        urlProviderName: SOLOGENIC,
+        alloy: alloyAsset,
+        // halted listed first to prove order does not select it
+        assets: [alloyAsset, haltedVariant, liveVariant],
+        memberDenoms: allMembers([alloyAsset, haltedVariant, liveVariant]),
+      })
+    ).toEqual({
+      coinMinimalDenom: "ibc/LIVE_XRP_VARIANT",
+      symbol: "XRP.live",
+    });
+  });
 });

--- a/packages/web/server/api/routers/bridge/external-url-constituents.ts
+++ b/packages/web/server/api/routers/bridge/external-url-constituents.ts
@@ -105,3 +105,83 @@ export function getAlloyConstituentExternalInterfaceMethods({
         ) as ExternalInterfaceBridgeTransferMethod[]
     );
 }
+
+/**
+ * The set of `external_interface` provider names that must NOT be surfaced for
+ * this alloy because the variant backing them is not actually reachable: the
+ * matching group sibling is either not a pool member (can't be obtained from the
+ * alloy 1:1) or is direction-halted (its bridge link is dead right now).
+ *
+ * Why this exists: an alloy can carry an `external_interface` of its OWN (e.g.
+ * allXRP carries a Sologenic link, allTON an Int3face link). Those alloy-own
+ * methods are just `{ name, url }` — they have no halt flag and no link to the
+ * variant they actually depend on, so the membership/halt gate on the
+ * constituent fallback can't see them. When the alloy-own connector is really a
+ * constituent connector by another name (the live case for every alloy that
+ * carries one), it would survive even though the route it points at is gated
+ * out, defeating the gate (and the dedup in `getExternalUrls` keeps the
+ * alloy-own copy over the dropped constituent copy).
+ *
+ * This returns the provider names to suppress so the caller can filter the
+ * alloy-own methods by name. A name is suppressed only if it appears on a gated
+ * (non-member or halted) sibling AND on no surfaced (member, non-halted)
+ * sibling — so a provider that is still reachable via a good sibling is kept.
+ *
+ * Correlation is by provider `name`; it only catches alloy-own connectors that
+ * share a name with a constituent (the case that matters). A genuinely
+ * alloy-native connector with a unique name is unaffected.
+ */
+export function getSuppressedAlloyExternalInterfaceNames({
+  alloy,
+  assets,
+  direction,
+  memberDenoms,
+}: {
+  alloy:
+    | Pick<Asset, "coinMinimalDenom" | "isAlloyed" | "variantGroupKey">
+    | null
+    | undefined;
+  assets: Asset[];
+  direction: "deposit" | "withdraw";
+  memberDenoms: Set<string>;
+}): Set<string> {
+  if (!alloy?.isAlloyed) return new Set();
+
+  const alloyDenom = alloy.coinMinimalDenom;
+
+  const isReachable = (asset: Asset) =>
+    memberDenoms.has(asset.coinMinimalDenom) &&
+    !(direction === "withdraw" && asset.haltWithdrawals) &&
+    !(direction === "deposit" && asset.haltDeposits);
+
+  const siblings = assets.filter(
+    (asset) =>
+      asset.variantGroupKey === alloyDenom &&
+      asset.coinMinimalDenom !== alloyDenom &&
+      !asset.isAlloyed
+  );
+
+  const externalNames = (asset: Asset): string[] =>
+    asset.transferMethods
+      .filter(
+        (method): method is ExternalInterfaceBridgeTransferMethod =>
+          method.type === "external_interface"
+      )
+      .map((method) => method.name);
+
+  // Names still reachable via at least one good sibling — never suppress these.
+  const reachableNames = new Set(
+    siblings.filter(isReachable).flatMap(externalNames)
+  );
+
+  // Names that appear on a gated sibling and nowhere reachable.
+  const suppressed = new Set<string>();
+  for (const sibling of siblings) {
+    if (isReachable(sibling)) continue;
+    for (const name of externalNames(sibling)) {
+      if (!reachableNames.has(name)) suppressed.add(name);
+    }
+  }
+
+  return suppressed;
+}

--- a/packages/web/server/api/routers/bridge/external-url-constituents.ts
+++ b/packages/web/server/api/routers/bridge/external-url-constituents.ts
@@ -98,11 +98,11 @@ export function getAlloyConstituentExternalInterfaceMethods({
         !(direction === "withdraw" && asset.haltWithdrawals) &&
         !(direction === "deposit" && asset.haltDeposits)
     )
-    .flatMap(
-      (variant) =>
-        variant.transferMethods.filter(
-          (method) => method.type === "external_interface"
-        ) as ExternalInterfaceBridgeTransferMethod[]
+    .flatMap((variant) =>
+      variant.transferMethods.filter(
+        (method): method is ExternalInterfaceBridgeTransferMethod =>
+          method.type === "external_interface"
+      )
     );
 }
 

--- a/packages/web/server/api/routers/bridge/external-url-constituents.ts
+++ b/packages/web/server/api/routers/bridge/external-url-constituents.ts
@@ -147,6 +147,14 @@ export function getSuppressedAlloyExternalInterfaceNames({
 }): Set<string> {
   if (!alloy?.isAlloyed) return new Set();
 
+  // An empty `memberDenoms` means membership is UNKNOWN (a failed transmuter
+  // pool read or a missing `contract`), not "no members". Suppressing on an
+  // unknown set would strip a known-good alloy-own connector (e.g. Sologenic on
+  // allXRP) on a transient pool-read failure, hiding a link the user can still
+  // use. Only suppress when we have a real member set to judge against; an
+  // empty set is a no-op (suppress nothing).
+  if (memberDenoms.size === 0) return new Set();
+
   const alloyDenom = alloy.coinMinimalDenom;
 
   const isReachable = (asset: Asset) =>

--- a/packages/web/server/api/routers/bridge/external-url-constituents.ts
+++ b/packages/web/server/api/routers/bridge/external-url-constituents.ts
@@ -37,15 +37,23 @@ import type {
  * custom external flow, so its `external_interface` is intentional. `unstable`
  * is warning-only and does not gate the UI, so unstable constituents are kept.
  *
- * Scope: this returns every viable variant in the family, including ones that
- * bridge to a differently-wrapped form of the asset (e.g. for allBTC, the
- * EVM-wrapped WBTC.eth / cbBTC / FBTC variants route out via Squid, alongside
- * the native-BTC ckBTC / nBTC / BTC.int3 variants). Whether a "withdraw BTC"
- * fallback should be narrowed to same-asset exits only is a canonical-variant
- * judgment with no single discriminating field in the asset list (symbol and
- * counterparty chain type both overlap across native and wrapped variants), so
- * it is intentionally left to the unified alloy -> variant resolver rather than
- * encoded as a per-asset heuristic here.
+ * Membership gating (REQUIRED): `variantGroupKey` is a display/grouping key, NOT
+ * alloy pool membership. A variant can share the alloy's `variantGroupKey` while
+ * not being a constituent of the alloy's transmuter pool, so the user cannot
+ * convert the alloy into it 1:1 and any route to it is a dead end. Concrete live
+ * example: BTC.int3 shares the allBTC group key but is NOT in the allBTC pool.
+ * The caller therefore must pass `memberDenoms` — the alloy's true pool-member
+ * denom set, read from the CW pool contract (`get_total_pool_liquidity` on
+ * `alloy.contract`, via `getCachedTransmuterTotalPoolLiquidity`). Only variants
+ * in that set are surfaced. Pass an empty set to surface nothing; the caller
+ * should only invoke this once it has resolved membership (fallback path).
+ *
+ * Scope (separate from membership): even among true members, this returns every
+ * viable one, including ones that bridge to a differently-wrapped form of the
+ * asset (e.g. EVM-wrapped WBTC variants via Squid). Narrowing a "withdraw BTC"
+ * fallback to same-asset exits only is a canonical-variant judgment with no
+ * single discriminating field in the asset list, so it is left to the unified
+ * resolver.
  *
  * The returned methods are not deduped among themselves; the caller is
  * responsible for collapsing duplicates (e.g. a provider that appears on both
@@ -55,6 +63,7 @@ export function getAlloyConstituentExternalInterfaceMethods({
   alloy,
   assets,
   direction,
+  memberDenoms,
 }: {
   alloy:
     | Pick<Asset, "coinMinimalDenom" | "isAlloyed" | "variantGroupKey">
@@ -62,6 +71,10 @@ export function getAlloyConstituentExternalInterfaceMethods({
     | undefined;
   assets: Asset[];
   direction: "deposit" | "withdraw";
+  /** The alloy's true pool-member coinMinimalDenoms (from the transmuter pool).
+   *  A grouped variant not in this set is excluded — it is not redeemable from
+   *  the alloy. */
+  memberDenoms: Set<string>;
 }): ExternalInterfaceBridgeTransferMethod[] {
   if (!alloy?.isAlloyed) return [];
 
@@ -69,7 +82,8 @@ export function getAlloyConstituentExternalInterfaceMethods({
   // `variantGroupKey` points back at the alloy's `coinMinimalDenom`. Match on
   // the alloy's own denom so we never depend on the alloy carrying its own
   // counterparty/transfer data. Exclude the alloy's own entry and any nested
-  // alloy so only true variants contribute.
+  // alloy so only true variants contribute, then gate by actual pool membership
+  // so we never surface a group-sibling the user cannot obtain from the alloy.
   const alloyDenom = alloy.coinMinimalDenom;
 
   return assets
@@ -78,6 +92,7 @@ export function getAlloyConstituentExternalInterfaceMethods({
         asset.variantGroupKey === alloyDenom &&
         asset.coinMinimalDenom !== alloyDenom &&
         !asset.isAlloyed &&
+        memberDenoms.has(asset.coinMinimalDenom) &&
         // Skip a constituent whose active direction is kill-switched; its
         // bridge link is dead right now.
         !(direction === "withdraw" && asset.haltWithdrawals) &&

--- a/packages/web/server/api/routers/bridge/external-url-constituents.ts
+++ b/packages/web/server/api/routers/bridge/external-url-constituents.ts
@@ -1,0 +1,92 @@
+import type {
+  Asset,
+  ExternalInterfaceBridgeTransferMethod,
+} from "@osmosis-labs/types";
+
+// Sibling: `external-url-convert-variant.ts` picks ONE variant to pre-convert
+// an alloy into before a third-party hand-off. This file is the other half:
+// it aggregates the external bridge links of MANY constituent variants so an
+// alloy with no transfer methods of its own still has fallbacks. Both feed
+// `getExternalUrls` and both expand the same `variantGroupKey` family; that
+// shared expansion is slated to collapse into the unified resolver.
+
+/**
+ * Given an alloy denom, return the `external_interface` transfer methods of all
+ * its constituent variants (non-alloyed assets whose `variantGroupKey` equals
+ * the alloy's `coinMinimalDenom`), excluding the alloy's own entry.
+ *
+ * Kept as a small, single-purpose seam: the variant-family lookup is done
+ * inline here, but isolated behind a named function so a future shared
+ * alloy -> variant resolver can replace the body with a single delegation
+ * without changing any caller. Mirrors the shape of
+ * `resolveExternalUrlConvertVariant` so the two external-URL consumers stay
+ * consistent.
+ *
+ * Why this exists: `getExternalUrls` previously read `external_interface`
+ * methods only from the from/to asset (the alloy itself on a withdraw). An
+ * alloy like allBTC carries an empty `transferMethods`, so if its only in-app
+ * quote route went down the user was stranded with no external fallback even
+ * though the constituents (WBTC.eth, nBTC, ...) carry perfectly good
+ * `external_interface` URLs. Aggregating the constituents closes that gap
+ * without per-asset assetlist hedges.
+ *
+ * Halt-aware: a constituent whose relevant direction is kill-switched
+ * (`haltWithdrawals` on a withdraw, `haltDeposits` on a deposit) is skipped, so
+ * a down variant's dead bridge link is never surfaced. `disabled` is NOT a skip
+ * reason: a disabled asset commonly routes the user through exactly this kind of
+ * custom external flow, so its `external_interface` is intentional. `unstable`
+ * is warning-only and does not gate the UI, so unstable constituents are kept.
+ *
+ * Scope: this returns every viable variant in the family, including ones that
+ * bridge to a differently-wrapped form of the asset (e.g. for allBTC, the
+ * EVM-wrapped WBTC.eth / cbBTC / FBTC variants route out via Squid, alongside
+ * the native-BTC ckBTC / nBTC / BTC.int3 variants). Whether a "withdraw BTC"
+ * fallback should be narrowed to same-asset exits only is a canonical-variant
+ * judgment with no single discriminating field in the asset list (symbol and
+ * counterparty chain type both overlap across native and wrapped variants), so
+ * it is intentionally left to the unified alloy -> variant resolver rather than
+ * encoded as a per-asset heuristic here.
+ *
+ * The returned methods are not deduped among themselves; the caller is
+ * responsible for collapsing duplicates (e.g. a provider that appears on both
+ * the alloy and a constituent).
+ */
+export function getAlloyConstituentExternalInterfaceMethods({
+  alloy,
+  assets,
+  direction,
+}: {
+  alloy:
+    | Pick<Asset, "coinMinimalDenom" | "isAlloyed" | "variantGroupKey">
+    | null
+    | undefined;
+  assets: Asset[];
+  direction: "deposit" | "withdraw";
+}): ExternalInterfaceBridgeTransferMethod[] {
+  if (!alloy?.isAlloyed) return [];
+
+  // For an alloy, `variantGroupKey === coinMinimalDenom`; a constituent's
+  // `variantGroupKey` points back at the alloy's `coinMinimalDenom`. Match on
+  // the alloy's own denom so we never depend on the alloy carrying its own
+  // counterparty/transfer data. Exclude the alloy's own entry and any nested
+  // alloy so only true variants contribute.
+  const alloyDenom = alloy.coinMinimalDenom;
+
+  return assets
+    .filter(
+      (asset) =>
+        asset.variantGroupKey === alloyDenom &&
+        asset.coinMinimalDenom !== alloyDenom &&
+        !asset.isAlloyed &&
+        // Skip a constituent whose active direction is kill-switched; its
+        // bridge link is dead right now.
+        !(direction === "withdraw" && asset.haltWithdrawals) &&
+        !(direction === "deposit" && asset.haltDeposits)
+    )
+    .flatMap(
+      (variant) =>
+        variant.transferMethods.filter(
+          (method) => method.type === "external_interface"
+        ) as ExternalInterfaceBridgeTransferMethod[]
+    );
+}

--- a/packages/web/server/api/routers/bridge/external-url-convert-variant.ts
+++ b/packages/web/server/api/routers/bridge/external-url-convert-variant.ts
@@ -19,21 +19,31 @@ export interface ExternalUrlConvertVariant {
  * Sologenic for allXRP, Picasso for allSOL) only recognises a specific bridge
  * *variant* (XRP.coreum, SOL.pica), not the alloy denom the user holds. Given
  * the external URL's provider name and the alloy being withdrawn, resolve the
- * sibling variant (same `variantGroupKey`) whose own `external_interface`
- * carries the same provider name, so the caller can convert alloy -> variant
- * before opening the URL.
+ * sibling variant whose own `external_interface` carries the same provider name,
+ * so the caller can convert alloy -> variant before opening the URL.
+ *
+ * Membership gating (REQUIRED): the matched variant MUST be a true constituent
+ * of the alloy's transmuter pool — i.e. its `coinMinimalDenom` is in
+ * `memberDenoms` (read from `get_total_pool_liquidity` on `alloy.contract`).
+ * `variantGroupKey` alone is a display grouping, not pool membership: a grouped
+ * sibling that is not pooled cannot be obtained by converting the alloy, so
+ * pre-selecting it would instruct a transmuter swap the pool rejects. This
+ * helper drives an action (the convert), so the gate is correctness-critical.
  *
  * Returns `undefined` when:
  * - the from-asset is not an alloy, or
- * - no sibling variant carries an `external_interface` with that provider name.
+ * - no pooled member variant carries an `external_interface` with that provider
+ *   name.
  *
- * Purely data-driven via the alloy's variant group; no per-site hardcoding. The
- * matched variant must not be the alloy itself.
+ * Data-driven via the alloy's pool membership + variant group; no per-site
+ * hardcoding. The matched variant must not be the alloy itself or a nested
+ * alloy.
  */
 export function resolveExternalUrlConvertVariant({
   urlProviderName,
   alloy,
   assets,
+  memberDenoms,
 }: {
   urlProviderName: string;
   /** The from-asset of the withdrawal (the alloy candidate). */
@@ -43,6 +53,9 @@ export function resolveExternalUrlConvertVariant({
   > | null;
   /** All asset-list assets (flattened). */
   assets: Asset[];
+  /** The alloy's true pool-member coinMinimalDenoms (from the transmuter pool).
+   *  Only a member can be a valid convert target. */
+  memberDenoms: Set<string>;
 }): ExternalUrlConvertVariant | undefined {
   if (!alloy?.isAlloyed || !alloy.variantGroupKey) return undefined;
 
@@ -50,6 +63,8 @@ export function resolveExternalUrlConvertVariant({
     (asset) =>
       asset.variantGroupKey === alloy.variantGroupKey &&
       asset.coinMinimalDenom !== alloy.coinMinimalDenom &&
+      !asset.isAlloyed &&
+      memberDenoms.has(asset.coinMinimalDenom) &&
       asset.transferMethods.some(
         (method) =>
           method.type === "external_interface" &&

--- a/packages/web/server/api/routers/bridge/external-url-convert-variant.ts
+++ b/packages/web/server/api/routers/bridge/external-url-convert-variant.ts
@@ -22,18 +22,32 @@ export interface ExternalUrlConvertVariant {
  * sibling variant whose own `external_interface` carries the same provider name,
  * so the caller can convert alloy -> variant before opening the URL.
  *
- * Membership gating (REQUIRED): the matched variant MUST be a true constituent
- * of the alloy's transmuter pool — i.e. its `coinMinimalDenom` is in
- * `memberDenoms` (read from `get_total_pool_liquidity` on `alloy.contract`).
- * `variantGroupKey` alone is a display grouping, not pool membership: a grouped
- * sibling that is not pooled cannot be obtained by converting the alloy, so
- * pre-selecting it would instruct a transmuter swap the pool rejects. This
- * helper drives an action (the convert), so the gate is correctness-critical.
+ * Membership gating (when membership is RESOLVED): the matched variant must be
+ * a true constituent of the alloy's transmuter pool, i.e. its
+ * `coinMinimalDenom` is in `memberDenoms` (read from `get_total_pool_liquidity`
+ * on `alloy.contract`). `variantGroupKey` alone is a display grouping, not pool
+ * membership: a grouped sibling that is not pooled cannot be obtained by
+ * converting the alloy, so pre-selecting it would instruct a transmuter swap the
+ * pool rejects. This helper drives an action (the convert), so when membership
+ * is known the gate is correctness-critical.
+ *
+ * When membership is UNKNOWN (an empty `memberDenoms`, from a failed pool read
+ * or a missing `contract`) the gate is bypassed and the target is resolved from
+ * the `variantGroupKey` family instead (best-effort). This mirrors the alloy-own
+ * suppression, which also no-ops on an unknown set so the alloy's own connector
+ * link is kept rather than stripped; the pre-convert is what makes that kept
+ * link usable, so it must fire too. (The constituent aggregator surfaces nothing
+ * on an unknown set, but the alloy-own link path is exactly the one that still
+ * needs a convert.) See the inline note on `membershipResolved` below for why
+ * stripping the pre-convert here would strand the alloy holder (the MTN-146
+ * case). The halt + sibling + provider-name checks always apply.
  *
  * Returns `undefined` when:
  * - the from-asset is not an alloy, or
- * - no pooled member variant carries an `external_interface` with that provider
- *   name.
+ * - no eligible variant carries an `external_interface` with that provider name
+ *   (eligible = a pooled member when membership is resolved, else any pooled-or-
+ *   grouped sibling when membership is unknown; never the alloy itself, a nested
+ *   alloy, or a withdrawals-halted variant).
  *
  * Data-driven via the alloy's pool membership + variant group; no per-site
  * hardcoding. The matched variant must not be the alloy itself or a nested

--- a/packages/web/server/api/routers/bridge/external-url-convert-variant.ts
+++ b/packages/web/server/api/routers/bridge/external-url-convert-variant.ts
@@ -1,5 +1,12 @@
 import type { Asset } from "@osmosis-labs/types";
 
+// Sibling: `external-url-constituents.ts` aggregates the external bridge links
+// of MANY constituent variants as fallbacks. This file is the other half: it
+// picks ONE variant to pre-convert the alloy into before a third-party
+// hand-off. Both feed `getExternalUrls` and both expand the same
+// `variantGroupKey` family; that shared expansion is slated to collapse into
+// the unified resolver.
+
 /** The variant a third-party external-interface site recognises in place of the
  *  alloy the user holds. */
 export interface ExternalUrlConvertVariant {

--- a/packages/web/server/api/routers/bridge/external-url-convert-variant.ts
+++ b/packages/web/server/api/routers/bridge/external-url-convert-variant.ts
@@ -65,6 +65,13 @@ export function resolveExternalUrlConvertVariant({
       asset.coinMinimalDenom !== alloy.coinMinimalDenom &&
       !asset.isAlloyed &&
       memberDenoms.has(asset.coinMinimalDenom) &&
+      // The convert always precedes a withdrawal, so never target a variant
+      // whose withdrawals are kill-switched: converting into it would strand the
+      // user on a halted denom. Mirrors the halt skip in the constituent
+      // link aggregator (external-url-constituents.ts) so the surfaced link and
+      // the convert target can't diverge when a halted and a live member share a
+      // provider name.
+      !asset.haltWithdrawals &&
       asset.transferMethods.some(
         (method) =>
           method.type === "external_interface" &&

--- a/packages/web/server/api/routers/bridge/external-url-convert-variant.ts
+++ b/packages/web/server/api/routers/bridge/external-url-convert-variant.ts
@@ -59,12 +59,24 @@ export function resolveExternalUrlConvertVariant({
 }): ExternalUrlConvertVariant | undefined {
   if (!alloy?.isAlloyed || !alloy.variantGroupKey) return undefined;
 
+  // An empty `memberDenoms` means membership is UNKNOWN (a failed transmuter
+  // pool read or a missing `contract`), not "no members". In that case the
+  // constituent link aggregator and the alloy-own suppression also degrade to
+  // best-effort (they surface the link rather than strip it), so the convert
+  // must degrade the same way: resolve the target from the `variantGroupKey`
+  // family so the pre-convert still fires. Otherwise the link opens with no
+  // pre-convert and strands the alloy holder on a site that only accepts the
+  // variant — the exact case MTN-146 exists to prevent. When membership IS
+  // resolved, gate strictly on it (only a true member is a valid convert
+  // target). The halt + sibling + provider-name checks always apply.
+  const membershipResolved = memberDenoms.size > 0;
+
   const variant = assets.find(
     (asset) =>
       asset.variantGroupKey === alloy.variantGroupKey &&
       asset.coinMinimalDenom !== alloy.coinMinimalDenom &&
       !asset.isAlloyed &&
-      memberDenoms.has(asset.coinMinimalDenom) &&
+      (!membershipResolved || memberDenoms.has(asset.coinMinimalDenom)) &&
       // The convert always precedes a withdrawal, so never target a variant
       // whose withdrawals are kill-switched: converting into it would strand the
       // user on a halted denom. Mirrors the halt skip in the constituent


### PR DESCRIPTION
## What this PR does

**Future-proofs alloys against asset-list data errors.** Today an alloy only offers an external bridge route if its own entry happens to have the right `external_interface` connector hand-populated. If that data is missing or wrong, the alloy silently has no fallback route (e.g. allBTC carries no transfer methods of its own, so a down in-app route strands the user) — or a stale connector points at a route the user can't actually take.

This PR makes the alloy's external routes **derive automatically from on-chain pool membership** instead of from hand-entered alloy data. `getExternalUrls` resolves the alloy's true transmuter-pool members and surfaces the `external_interface` connectors of those members — **adding** a route when a member carries a connector and **excluding** one when the variant isn't (or is no longer) a pool member. So the connector list self-corrects as pool composition changes, with no per-alloy data maintenance.

## Why membership is the right key

`variantGroupKey` is a display/grouping key, NOT pool membership. A variant can share an alloy's `variantGroupKey` while not being in its pool, so the user cannot convert the alloy into it 1:1 and a route to it is a dead end. Driving the connector list off the **true pool membership** (`get_total_pool_liquidity` on the alloy contract) is what makes "add/remove automatically" correct rather than just "show every grouped sibling."

Verified live (`get_total_pool_liquidity`, 2026-06-19): **BTC.int3 shares the allBTC group key but is not in the allBTC pool**; 8 of 14 allBTC group members, 10 of 12 allETH, and 9 of 12 allUSDT are non-constituents — so a naive `variantGroupKey` fan-out would surface mostly dead routes. The membership read is cached (30s) and fired only when a transferred asset is an alloy, on the fallback path.

It is also **halt-aware**: a constituent whose active direction is kill-switched is skipped, so a temporarily-down member's link is not surfaced.

## What it does NOT do

- **Does NOT convert the alloy to a variant before opening a link** — that is `resolveExternalUrlConvertVariant`, shipped in #4385 (now merged to `stage`). This PR makes the links *appear*; the convert (from #4385) changes what happens when you *click*.
- **Does NOT change the in-app quote / route picker** (`useBridgesSupportedAssets`). This PR only affects the external-URL fallback list, not which in-app route is selected or recommended.
- **Does NOT narrow native vs wrapped among true members.** Among real pool members, the family can still include differently-wrapped forms (e.g. allBTC members map to native ckBTC/nBTC plus EVM-wrapped WBTC variants). Canonical-exit narrowing has no single discriminating asset-list field, so it is intentionally left out rather than encoded as a per-asset heuristic here.
- **Deposit asymmetry (by design):** the helper is bidirectional and surfaces a constituent's link on a deposit too, but the #4385 pre-convert is withdraw-only, so on a deposit no in-app convert is offered before the hand-off (a deposit convert would have to happen *after* delivery).
- **Does NOT route-gate the connectors by the selected destination chain** (unlike provider deep-links such as Skip:Go, which only surface for the exact selected route). This is intentional: an `external_interface` connector is `{ name, url }` with no destination field, so it is an asset-level entry point to a third-party bridge where the user picks the route on the provider site (hence the route-neutral header and caveat), not a per-route deep link. The meaningful gate for an alloy is pool membership, which IS applied. A provider link being route-specific while a connector is asset-level is by design, not an inconsistency.

## Changes

- **`external-url-constituents.ts`** (new): for an alloy, aggregates each pool-member constituent's `external_interface` methods; excludes the alloy itself, nested alloys, non-members, and direction-halted constituents.
- **`bridge-transfer.ts` `getExternalUrls`**: resolves each alloy side's true member denom set (`getCachedTransmuterTotalPoolLiquidity`) and feeds it into the aggregator and the convert resolver; concats the constituent methods (existing provider-name / host dedup unchanged); surfaces nothing on a failed membership read rather than risk a dead route.
- **Membership-gates `resolveExternalUrlConvertVariant`** (the #4385 helper) and adds its missing `isAlloyed` nested-alloy guard, so the convert never targets a non-member.
- **Halt-aligns the convert resolver**: it now also skips `haltWithdrawals` members, so the surfaced link and the convert target cannot diverge when a halted and a live member share a provider name.
- **Suppresses an alloy-own connector** whose provider name is carried only by a gated (non-member or halted) sibling, so a stale alloy-own copy cannot defeat the membership gate / win the dedup over a dropped constituent. On UNRESOLVED membership (a failed pool read or missing contract, i.e. an empty member set) all three degrade to best-effort consistently: suppression is a no-op, the constituent aggregator adds nothing, and the pre-convert resolver falls back to the variantGroupKey family so the alloy-own link keeps its convert. A transient failure therefore degrades to the alloy own links WITH their pre-convert, never stripping the link nor opening it un-converted.
- **Route-neutral More-options copy + caveat**: drops the misleading "from {x} to {y}" header for the connector list, adds an "opens a third-party site, pick your route there" caveat; removes the now-dead `chooseAnAlternativeProvider*` keys and adds `externalSiteCaveat` across all locales (translated), shown in both the multi-provider list and the single-provider splash.

Real-data effect (allBTC withdraw): before, with the in-app route down and no alloy-own connector populated, the user saw nothing; this PR derives `Nomic, Omnity, Squid` from the pooled members (and excludes the dead `Int3face` route, since BTC.int3 is not in the pool, plus halted constituents like Nitro via RBTC.rt and Gravity via WBTC.eth.grv).

## Manual test matrix (alloy withdraw → "More options")

Observed on the deploys (withdraw flow → More options external-provider list), stage vs this PR's preview. Links open the asset page; start a withdraw from there.

- **Stage (current prod):** https://stage.osmosis.zone
- **This PR preview:** https://osmosis-frontend-git-johnnywyles-mtn-148-bridge-aggregat-d42eb7.vercel.dev-osmosis.zone

> **Two sources feed this list.** (1) Provider deep-links from `getExternalUrl` (e.g. **Skip:Go**) — route-specific, surfaced only for destinations the provider supports for the selected asset; **unchanged by this PR**. (2) `external_interface` connectors (Nomic, Omnity, Squid-as-connector, Sologenic, etc.) — asset-level, now aggregated from pooled constituents by this PR. So the new behavior to look for is added/dropped `external_interface` connectors, not Skip.
>
> Stage already reflects the merged assetlist connector-removal (Int3face stripped from the dead alloys), so it is **not** the pre-merge state the original predictions assumed.
>
> **Copy:** header is route-neutral (no "from {x} to {y}") with a "third-party site, pick your route there" caveat.

### Observed (2026-07-01)

| Alloy | Stage | Preview (this PR) | Delta | Asset page (stage / preview) |
| -- | -- | -- | -- | -- |
| **allBTC** | Nomic | Omnity + Squid | constituent connectors added (BTC destination, so Skip not offered) | [stage](https://stage.osmosis.zone/assets/BTC) · [preview](https://osmosis-frontend-git-johnnywyles-mtn-148-bridge-aggregat-d42eb7.vercel.dev-osmosis.zone/assets/BTC) |
| **allETH** | Skip | Skip + Squid | Squid (constituent) added | [stage](https://stage.osmosis.zone/assets/ETH) · [preview](https://osmosis-frontend-git-johnnywyles-mtn-148-bridge-aggregat-d42eb7.vercel.dev-osmosis.zone/assets/ETH) |
| **allUSDT** | Skip | Skip + Squid | Squid (constituent) added | [stage](https://stage.osmosis.zone/assets/USDT) · [preview](https://osmosis-frontend-git-johnnywyles-mtn-148-bridge-aggregat-d42eb7.vercel.dev-osmosis.zone/assets/USDT) |
| **allXRP** | Skip + Sologenic | Skip + Sologenic | no change | [stage](https://stage.osmosis.zone/assets/XRP) · [preview](https://osmosis-frontend-git-johnnywyles-mtn-148-bridge-aggregat-d42eb7.vercel.dev-osmosis.zone/assets/XRP) |
| **allSOL** | Wormhole | Wormhole | no change | [stage](https://stage.osmosis.zone/assets/SOL) · [preview](https://osmosis-frontend-git-johnnywyles-mtn-148-bridge-aggregat-d42eb7.vercel.dev-osmosis.zone/assets/SOL) |
| **allTON** | (same as preview) | (same as stage) | no change | [stage](https://stage.osmosis.zone/assets/TON) · [preview](https://osmosis-frontend-git-johnnywyles-mtn-148-bridge-aggregat-d42eb7.vercel.dev-osmosis.zone/assets/TON) |
| **allDOGE** | Int3face + Omnity | Int3face + Omnity | no change (both backed by pooled members) | [stage](https://stage.osmosis.zone/assets/DOGE) · [preview](https://osmosis-frontend-git-johnnywyles-mtn-148-bridge-aggregat-d42eb7.vercel.dev-osmosis.zone/assets/DOGE) |

### Notes / open items from the observed run

- **Skip is route-specific.** It shows on ETH/USDT/XRP (destinations it serves for those assets) but not on the BTC withdraw, where a native-BTC destination was selected. That asymmetry is provider behavior (`getExternalUrl` only runs for bridges in `allBridges`, i.e. those returning a supported variant for the selected route), not introduced here.
- **allBTC: Nomic on stage, but Omnity + Squid (not Nomic) on preview** — worth confirming. Nomic is expected to remain a valid allBTC constituent connector; if it genuinely drops on the preview while Omnity/Squid surface, that needs a look (possible membership-gate or dedup interaction). To re-check directly on the preview before merge.
- **allDOGE is the no-regression control** — Int3face + Omnity on both, unchanged, as expected (DOGE.int3 is a true pool member).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes bridge fallback and pre-convert selection for alloy withdrawals; incorrect membership or suppression could hide valid links or suggest dead routes, though behavior is heavily unit-tested and degrades conservatively on pool-read failures.
> 
> **Overview**
> **External bridge fallbacks for alloys** now come from true transmuter pool members, not only the alloy’s own asset-list `external_interface` entries. `getExternalUrls` loads pool composition via `getCachedTransmuterTotalPoolLiquidity`, merges constituent connectors (with halt and membership filters), suppresses misleading alloy-own provider names when no reachable sibling exists, and passes `memberDenoms` into `resolveExternalUrlConvertVariant` so pre-convert targets stay aligned with surfaced links.
> 
> **More bridge options UI** drops the “from chain → to chain” header in favor of route-neutral deposit/withdraw copy, adds an `externalSiteCaveat` under provider lists, and removes unused `chooseAnAlternativeProvider*` locale keys (new caveat string in all locales).
> 
> New helpers in `external-url-constituents.ts` plus expanded unit tests cover membership gating, suppression on failed pool reads, and halt-aware convert resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f335b08f6e5bb9e08f0af97a5246fb5a17afdfae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


