### PR TITLE
fix(bridge): don't crash tx history when a transfer's chain is delisted

### DIFF
--- a/packages/bridge/src/ibc/__tests__/ibc-transfer-status.spec.ts
+++ b/packages/bridge/src/ibc/__tests__/ibc-transfer-status.spec.ts
@@ -441,4 +441,26 @@ describe("IbcTransferStatusProvider", () => {
 
     expect(url).toBe(`https://www.mintscan.io/osmosis/txs/ABC123`);
   });
+
+  it("returns an empty explorer url (does not throw) when the from-chain is not in the registry", () => {
+    // A saved snapshot may reference a chain that has since been delisted from
+    // the registry. The explorer link is cosmetic and must degrade to no link
+    // rather than throwing into the transaction history render path, but should
+    // still log a breadcrumb so an unexpected missing chain stays visible.
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const snapshot: TxSnapshot = createTxSnapshot({
+      sendTxHash: "ABC123",
+      fromChain: {
+        chainId: "stargaze-1",
+        prettyName: "Stargaze",
+        chainType: "cosmos",
+      },
+    });
+
+    expect(() => provider.makeExplorerUrl(snapshot)).not.toThrow();
+    expect(provider.makeExplorerUrl(snapshot)).toBe("");
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("chain not found: stargaze-1")
+    );
+  });
 });

--- a/packages/bridge/src/ibc/transfer-status.ts
+++ b/packages/bridge/src/ibc/transfer-status.ts
@@ -323,7 +323,16 @@ export class IbcTransferStatusProvider implements TransferStatusProvider {
       (chain) => chain.chain_id === fromChainId
     );
 
