### PR TITLE
fix(bridge): remove dead Int3face alloy routes for pool-exited variants

### DIFF
--- a/packages/bridge/src/int3face/types.ts
+++ b/packages/bridge/src/int3face/types.ts
@@ -44,10 +44,11 @@ export const getInt3faceBridgeConfig = (
     chainType: "bitcoin",
     int3MinimalDenom: getInt3BTCMinimalDenom({ env }),
     int3TokenSymbol: "BTC.int3",
-    allTokenMinimalDenom:
-      env === "mainnet"
-        ? "factory/osmo1z6r6qdknhgsc0zeracktgpcxf43j6sekq07nw8sxduc9lg0qjjlqfu25e3/alloyed/allBTC"
-        : undefined,
+    // BTC.int3 was force-exited from the allBTC transmuter pool (2026-06-15), so
+    // an alloy holder can no longer redeem allBTC into BTC.int3. Advertising the
+    // alloy withdraw route would be a dead end. The standalone BTC.int3 variant
+    // route is unaffected.
+    allTokenMinimalDenom: undefined,
     denom: "BTC",
     address: "btc",
   };
@@ -86,10 +87,10 @@ export const getInt3faceBridgeConfig = (
     chainType: "xrpl",
     int3MinimalDenom: getInt3XRPMinimalDenom({ env }),
     int3TokenSymbol: "XRP.int3",
-    allTokenMinimalDenom:
-      env === "mainnet"
-        ? "factory/osmo1qnglc04tmhg32uc4kxlxh55a5cmhj88cpa3rmtly484xqu82t79sfv94w0/alloyed/allXRP"
-        : undefined,
+    // XRP.xrpl.int3 was force-exited from the allXRP transmuter pool (2026-06-15)
+    // (get_corrupted_denoms now empty). No alloy redemption path remains, so the
+    // alloy withdraw route is a dead end. Standalone XRP.int3 route unaffected.
+    allTokenMinimalDenom: undefined,
     denom: "XRP",
     address: "xrp",
   };
@@ -114,10 +115,10 @@ export const getInt3faceBridgeConfig = (
     chainType: "ton",
     int3MinimalDenom: getInt3TONMinimalDenom({ env }),
     int3TokenSymbol: "TON.int3",
-    allTokenMinimalDenom:
-      env === "mainnet"
-        ? "factory/osmo12lnwf54yd30p6amzaged2atln8k0l32n7ncxf04ctg7u7ymnsy7qkqgsw4/alloyed/allTON"
-        : undefined,
+    // TON.int3 was force-exited from the allTON transmuter pool (2026-06-15). No
+    // alloy redemption path remains, so the alloy withdraw route is a dead end.
+    // Standalone TON.int3 route unaffected.
+    allTokenMinimalDenom: undefined,
     denom: "TON",
     address: "ton",
   };
@@ -128,10 +129,10 @@ export const getInt3faceBridgeConfig = (
     chainType: "solana",
     int3MinimalDenom: getInt3SOLMinimalDenom({ env }),
     int3TokenSymbol: "SOL.int3",
-    allTokenMinimalDenom:
-      env === "mainnet"
-        ? "factory/osmo1n3n75av8awcnw4jl62n3l48e6e4sxqmaf97w5ua6ddu4s475q5qq9udvx4/alloyed/allSOL"
-        : undefined,
+    // SOL.int3 was force-exited from the allSOL transmuter pool (2026-06-15). No
+    // alloy redemption path remains, so the alloy withdraw route is a dead end.
+    // Standalone SOL.int3 route unaffected.
+    allTokenMinimalDenom: undefined,
     denom: "SOL",
     address: "solana",
   };


### PR DESCRIPTION
## What

Sets `allTokenMinimalDenom` to `undefined` for **BTC, XRP, TON, SOL** in the Int3face bridge config (`packages/bridge/src/int3face/types.ts`), removing the in-app Int3face *alloy* withdraw quote route for those four.

## Why

Int3face advertises a withdraw `["quote"]` route for an alloy when the config carries an `allTokenMinimalDenom` for it. That route internally swaps `allXxx → Xxx.int3` before bridging, which only works if `Xxx.int3` is a true constituent of the alloy's transmuter pool.

**BTC.int3, XRP.xrpl.int3, TON.int3 and SOL.int3 were force-exited from their alloy pools on 2026-06-15** (Int3face wind-down — see MTN-103). An alloy holder can no longer redeem into those variants, so the advertised route is a dead end: the internal swap has no path. This is the config-vs-onchain drift class — the route is in code, not assetlist data, so it can't be fixed by an assetlist edit.

## What is kept

| Alloy | int3 leg in pool? | Route |
|---|---|---|
| DOGE | Yes (99.5% in alloy) | **kept** |
| LTC / BCH / TRUMP / PENGU | Yes — sole constituent | **kept** |
| BTC / XRP / TON / SOL | No — pool-exited 2026-06-15 | **removed** |

Membership re-verified via live `get_total_pool_liquidity` on each alloy's transmuter contract on **2026-07-02** (the acceptance-gate re-check at implementation time): all four int3 legs (BTC.int3, XRP.xrpl.int3, TON.int3, SOL.int3) are still absent from their pools, so the removals stand. The standalone `.int3` *variant* routes (e.g. XRP.int3 → XRPL) are untouched — only the alloy route entry changes.

## Test / verify

- `packages/bridge` typecheck: clean; lint: clean.
- No unit test added — the change removes dead config constants (data, not logic); membership is the runtime fact, verified onchain.
- To verify on a deploy: withdrawing **allBTC / allXRP / allTON / allSOL** no longer lists an Int3face route; **allDOGE** (and LTC/BCH/TRUMP/PENGU) still do.

## Follow-up

The remaining 5 entries + the whole `isAllAsset` mechanism get stripped at Int3face final shutdown (MTN-103 step 10), at which point alloy holders fall through to the MTN-146 convert-before-external path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change that removes broken withdraw UI routes; no auth or transaction logic changes, and working alloy and standalone int3 paths remain.
> 
> **Overview**
> Stops advertising Int3face **alloy** withdraw routes for **allBTC, allXRP, allTON, and allSOL** on mainnet by clearing `allTokenMinimalDenom` for BTC, XRP, TON, and SOL in `getInt3faceBridgeConfig`.
> 
> Those `.int3` legs were force-exited from their transmuter pools (2026-06-15), so the prior flow—swap alloy → `.int3` then bridge—no longer works. Without the alloy denom in config, the bridge no longer exposes the dead `quote` withdraw path for those assets. **Standalone** `.int3` variant withdraws are unchanged. Alloy routes for DOGE, LTC, BCH, TRUMP, and PENGU are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2137b45ce6989e480df9cdb3e1e0d5cba5ef622. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
