### PR TITLE
feat(swap-tool): add 25/50/75/Max amount presets to the From field

### DIFF
--- a/packages/e2e/pages/trade-page.ts
+++ b/packages/e2e/pages/trade-page.ts
@@ -56,7 +56,9 @@ export class TradePage extends BasePage {
       '//div[@class]/button[.="Sell"]/p[@class]/..'
     );
     this.confirmSwapBtn = page.locator('//div[@class]/button[.="Confirm"]');
-    this.swapMaxBtn = page.locator('//span[.="Max"]');
+    // The Max preset pill renders its label as direct button text (it moved
+    // into the 25/50/75/Max preset row), so locate by role rather than span.
+    this.swapMaxBtn = page.getByRole("button", { name: "Max", exact: true });
     this.flipAssetsBtn = page.locator(
       '//div/button[contains(@class, "ease-bounce")]'
     );

--- a/packages/web/components/place-limit-tool/index.tsx
+++ b/packages/web/components/place-limit-tool/index.tsx
@@ -31,6 +31,10 @@ import {
   USDT_BASE_DENOM,
 } from "~/components/place-limit-tool/defaults";
 import { LimitPriceSelector } from "~/components/place-limit-tool/limit-price-selector";
+import {
+  AmountPresetFraction,
+  AmountPresetRow,
+} from "~/components/swap-tool/amount-preset-row";
 import { TRADE_TYPES } from "~/components/swap-tool/order-type-selector";
 import { PriceSelector } from "~/components/swap-tool/price-selector";
 import { TradeDetails } from "~/components/swap-tool/trade-details";
@@ -789,6 +793,36 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
                 assetQueryInput={swapState.marketState.assetsQueryInput}
               />
             </div>
+            {(() => {
+              // Pick the underlying input whose balance the fraction should
+              // apply against. For market mode it's `marketState.inAmountInput`
+              // (sell tab denominates this in base, buy tab in quote — both
+              // correctly the asset the user is spending). For limit mode the
+              // sell tab uses `swapState.inAmountInput` (base, the asset being
+              // sold). Limit-buy is omitted because `swapState.inAmountInput`
+              // is denominated in the asset being acquired, so a balance
+              // fraction has no useful meaning there.
+              const presetInput =
+                type === "market"
+                  ? swapState.marketState.inAmountInput
+                  : tab === "sell"
+                  ? swapState.inAmountInput
+                  : null;
+              if (!presetInput) return null;
+              const balanceZero =
+                !presetInput.balance || presetInput.balance.toDec().isZero();
+              return (
+                <AmountPresetRow
+                  onSelect={(fraction: AmountPresetFraction) => {
+                    presetInput.setFraction(fraction);
+                    inputRef.current?.focus();
+                  }}
+                  activeFraction={presetInput.fraction}
+                  isDisabled={balanceZero}
+                  isLoadingMax={false}
+                />
+              );
+            })()}
             <AssetFieldsetFooter>
               <button
                 type="button"

--- a/packages/web/components/place-limit-tool/index.tsx
+++ b/packages/web/components/place-limit-tool/index.tsx
@@ -171,6 +171,15 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
 
     const [fiatAmount, setFiatAmount] = useState<string>("");
 
+    // Highlight state for the amount presets in limit-buy. Unlike market and
+    // limit-sell (which drive a `useAmountInput` whose own `fraction` tracks
+    // the active preset), limit-buy computes the spend amount imperatively via
+    // `setAmountSafe`, so the active fraction has to be tracked here and
+    // cleared whenever the user edits the amount manually.
+    const [limitBuyFraction, setLimitBuyFraction] = useState<number | null>(
+      null
+    );
+
     const setBase = useCallback((base: string) => set({ from: base }), [set]);
 
     useEffect(() => {
@@ -365,6 +374,33 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
       ]
     );
 
