### PR TITLE
fix(bridge): make all default route hoists halt-aware

### DIFF
--- a/packages/web/components/bridge/amount-and-review-screen.tsx
+++ b/packages/web/components/bridge/amount-and-review-screen.tsx
@@ -129,6 +129,10 @@ export const AmountAndReviewScreen = observer(
 
     const supportedAssets = useBridgesSupportedAssets({
       assets: withdrawAsset ? [withdrawAsset] : assetsInOsmosis,
+      // The full variant family, so the default-selection halt check can see a
+      // sibling variant's halt flag even when `assets` is scoped to the single
+      // selected variant on withdraw.
+      variantAssets: assetsInOsmosis,
       chain: {
         chainId: accountStore.osmosisChainId,
         chainType: "cosmos",

--- a/packages/web/components/bridge/use-bridges-supported-assets.ts
+++ b/packages/web/components/bridge/use-bridges-supported-assets.ts
@@ -271,74 +271,86 @@ export const useBridgesSupportedAssets = ({
   }, [successfulQueries]);
 
   const supportedChains = useMemo(() => {
-    // Check if this is a USDC withdrawal to prioritize Noble
-    const isUsdcWithdrawal =
-      direction === "withdraw" &&
-      assets?.some(
-        (asset) =>
-          asset.coinDenom?.toUpperCase().includes("USDC") ||
-          asset.coinGeckoId === "usd-coin"
-      );
+    // Positional default hoists: for certain assets we prefer a specific
+    // destination chain as the "Recommended" (index 0) route. Each hoist is only
+    // applied while its destination route is actually usable, otherwise the
+    // default would land the user on a dead route.
+    //
+    // A hoist is suppressed when the family variant that *represents its
+    // destination route* is kill-switch halted in the active direction. Details:
+    //
+    // - Scan the full variant family (`variantAssets`), not `assets`: on withdraw
+    //   `assets` is the single selected variant (e.g. the alloy), which never
+    //   carries the destination variant's halt flag, so the guard would miss it.
+    // - Halt is direction-specific: a withdraw-halted variant must not block the
+    //   deposit hoist and vice versa.
+    // - Gate on the kill-switch halt flags only, not `isUnstable`: the kill
+    //   switch already suppresses routing elsewhere (e.g. the external link-out
+    //   in amount-screen.tsx), whereas `isUnstable` is warning-only and does not
+    //   gate the UI.
+    //
+    // `matchesAsset` selects the assets this hoist applies to; `matchesRouteVariant`
+    // selects the single family member whose halt flags represent the hoisted
+    // destination route (undefined => the same predicate as `matchesAsset`, used
+    // when the asset and its destination route are the same entry).
+    type HoistRule = {
+      chainId: string;
+      matchesAsset: (asset: MinimalAsset) => boolean | undefined;
+      matchesRouteVariant?: (asset: MinimalAsset) => boolean | undefined;
+    };
 
-    // Check if this is a USDC deposit to prioritize Noble
-    const isUsdcDeposit =
-      direction === "deposit" &&
-      assets?.some(
-        (asset) =>
-          asset.coinDenom?.toUpperCase().includes("USDC") ||
-          asset.coinGeckoId === "usd-coin"
-      );
-
+    const isUsdcAsset = (asset: MinimalAsset) =>
+      asset.coinDenom?.toUpperCase().includes("USDC") ||
+      asset.coinGeckoId === "usd-coin";
     const isXrpAsset = (asset: MinimalAsset) =>
       asset.coinDenom?.toUpperCase().includes("XRP") ||
       asset.coinGeckoId === "ripple";
+    const isAtomAsset = (asset: MinimalAsset) =>
+      asset.coinMinimalDenom ===
+        "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2" ||
+      asset.coinGeckoId === "cosmos";
 
-    // The XRPL EVM hoist below is a positional default. Only apply it while the
-    // XRPL EVM route is actually usable: if the xrplevm XRP variant is
-    // withdrawal-halted (the kill switch), defaulting to it would land the user
-    // on a dead route. Detect that variant by its chain-qualified denom and skip
-    // the hoist when it is halted, falling through to the next route (Coreum /
-    // Int3face / XRPL).
-    //
-    // Gate on the kill-switch halt flags only, not `isUnstable`: the kill switch
-    // already suppresses routing elsewhere (e.g. the external link-out in
-    // amount-screen.tsx), whereas `isUnstable` is warning-only and does not gate
-    // the UI. Keeping the default-selection signal consistent with that policy.
-    //
-    // Scan the full variant family (`variantAssets`), not `assets`: on withdraw
-    // `assets` is the single selected variant (the alloy), which never carries
-    // the xrplevm variant's halt flag, so the guard would miss it. Halt is
-    // direction-specific (a withdraw-halted variant must not block the deposit
-    // hoist and vice versa), so compute each direction separately.
-    const xrplEvmVariants = (variantAssets ?? assets)?.filter(
-      (asset) =>
-        isXrpAsset(asset) && asset.coinDenom?.toLowerCase().includes("xrplevm")
-    );
-    const isXrplEvmWithdrawalsHalted = Boolean(
-      xrplEvmVariants?.some((asset) => asset.areWithdrawalsHalted)
-    );
-    const isXrplEvmDepositsHalted = Boolean(
-      xrplEvmVariants?.some((asset) => asset.areDepositsHalted)
-    );
+    const hoistRules: HoistRule[] = [
+      // USDC -> Noble. The destination route is native Noble USDC, i.e. the
+      // canonical USDC entry itself, so the route-variant matcher is the asset
+      // matcher.
+      { chainId: "noble-1", matchesAsset: isUsdcAsset },
+      // XRP -> XRPL EVM. The destination route is the chain-qualified xrplevm
+      // variant (e.g. XRP.xrplevm), not the selected alloy, so it needs its own
+      // route-variant matcher.
+      {
+        chainId: "xrplevm_1440000-1",
+        matchesAsset: isXrpAsset,
+        matchesRouteVariant: (asset) =>
+          isXrpAsset(asset) &&
+          asset.coinDenom?.toLowerCase().includes("xrplevm"),
+      },
+      // ATOM -> Cosmos Hub. The destination route is native ATOM, i.e. the
+      // canonical ATOM entry itself.
+      { chainId: "cosmoshub-4", matchesAsset: isAtomAsset },
+    ];
 
-    // Check if this is a XRP withdrawal to prioritize XRPL EVM
-    const isXrpWithdrawal =
-      direction === "withdraw" &&
-      !isXrplEvmWithdrawalsHalted &&
-      assets?.some(isXrpAsset);
-
-    // Check if this is a XRP deposit to prioritize XRPL EVM
-    const isXrpDeposit =
-      direction === "deposit" &&
-      !isXrplEvmDepositsHalted &&
-      assets?.some(isXrpAsset);
-
-    // Check if this is ATOM to prioritize Cosmos Hub
-    const isAtom = assets?.some(
-      (asset) =>
-        asset.coinMinimalDenom ===
-          "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2" ||
-        asset.coinGeckoId === "cosmos"
+    // A hoist is active when the current transfer involves the hoist's asset AND
+    // the destination route variant is not halted in the active direction.
+    const activeHoistChainIds = new Set(
+      hoistRules
+        .filter((rule) => {
+          if (!assets?.some(rule.matchesAsset)) return false;
+          const matchesRouteVariant =
+            rule.matchesRouteVariant ?? rule.matchesAsset;
+          const routeVariants = (variantAssets ?? assets)?.filter(
+            matchesRouteVariant
+          );
+          const isHalted = Boolean(
+            routeVariants?.some((asset) =>
+              direction === "withdraw"
+                ? asset.areWithdrawalsHalted
+                : asset.areDepositsHalted
+            )
+          );
+          return !isHalted;
+        })
+        .map((rule) => rule.chainId)
     );
 
     return Array.from(
@@ -347,52 +359,11 @@ export const useBridgesSupportedAssets = ({
         successfulQueries
           .flatMap(({ data }) => data!.supportedAssets.availableChains)
           .sort((a, b) => {
-            // For USDC withdrawals, prioritize Noble first
-            if (isUsdcWithdrawal) {
-              if (a.chainId === "noble-1" && b.chainId !== "noble-1") return -1;
-              if (a.chainId !== "noble-1" && b.chainId === "noble-1") return 1;
-            }
-
-            // For USDC deposits, prioritize Noble first
-            if (isUsdcDeposit) {
-              if (a.chainId === "noble-1" && b.chainId !== "noble-1") return -1;
-              if (a.chainId !== "noble-1" && b.chainId === "noble-1") return 1;
-            }
-
-            // For XRP withdrawals, prioritize XPRL EVM first
-            if (isXrpWithdrawal) {
-              if (
-                a.chainId === "xrplevm_1440000-1" &&
-                b.chainId !== "xrplevm_1440000-1"
-              )
-                return -1;
-              if (
-                a.chainId !== "xrplevm_1440000-1" &&
-                b.chainId === "xrplevm_1440000-1"
-              )
-                return 1;
-            }
-
-            // For XRP deposits, prioritize XPRL EVM first
-            if (isXrpDeposit) {
-              if (
-                a.chainId === "xrplevm_1440000-1" &&
-                b.chainId !== "xrplevm_1440000-1"
-              )
-                return -1;
-              if (
-                a.chainId !== "xrplevm_1440000-1" &&
-                b.chainId === "xrplevm_1440000-1"
-              )
-                return 1;
-            }
-
-            // For ATOM, prioritize Cosmos Hub first
-            if (isAtom) {
-              if (a.chainId === "cosmoshub-4" && b.chainId !== "cosmoshub-4")
-                return -1;
-              if (a.chainId !== "cosmoshub-4" && b.chainId === "cosmoshub-4")
-                return 1;
+            // Apply each active positional hoist: pin its destination chain
+            // first. Only hoists whose destination route is usable are present.
+            for (const chainId of activeHoistChainIds) {
+              if (a.chainId === chainId && b.chainId !== chainId) return -1;
+              if (a.chainId !== chainId && b.chainId === chainId) return 1;
             }
 
             // prioritize bitcoin and doge chains first, then evm

--- a/packages/web/components/bridge/use-bridges-supported-assets.ts
+++ b/packages/web/components/bridge/use-bridges-supported-assets.ts
@@ -279,23 +279,36 @@ export const useBridgesSupportedAssets = ({
           asset.coinGeckoId === "usd-coin"
       );
 
+    const isXrpAsset = (asset: MinimalAsset) =>
+      asset.coinDenom?.toUpperCase().includes("XRP") ||
+      asset.coinGeckoId === "ripple";
+
+    // The XRPL EVM hoist below is a positional default. Only apply it while the
+    // XRPL EVM route is actually usable: if the xrplevm XRP variant is
+    // withdrawal-halted (kill switch) or unstable (e.g. bridge down), defaulting
+    // to it would land the user on a dead route. Detect that variant by its
+    // chain-qualified denom and skip the hoist when it is non-viable, falling
+    // through to the next route (Coreum / Int3face / XRPL).
+    const isXrplEvmVariantUnviable = Boolean(
+      assets?.some(
+        (asset) =>
+          isXrpAsset(asset) &&
+          asset.coinDenom?.toLowerCase().includes("xrplevm") &&
+          (asset.areWithdrawalsHalted || asset.isUnstable)
+      )
+    );
+
     // Check if this is a XRP withdrawal to prioritize XRPL EVM
     const isXrpWithdrawal =
       direction === "withdraw" &&
-      assets?.some(
-        (asset) =>
-          asset.coinDenom?.toUpperCase().includes("XRP") ||
-          asset.coinGeckoId === "ripple"
-      );
+      !isXrplEvmVariantUnviable &&
+      assets?.some(isXrpAsset);
 
     // Check if this is a XRP deposit to prioritize XRPL EVM
     const isXrpDeposit =
       direction === "deposit" &&
-      assets?.some(
-        (asset) =>
-          asset.coinDenom?.toUpperCase().includes("XRP") ||
-          asset.coinGeckoId === "ripple"
-      );
+      !isXrplEvmVariantUnviable &&
+      assets?.some(isXrpAsset);
 
     // Check if this is ATOM to prioritize Cosmos Hub
     const isAtom = assets?.some(

--- a/packages/web/components/bridge/use-bridges-supported-assets.ts
+++ b/packages/web/components/bridge/use-bridges-supported-assets.ts
@@ -299,6 +299,8 @@ export const useBridgesSupportedAssets = ({
       matchesRouteVariant?: (asset: MinimalAsset) => boolean | undefined;
     };
 
+    // Asset matchers select which transfers a hoist applies to (broad: any
+    // family member). They are intentionally wide.
     const isUsdcAsset = (asset: MinimalAsset) =>
       asset.coinDenom?.toUpperCase().includes("USDC") ||
       asset.coinGeckoId === "usd-coin";
@@ -311,10 +313,16 @@ export const useBridgesSupportedAssets = ({
       asset.coinGeckoId === "cosmos";
 
     const hoistRules: HoistRule[] = [
-      // USDC -> Noble. The destination route is native Noble USDC, i.e. the
-      // canonical USDC entry itself, so the route-variant matcher is the asset
-      // matcher.
-      { chainId: "noble-1", matchesAsset: isUsdcAsset },
+      // USDC -> Noble. The destination route is *native Noble* USDC, i.e. the
+      // canonical `USDC` entry (bridged variants are chain-qualified: USDC.eth.grv,
+      // USDC.avax.axl, ...). The route-variant matcher must be narrow: reusing the
+      // broad `isUsdcAsset` would let a halted bridged sibling (e.g. USDC.eth.grv)
+      // wrongly suppress the Noble default even when native Noble USDC is fine.
+      {
+        chainId: "noble-1",
+        matchesAsset: isUsdcAsset,
+        matchesRouteVariant: (asset) => asset.coinDenom?.toUpperCase() === "USDC",
+      },
       // XRP -> XRPL EVM. The destination route is the chain-qualified xrplevm
       // variant (e.g. XRP.xrplevm), not the selected alloy, so it needs its own
       // route-variant matcher.
@@ -325,9 +333,15 @@ export const useBridgesSupportedAssets = ({
           isXrpAsset(asset) &&
           asset.coinDenom?.toLowerCase().includes("xrplevm"),
       },
-      // ATOM -> Cosmos Hub. The destination route is native ATOM, i.e. the
-      // canonical ATOM entry itself.
-      { chainId: "cosmoshub-4", matchesAsset: isAtomAsset },
+      // ATOM -> Cosmos Hub. The destination route is native ATOM. `isAtomAsset`
+      // is already narrow (exact native denom / `cosmos` CoinGecko id, which no
+      // bridged ATOM variant shares), so it is safe to reuse as the route-variant
+      // matcher.
+      {
+        chainId: "cosmoshub-4",
+        matchesAsset: isAtomAsset,
+        matchesRouteVariant: isAtomAsset,
+      },
     ];
 
     // A hoist is active when the current transfer involves the hoist's asset AND

--- a/packages/web/components/bridge/use-bridges-supported-assets.ts
+++ b/packages/web/components/bridge/use-bridges-supported-assets.ts
@@ -321,7 +321,8 @@ export const useBridgesSupportedAssets = ({
       {
         chainId: "noble-1",
         matchesAsset: isUsdcAsset,
-        matchesRouteVariant: (asset) => asset.coinDenom?.toUpperCase() === "USDC",
+        matchesRouteVariant: (asset) =>
+          asset.coinDenom?.toUpperCase() === "USDC",
       },
       // XRP -> XRPL EVM. The destination route is the chain-qualified xrplevm
       // variant (e.g. XRP.xrplevm), not the selected alloy, so it needs its own

--- a/packages/web/components/bridge/use-bridges-supported-assets.ts
+++ b/packages/web/components/bridge/use-bridges-supported-assets.ts
@@ -285,29 +285,34 @@ export const useBridgesSupportedAssets = ({
 
     // The XRPL EVM hoist below is a positional default. Only apply it while the
     // XRPL EVM route is actually usable: if the xrplevm XRP variant is
-    // withdrawal-halted (kill switch) or unstable (e.g. bridge down), defaulting
-    // to it would land the user on a dead route. Detect that variant by its
-    // chain-qualified denom and skip the hoist when it is non-viable, falling
-    // through to the next route (Coreum / Int3face / XRPL).
-    const isXrplEvmVariantUnviable = Boolean(
+    // withdrawal-halted (the kill switch), defaulting to it would land the user
+    // on a dead route. Detect that variant by its chain-qualified denom and skip
+    // the hoist when it is halted, falling through to the next route (Coreum /
+    // Int3face / XRPL).
+    //
+    // Gate on `areWithdrawalsHalted` only, not `isUnstable`: the kill switch
+    // already suppresses routing elsewhere (e.g. the external link-out in
+    // amount-screen.tsx), whereas `isUnstable` is warning-only and does not gate
+    // the UI. Keeping the default-selection signal consistent with that policy.
+    const isXrplEvmVariantHalted = Boolean(
       assets?.some(
         (asset) =>
           isXrpAsset(asset) &&
           asset.coinDenom?.toLowerCase().includes("xrplevm") &&
-          (asset.areWithdrawalsHalted || asset.isUnstable)
+          asset.areWithdrawalsHalted
       )
     );
 
     // Check if this is a XRP withdrawal to prioritize XRPL EVM
     const isXrpWithdrawal =
       direction === "withdraw" &&
-      !isXrplEvmVariantUnviable &&
+      !isXrplEvmVariantHalted &&
       assets?.some(isXrpAsset);
 
     // Check if this is a XRP deposit to prioritize XRPL EVM
     const isXrpDeposit =
       direction === "deposit" &&
-      !isXrplEvmVariantUnviable &&
+      !isXrplEvmVariantHalted &&
       assets?.some(isXrpAsset);
 
     // Check if this is ATOM to prioritize Cosmos Hub

--- a/packages/web/components/bridge/use-bridges-supported-assets.ts
+++ b/packages/web/components/bridge/use-bridges-supported-assets.ts
@@ -39,10 +39,20 @@ export type SupportedChain = ReturnType<
 
 export const useBridgesSupportedAssets = ({
   assets,
+  variantAssets,
   chain,
   direction,
 }: {
   assets: MinimalAsset[] | undefined;
+  /**
+   * The full variant family of the selected asset (alloy + every constituent /
+   * wrapped variant), used only to detect a halted route variant for the
+   * default-selection hoist. On withdraw, `assets` is scoped to the single
+   * selected variant (the alloy), so it cannot see a sibling variant's halt
+   * flag; this carries the whole family so the halt check is accurate. Falls
+   * back to `assets` when not provided.
+   */
+  variantAssets?: MinimalAsset[] | undefined;
   chain: BridgeChain;
   direction: "deposit" | "withdraw";
 }) => {
@@ -290,29 +300,37 @@ export const useBridgesSupportedAssets = ({
     // the hoist when it is halted, falling through to the next route (Coreum /
     // Int3face / XRPL).
     //
-    // Gate on `areWithdrawalsHalted` only, not `isUnstable`: the kill switch
+    // Gate on the kill-switch halt flags only, not `isUnstable`: the kill switch
     // already suppresses routing elsewhere (e.g. the external link-out in
     // amount-screen.tsx), whereas `isUnstable` is warning-only and does not gate
     // the UI. Keeping the default-selection signal consistent with that policy.
-    const isXrplEvmVariantHalted = Boolean(
-      assets?.some(
-        (asset) =>
-          isXrpAsset(asset) &&
-          asset.coinDenom?.toLowerCase().includes("xrplevm") &&
-          asset.areWithdrawalsHalted
-      )
+    //
+    // Scan the full variant family (`variantAssets`), not `assets`: on withdraw
+    // `assets` is the single selected variant (the alloy), which never carries
+    // the xrplevm variant's halt flag, so the guard would miss it. Halt is
+    // direction-specific (a withdraw-halted variant must not block the deposit
+    // hoist and vice versa), so compute each direction separately.
+    const xrplEvmVariants = (variantAssets ?? assets)?.filter(
+      (asset) =>
+        isXrpAsset(asset) && asset.coinDenom?.toLowerCase().includes("xrplevm")
+    );
+    const isXrplEvmWithdrawalsHalted = Boolean(
+      xrplEvmVariants?.some((asset) => asset.areWithdrawalsHalted)
+    );
+    const isXrplEvmDepositsHalted = Boolean(
+      xrplEvmVariants?.some((asset) => asset.areDepositsHalted)
     );
 
     // Check if this is a XRP withdrawal to prioritize XRPL EVM
     const isXrpWithdrawal =
       direction === "withdraw" &&
-      !isXrplEvmVariantHalted &&
+      !isXrplEvmWithdrawalsHalted &&
       assets?.some(isXrpAsset);
 
     // Check if this is a XRP deposit to prioritize XRPL EVM
     const isXrpDeposit =
       direction === "deposit" &&
-      !isXrplEvmVariantHalted &&
+      !isXrplEvmDepositsHalted &&
       assets?.some(isXrpAsset);
 
     // Check if this is ATOM to prioritize Cosmos Hub
@@ -399,7 +417,7 @@ export const useBridgesSupportedAssets = ({
           .map((chain) => [chain.chainId, chain])
       ).values()
     );
-  }, [successfulQueries, direction, assets]);
+  }, [successfulQueries, direction, assets, variantAssets]);
 
   return { supportedAssetsByChainId, supportedChains, isLoading };
 };


### PR DESCRIPTION
Makes every hardcoded positional default hoist in `supportedChains` (`use-bridges-supported-assets.ts`) halt-aware, so a "Recommended" (index 0) default is never pinned to a dead route. The three baked-in hoists (USDC to Noble, XRP to XRPL EVM, ATOM to Cosmos Hub) are now a declarative `hoistRules` table; each is applied only when the family variant representing its destination route is not kill-switch halted in the active direction. When it is halted, the hoist is skipped and the default falls through to the next viable route.

## Why

The ordering hoisted a preferred chain to index 0 for matching assets **unconditionally**, ignoring halt state, so when a route was bridge-down the default landed the user there anyway. The original trigger was allXRP withdraw defaulting onto the bridge-down XRPL EVM route. Rather than special-case XRPL EVM, this gates all three hoists uniformly (and any future one added to the table).

## Two-lever design

The halt signal lives on the **asset** (`MinimalAsset.areWithdrawalsHalted` / `areDepositsHalted`), sourced from the assetlist. This PR reads it. The **data half** (flagging a route variant halted in the assetlist when its bridge is down) is what makes a guard fire. With no flag set, ordering is unchanged, so this is safe to land ahead of the data. The xrplevm variant already carries the flags.

## How each hoist finds its destination-route variant

Each rule has a narrow `matchesRouteVariant` selecting only the entry that represents its destination route, so a halted *bridged sibling* can never suppress a healthy native default (a real risk caught in review, since the asset matchers are deliberately broad):

- **XRP to XRPL EVM**: the destination is the chain-qualified `xrplevm` variant (`coinDenom` contains `xrplevm`, e.g. `XRP.xrplevm`), NOT the selected alloy.
- **USDC to Noble**: the destination is native Noble USDC, matched by the canonical `USDC` symbol only (bridged variants are chain-qualified: `USDC.eth.grv`, `USDC.avax.axl`, ...). Without this, a halted `USDC.eth.grv` sibling would wrongly suppress the Noble default.
- **ATOM to Cosmos Hub**: native ATOM, matched by exact native denom / `cosmos` CoinGecko id (which no bridged ATOM variant shares).

Two supporting points, both from bot review:
- The scan runs over the **full variant family** (`variantAssets`, fed from `getBridgeAssetWithVariants` at the caller), not the single selected `assets`. On withdraw `assets` is just the selected variant (the alloy), which never carries a sibling variant's halt flag.
- Halt is **direction-specific**: withdraw hoists gate on `areWithdrawalsHalted`, deposit hoists on `areDepositsHalted`.

Gated on the kill-switch halt flags only, not `isUnstable` (the kill switch already suppresses routing elsewhere; `isUnstable` is warning-only and does not gate the UI).

## Test / verify
- To verify on a deploy: with a route variant flagged halted, the corresponding default (USDC/XRP/ATOM) is no longer auto-selected and falls through to the next viable route; with no flag, ordering is unchanged. XRP route is currently halted as the IBC connection is down so this is the appropriate test route.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default bridge destination selection for real transfers; behavior is flag-gated and falls back to prior ordering when routes are healthy.
> 
> **Overview**
> Bridge **recommended chain ordering** no longer pins Noble, XRPL EVM, or Cosmos Hub to index 0 when the **destination route variant** is kill-switch halted for the active direction (`areWithdrawalsHalted` / `areDepositsHalted`).
> 
> The previous inline sort rules are replaced with a **`hoistRules`** table. Each rule applies only if the transfer matches the asset family and the **narrow route-variant matcher** (e.g. native `USDC` for Noble, `xrplevm` XRP for XRPL EVM) is not halted—so a halted bridged sibling cannot block a healthy native default.
> 
> **`amount-and-review-screen`** passes **`variantAssets: assetsInOsmosis`** into `useBridgesSupportedAssets` so withdraw flows (where `assets` is only the selected alloy) can still read sibling variants’ halt flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d7721335df7b83536ab3e49bfa595fd5d87d3ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