-    if (!chain) throw new Error("Chain not found: " + fromChainId);
+    // Chain may no longer be in the registry (e.g. a delisted chain in an old
+    // saved snapshot). The explorer link is cosmetic, so degrade to no link
+    // rather than throwing into the transaction history render path, but keep
+    // a breadcrumb so an unexpected missing chain is still visible.
+    if (!chain) {
+      console.warn(
+        `[IbcTransferStatus] Cannot build explorer URL, chain not found: ${fromChainId}`
+      );
+      return "";
+    }
     if (chain.explorers.length === 0) {
       // attempt to link to mintscan since this is an IBC transfer
       return `https://www.mintscan.io/${chain.chain_name}/txs/${sendTxHash}`;

--- a/packages/bridge/src/int3face/transfer-status.ts
+++ b/packages/bridge/src/int3face/transfer-status.ts
@@ -163,7 +163,16 @@ export class Int3faceTransferStatusProvider implements TransferStatusProvider {
       (chain) => chain.chain_id === fromChainId
     );
 
-    if (!chain) throw new Error("Chain not found: " + fromChainId);
+    // Chain may no longer be in the registry (e.g. a delisted chain in an old
+    // saved snapshot). The explorer link is cosmetic, so degrade to no link
+    // rather than throwing into the transaction history render path, but keep
+    // a breadcrumb so an unexpected missing chain is still visible.
+    if (!chain) {
+      console.warn(
+        `[Int3faceTransferStatus] Cannot build explorer URL, chain not found: ${fromChainId}`
+      );
+      return "";
+    }
     if (chain.explorers.length === 0) {
       // attempt to link to mintscan since this is an IBC transfer
       return `https://www.mintscan.io/${chain.chain_name}/txs/${sendTxHash}`;

--- a/packages/bridge/src/interface.ts
+++ b/packages/bridge/src/interface.ts
@@ -605,6 +605,10 @@ export interface TransferStatusProvider {
    */
   trackTxStatus(snapshot: TxSnapshot): void;
 
-  /** Make url to this tx explorer. */
+  /**
+   * Make url to this tx explorer. Returns "" when no explorer link can be
+   * resolved (e.g. the snapshot's from-chain is no longer in the registry),
+   * so callers should treat an empty string as "no link available".
+   */
   makeExplorerUrl(snapshot: TxSnapshot): string;
 }

--- a/packages/bridge/src/nomic/transfer-status.ts
+++ b/packages/bridge/src/nomic/transfer-status.ts
@@ -86,7 +86,16 @@ export class NomicTransferStatusProvider implements TransferStatusProvider {
       (chain) => chain.chain_id === fromChainId
     );
 
-    if (!chain) throw new Error("Chain not found: " + fromChainId);
+    // Chain may no longer be in the registry (e.g. a delisted chain in an old
+    // saved snapshot). The explorer link is cosmetic, so degrade to no link
+    // rather than throwing into the transaction history render path, but keep
+    // a breadcrumb so an unexpected missing chain is still visible.
+    if (!chain) {
+      console.warn(
+        `[NomicTransferStatus] Cannot build explorer URL, chain not found: ${fromChainId}`
+      );
+      return "";
+    }
     if (chain.explorers.length === 0) {
       // attempt to link to mintscan since this is an IBC transfer
       return `https://www.mintscan.io/${chain.chain_name}/txs/${sendTxHash}`;

--- a/packages/bridge/src/skip/transfer-status.ts
+++ b/packages/bridge/src/skip/transfer-status.ts
@@ -119,7 +119,16 @@ export class SkipTransferStatusProvider implements TransferStatusProvider {
         (chain) => chain.chain_id === fromChainId
       );
 
-      if (!chain) throw new Error("Chain not found: " + fromChainId);
+      // Chain may no longer be in the registry (e.g. a delisted chain in an
+      // old saved snapshot). The explorer link is cosmetic, so degrade to no
+      // link rather than throwing into the transaction history render path,
+      // but keep a breadcrumb so an unexpected missing chain is still visible.
+      if (!chain) {
+        console.warn(
+          `[SkipTransferStatus] Cannot build explorer URL, chain not found: ${fromChainId}`
+        );
+        return "";
+      }
 
       if (chain.explorers.length === 0) {
         // attempt to link to mintscan since this is an IBC transfer

--- a/packages/bridge/src/squid/transfer-status.ts
+++ b/packages/bridge/src/squid/transfer-status.ts
@@ -140,7 +140,16 @@ export class SquidTransferStatusProvider implements TransferStatusProvider {
         (chain) => chain.chain_id === fromChainId
       );
 
-      if (!chain) throw new Error("Chain not found: " + fromChainId);
+      // Chain may no longer be in the registry (e.g. a delisted chain in an
+      // old saved snapshot). The explorer link is cosmetic, so degrade to no
+      // link rather than throwing into the transaction history render path,
+      // but keep a breadcrumb so an unexpected missing chain is still visible.
+      if (!chain) {
+        console.warn(
+          `[SquidTransferStatus] Cannot build explorer URL, chain not found: ${fromChainId}`
+        );
+        return "";
+      }
 
       if (chain.explorers.length === 0) {
         // attempt to link to mintscan since this is an IBC transfer

--- a/packages/web/stores/transfer-history.tsx
+++ b/packages/web/stores/transfer-history.tsx
@@ -82,12 +82,24 @@ export class TransferHistoryStore implements TransferStatusReceiver {
         snapshot.provider.startsWith(source.providerId)
       );
       if (statusSource && snapshot.osmoBech32Address === accountAddress) {
+        // makeExplorerUrl already returns "" when it can't resolve a link
+        // (e.g. the tx's chain is no longer in the registry). This try/catch
+        // is a render-safety backstop: an explorer URL is cosmetic, so any
+        // unexpected throw from a status provider must not escape this computed
+        // and crash the transaction history / portfolio page. Fall back to an
+        // empty URL, which the UI renders as "no explorer link".
+        let explorerUrl = "";
+        try {
+          explorerUrl = statusSource.makeExplorerUrl(snapshot);
+        } catch (e) {
+          console.error("Failed to build transfer explorer URL", e);
+        }
         histories.push({
           ...snapshot,
           sendTxHash: snapshot.sendTxHash,
           createdAt: new Date(snapshot.createdAtUnix * 1000),
           providerName: statusSource.sourceDisplayName,
-          explorerUrl: statusSource.makeExplorerUrl(snapshot),
+          explorerUrl,
         });
       }
     });


### PR DESCRIPTION
## Problem

The portfolio / transaction-history page could white-screen for a user whose local transfer history held a transfer on a chain that is no longer in the chain registry (real trigger: a delisted `stargaze-1` transfer persisted in IndexedDB).

`getHistoriesByAccount` (a mobx `computedFn` in `packages/web/stores/transfer-history.tsx`) calls `statusSource.makeExplorerUrl(snapshot)` for every saved transfer. `makeExplorerUrl` threw `Error("Chain not found: " + chainId)` when the snapshot's from-chain was missing from the registry. That throw escaped the mobx computed into React render and crashed the whole transaction-history view. Users without such a transfer in their local history were unaffected, which made it look intermittent.

An explorer link is cosmetic, so its failure should degrade to "no link", not take down the page.

## Fix

Two layers:

1. **Graceful providers.** `makeExplorerUrl` now returns `""` instead of throwing when the from-chain is not in the registry, across all five status providers (`ibc`, `int3face`, `squid`, `skip`, `nomic`). This fixes the actual trigger. It is not a silent fail: each degrade path logs a `console.warn` breadcrumb with the provider and chain id, so a genuinely-unexpected missing chain stays visible in the console (a delisted chain in old localStorage is expected, hence `warn` not `error`).
2. **Render-safety backstop.** The `makeExplorerUrl` call in the store computed is wrapped in a per-snapshot `try/catch` that falls back to `explorerUrl: ""` and logs at `console.error`. A throw from any provider (including a future one) now affects at most that one row instead of crashing the page.

The consumer (`transaction-transfer-details.tsx`) already gates the explorer link on a truthy `explorerUrl` (both when deriving it and at render), so `""` degrades cleanly to no link. It is the only consumer of this field in `packages/web`.

The interface contract in `packages/bridge/src/interface.ts` now documents that `""` means "no link available".

## Changes

- `packages/bridge/src/{ibc,int3face,squid,skip,nomic}/transfer-status.ts`: `if (!chain) throw ...` becomes a `console.warn` breadcrumb plus `return ""`.
- `packages/web/stores/transfer-history.tsx`: per-snapshot `try/catch` guard around `makeExplorerUrl`.
- `packages/bridge/src/interface.ts`: document the empty-string return contract.
- `packages/bridge/src/ibc/__tests__/ibc-transfer-status.spec.ts`: regression test asserting a `stargaze-1` snapshot returns `""`, does not throw, and logs the breadcrumb.

8 files changed, 90 insertions(+), 7 deletions(-).

## Testing

- `packages/bridge` IBC transfer-status suite: 11/11 pass, including the new regression test (which fails against the pre-fix throw).
- `packages/bridge` `tsc` build: clean.
- `packages/web` `tsc --noEmit`: no errors in the touched file.
- Prettier: content-clean on all touched files.

## Risk

Low and contained. The only behavior change is that an unresolvable explorer link now yields no link instead of a thrown error; the mintscan fallback and the normal `txPage` path are unchanged. Verified there is no other reader of the store's `explorerUrl` field that would render an empty `href`.