+    // Applies a fraction of the quote balance the buyer spends in limit-buy.
+    // Mirrors the previous Max button's buy math (quote balance when the fiat
+    // field is focused, quote balance converted to base via the limit price
+    // when the token field is focused), scaled by the chosen fraction.
+    const setLimitBuyBalanceFraction = useCallback(
+      (fraction: AmountPresetFraction) => {
+        const quoteBalance = swapState.quoteTokenBalance?.toDec();
+        if (!quoteBalance) return;
+        const scaledQuote = quoteBalance.mul(new Dec(fraction));
+        const amount =
+          focused === "fiat"
+            ? scaledQuote.toString()
+            : swapState.priceState.price && !swapState.priceState.price.isZero()
+            ? scaledQuote.quo(swapState.priceState.price).toString()
+            : undefined;
+        if (amount === undefined) return;
+        setAmountSafe(focused, amount);
+        setLimitBuyFraction(fraction);
+      },
+      [
+        focused,
+        setAmountSafe,
+        swapState.quoteTokenBalance,
+        swapState.priceState.price,
+      ]
+    );
+
     // Adjusts the token value when the user updates the fiat value
     useEffect(() => {
       if (
@@ -427,44 +463,6 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
       swapState.priceState.price,
       type,
       swapState.baseAsset?.coinDecimals,
-    ]);
-
-    const toggleMax = useCallback(() => {
-      if (tab === "buy") {
-        // Tab is buy so use quote amount
-
-        // Determine amount based on current input
-        const amount =
-          focused === "fiat"
-            ? swapState.quoteTokenBalance?.toDec().toString()
-            : swapState.quoteTokenBalance
-                ?.toDec()
-                .quo(swapState.priceState.price)
-                .toString();
-
-        setAmountSafe(focused, amount);
-
-        return;
-      }
-
-      // Tab must be sell so we use base amount
-
-      // Determine amount based on current input
-      const amount =
-        focused === "token"
-          ? swapState.baseTokenBalance?.toDec().toString()
-          : swapState.baseTokenBalance
-              ?.toDec()
-              .mul(swapState.priceState.price)
-              .toString();
-      return setAmountSafe(focused, amount);
-    }, [
-      tab,
-      setAmountSafe,
-      swapState.baseTokenBalance,
-      swapState.quoteTokenBalance,
-      focused,
-      swapState.priceState.price,
     ]);
 
     const inputValue = useMemo(() => {
@@ -714,9 +712,12 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
             <AssetFieldsetHeader>
               <AssetFieldsetHeaderLabel>
                 <span
-                  className={classNames("body2 sm:caption text-osmoverse-300", {
-                    "text-rust-400": errorDisplay,
-                  })}
+                  className={classNames(
+                    "body2 sm:caption py-1.5 text-osmoverse-300",
+                    {
+                      "text-rust-400": errorDisplay,
+                    }
+                  )}
                 >
                   {errorDisplay ? (
                     errorDisplay
@@ -745,11 +746,63 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
                         notation: "standard",
                       })
                 }
-                onMax={toggleMax}
                 openAddFundsModal={openAddFundsModal}
                 showAddFundsButton={!hasFunds}
               />
             </AssetFieldsetHeader>
+            {hasFunds && (
+              <div className="flex justify-end">
+                {(() => {
+                  // Limit-buy is special: the visible spend amount is driven
+                  // by `fiatAmount` / `swapState.inAmountInput` through
+                  // `setAmountSafe`, not by a single `useAmountInput` whose
+                  // `fraction` we can reuse. So it routes through the
+                  // imperative `setLimitBuyBalanceFraction` and tracks its
+                  // own highlight in `limitBuyFraction`.
+                  if (type === "limit" && tab === "buy") {
+                    const balanceZero =
+                      !swapState.quoteTokenBalance ||
+                      swapState.quoteTokenBalance.toDec().isZero();
+                    return (
+                      <AmountPresetRow
+                        onSelect={(fraction: AmountPresetFraction) => {
+                          setLimitBuyBalanceFraction(fraction);
+                          inputRef.current?.focus();
+                        }}
+                        activeFraction={limitBuyFraction}
+                        isDisabled={balanceZero}
+                        isLoadingMax={false}
+                      />
+                    );
+                  }
+
+                  // Market mode and limit-sell drive a `useAmountInput`
+                  // directly, always on the asset the user spends:
+                  //  - market: `marketState.inAmountInput` (sell tab is base,
+                  //    buy tab is quote).
+                  //  - limit sell: `swapState.inAmountInput` (base, the asset
+                  //    being sold).
+                  const presetInput =
+                    type === "market"
+                      ? swapState.marketState.inAmountInput
+                      : swapState.inAmountInput;
+                  const balanceZero =
+                    !presetInput.balance ||
+                    presetInput.balance.toDec().isZero();
+                  return (
+                    <AmountPresetRow
+                      onSelect={(fraction: AmountPresetFraction) => {
+                        presetInput.setFraction(fraction);
+                        inputRef.current?.focus();
+                      }}
+                      activeFraction={presetInput.fraction}
+                      isDisabled={balanceZero}
+                      isLoadingMax={false}
+                    />
+                  );
+                })()}
+              </div>
+            )}
             <div className="flex items-center justify-between py-3 ">
               <AssetFieldsetInput
                 page={page}
@@ -770,7 +823,10 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
                     ? "0.01"
                     : inputValue
                 }
-                onInputChange={(e) => setAmountSafe(focused, e.target.value)}
+                onInputChange={(e) => {
+                  setLimitBuyFraction(null);
+                  setAmountSafe(focused, e.target.value);
+                }}
                 data-testid={`trade-input-${type}`}
               />
               <AssetFieldsetTokenSelector
@@ -793,36 +849,6 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
                 assetQueryInput={swapState.marketState.assetsQueryInput}
               />
             </div>
-            {(() => {
-              // Pick the underlying input whose balance the fraction should
-              // apply against. For market mode it's `marketState.inAmountInput`
-              // (sell tab denominates this in base, buy tab in quote — both
-              // correctly the asset the user is spending). For limit mode the
-              // sell tab uses `swapState.inAmountInput` (base, the asset being
-              // sold). Limit-buy is omitted because `swapState.inAmountInput`
-              // is denominated in the asset being acquired, so a balance
-              // fraction has no useful meaning there.
-              const presetInput =
-                type === "market"
-                  ? swapState.marketState.inAmountInput
-                  : tab === "sell"
-                  ? swapState.inAmountInput
-                  : null;
-              if (!presetInput) return null;
-              const balanceZero =
-                !presetInput.balance || presetInput.balance.toDec().isZero();
-              return (
-                <AmountPresetRow
-                  onSelect={(fraction: AmountPresetFraction) => {
-                    presetInput.setFraction(fraction);
-                    inputRef.current?.focus();
-                  }}
-                  activeFraction={presetInput.fraction}
-                  isDisabled={balanceZero}
-                  isLoadingMax={false}
-                />
-              );
-            })()}
             <AssetFieldsetFooter>
               <button
                 type="button"

--- a/packages/web/components/place-limit-tool/index.tsx
+++ b/packages/web/components/place-limit-tool/index.tsx
@@ -418,6 +418,21 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
           presetInput.setFraction(fraction);
           return;
         }
