### PR TITLE
feat(bridge): logo lookup for external_interface connectors

### DIFF
--- a/packages/types/src/asset-types.ts
+++ b/packages/types/src/asset-types.ts
@@ -97,6 +97,10 @@ export type ExternalInterfaceBridgeTransferMethod = {
   type: "external_interface";
   depositUrl?: string;
   withdrawUrl?: string;
+  /** Optional connector logo, sourced from the asset list. When present it is
+   *  the authoritative logo for this external bridge; the frontend falls back to
+   *  a name-keyed map and then a generic placeholder when absent. */
+  logoUri?: string;
 };
 
 export interface CosmosCounterparty {

--- a/packages/web/server/api/routers/bridge-transfer.ts
+++ b/packages/web/server/api/routers/bridge-transfer.ts
@@ -45,7 +45,11 @@ import { z } from "zod";
 
 import { IS_TESTNET } from "~/config/env";
 import { resolveExternalUrlConvertVariant } from "~/server/api/routers/bridge/external-url-convert-variant";
-import { BridgeLogoUrls, ExternalBridgeLogoUrls } from "~/utils/bridge";
+import {
+  BridgeLogoUrls,
+  ExternalBridgeLogoUrls,
+  getExternalInterfaceLogo,
+} from "~/utils/bridge";
 import { INSUFFICIENT_FEE_TOKENS_OSMOSIS_MARKER } from "~/utils/error";
 
 export type BridgeChainWithDisplayInfo = (
@@ -657,13 +661,13 @@ export const bridgeTransferRouter = createTRPCRouter({
             input.fromChain?.chainId === "osmosis-1" && withdrawUrl
               ? {
                   urlProviderName: name,
-                  logo: ExternalBridgeLogoUrls["Generic"],
+                  logo: getExternalInterfaceLogo(name),
                   url: withdrawUrl,
                 }
               : input.toChain?.chainId === "osmosis-1" && depositUrl
               ? {
                   urlProviderName: name,
-                  logo: ExternalBridgeLogoUrls["Generic"],
+                  logo: getExternalInterfaceLogo(name),
                   url: depositUrl,
                 }
               : undefined;

--- a/packages/web/server/api/routers/bridge-transfer.ts
+++ b/packages/web/server/api/routers/bridge-transfer.ts
@@ -677,16 +677,24 @@ export const bridgeTransferRouter = createTRPCRouter({
                 }
               : undefined;
 
-          // ensure is not already in provider URLs before adding
-          if (
-            urlToAdd &&
-            !externalUrls.some(
+          if (urlToAdd) {
+            const existing = externalUrls.find(
               ({ urlProviderName, url }) =>
-                urlProviderName === urlToAdd.urlProviderName ||
-                url.host === urlToAdd.url.host
-            )
-          ) {
-            externalUrls.push(urlToAdd);
+                urlProviderName === urlToAdd!.urlProviderName ||
+                url.host === urlToAdd!.url.host
+            );
+            if (!existing) {
+              externalUrls.push(urlToAdd);
+            } else if (
+              // Dedup keeps the first-added entry, but if a later duplicate
+              // (e.g. the deposit-side method) carries a real logo while the
+              // kept one only has the Generic placeholder, upgrade the logo so
+              // the authoritative connector logo isn't lost to ordering.
+              existing.logo === ExternalBridgeLogoUrls["Generic"] &&
+              urlToAdd.logo !== ExternalBridgeLogoUrls["Generic"]
+            ) {
+              existing.logo = urlToAdd.logo;
+            }
           }
         }
       );

--- a/packages/web/server/api/routers/bridge-transfer.ts
+++ b/packages/web/server/api/routers/bridge-transfer.ts
@@ -644,7 +644,12 @@ export const bridgeTransferRouter = createTRPCRouter({
       ) as ExternalInterfaceBridgeTransferMethod[];
 
       externalTransferMethods.forEach(
-        ({ name, depositUrl: depositUrl_, withdrawUrl: withdrawUrl_ }) => {
+        ({
+          name,
+          depositUrl: depositUrl_,
+          withdrawUrl: withdrawUrl_,
+          logoUri,
+        }) => {
           let depositUrl, withdrawUrl;
           try {
             depositUrl = depositUrl_ ? new URL(depositUrl_) : undefined;
@@ -661,13 +666,13 @@ export const bridgeTransferRouter = createTRPCRouter({
             input.fromChain?.chainId === "osmosis-1" && withdrawUrl
               ? {
                   urlProviderName: name,
-                  logo: getExternalInterfaceLogo(name),
+                  logo: getExternalInterfaceLogo(name, logoUri),
                   url: withdrawUrl,
                 }
               : input.toChain?.chainId === "osmosis-1" && depositUrl
               ? {
                   urlProviderName: name,
-                  logo: getExternalInterfaceLogo(name),
+                  logo: getExternalInterfaceLogo(name, logoUri),
                   url: depositUrl,
                 }
               : undefined;

--- a/packages/web/server/api/routers/bridge-transfer.ts
+++ b/packages/web/server/api/routers/bridge-transfer.ts
@@ -680,8 +680,8 @@ export const bridgeTransferRouter = createTRPCRouter({
           if (urlToAdd) {
             const existing = externalUrls.find(
               ({ urlProviderName, url }) =>
-                urlProviderName === urlToAdd!.urlProviderName ||
-                url.host === urlToAdd!.url.host
+                urlProviderName === urlToAdd.urlProviderName ||
+                url.host === urlToAdd.url.host
             );
             if (!existing) {
               externalUrls.push(urlToAdd);

--- a/packages/web/utils/__tests__/bridge-logo.spec.ts
+++ b/packages/web/utils/__tests__/bridge-logo.spec.ts
@@ -1,0 +1,37 @@
+import { getExternalInterfaceLogo } from "../bridge";
+
+describe("getExternalInterfaceLogo", () => {
+  it("returns the brand logo for a mapped connector name", () => {
+    expect(getExternalInterfaceLogo("Osmosis Wormhole Connect")).toBe(
+      "/bridges/wormhole.svg"
+    );
+    expect(getExternalInterfaceLogo("Sandwichswap Wormhole Portal Bridge")).toBe(
+      "/external-bridges/portalbridge.svg"
+    );
+    expect(getExternalInterfaceLogo("Bskt.fi Wormhole Bridge")).toBe(
+      "/external-bridges/portalbridge.svg"
+    );
+    expect(getExternalInterfaceLogo("Squid")).toBe("/bridges/squid.svg");
+  });
+
+  it("falls back to the Generic placeholder for an unmapped connector", () => {
+    // Connectors whose brand asset isn't sourced yet (MTN-196 follow-up).
+    expect(getExternalInterfaceLogo("Omnity Bridge")).toBe(
+      "/external-bridges/generic.svg"
+    );
+    expect(getExternalInterfaceLogo("Sologenic TX Bridge")).toBe(
+      "/external-bridges/generic.svg"
+    );
+    // "Dymension Portal" must NOT borrow the Wormhole Portal logo.
+    expect(getExternalInterfaceLogo("Dymension Portal")).toBe(
+      "/external-bridges/generic.svg"
+    );
+  });
+
+  it("falls back to Generic for an unknown / empty name", () => {
+    expect(getExternalInterfaceLogo("Totally New Bridge")).toBe(
+      "/external-bridges/generic.svg"
+    );
+    expect(getExternalInterfaceLogo("")).toBe("/external-bridges/generic.svg");
+  });
+});

--- a/packages/web/utils/__tests__/bridge-logo.spec.ts
+++ b/packages/web/utils/__tests__/bridge-logo.spec.ts
@@ -19,6 +19,20 @@ describe("getExternalInterfaceLogo", () => {
     );
   });
 
+  it("treats a blank/whitespace logoUri as absent (falls through, not a broken image)", () => {
+    // A mapped name with an empty logoUri falls to the map, not "".
+    expect(getExternalInterfaceLogo("Osmosis Wormhole Connect", "")).toBe(
+      "/bridges/wormhole.svg"
+    );
+    expect(getExternalInterfaceLogo("Osmosis Wormhole Connect", "   ")).toBe(
+      "/bridges/wormhole.svg"
+    );
+    // An unmapped name with an empty logoUri falls all the way to Generic.
+    expect(getExternalInterfaceLogo("Omnity Bridge", "")).toBe(
+      "/external-bridges/generic.svg"
+    );
+  });
+
   it("falls back to the Generic placeholder for an unmapped connector", () => {
     // Connectors whose brand asset isn't sourced yet (MTN-196 follow-up).
     expect(getExternalInterfaceLogo("Omnity Bridge")).toBe(

--- a/packages/web/utils/__tests__/bridge-logo.spec.ts
+++ b/packages/web/utils/__tests__/bridge-logo.spec.ts
@@ -5,12 +5,6 @@ describe("getExternalInterfaceLogo", () => {
     expect(getExternalInterfaceLogo("Osmosis Wormhole Connect")).toBe(
       "/bridges/wormhole.svg"
     );
-    expect(getExternalInterfaceLogo("Sandwichswap Wormhole Portal Bridge")).toBe(
-      "/external-bridges/portalbridge.svg"
-    );
-    expect(getExternalInterfaceLogo("Bskt.fi Wormhole Bridge")).toBe(
-      "/external-bridges/portalbridge.svg"
-    );
     expect(getExternalInterfaceLogo("Squid")).toBe("/bridges/squid.svg");
   });
 

--- a/packages/web/utils/__tests__/bridge-logo.spec.ts
+++ b/packages/web/utils/__tests__/bridge-logo.spec.ts
@@ -8,6 +8,17 @@ describe("getExternalInterfaceLogo", () => {
     expect(getExternalInterfaceLogo("Squid")).toBe("/bridges/squid.svg");
   });
 
+  it("prefers an asset-list logoUri over the name map", () => {
+    // Data-provided logo is authoritative, even for a name that is also mapped.
+    expect(
+      getExternalInterfaceLogo("Osmosis Wormhole Connect", "/x/from-data.svg")
+    ).toBe("/x/from-data.svg");
+    // ...and for an unmapped name, logoUri still wins over Generic.
+    expect(getExternalInterfaceLogo("Omnity Bridge", "/x/omnity.svg")).toBe(
+      "/x/omnity.svg"
+    );
+  });
+
   it("falls back to the Generic placeholder for an unmapped connector", () => {
     // Connectors whose brand asset isn't sourced yet (MTN-196 follow-up).
     expect(getExternalInterfaceLogo("Omnity Bridge")).toBe(

--- a/packages/web/utils/bridge.ts
+++ b/packages/web/utils/bridge.ts
@@ -44,8 +44,24 @@ const ExternalInterfaceLogoUrls: Record<string, string> = {
   Squid: "/bridges/squid.svg",
 };
 
-/** Logo for an `external_interface` connector by its asset-list `name`, falling
- *  back to the Generic placeholder when no correct brand asset exists yet. */
-export function getExternalInterfaceLogo(name: string): string {
-  return ExternalInterfaceLogoUrls[name] ?? ExternalBridgeLogoUrls["Generic"];
+/**
+ * Logo for an `external_interface` connector, resolved in priority order:
+ * 1. `logoUri` from the asset-list connector data (authoritative; the durable
+ *    home for connector logos),
+ * 2. the name-keyed {@link ExternalInterfaceLogoUrls} map (frontend fallback for
+ *    connectors whose data doesn't yet carry a logo),
+ * 3. the Generic placeholder.
+ *
+ * The name-map is the interim layer: as connectors gain a `logo_uri` in the
+ * assetlist it is superseded per-connector, and can be retired once all carry one.
+ */
+export function getExternalInterfaceLogo(
+  name: string,
+  logoUri?: string
+): string {
+  return (
+    logoUri ??
+    ExternalInterfaceLogoUrls[name] ??
+    ExternalBridgeLogoUrls["Generic"]
+  );
 }

--- a/packages/web/utils/bridge.ts
+++ b/packages/web/utils/bridge.ts
@@ -22,3 +22,33 @@ export const ExternalBridgeLogoUrls: Record<Bridge | "Generic", string> = {
   Penumbra: "/networks/penumbra.svg",
   Int3face: "/bridges/int3face.svg",
 };
+
+/**
+ * Logos for third-party `external_interface` bridge connectors, keyed by the
+ * asset-list transfer-method `name` (e.g. "Osmosis Wormhole Connect"), NOT the
+ * `Bridge` enum. These links come from asset data, not a provider module, so
+ * `ExternalBridgeLogoUrls` (enum-keyed) can't resolve them — they previously all
+ * fell back to the Generic placeholder. Use {@link getExternalInterfaceLogo}.
+ *
+ * Only names whose brand asset is genuinely present + correct are listed; any
+ * other connector falls back to Generic (no broken image, no regression). Add a
+ * new entry only alongside a real brand asset under `/public/external-bridges`
+ * or `/public/bridges` — do NOT map to an unrelated chain logo (e.g. "Dymension
+ * Portal" is Dymension's portal, not Wormhole Portal, so it stays Generic until
+ * a Dymension asset exists). Remaining unmapped names tracked in MTN-196.
+ */
+const ExternalInterfaceLogoUrls: Record<string, string> = {
+  // Wormhole + Wormhole Portal family (the existing wormhole/portalbridge assets
+  // are the correct brand for these).
+  "Osmosis Wormhole Connect": "/bridges/wormhole.svg",
+  "Sandwichswap Wormhole Portal Bridge": "/external-bridges/portalbridge.svg",
+  "Bskt.fi Wormhole Bridge": "/external-bridges/portalbridge.svg",
+  // Squid as an external_interface (same brand as the Squid provider).
+  Squid: "/bridges/squid.svg",
+};
+
+/** Logo for an `external_interface` connector by its asset-list `name`, falling
+ *  back to the Generic placeholder when no correct brand asset exists yet. */
+export function getExternalInterfaceLogo(name: string): string {
+  return ExternalInterfaceLogoUrls[name] ?? ExternalBridgeLogoUrls["Generic"];
+}

--- a/packages/web/utils/bridge.ts
+++ b/packages/web/utils/bridge.ts
@@ -59,8 +59,12 @@ export function getExternalInterfaceLogo(
   name: string,
   logoUri?: string
 ): string {
+  // Treat a blank/whitespace `logoUri` as absent, not authoritative: asset data
+  // could carry a present-but-empty string, and `??` would return it verbatim
+  // (a broken image) instead of falling through to the name map / Generic.
+  const dataLogo = logoUri?.trim() || undefined;
   return (
-    logoUri ??
+    dataLogo ??
     ExternalInterfaceLogoUrls[name] ??
     ExternalBridgeLogoUrls["Generic"]
   );

--- a/packages/web/utils/bridge.ts
+++ b/packages/web/utils/bridge.ts
@@ -38,11 +38,8 @@ export const ExternalBridgeLogoUrls: Record<Bridge | "Generic", string> = {
  * a Dymension asset exists). Remaining unmapped names tracked in MTN-196.
  */
 const ExternalInterfaceLogoUrls: Record<string, string> = {
-  // Wormhole + Wormhole Portal family (the existing wormhole/portalbridge assets
-  // are the correct brand for these).
+  // Wormhole (the existing wormhole asset is the correct brand).
   "Osmosis Wormhole Connect": "/bridges/wormhole.svg",
-  "Sandwichswap Wormhole Portal Bridge": "/external-bridges/portalbridge.svg",
-  "Bskt.fi Wormhole Bridge": "/external-bridges/portalbridge.svg",
   // Squid as an external_interface (same brand as the Squid provider).
   Squid: "/bridges/squid.svg",
 };


### PR DESCRIPTION
## What

Makes the frontend read a connector's logo from the asset list, so third-party `external_interface` bridges on the "More options" screen show a real brand logo instead of the Generic placeholder.

Logos resolve in priority order: **asset-list `logoUri` (authoritative) → frontend name-keyed map (thin interim fallback) → Generic**. The asset list is the durable home for connector logos (populated by osmosis-labs/assetlists#3639); the name-map now only covers connectors whose data hasn't been given a `logoUri` yet, and can be retired once they all have one.

**Scope: this only affects `external_interface` connector logos.** There are two separate maps: this PR's `ExternalInterfaceLogoUrls` (connector logos, keyed by connector name) and the pre-existing enum-keyed `ExternalBridgeLogoUrls` (provider-generated links like Skip:Go/Squid/Wormhole from `getExternalUrl`). Only Wormhole Connect + Squid are hardcoded in the connector map; every other connector pulls its logo from the assetlist `logoUri`, else Generic. Skip is NOT in the connector map -- it is a provider link resolving from the (unchanged) enum map.

**Display-only, route-neutral.** The `logoUri` is a passenger field: it is never a dedup key, filter, or sort input in `getExternalUrls`. Which connectors/routes surface, their order, and which entry wins on a name/host collision are all decided exactly as before -- the only new behaviour is that a kept entry's logo may be upgraded from Generic to a real logo. This does not change what a user can bridge or how.

**Forward-looking data path.** The `logoUri`-from-data resolution goes live only once osmosis-labs/assetlists#3639 (which populates `logo_uri` and hosts the SVGs) reaches `main`; that PR is in turn blocked on this one merging. Until then the two hardcoded names (Wormhole Connect, Squid) render and everything else is Generic -- no behaviour change on merge, no broken images. The data path is covered by the unit tests here; a server-side dedup test + `logoUri` mock fixture are a tracked fast-follow.


## Why

`getExternalUrls` resolved logos two ways: provider-generated links (Skip:Go, Squid, ...) via `ExternalBridgeLogoUrls[providerName]` (keyed on the `Bridge` enum → real logo), but `external_interface` links from asset data were hardcoded to `ExternalBridgeLogoUrls["Generic"]` — the map has no entry for the asset-list connector `name` strings (`"Omnity Bridge"`, `"Sologenic TX Bridge"`, ...), so every one showed the placeholder. More visible after #4386 (MTN-148), which surfaces many more of these connectors.

## Changes

- `packages/types`: `ExternalInterfaceBridgeTransferMethod` gains optional `logoUri` (the asset-list-sourced logo).
- `packages/web/utils/bridge.ts`: `getExternalInterfaceLogo(name, logoUri?)` resolves `logoUri ?? nameMap[name] ?? Generic`. The name-map (`ExternalInterfaceLogoUrls`) carries only connectors that map to a correct existing frontend brand asset — currently **Osmosis Wormhole Connect** and **Squid**.
- `bridge-transfer.ts` `getExternalUrls`: passes each connector's `logoUri` into the resolver (both external-URL logo assignments).
- `bridge-logo.spec.ts`: **5 tests** — mapped names resolve, `logoUri` wins over the map, a blank/whitespace `logoUri` falls through (not a broken image), unmapped/empty fall back to Generic.

## Test / verify

- `cd packages/web && node ../../node_modules/jest/bin/jest.js bridge-logo` — 5/5 pass.
- Typecheck + lint clean on touched files.
- On a deploy once osmosis-labs/assetlists#3639 lands: connectors with a `logoUri` (Squid, Wormhole Connect, Sologenic, Dymension, Gravity, OBridge) show their real logo; any without one fall back to Generic.

These were generated locally as the assetlist cannot merge with the logoURIs until this PR also merges.
<img width="373" height="344" alt="image" src="https://github.com/user-attachments/assets/1958ffb6-8817-4288-acce-f72d713205c0" />
<img width="373" height="343" alt="image" src="https://github.com/user-attachments/assets/90490347-d805-4960-8224-a3c175dce5e4" />
<img width="368" height="350" alt="image" src="https://github.com/user-attachments/assets/3e62d6c9-757a-444f-87d1-40a3327c8524" />
<img width="371" height="301" alt="image" src="https://github.com/user-attachments/assets/f3ed06a2-b129-4a03-abf8-4159594c62c2" />


## Related

- **osmosis-labs/assetlists#3639** — populates `logoUri` on the connectors + hosts the SVGs (the data half; this PR is the read half). that PR is blocked on this frontend PR reaching `main`.
- Surfaced while reviewing #4386 (MTN-148): Skip showed a logo, the external_interface bridges didn't. Independent of #4386's routing logic.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only logo resolution on external bridge URLs; no auth, routing, or transfer logic changes beyond optional logo field on deduped entries.
> 
> **Overview**
> Third-party **`external_interface`** options on the bridge “More options” flow now get **real connector logos** instead of always using the Generic placeholder.
> 
> **`ExternalInterfaceBridgeTransferMethod`** gains optional **`logoUri`** from the asset list. **`getExternalInterfaceLogo`** resolves logos as **`logoUri` → name-keyed interim map (Wormhole Connect, Squid) → Generic**, with blank/whitespace `logoUri` treated as missing so images don’t break. **`getExternalUrls`** uses that resolver and, when deduping by name/host, **upgrades** a kept entry’s logo from Generic if a later duplicate has a better one—routing and which URL wins are unchanged.
> 
> Unit tests cover the resolver; provider enum logos are untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a23de6ecd97ce7d371b5f8cf2eb26e82c399b281. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->




