### PR TITLE
ci(e2e): skip preview E2E suite for draft PRs

### DIFF
--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -1,16 +1,25 @@
 name: Preview frontend E2E tests
 
+# Run on non-draft PR pushes (and when a draft is marked ready for review),
+# plus direct pushes to stage for post-merge validation. Draft PRs skip the
+# suite entirely — the preview E2E tests spend real funds on every run.
 on:
   push:
-    branches-ignore:
-      - master
+    branches:
+      - stage
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
+# Every other job needs one of these two root jobs, so gating them on
+# non-draft skips the whole suite for draft PRs. The fork guard keeps
+# secret-less fork PRs from starting runs that can only fail.
 jobs:
   wait-for-deployment:
+    if: github.event_name == 'push' || (github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == false)
     runs-on: ubuntu-latest
     outputs:
       environment_url: ${{steps.vercel.outputs.environment_url}}
@@ -31,6 +40,7 @@ jobs:
         run: echo "$environment_url"
 
   check-balances:
+    if: github.event_name == 'push' || (github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == false)
     runs-on: ubuntu-latest
     permissions:
       actions: write
@@ -154,7 +164,7 @@ jobs:
                   -f dry_run=false \
                   -f topup_multiplier=1.5 \
                   -f reserve_osmo=5 \
-                  -f reserve_usdc=500
+                  -f reserve_usdc=250
                 echo "Topup workflow dispatched (balance outcome: $OUTCOME)."
               fi
             else


### PR DESCRIPTION
## What is the purpose of the change:

Stop the preview E2E suite from running on draft PRs. The preview E2E tests spend real funds on every run, so drafts should not trigger them; the suite now runs only when a PR is (or becomes) ready for review, plus on pushes to `stage` for post-merge validation.

### Linear Task

N/A — no tracked issue for this change.

## Brief Changelog

- Switch the `frontend-e2e-tests.yml` trigger from `push` on all branches to `pull_request` (`opened`, `reopened`, `synchronize`, `ready_for_review`), keeping a `push` trigger for `stage` only.
- Gate the two root jobs (`wait-for-deployment`, `check-balances`) on non-draft, non-fork PRs — every other job depends on them, so draft PRs skip the whole suite, and marking a draft ready immediately runs it.
- Lower the auto-topup `reserve_usdc` from 500 to 250 to match the reduced spend.

## Testing and Verifying

This change has not been tested locally because workflow triggers only take effect once merged; the YAML matches the existing `pull_request`-triggered workflows in this repo, and the draft/fork gating uses standard `github.event.pull_request` fields. Will verify on the first draft PR after merge (no run) and on marking it ready (run starts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when costly E2E runs and can leave draft PRs without preview E2E until marked ready; misconfigured triggers or `if` conditions could skip needed runs or still run on forks.
> 
> **Overview**
> Stops **fund-spending preview E2E** from running on draft PRs and limits when the workflow fires at all.
> 
> **Triggers** move from broad `push` (all branches except `master`) to `pull_request` (`opened`, `reopened`, `synchronize`, `ready_for_review`) plus **`push` to `stage` only** for post-merge checks. **`wait-for-deployment`** and **`check-balances`** get an `if` so they run on `stage` pushes or on **non-draft, non-fork** PRs; downstream jobs depend on those roots, so drafts and fork PRs skip the full suite until a draft is marked ready.
> 
> Auto-topup dispatch lowers **`reserve_usdc`** from **500 → 250** to align with reduced spend.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 773df786501c620295745f4d62aa27d7ee7fe5ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->