+        // Fiat focused: mirror the removed Max button's per-tab balance math,
+        // scaled by the fraction, routed through `setAmountSafe` so the
+        // visible fiat amount, market amounts, and quote type stay in sync.
+        if (tab === "buy") {
+          // Market buy spends the quote asset; its fiat value is the quote
+          // balance as-is (matching the removed Max button's buy branch).
+          const quoteBalance = swapState.quoteTokenBalance?.toDec();
+          if (!quoteBalance) return;
+          setAmountSafe(
+            "fiat",
+            quoteBalance.mul(new Dec(fraction)).toString(),
+            10
+          );
+          return;
+        }
         const baseBalance = swapState.baseTokenBalance?.toDec();
         const price = swapState.priceState.price;
         if (!baseBalance || !price || price.isZero()) return;
@@ -430,10 +445,12 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
       [
         focused,
         setAmountSafe,
+        tab,
         type,
         swapState.marketState.inAmountInput,
         swapState.inAmountInput,
         swapState.baseTokenBalance,
+        swapState.quoteTokenBalance,
         swapState.priceState.price,
       ]
     );

--- a/packages/web/components/place-limit-tool/index.tsx
+++ b/packages/web/components/place-limit-tool/index.tsx
@@ -401,6 +401,43 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
       ]
     );
 
+    // Applies a fraction of the base balance being spent in market mode and
+    // limit-sell, honoring the active input focus. Token focus drives the
+    // input's own fraction (which routes Max through the gas reserve); fiat
+    // focus mirrors the previous Max button, scaled: base balance x price via
+    // `setAmountSafe`, so the visible fiat amount, market amounts, and quote
+    // type stay in sync instead of the display going stale while the
+    // underlying order amount changes.
+    const setSellBalanceFraction = useCallback(
+      (fraction: AmountPresetFraction) => {
+        const presetInput =
+          type === "market"
+            ? swapState.marketState.inAmountInput
+            : swapState.inAmountInput;
+        if (focused === "token") {
+          presetInput.setFraction(fraction);
+          return;
+        }
+        const baseBalance = swapState.baseTokenBalance?.toDec();
+        const price = swapState.priceState.price;
+        if (!baseBalance || !price || price.isZero()) return;
+        setAmountSafe(
+          "fiat",
+          baseBalance.mul(new Dec(fraction)).mul(price).toString(),
+          10
+        );
+      },
+      [
+        focused,
+        setAmountSafe,
+        type,
+        swapState.marketState.inAmountInput,
+        swapState.inAmountInput,
+        swapState.baseTokenBalance,
+        swapState.priceState.price,
+      ]
+    );
+
     // Adjusts the token value when the user updates the fiat value
     useEffect(() => {
       if (
@@ -792,7 +829,7 @@ export const PlaceLimitTool: FunctionComponent<PlaceLimitToolProps> = observer(
                   return (
                     <AmountPresetRow
                       onSelect={(fraction: AmountPresetFraction) => {
-                        presetInput.setFraction(fraction);
+                        setSellBalanceFraction(fraction);
                         inputRef.current?.focus();
                       }}
                       activeFraction={presetInput.fraction}

--- a/packages/web/components/swap-tool/amount-preset-row.tsx
+++ b/packages/web/components/swap-tool/amount-preset-row.tsx
@@ -1,0 +1,56 @@
+import classNames from "classnames";
+import { FunctionComponent } from "react";
+
+export type AmountPresetFraction = 0.25 | 0.5 | 0.75 | 1;
+
+const PRESETS: { fraction: AmountPresetFraction; label: string }[] = [
+  { fraction: 0.25, label: "25%" },
+  { fraction: 0.5, label: "50%" },
+  { fraction: 0.75, label: "75%" },
+  { fraction: 1, label: "Max" },
+];
+
+export const AmountPresetRow: FunctionComponent<{
+  onSelect: (fraction: AmountPresetFraction) => void;
+  activeFraction: number | null;
+  isDisabled: boolean;
+  isLoadingMax: boolean;
+}> = ({ onSelect, activeFraction, isDisabled, isLoadingMax }) => {
+  // 25/50/75 are intentionally not gas-aware. Only the Max pill subtracts the
+  // gas reserve via `useAmountInput`'s `maxAmountWithGas`. A user choosing 75%
+  // of the fee asset can therefore still hit gas-exhaustion at execution; this
+  // matches the explicit semantic that "50%" means "50% of balance" and not
+  // "50% of (balance - gas)".
+  return (
+    <div className="flex w-full items-center gap-1">
+      {PRESETS.map(({ fraction, label }) => {
+        const isActive = activeFraction === fraction;
+        return (
+          <button
+            key={`amount-preset-${fraction}`}
+            type="button"
+            disabled={isDisabled || (fraction === 1 && isLoadingMax)}
+            onClick={() => onSelect(fraction)}
+            className={classNames(
+              "sm:body2 flex-1 rounded-3xl border border-osmoverse-700 py-1.5 text-center transition-colors",
+              {
+                "bg-wosmongton-100": isActive,
+                "hover:bg-osmoverse-850": !isActive && !isDisabled,
+                "cursor-not-allowed opacity-50": isDisabled,
+              }
+            )}
+          >
+            <span
+              className={classNames("body2 font-semibold sm:caption", {
+                "text-osmoverse-900": isActive,
+                "text-wosmongton-100": !isActive,
+              })}
+            >
+              {label}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+};

--- a/packages/web/components/swap-tool/amount-preset-row.tsx
+++ b/packages/web/components/swap-tool/amount-preset-row.tsx
@@ -1,6 +1,8 @@
 import classNames from "classnames";
 import { FunctionComponent } from "react";
 
+import { Spinner } from "~/components/loaders";
+
 export type AmountPresetFraction = 0.25 | 0.5 | 0.75 | 1;
 
 const PRESETS: { fraction: AmountPresetFraction; label: string }[] = [
@@ -10,44 +12,87 @@ const PRESETS: { fraction: AmountPresetFraction; label: string }[] = [
   { fraction: 1, label: "Max" },
 ];
 
+/**
+ * Balance-fraction shortcuts rendered as a row of compact pill buttons,
+ * matching the look of the standalone "Max" button they replaced (`rounded-5xl`
+ * bordered pill, wosmongton text, filled when active). Sits on its own
+ * right-aligned line directly beneath the available-balance line of the asset
+ * fieldset (above the amount input and token selector).
+ *
+ * 25/50/75 are intentionally not gas-aware. Only "Max" subtracts the gas
+ * reserve via `useAmountInput`'s `maxAmountWithGas`. A user choosing 75% of
+ * the fee asset can therefore still hit gas-exhaustion at execution; this
+ * matches the explicit semantic that "50%" means "50% of balance" and not
+ * "50% of (balance - gas)".
+ */
 export const AmountPresetRow: FunctionComponent<{
   onSelect: (fraction: AmountPresetFraction) => void;
+  /**
+   * The currently-active fraction, used to highlight the matching pill. Kept
+   * as `number | null` (not `AmountPresetFraction`) because it is fed directly
+   * from `useAmountInput.fraction` / the limit-buy highlight state, both of
+   * which store an arbitrary `number | null`. The `=== fraction` comparison
+   * below is still exhaustive against the four preset literals.
+   */
   activeFraction: number | null;
+  /**
+   * Disables every preset. Used by callers that render the row unconditionally
+   * (e.g. place-limit-tool passes `balanceZero`). Callers that already gate the
+   * whole row on wallet/balance upstream (e.g. swap-tool) pass `false`.
+   */
   isDisabled: boolean;
+  /**
+   * Disables the Max preset only. The 25/50/75 presets are not gas-aware, so
+   * gas-specific concerns (estimation in flight, insufficient balance to cover
+   * the fee on a Max swap) must not grey them out.
+   */
+  isMaxDisabled?: boolean;
   isLoadingMax: boolean;
-}> = ({ onSelect, activeFraction, isDisabled, isLoadingMax }) => {
-  // 25/50/75 are intentionally not gas-aware. Only the Max pill subtracts the
-  // gas reserve via `useAmountInput`'s `maxAmountWithGas`. A user choosing 75%
-  // of the fee asset can therefore still hit gas-exhaustion at execution; this
-  // matches the explicit semantic that "50%" means "50% of balance" and not
-  // "50% of (balance - gas)".
+}> = ({
+  onSelect,
+  activeFraction,
+  isDisabled,
+  isMaxDisabled = false,
+  isLoadingMax,
+}) => {
   return (
-    <div className="flex w-full items-center gap-1">
+    <div className="flex items-center gap-1">
       {PRESETS.map(({ fraction, label }) => {
         const isActive = activeFraction === fraction;
+        const isMax = fraction === 1;
+        const isMaxLoading = isMax && isLoadingMax;
+        const buttonDisabled =
+          isDisabled || (isMax && (isMaxDisabled || isLoadingMax));
         return (
           <button
             key={`amount-preset-${fraction}`}
             type="button"
-            disabled={isDisabled || (fraction === 1 && isLoadingMax)}
+            disabled={buttonDisabled}
             onClick={() => onSelect(fraction)}
             className={classNames(
-              "sm:body2 flex-1 rounded-3xl border border-osmoverse-700 py-1.5 text-center transition-colors",
-              {
-                "bg-wosmongton-100": isActive,
-                "hover:bg-osmoverse-850": !isActive && !isDisabled,
-                "cursor-not-allowed opacity-50": isDisabled,
-              }
+              "caption flex h-6 items-center justify-center rounded-5xl border px-2 transition-colors disabled:pointer-events-none disabled:opacity-50",
+              // Hold the Max pill at its resting "Max" width so swapping the
+              // label for the spinner doesn't shrink the pill and reflow the
+              // row.
+              isMax && "min-w-[2.75rem]",
+              isActive
+                ? "border-wosmongton-100 bg-wosmongton-100 text-osmoverse-900"
+                : "border-osmoverse-700 text-wosmongton-300 hover:bg-osmoverse-800"
             )}
           >
-            <span
-              className={classNames("body2 font-semibold sm:caption", {
-                "text-osmoverse-900": isActive,
-                "text-wosmongton-100": !isActive,
-              })}
-            >
-              {label}
-            </span>
+            {/* On the Max pill, the spinner replaces the label while gas
+                estimation is in flight (the pill keeps its width via min-w, so
+                the row doesn't move). */}
+            {isMaxLoading ? (
+              <Spinner
+                className={classNames("!h-3 !w-3 shrink-0", {
+                  "text-osmoverse-900": isActive,
+                  "text-wosmongton-300": !isActive,
+                })}
+              />
+            ) : (
+              label
+            )}
           </button>
         );
       })}

--- a/packages/web/components/swap-tool/index.tsx
+++ b/packages/web/components/swap-tool/index.tsx
@@ -30,6 +30,10 @@ import {
 } from "~/components/complex/asset-fieldset";
 import { tError } from "~/components/localization";
 import { USDC_BASE_DENOM } from "~/components/place-limit-tool/defaults";
+import {
+  AmountPresetFraction,
+  AmountPresetRow,
+} from "~/components/swap-tool/amount-preset-row";
 import { TradeDetails } from "~/components/swap-tool/trade-details";
 import { getShouldHideSlippage } from "~/components/swap-tool/utils";
 import { GenericDisclaimer } from "~/components/tooltip/generic-disclaimer";
@@ -416,13 +420,6 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
                     </span>
                   </AssetFieldsetHeaderLabel>
                   <AssetFieldsetHeaderBalance
-                    onMax={() => {
-                      if (quoteType !== "out-given-in") {
-                        setQuoteType("out-given-in");
-                      }
-                      swapState.inAmountInput.toggleMax();
-                      fromAmountInputEl.current?.focus();
-                    }}
                     availableBalance={
                       swapState.inAmountInput.balance &&
                       formatPretty(
@@ -443,13 +440,6 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
                         swapState.inAmountInput.balance.toDec().isZero())
                     }
                     openAddFundsModal={openAddFundsModal}
-                    isLoadingMaxButton={isLoadingMaxButton}
-                    isMaxButtonDisabled={
-                      !swapState.inAmountInput.balance ||
-                      swapState.inAmountInput.balance.toDec().isZero() ||
-                      swapState.inAmountInput.notEnoughBalanceForMax ||
-                      isLoadingMaxButton
-                    }
                   />
                 </AssetFieldsetHeader>
                 <div className="flex items-center justify-between py-3">
@@ -505,6 +495,26 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
                     data-testid="token-in"
                   />
                 </div>
+                <AmountPresetRow
+                  onSelect={useCallback(
+                    (fraction: AmountPresetFraction) => {
+                      if (quoteType !== "out-given-in") {
+                        setQuoteType("out-given-in");
+                      }
+                      swapState.inAmountInput.setFraction(fraction);
+                      fromAmountInputEl.current?.focus();
+                    },
+                    [quoteType, setQuoteType, swapState.inAmountInput]
+                  )}
+                  activeFraction={swapState.inAmountInput.fraction}
+                  isDisabled={
+                    !swapState.inAmountInput.balance ||
+                    swapState.inAmountInput.balance.toDec().isZero() ||
+                    swapState.inAmountInput.notEnoughBalanceForMax ||
+                    isLoadingMaxButton
+                  }
+                  isLoadingMax={isLoadingMaxButton}
+                />
                 <AssetFieldsetFooter>
                   <span
                     className={classNames(

--- a/packages/web/components/swap-tool/index.tsx
+++ b/packages/web/components/swap-tool/index.tsx
@@ -338,6 +338,17 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
       !swapState.inAmountInput?.balance?.toDec().isZero() &&
       swapState.inAmountInput.isLoadingCurrentBalanceNetworkFee;
 
+    const onSelectAmountPreset = useCallback(
+      (fraction: AmountPresetFraction) => {
+        if (quoteType !== "out-given-in") {
+          setQuoteType("out-given-in");
+        }
+        swapState.inAmountInput.setFraction(fraction);
+        fromAmountInputEl.current?.focus();
+      },
+      [quoteType, setQuoteType, swapState.inAmountInput]
+    );
+
     const isConfirmationDisabled =
       isSendingTx ||
       isWalletLoading ||
@@ -442,6 +453,21 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
                     openAddFundsModal={openAddFundsModal}
                   />
                 </AssetFieldsetHeader>
+                {account?.isWalletConnected &&
+                  swapState.inAmountInput.balance &&
+                  !swapState.inAmountInput.balance.toDec().isZero() && (
+                    <div className="flex justify-end">
+                      <AmountPresetRow
+                        onSelect={onSelectAmountPreset}
+                        activeFraction={swapState.inAmountInput.fraction}
+                        isDisabled={false}
+                        isMaxDisabled={
+                          swapState.inAmountInput.notEnoughBalanceForMax
+                        }
+                        isLoadingMax={isLoadingMaxButton}
+                      />
+                    </div>
+                  )}
                 <div className="flex items-center justify-between py-3">
                   <AssetFieldsetInput
                     ref={fromAmountInputEl}
@@ -495,26 +521,6 @@ export const SwapTool: FunctionComponent<SwapToolProps> = observer(
                     data-testid="token-in"
                   />
                 </div>
-                <AmountPresetRow
-                  onSelect={useCallback(
-                    (fraction: AmountPresetFraction) => {
-                      if (quoteType !== "out-given-in") {
-                        setQuoteType("out-given-in");
-                      }
-                      swapState.inAmountInput.setFraction(fraction);
-                      fromAmountInputEl.current?.focus();
-                    },
-                    [quoteType, setQuoteType, swapState.inAmountInput]
-                  )}
-                  activeFraction={swapState.inAmountInput.fraction}
-                  isDisabled={
-                    !swapState.inAmountInput.balance ||
-                    swapState.inAmountInput.balance.toDec().isZero() ||
-                    swapState.inAmountInput.notEnoughBalanceForMax ||
-                    isLoadingMaxButton
-                  }
-                  isLoadingMax={isLoadingMaxButton}
-                />
                 <AssetFieldsetFooter>
                   <span
                     className={classNames(

--- a/packages/web/hooks/input/__tests__/use-amount-input.spec.ts
+++ b/packages/web/hooks/input/__tests__/use-amount-input.spec.ts
@@ -2,6 +2,7 @@
 import { DEFAULT_VS_CURRENCY } from "@osmosis-labs/server";
 import { Currency } from "@osmosis-labs/types";
 import { CoinPretty, Dec, DecUtils, PricePretty } from "@osmosis-labs/unit";
+import { isValidNumericalRawInput } from "@osmosis-labs/utils";
 import { act, waitFor } from "@testing-library/react";
 
 import { server, trpcMsw } from "~/__tests__/msw";
@@ -12,7 +13,6 @@ import {
 } from "~/__tests__/test-utils";
 import { ChainList } from "~/config/generated/chain-list";
 
-import { isValidNumericalRawInput } from "@osmosis-labs/utils";
 import { useAmountInput } from "../use-amount-input";
 
 describe("useAmountInput", () => {
@@ -240,6 +240,90 @@ describe("useAmountInput", () => {
       expect(result.current.isMaxValue).toBe(false);
       expect(result.current.isHalfValue).toBe(true);
       expect(result.current.inputAmount).toBe("500");
+    });
+  });
+
+  it("calculates quarter amount", async () => {
+    const mockGasAmount = new CoinPretty(
+      osmoMockCurrency,
+      new Dec(1).mul(DecUtils.getTenExponentN(osmoMockCurrency.coinDecimals))
+    );
+
+    const { result, rootStore } = renderHookWithProviders(() =>
+      useAmountInput({ currency: osmoMockCurrency, gasAmount: mockGasAmount })
+    );
+
+    await waitFor(() => {
+      expect(result.current.inputAmount).toBe("");
+    });
+
+    await connectTestWallet({
+      accountStore: rootStore.accountStore,
+      chainId: ChainList[0].chain_id,
+    });
+
+    act(() => {
+      result.current.setFraction(0.25);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isMaxValue).toBe(false);
+      expect(result.current.isHalfValue).toBe(false);
+      expect(result.current.isQuarterValue).toBe(true);
+      expect(result.current.isThreeQuartersValue).toBe(false);
+      expect(result.current.inputAmount).toBe("250");
+    });
+
+    // amount-vs-balance fallback: manual entry equal to balance * 0.25 should
+    // still light up isQuarterValue after the fraction is cleared.
+    act(() => {
+      result.current.setAmount("250");
+    });
+
+    await waitFor(() => {
+      expect(result.current.fraction).toBe(null);
+      expect(result.current.isQuarterValue).toBe(true);
+    });
+  });
+
+  it("calculates three-quarters amount", async () => {
+    const mockGasAmount = new CoinPretty(
+      osmoMockCurrency,
+      new Dec(1).mul(DecUtils.getTenExponentN(osmoMockCurrency.coinDecimals))
+    );
+
+    const { result, rootStore } = renderHookWithProviders(() =>
+      useAmountInput({ currency: osmoMockCurrency, gasAmount: mockGasAmount })
+    );
+
+    await waitFor(() => {
+      expect(result.current.inputAmount).toBe("");
+    });
+
+    await connectTestWallet({
+      accountStore: rootStore.accountStore,
+      chainId: ChainList[0].chain_id,
+    });
+
+    act(() => {
+      result.current.setFraction(0.75);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isMaxValue).toBe(false);
+      expect(result.current.isHalfValue).toBe(false);
+      expect(result.current.isQuarterValue).toBe(false);
+      expect(result.current.isThreeQuartersValue).toBe(true);
+      expect(result.current.inputAmount).toBe("750");
+    });
+
+    act(() => {
+      result.current.setAmount("750");
+    });
+
+    await waitFor(() => {
+      expect(result.current.fraction).toBe(null);
+      expect(result.current.isThreeQuartersValue).toBe(true);
     });
   });
 

--- a/packages/web/hooks/input/use-amount-input.ts
+++ b/packages/web/hooks/input/use-amount-input.ts
@@ -131,12 +131,32 @@ export function useAmountInput({
     }
   }, [currency, inputAmount, fraction, rawCurrencyBalance, maxAmountWithGas]);
 
+  const isQuarterValue = useMemo(
+    () =>
+      fraction === 0.25 ||
+      (rawCurrencyBalance && amount
+        ? new Dec(amount.toCoin().amount).equals(
+            new Dec(rawCurrencyBalance).mul(new Dec(0.25))
+          )
+        : false),
+    [amount, fraction, rawCurrencyBalance]
+  );
   const isHalfValue = useMemo(
     () =>
       fraction === 0.5 ||
       (rawCurrencyBalance && amount
         ? new Dec(amount.toCoin().amount).equals(
             new Dec(rawCurrencyBalance).mul(new Dec(0.5))
+          )
+        : false),
+    [amount, fraction, rawCurrencyBalance]
+  );
+  const isThreeQuartersValue = useMemo(
+    () =>
+      fraction === 0.75 ||
+      (rawCurrencyBalance && amount
+        ? new Dec(amount.toCoin().amount).equals(
+            new Dec(rawCurrencyBalance).mul(new Dec(0.75))
           )
         : false),
     [amount, fraction, rawCurrencyBalance]
@@ -211,7 +231,9 @@ export function useAmountInput({
     fraction,
     isEmpty: inputAmountWithFraction === "",
     error,
+    isQuarterValue,
     isHalfValue,
+    isThreeQuartersValue,
     isMaxValue,
     setAmount,
     reset,


### PR DESCRIPTION
## What is the purpose of the change

Adds four amount preset shortcuts (25% | 50% | 75% | Max) on the From field of both the swap tool and the place-limit tool, so users no longer have to type percentage amounts manually. A common community request; previously only a standalone Max button existed.

The presets are wired to the existing `useAmountInput.setFraction` primitive (`balance × percentage`), rendered as compact pill buttons on their own right-aligned line beneath the available-balance line. The Max preset replaces the old standalone Max button (the `toggleMax` button in place-limit-tool was removed).

### Linear Task

https://linear.app/osmosis/issue/MTN-15/feat-amount-preset-shortcuts-on-swap-tab

## Brief Changelog

**packages/web/components/swap-tool/amount-preset-row.tsx** (new)
- Presentational row of four pill buttons (`25% | 50% | 75% | Max`), `rounded-5xl` bordered pills matching the old Max button, filled (`bg-wosmongton-100`) when active. Props: `onSelect(fraction)`, `activeFraction`, `isDisabled` (all presets), `isMaxDisabled` (Max only), `isLoadingMax`.

**packages/web/hooks/input/use-amount-input.ts**
- Added `isQuarterValue` and `isThreeQuartersValue` derived flags, mirroring the existing `isHalfValue` / `isMaxValue` pattern exactly (including the amount-vs-balance fallback so the active pill doesn't flicker after `setAmount` clears the fraction).

**packages/web/components/swap-tool/index.tsx**
- Renders the preset row (gated on wallet-connected + non-zero balance). `onSelect` forces `quoteType` back to `out-given-in`, calls `inAmountInput.setFraction`, and refocuses the input. Removed `onMax` from the header balance.

**packages/web/components/place-limit-tool/index.tsx**
- Renders the preset row for market, limit-sell, and limit-buy. Limit-buy applies the fraction to the quote balance the buyer spends via `setLimitBuyBalanceFraction`, with local highlight state cleared on manual input. Removed the standalone `toggleMax` button. Header label vertical padding aligned with swap-tool so the two tabs match.

## Gas semantics

- Only the **Max** preset is gas-aware: `setFraction(1)` routes through `maxAmountWithGas` and subtracts the gas reserve (only when the input asset is also the fee asset).
- **25/50/75 are intentionally not gas-aware**: they use raw `balance × fraction`, keeping them accessible rather than gating selection on a mostly-irrelevant gas query. The existing button-level `InsufficientBalanceForFeeError` is the signal if gas can't be covered.
- The gas-estimation loading state and `notEnoughBalanceForMax` disable only the Max pill; during estimation the Max label is replaced by a centered spinner and the pill holds its width so the row does not reflow.

**packages/e2e/pages/trade-page.ts**
- `swapMaxBtn` now locates the Max preset by button role: the old `//span[.="Max"]` XPath stopped matching once the label became direct button text inside the preset pill, which timed out `clickMaxAmountButton` in preview-trade-tests.

## Updates (2026-07-03)

- Post-ready bot round: sell-side presets (market and limit-sell) now honor the active input focus. Token focus keeps the input-fraction path (Max stays gas-aware); fiat focus mirrors the removed Max button scaled by the fraction (base balance × price via `setAmountSafe`), so the visible fiat amount, market amounts, and quote type stay in sync instead of the display going stale.
- Second bot round: the fiat-focus path now branches per tab, mirroring the removed Max button exactly (quote balance as-is on buy, base balance × price on sell); market buy defaults to fiat focus and was scaling the wrong balance.
- Heads-up for reviewers: the pill row is being replaced by a continuous balance-fraction slider (design iteration in progress with detent snapping, hover percent, commit-on-release quoting). Hold off on pill-styling review; the behavioral wiring (fraction semantics, gas-aware max, focus handling) carries over.

## Testing

- `use-amount-input.spec.ts`: 18/18 passing, including quarter / three-quarters fraction and amount-vs-balance fallback specs.
- tsc, eslint, prettier clean on touched files.
- Reviewed by osmosis-frontend-reviewer: no blockers. Two product questions resolved: token-focused Max-buy truncation matches the old `toggleMax` behavior (accepted); 25/50/75 non-gas-aware by design.

## Still needs a human pass

- Manual check on the preview deploy: pill styling/layout on swap + limit tabs (desktop and 375px mobile), active-pill highlight behavior, Max spinner during gas estimation.
