### PR TITLE
fix(bridge): account for additive Skip bridge fees in max-amount deposits

### DIFF
--- a/packages/bridge/src/interface.ts
+++ b/packages/bridge/src/interface.ts
@@ -486,7 +486,13 @@ export interface BridgeQuote {
   /**
    * The fee for the transfer.
    */
-  transferFee: BridgeCoin & { chainId: number | string };
+  transferFee: BridgeCoin & {
+    chainId: number | string;
+    /** When true, the fee is charged on top of the input amount — the sent
+     *  transaction requires `amount + fee` from the user's balance — rather
+     *  than being deducted from the transferred amount in transit. */
+    isAdditive?: boolean;
+  };
   /**
    * The estimated time to execute the transfer, represented in seconds.
    */

--- a/packages/bridge/src/skip/__tests__/skip-bridge-provider.spec.ts
+++ b/packages/bridge/src/skip/__tests__/skip-bridge-provider.spec.ts
@@ -3,6 +3,7 @@ import { CacheEntry } from "cachified";
 import { LRUCache } from "lru-cache";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { rest } from "msw";
+import { createPublicClient } from "viem";
 
 import { MockAssetLists } from "../../__tests__/mock-asset-lists";
 import { server } from "../../__tests__/msw";
@@ -267,6 +268,7 @@ describe("SkipBridgeProvider", () => {
         coinGeckoId: undefined,
         address: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
         decimals: 18,
+        isAdditive: false,
       },
       estimatedTime: 30,
       transactionRequest: {
@@ -286,6 +288,60 @@ describe("SkipBridgeProvider", () => {
         address: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
       },
     });
+  });
+
+  it("flags the transfer fee as additive when Skip reports FEE_BEHAVIOR_ADDITIONAL", async () => {
+    server.use(
+      rest.post("https://api.skip.money/v2/fungible/route", (_req, res, ctx) =>
+        res(
+          ctx.json({
+            ...ETH_EthereumToOsmosis_Route,
+            estimated_fees: [
+              {
+                fee_type: "BRIDGE",
+                bridge_id: "AXELAR",
+                // matches the axelar_transfer op's fee_amount in the route mock
+                amount: "73924361079993",
+                usd_amount: "0.26",
+                origin_asset: null,
+                chain_id: "1",
+                tx_index: 0,
+                fee_behavior: "FEE_BEHAVIOR_ADDITIONAL",
+              },
+            ],
+          })
+        )
+      ),
+      rest.post("https://api.skip.money/v2/fungible/msgs", (_req, res, ctx) =>
+        res(ctx.json(ETH_EthereumToOsmosis_Msgs))
+      )
+    );
+
+    const quote = await provider.getQuote({
+      fromAmount: "10000000000000000000",
+      toAsset: {
+        denom: "ETH",
+        address:
+          "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
+        decimals: 18,
+      },
+      toChain: {
+        chainId: "osmosis-1",
+        chainName: "osmosis",
+        chainType: "cosmos",
+      },
+      fromAsset: {
+        denom: "WETH",
+        address: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        decimals: 18,
+      },
+      fromChain: { chainId: 1, chainName: "Ethereum", chainType: "evm" },
+      toAddress: "osmo107vyuer6wzfe7nrrsujppa0pvx35fvplp4t7tx",
+      fromAddress: "0x7863Ec05b123885c7609B05c35Df777F3F180258",
+      slippage: 0.01,
+    });
+
+    expect(quote.transferFee.isAdditive).toBe(true);
   });
 
   it("should handle unsupported asset error", async () => {
@@ -386,6 +442,20 @@ describe("SkipBridgeProvider", () => {
     expect(gasCost).toBeDefined();
     expect(gasCost?.amount).toBeDefined();
     expect(gasCost?.denom).toBe("ETH");
+
+    // The sender's balance is overridden so estimation succeeds even when
+    // the wallet can't currently fund value + fee (max-amount inputs).
+    const client = (createPublicClient as jest.Mock).mock.results.at(-1)?.value;
+    expect(client.estimateGas).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stateOverride: [
+          {
+            address: "0xabc",
+            balance: BigInt("0x3e8") + BigInt("1000000000000000000"),
+          },
+        ],
+      })
+    );
   });
 
   it("should estimate gas cost - Cosmos transactions", async () => {

--- a/packages/bridge/src/skip/__tests__/skip-bridge-provider.spec.ts
+++ b/packages/bridge/src/skip/__tests__/skip-bridge-provider.spec.ts
@@ -31,6 +31,10 @@ jest.mock("viem", () => ({
     estimateGas: jest.fn().mockResolvedValue(BigInt("21000")),
     request: jest.fn().mockResolvedValue("0x4a817c800"),
     getGasPrice: jest.fn().mockResolvedValue(BigInt("20000000000")),
+    estimateFeesPerGas: jest.fn().mockResolvedValue({
+      maxFeePerGas: BigInt("40000000000"),
+      maxPriorityFeePerGas: BigInt("1000000000"),
+    }),
     readContract: jest.fn().mockResolvedValue(BigInt("100")),
   })),
   encodeFunctionData: jest.fn().mockReturnValue("0xabcdef"),
@@ -282,7 +286,9 @@ describe("SkipBridgeProvider", () => {
         },
       },
       estimatedGasFee: {
-        amount: "420000000000000",
+        // 21000 gas * 40 gwei maxFeePerGas — the wallet's worst-case
+        // (EIP-1559) price, not the legacy 20 gwei gasPrice
+        amount: "840000000000000",
         denom: "ETH",
         decimals: 18,
         address: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",

--- a/packages/bridge/src/skip/__tests__/skip-bridge-provider.spec.ts
+++ b/packages/bridge/src/skip/__tests__/skip-bridge-provider.spec.ts
@@ -355,6 +355,66 @@ describe("SkipBridgeProvider", () => {
     expect(quote.transferFee.isAdditive).toBe(true);
   });
 
+  it("ignores non-bridge fee_behavior entries when flagging the transfer fee", async () => {
+    server.use(
+      rest.post("https://api.skip.money/v2/fungible/route", (_req, res, ctx) =>
+        res(
+          ctx.json({
+            ...ETH_OsmosisToEthereum_Route,
+            estimated_fees: [
+              {
+                // an additive relay fee must not mark the (deducted)
+                // Cosmos-source bridge fee as additive
+                fee_type: "SMART_RELAY",
+                bridge_id: "IBC",
+                amount: "100",
+                usd_amount: "0.01",
+                origin_asset: null,
+                chain_id: "osmosis-1",
+                tx_index: 0,
+                fee_behavior: "FEE_BEHAVIOR_ADDITIONAL",
+              },
+            ],
+          })
+        )
+      ),
+      rest.post("https://api.skip.money/v2/fungible/msgs", (_req, res, ctx) =>
+        res(ctx.json(ETH_OsmosisToEthereum_Msgs))
+      )
+    );
+
+    (estimateGasFee as jest.Mock).mockResolvedValue({
+      gas: "420000",
+      amount: [{ denom: "uosmo", amount: "1232" }],
+    });
+
+    const quote = await provider.getQuote({
+      fromAmount: "10000000000000000000",
+      fromAsset: {
+        denom: "ETH",
+        address:
+          "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
+        decimals: 18,
+      },
+      fromChain: {
+        chainId: "osmosis-1",
+        chainName: "osmosis",
+        chainType: "cosmos",
+      },
+      toAsset: {
+        denom: "WETH",
+        address: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+        decimals: 18,
+      },
+      toChain: { chainId: 1, chainName: "Ethereum", chainType: "evm" },
+      fromAddress: "osmo107vyuer6wzfe7nrrsujppa0pvx35fvplp4t7tx",
+      toAddress: "0x7863Ec05b123885c7609B05c35Df777F3F180258",
+      slippage: 0.01,
+    });
+
+    expect(quote.transferFee.isAdditive).toBe(false);
+  });
+
   it("should handle unsupported asset error", async () => {
     server.use(
       rest.get(

--- a/packages/bridge/src/skip/__tests__/skip-bridge-provider.spec.ts
+++ b/packages/bridge/src/skip/__tests__/skip-bridge-provider.spec.ts
@@ -301,25 +301,63 @@ describe("SkipBridgeProvider", () => {
     });
   });
 
-  it("flags the transfer fee as additive when Skip reports FEE_BEHAVIOR_ADDITIONAL", async () => {
+  // the Axelar BRIDGE fee entry Skip returns for the
+  // ETH_EthereumToOsmosis_Route mock (fee_behavior varies per test)
+  const axelarBridgeFee = {
+    fee_type: "BRIDGE",
+    bridge_id: "AXELAR",
+    // matches the axelar_transfer op's fee_amount in the route mock
+    amount: "73924361079993",
+    usd_amount: "0.26",
+    origin_asset: {
+      denom: "ethereum-native",
+      chain_id: "1",
+      origin_denom: "ethereum-native",
+      origin_chain_id: "1",
+      trace: "",
+      is_cw20: false,
+      is_evm: true,
+      is_svm: false,
+      symbol: "ETH",
+      name: "Ethereum",
+      decimals: 18,
+      coingecko_id: "ethereum",
+    },
+    chain_id: "1",
+    tx_index: 0,
+  };
+
+  const ethereumToOsmosisQuoteParams: GetBridgeQuoteParams = {
+    fromAmount: "10000000000000000000",
+    toAsset: {
+      denom: "ETH",
+      address:
+        "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
+      decimals: 18,
+    },
+    toChain: {
+      chainId: "osmosis-1",
+      chainName: "osmosis",
+      chainType: "cosmos",
+    },
+    fromAsset: {
+      denom: "WETH",
+      address: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+      decimals: 18,
+    },
+    fromChain: { chainId: 1, chainName: "Ethereum", chainType: "evm" },
+    toAddress: "osmo107vyuer6wzfe7nrrsujppa0pvx35fvplp4t7tx",
+    fromAddress: "0x7863Ec05b123885c7609B05c35Df777F3F180258",
+    slippage: 0.01,
+  };
+
+  const useEthereumToOsmosisRouteWithFeeBehavior = (fee_behavior: string) =>
     server.use(
       rest.post("https://api.skip.money/v2/fungible/route", (_req, res, ctx) =>
         res(
           ctx.json({
             ...ETH_EthereumToOsmosis_Route,
-            estimated_fees: [
-              {
-                fee_type: "BRIDGE",
-                bridge_id: "AXELAR",
-                // matches the axelar_transfer op's fee_amount in the route mock
-                amount: "73924361079993",
-                usd_amount: "0.26",
-                origin_asset: null,
-                chain_id: "1",
-                tx_index: 0,
-                fee_behavior: "FEE_BEHAVIOR_ADDITIONAL",
-              },
-            ],
+            estimated_fees: [{ ...axelarBridgeFee, fee_behavior }],
           })
         )
       ),
@@ -328,29 +366,26 @@ describe("SkipBridgeProvider", () => {
       )
     );
 
-    const quote = await provider.getQuote({
-      fromAmount: "10000000000000000000",
-      toAsset: {
-        denom: "ETH",
-        address:
-          "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
-        decimals: 18,
-      },
-      toChain: {
-        chainId: "osmosis-1",
-        chainName: "osmosis",
-        chainType: "cosmos",
-      },
-      fromAsset: {
-        denom: "WETH",
-        address: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
-        decimals: 18,
-      },
-      fromChain: { chainId: 1, chainName: "Ethereum", chainType: "evm" },
-      toAddress: "osmo107vyuer6wzfe7nrrsujppa0pvx35fvplp4t7tx",
-      fromAddress: "0x7863Ec05b123885c7609B05c35Df777F3F180258",
-      slippage: 0.01,
-    });
+  it("flags the transfer fee as additive when Skip reports FEE_BEHAVIOR_ADDITIONAL", async () => {
+    useEthereumToOsmosisRouteWithFeeBehavior("FEE_BEHAVIOR_ADDITIONAL");
+
+    const quote = await provider.getQuote(ethereumToOsmosisQuoteParams);
+
+    expect(quote.transferFee.isAdditive).toBe(true);
+  });
+
+  it("trusts an explicit FEE_BEHAVIOR_DEDUCTED over the EVM additive default", async () => {
+    useEthereumToOsmosisRouteWithFeeBehavior("FEE_BEHAVIOR_DEDUCTED");
+
+    const quote = await provider.getQuote(ethereumToOsmosisQuoteParams);
+
+    expect(quote.transferFee.isAdditive).toBe(false);
+  });
+
+  it("falls back to additive on EVM sources when fee_behavior is FEE_BEHAVIOR_UNSPECIFIED", async () => {
+    useEthereumToOsmosisRouteWithFeeBehavior("FEE_BEHAVIOR_UNSPECIFIED");
+
+    const quote = await provider.getQuote(ethereumToOsmosisQuoteParams);
 
     expect(quote.transferFee.isAdditive).toBe(true);
   });
@@ -369,7 +404,20 @@ describe("SkipBridgeProvider", () => {
                 bridge_id: "IBC",
                 amount: "100",
                 usd_amount: "0.01",
-                origin_asset: null,
+                origin_asset: {
+                  denom: "uosmo",
+                  chain_id: "osmosis-1",
+                  origin_denom: "uosmo",
+                  origin_chain_id: "osmosis-1",
+                  trace: "",
+                  is_cw20: false,
+                  is_evm: false,
+                  is_svm: false,
+                  symbol: "OSMO",
+                  name: "Osmosis",
+                  decimals: 6,
+                  coingecko_id: "osmosis",
+                },
                 chain_id: "osmosis-1",
                 tx_index: 0,
                 fee_behavior: "FEE_BEHAVIOR_ADDITIONAL",

--- a/packages/bridge/src/skip/__tests__/skip-bridge-provider.spec.ts
+++ b/packages/bridge/src/skip/__tests__/skip-bridge-provider.spec.ts
@@ -163,6 +163,9 @@ describe("SkipBridgeProvider", () => {
         chainId: 1,
         address: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
         decimals: 18,
+        // Cosmos-source: no explicit fee_behavior and not EVM-source,
+        // so the fee is treated as deducted from the transferred amount
+        isAdditive: false,
       },
       estimatedTime: 30,
       transactionRequest: {
@@ -272,7 +275,9 @@ describe("SkipBridgeProvider", () => {
         coinGeckoId: undefined,
         address: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
         decimals: 18,
-        isAdditive: false,
+        // EVM-source with no explicit fee_behavior in the route's
+        // estimated_fees: assumed additive per Skip's documented fee model
+        isAdditive: true,
       },
       estimatedTime: 30,
       transactionRequest: {

--- a/packages/bridge/src/skip/index.ts
+++ b/packages/bridge/src/skip/index.ts
@@ -27,7 +27,6 @@ import { BridgeQuoteError } from "../errors";
 import {
   BridgeAsset,
   BridgeChain,
-  BridgeCoin,
   BridgeExternalUrl,
   BridgeProvider,
   BridgeProviderContext,
@@ -163,7 +162,7 @@ export class SkipBridgeProvider implements BridgeProvider {
           toChain
         );
 
-        let transferFee: BridgeCoin & { chainId: number | string } = {
+        let transferFee: BridgeQuote["transferFee"] = {
           ...fromAsset,
           coinGeckoId: sourceAsset.coingecko_id,
           amount: "0",
@@ -186,6 +185,14 @@ export class SkipBridgeProvider implements BridgeProvider {
                   : feeAsset.token_contract!,
               decimals: feeAsset.decimals ?? 6,
               coinGeckoId: feeAsset.coingecko_id,
+              // For EVM-source transfers Skip charges the bridge fee on top of
+              // amount_in (the built tx's value is amount + fee), so max-amount
+              // inputs must leave room for it. Cosmos-source fees are deducted.
+              isAdditive: route.estimated_fees?.some(
+                (fee) =>
+                  fee.fee_behavior === "FEE_BEHAVIOR_ADDITIONAL" &&
+                  fee.amount === operation.axelar_transfer.fee_amount
+              ),
             };
           }
         }
@@ -910,6 +917,20 @@ export class SkipBridgeProvider implements BridgeProvider {
     txData: EvmBridgeTransactionRequest
   ) {
     try {
+      // Override the sender's balance to cover the tx value plus gas so the
+      // estimate prices the tx even when the wallet can't currently fund it.
+      // Skip charges additive bridge fees inside the tx value, so a max-amount
+      // input always exceeds the balance and the node would otherwise reject
+      // the estimate with "insufficient funds". Affordability is checked
+      // client-side against this estimate, not here.
+      const balanceOverride = {
+        address: params.fromAddress as Address,
+        balance:
+          (!isNil(txData.value) ? BigInt(txData.value) : BigInt(0)) +
+          // 1 native token (18 decimals) of headroom for the gas cost itself
+          BigInt("1000000000000000000"),
+      };
+
       if (!txData.approvalTransactionRequest) {
         return await provider
           .estimateGas({
@@ -917,6 +938,7 @@ export class SkipBridgeProvider implements BridgeProvider {
             to: txData.to,
             data: txData.data,
             value: !isNil(txData.value) ? BigInt(txData.value) : undefined,
+            stateOverride: [balanceOverride],
           })
           .then((gas) => BigInt(gas));
       }
@@ -947,6 +969,7 @@ export class SkipBridgeProvider implements BridgeProvider {
           data: txData.data,
           value: !isNil(txData.value) ? BigInt(txData.value) : undefined,
           stateOverride: [
+            balanceOverride,
             {
               address: txData.approvalTransactionRequest.to as Address,
               stateDiff: [

--- a/packages/bridge/src/skip/index.ts
+++ b/packages/bridge/src/skip/index.ts
@@ -837,7 +837,14 @@ export class SkipBridgeProvider implements BridgeProvider {
         return;
       }
 
-      const gasPrice = await provider.getGasPrice();
+      // Price gas at the wallet's worst case: wallets sign EIP-1559 txs
+      // budgeting maxFeePerGas (~2x base fee + tip), so a max-amount input
+      // clamped by a legacy eth_gasPrice estimate (~base + tip) still
+      // overshoots the sender's balance at signing time.
+      const gasPrice = await provider
+        .estimateFeesPerGas()
+        .then((fees) => fees.maxFeePerGas)
+        .catch(() => provider.getGasPrice());
 
       if (!gasPrice) {
         throw new Error("Failed to get gas price");

--- a/packages/bridge/src/skip/index.ts
+++ b/packages/bridge/src/skip/index.ts
@@ -169,6 +169,20 @@ export class SkipBridgeProvider implements BridgeProvider {
           chainId: fromChain.chainId,
         };
 
+        // Per Skip's fee docs, EVM-source bridge fees are charged on top of
+        // amount_in (the built tx's value is amount + fee) while Cosmos-source
+        // fees are deducted in transit. Prefer the API's explicit fee_behavior
+        // when present; otherwise assume additive for EVM sources so
+        // max-amount inputs reserve the fee (over-reserving strands fee-sized
+        // dust, under-reserving fails the wallet signature).
+        const feeBehaviors =
+          route.estimated_fees
+            ?.map((fee) => fee.fee_behavior)
+            .filter(Boolean) ?? [];
+        const isAdditiveFee = feeBehaviors.length
+          ? feeBehaviors.includes("FEE_BEHAVIOR_ADDITIONAL")
+          : fromChain.chainType === "evm";
+
         for (const operation of route.operations) {
           if ("axelar_transfer" in operation) {
             const feeAsset = operation.axelar_transfer.fee_asset;
@@ -185,14 +199,7 @@ export class SkipBridgeProvider implements BridgeProvider {
                   : feeAsset.token_contract!,
               decimals: feeAsset.decimals ?? 6,
               coinGeckoId: feeAsset.coingecko_id,
-              // For EVM-source transfers Skip charges the bridge fee on top of
-              // amount_in (the built tx's value is amount + fee), so max-amount
-              // inputs must leave room for it. Cosmos-source fees are deducted.
-              isAdditive: route.estimated_fees?.some(
-                (fee) =>
-                  fee.fee_behavior === "FEE_BEHAVIOR_ADDITIONAL" &&
-                  fee.amount === operation.axelar_transfer.fee_amount
-              ),
+              isAdditive: isAdditiveFee,
             };
           }
         }

--- a/packages/bridge/src/skip/index.ts
+++ b/packages/bridge/src/skip/index.ts
@@ -172,15 +172,18 @@ export class SkipBridgeProvider implements BridgeProvider {
         // Per Skip's fee docs, EVM-source bridge fees are charged on top of
         // amount_in (the built tx's value is amount + fee) while Cosmos-source
         // fees are deducted in transit. Prefer the API's explicit fee_behavior
-        // when present; otherwise assume additive for EVM sources so
-        // max-amount inputs reserve the fee (over-reserving strands fee-sized
-        // dust, under-reserving fails the wallet signature).
-        const feeBehaviors =
+        // on the BRIDGE fee entries (the ones transferFee represents — other
+        // fee types like SMART_RELAY say nothing about the bridge fee);
+        // otherwise assume additive for EVM sources so max-amount inputs
+        // reserve the fee (over-reserving strands fee-sized dust,
+        // under-reserving fails the wallet signature).
+        const bridgeFeeBehaviors =
           route.estimated_fees
-            ?.map((fee) => fee.fee_behavior)
+            ?.filter((fee) => fee.fee_type === "BRIDGE")
+            .map((fee) => fee.fee_behavior)
             .filter(Boolean) ?? [];
-        const isAdditiveFee = feeBehaviors.length
-          ? feeBehaviors.includes("FEE_BEHAVIOR_ADDITIONAL")
+        const isAdditiveFee = bridgeFeeBehaviors.length
+          ? bridgeFeeBehaviors.includes("FEE_BEHAVIOR_ADDITIONAL")
           : fromChain.chainType === "evm";
 
         for (const operation of route.operations) {

--- a/packages/bridge/src/skip/index.ts
+++ b/packages/bridge/src/skip/index.ts
@@ -182,9 +182,12 @@ export class SkipBridgeProvider implements BridgeProvider {
             ?.filter((fee) => fee.fee_type === "BRIDGE")
             .map((fee) => fee.fee_behavior)
             .filter(Boolean) ?? [];
-        const isAdditiveFee = bridgeFeeBehaviors.length
-          ? bridgeFeeBehaviors.includes("FEE_BEHAVIOR_ADDITIONAL")
-          : fromChain.chainType === "evm";
+        // Unknown/unspecified behaviors fall through to the EVM default so
+        // they fail toward over-reserving; only an explicit DEDUCTED opts out.
+        const isAdditiveFee =
+          bridgeFeeBehaviors.includes("FEE_BEHAVIOR_ADDITIONAL") ||
+          (!bridgeFeeBehaviors.includes("FEE_BEHAVIOR_DEDUCTED") &&
+            fromChain.chainType === "evm");
 
         for (const operation of route.operations) {
           if ("axelar_transfer" in operation) {

--- a/packages/bridge/src/skip/types.ts
+++ b/packages/bridge/src/skip/types.ts
@@ -95,8 +95,12 @@ export type SkipEstimatedFee = {
   chain_id: string;
   tx_index: number;
   /** `FEE_BEHAVIOR_ADDITIONAL`: charged on top of `amount_in` (EVM-source transfers).
-   *  `FEE_BEHAVIOR_DEDUCTED`: taken out of the transferred amount (Cosmos-source transfers). */
-  fee_behavior?: "FEE_BEHAVIOR_ADDITIONAL" | "FEE_BEHAVIOR_DEDUCTED";
+   *  `FEE_BEHAVIOR_DEDUCTED`: taken out of the transferred amount (Cosmos-source transfers).
+   *  `FEE_BEHAVIOR_UNSPECIFIED`: proto3 zero-value; treated as unknown. */
+  fee_behavior?:
+    | "FEE_BEHAVIOR_ADDITIONAL"
+    | "FEE_BEHAVIOR_DEDUCTED"
+    | "FEE_BEHAVIOR_UNSPECIFIED";
 };
 
 export type SkipOperation =

--- a/packages/bridge/src/skip/types.ts
+++ b/packages/bridge/src/skip/types.ts
@@ -81,7 +81,22 @@ export type SkipRouteResponse = {
   usd_amount_out?: string;
   swap_price_impact_percent?: string;
 
+  estimated_fees?: SkipEstimatedFee[];
+
   estimated_route_duration_seconds: number;
+};
+
+export type SkipEstimatedFee = {
+  fee_type: string;
+  bridge_id: string;
+  amount: string;
+  usd_amount: string;
+  origin_asset: SkipAsset | null;
+  chain_id: string;
+  tx_index: number;
+  /** `FEE_BEHAVIOR_ADDITIONAL`: charged on top of `amount_in` (EVM-source transfers).
+   *  `FEE_BEHAVIOR_DEDUCTED`: taken out of the transferred amount (Cosmos-source transfers). */
+  fee_behavior?: "FEE_BEHAVIOR_ADDITIONAL" | "FEE_BEHAVIOR_DEDUCTED";
 };
 
 export type SkipOperation =

--- a/packages/web/components/bridge/amount-screen.tsx
+++ b/packages/web/components/bridge/amount-screen.tsx
@@ -1266,6 +1266,11 @@ export const AmountScreen = observer(
             isInsufficientBal={Boolean(isInsufficientBal)}
             isInsufficientFee={Boolean(isInsufficientFee)}
             transferGasCost={selectedQuote?.gasCost}
+            additiveTransferFee={
+              selectedQuote?.isAdditiveFee
+                ? selectedQuote.transferFee
+                : undefined
+            }
             /** Wait for all quotes to resolve before modifying input amount.
              *  This helps reduce thrash while the best quote is being determined.
              *  Only once we get the best quote, we can modify the input amount

--- a/packages/web/components/bridge/use-bridge-quotes.ts
+++ b/packages/web/components/bridge/use-bridge-quotes.ts
@@ -448,6 +448,23 @@ export const useBridgeQuotes = ({
     );
     const inputAmount = inputCoin.toDec();
 
+    // Additive fees (e.g. Skip EVM bridge fees) are charged on top of the input,
+    // so the wallet must fund input + fee + gas. Compare that against the
+    // balance rather than deducting from the input — otherwise a manual amount
+    // (or a max on a dust balance) passes validation but fails at signing.
+    // Cross-denom coverage (native fee/gas vs a token input) is tracked in
+    // MTN-216.
+    if (selectedQuote.isAdditiveFee && availableBalance) {
+      let requiredAmount = inputAmount;
+      if (isFeeSameAsset) {
+        requiredAmount = requiredAmount.add(selectedQuote.transferFee.toDec());
+      }
+      if (isGasSameAsset) {
+        requiredAmount = requiredAmount.add(selectedQuote.gasCost.toDec());
+      }
+      return requiredAmount.gt(availableBalance.toDec());
+    }
+
     let totalFeeCoinAmount = new Dec(0);
     if (isGasSameAsset) {
       totalFeeCoinAmount = totalFeeCoinAmount.add(
@@ -467,7 +484,7 @@ export const useBridgeQuotes = ({
     }
 
     return false;
-  }, [someError, inputCoin, selectedQuote]);
+  }, [someError, inputCoin, selectedQuote, availableBalance]);
 
   // Extract fee details from error message if available (for bridge amount errors)
   const insufficientFeeDetails = useMemo(() => {

--- a/packages/web/components/bridge/use-bridge-quotes.ts
+++ b/packages/web/components/bridge/use-bridge-quotes.ts
@@ -263,6 +263,9 @@ export const useBridgeQuotes = ({
             return {
               gasCost: estimatedGasFee?.amount.maxDecimals(8),
               transferFee: transferFee.amount.maxDecimals(8),
+              // fee charged on top of the input amount, so max-amount
+              // inputs must leave room for it in the user's balance
+              isAdditiveFee: transferFee.isAdditive === true,
               expectedOutput: expectedOutput.amount,
               expectedOutputFiat: expectedOutput.fiatValue,
               transferFeeFiat: transferFee.fiatValue,

--- a/packages/web/components/control/__tests__/crypto-fiat-input-max-guard.spec.tsx
+++ b/packages/web/components/control/__tests__/crypto-fiat-input-max-guard.spec.tsx
@@ -25,7 +25,7 @@ function makeGasCost(amount: string) {
   return new CoinPretty(ATOM_CURRENCY, amount);
 }
 
-const MUL_GAS_SLIPPAGE = new Dec("1.1");
+const MUL_GAS_SLIPPAGE = new Dec("2");
 
 function expectedMaxAfterGas(balanceRaw: string, gasRaw: string) {
   const balance = new CoinPretty(ATOM_CURRENCY, balanceRaw);

--- a/packages/web/components/control/__tests__/crypto-fiat-input-max-guard.spec.tsx
+++ b/packages/web/components/control/__tests__/crypto-fiat-input-max-guard.spec.tsx
@@ -43,6 +43,8 @@ interface Props {
   canSetMax?: boolean;
   address?: string;
   additiveTransferFee?: CoinPretty;
+  isInsufficientBal?: boolean;
+  isInsufficientFee?: boolean;
 }
 
 function renderInput({
@@ -54,6 +56,8 @@ function renderInput({
   canSetMax = true,
   address = "uatom",
   additiveTransferFee,
+  isInsufficientBal = false,
+  isInsufficientFee = false,
 }: Props) {
   const balance = makeBalance(balanceRaw);
   return render(
@@ -77,8 +81,8 @@ function renderInput({
       onChangeCryptoInput={onChangeCryptoInput}
       fiatInput=""
       onChangeFiatInput={jest.fn()}
-      isInsufficientBal={false}
-      isInsufficientFee={false}
+      isInsufficientBal={isInsufficientBal}
+      isInsufficientFee={isInsufficientFee}
     />
   );
 }
@@ -352,132 +356,65 @@ describe("CryptoFiatInput gasAppliedToMax guard", () => {
     });
   });
 
-  it("clamps max to zero when gas plus the additive fee exceed the balance", async () => {
-    // Reproduces the dust-balance Skip deposit that failed on-chain: the
-    // additive bridge fee plus gas head-room cost more than the whole balance,
-    // so there is no fundable amount. The input must clamp to zero instead of
-    // leaving the full balance (which builds a tx whose value exceeds the
-    // balance and fails at signing).
-    const balanceRaw = "82750538726230";
-    const gasRaw = "16746229134611";
-    const feeRaw = "63381527751084";
+  it("leaves the input at the full balance when fees exceed it (quote stays visible)", async () => {
+    // Dust-balance Skip deposit: the additive bridge fee plus gas head-room
+    // cost more than the whole balance, so there is no fundable max. The input
+    // must NOT be clamped to zero — keeping it non-zero lets the quote and its
+    // fee breakdown render; useBridgeQuotes flags the shortfall and blocks the
+    // transfer.
+    const balanceRaw = "30000";
+    const gasRaw = "16000"; // *2 slippage = 32000, already over balance
+    const feeRaw = "20000";
     const onChangeCryptoInput = jest.fn();
 
-    const ETH_CURRENCY = {
-      coinDecimals: 18,
-      coinDenom: "ETH",
-      coinMinimalDenom: "wei",
-    };
-    const balance = new CoinPretty(ETH_CURRENCY, balanceRaw);
-
-    const { queryByText } = render(
-      <CryptoFiatInput
-        currentUnit="crypto"
-        setCurrentUnit={jest.fn()}
-        isMax={true}
-        setIsMax={jest.fn()}
-        canSetMax={true}
-        transferGasCost={new CoinPretty(ETH_CURRENCY, gasRaw)}
-        additiveTransferFee={new CoinPretty(ETH_CURRENCY, feeRaw)}
-        transferGasChain={{ prettyName: "Ethereum" }}
-        assetPrice={undefined}
-        assetWithBalance={{
-          denom: "ETH",
-          address: "wei",
-          decimals: 18,
-          amount: balance,
-        }}
-        cryptoInput={balance.toDec().toString()}
-        onChangeCryptoInput={onChangeCryptoInput}
-        fiatInput=""
-        onChangeFiatInput={jest.fn()}
-        isInsufficientBal={false}
-        isInsufficientFee={false}
-      />
-    );
-
-    await waitFor(() => {
-      expect(onChangeCryptoInput).toHaveBeenCalledWith("0");
+    renderInput({
+      isMax: true,
+      cryptoInput: makeBalance(balanceRaw).toDec().toString(),
+      transferGasCost: makeGasCost(gasRaw),
+      additiveTransferFee: new CoinPretty(ATOM_CURRENCY, feeRaw),
+      balanceRaw,
+      onChangeCryptoInput,
     });
 
-    // the user is told why max resolved to zero
-    await waitFor(() => {
-      expect(
-        queryByText("components.cryptoFiatInput.feesExceedBalance")
-      ).toBeInTheDocument();
-    });
+    await new Promise((r) => setTimeout(r, 100));
+    expect(onChangeCryptoInput).not.toHaveBeenCalledWith("0");
   });
 
-  it("keeps max at zero when quoting drops out after a fees-exceed-balance clamp", async () => {
-    // After clamping to zero the input stops quoting, so gas/fee go undefined.
-    // The no-quote branch must NOT restore the full balance — doing so would
-    // re-enable the unfundable transfer and oscillate the input.
-    const balanceRaw = "82750538726230";
-    const gasRaw = "16746229134611";
-    const feeRaw = "63381527751084";
-    const onChangeCryptoInput = jest.fn();
-
-    const ETH_CURRENCY = {
-      coinDecimals: 18,
-      coinDenom: "ETH",
-      coinMinimalDenom: "wei",
-    };
-    const balance = new CoinPretty(ETH_CURRENCY, balanceRaw);
-
-    const baseProps = {
-      currentUnit: "crypto" as const,
-      setCurrentUnit: jest.fn(),
-      setIsMax: jest.fn(),
-      canSetMax: true,
-      transferGasChain: { prettyName: "Ethereum" },
-      assetPrice: undefined,
-      assetWithBalance: {
-        denom: "ETH",
-        address: "wei",
-        decimals: 18,
-        amount: balance,
-      },
-      fiatInput: "",
-      onChangeFiatInput: jest.fn(),
-      isInsufficientBal: false,
-      isInsufficientFee: false,
-    };
-
-    // 1) Quote present, fees exceed balance -> clamp to zero
-    const { rerender } = render(
-      <CryptoFiatInput
-        {...baseProps}
-        isMax={true}
-        transferGasCost={new CoinPretty(ETH_CURRENCY, gasRaw)}
-        additiveTransferFee={new CoinPretty(ETH_CURRENCY, feeRaw)}
-        cryptoInput={balance.toDec().toString()}
-        onChangeCryptoInput={onChangeCryptoInput}
-      />
-    );
-
-    await waitFor(() => {
-      expect(onChangeCryptoInput).toHaveBeenCalledWith("0");
+  it("shows the fee-specific message when an additive fee makes the balance insufficient", () => {
+    const { queryByText } = renderInput({
+      isMax: false,
+      cryptoInput: "1",
+      transferGasCost: makeGasCost("5000"),
+      additiveTransferFee: new CoinPretty(ATOM_CURRENCY, "30000"),
+      balanceRaw: "2000000",
+      onChangeCryptoInput: jest.fn(),
+      isInsufficientFee: true,
     });
 
-    onChangeCryptoInput.mockClear();
+    expect(
+      queryByText("components.cryptoFiatInput.feesExceedBalance")
+    ).toBeInTheDocument();
+    expect(
+      queryByText("components.cryptoFiatInput.insufficientFunds")
+    ).not.toBeInTheDocument();
+  });
 
-    // 2) Input is now zero so quoting stops: gas and fee go undefined
-    rerender(
-      <CryptoFiatInput
-        {...baseProps}
-        isMax={true}
-        transferGasCost={undefined}
-        additiveTransferFee={undefined}
-        cryptoInput="0"
-        onChangeCryptoInput={onChangeCryptoInput}
-      />
-    );
+  it("shows the generic insufficient-funds message when there is no additive fee", () => {
+    const { queryByText } = renderInput({
+      isMax: false,
+      cryptoInput: "1",
+      transferGasCost: makeGasCost("5000"),
+      balanceRaw: "2000000",
+      onChangeCryptoInput: jest.fn(),
+      isInsufficientBal: true,
+    });
 
-    // The full balance must NOT be restored.
-    await new Promise((r) => setTimeout(r, 100));
-    expect(onChangeCryptoInput).not.toHaveBeenCalledWith(
-      trimPlaceholderZeros(balance.toDec().toString())
-    );
+    expect(
+      queryByText("components.cryptoFiatInput.insufficientFunds")
+    ).toBeInTheDocument();
+    expect(
+      queryByText("components.cryptoFiatInput.feesExceedBalance")
+    ).not.toBeInTheDocument();
   });
 
   it("leaves the full balance usable when the additive fee denom differs from the input", async () => {

--- a/packages/web/components/control/__tests__/crypto-fiat-input-max-guard.spec.tsx
+++ b/packages/web/components/control/__tests__/crypto-fiat-input-max-guard.spec.tsx
@@ -288,6 +288,70 @@ describe("CryptoFiatInput gasAppliedToMax guard", () => {
     });
   });
 
+  it("re-applies when an additive fee arrives after a gas-only application", async () => {
+    const balanceRaw = "2000000";
+    const gasRaw = "5000";
+    const feeRaw = "30000";
+    const onChangeCryptoInput = jest.fn();
+
+    // 1) gas-only quote applies and latches the guard
+    const { rerender } = renderInput({
+      isMax: true,
+      cryptoInput: makeBalance(balanceRaw).toDec().toString(),
+      transferGasCost: makeGasCost(gasRaw),
+      balanceRaw,
+      onChangeCryptoInput,
+    });
+
+    const gasOnlyExpected = expectedMaxAfterGas(balanceRaw, gasRaw);
+    await waitFor(() => {
+      expect(onChangeCryptoInput).toHaveBeenCalledWith(gasOnlyExpected);
+    });
+
+    onChangeCryptoInput.mockClear();
+
+    // 2) the selected quote switches to one with an additive fee
+    //    (e.g. best provider becomes Skip) — the fee must also be reserved
+    const balance = makeBalance(balanceRaw);
+    rerender(
+      <CryptoFiatInput
+        currentUnit="crypto"
+        setCurrentUnit={jest.fn()}
+        isMax={true}
+        setIsMax={jest.fn()}
+        canSetMax={true}
+        transferGasCost={makeGasCost(gasRaw)}
+        additiveTransferFee={new CoinPretty(ATOM_CURRENCY, feeRaw)}
+        transferGasChain={{ prettyName: "Cosmos Hub" }}
+        assetPrice={undefined}
+        assetWithBalance={{
+          denom: "ATOM",
+          address: "uatom",
+          decimals: 6,
+          amount: balance,
+        }}
+        cryptoInput={gasOnlyExpected}
+        onChangeCryptoInput={onChangeCryptoInput}
+        fiatInput=""
+        onChangeFiatInput={jest.fn()}
+        isInsufficientBal={false}
+        isInsufficientFee={false}
+      />
+    );
+
+    const withFeeExpected = trimPlaceholderZeros(
+      balance
+        .toDec()
+        .sub(makeGasCost(gasRaw).toDec().mul(MUL_GAS_SLIPPAGE))
+        .sub(new CoinPretty(ATOM_CURRENCY, feeRaw).toDec())
+        .toString()
+    );
+
+    await waitFor(() => {
+      expect(onChangeCryptoInput).toHaveBeenCalledWith(withFeeExpected);
+    });
+  });
+
   it("sets full balance when transferGasCost is undefined", async () => {
     const balanceRaw = "2000000";
     const onChangeCryptoInput = jest.fn();

--- a/packages/web/components/control/__tests__/crypto-fiat-input-max-guard.spec.tsx
+++ b/packages/web/components/control/__tests__/crypto-fiat-input-max-guard.spec.tsx
@@ -42,6 +42,7 @@ interface Props {
   onChangeCryptoInput: jest.Mock;
   canSetMax?: boolean;
   address?: string;
+  additiveTransferFee?: CoinPretty;
 }
 
 function renderInput({
@@ -52,6 +53,7 @@ function renderInput({
   onChangeCryptoInput,
   canSetMax = true,
   address = "uatom",
+  additiveTransferFee,
 }: Props) {
   const balance = makeBalance(balanceRaw);
   return render(
@@ -62,6 +64,7 @@ function renderInput({
       setIsMax={jest.fn()}
       canSetMax={canSetMax}
       transferGasCost={transferGasCost}
+      additiveTransferFee={additiveTransferFee}
       transferGasChain={{ prettyName: "Cosmos Hub" }}
       assetPrice={undefined}
       assetWithBalance={{
@@ -228,6 +231,60 @@ describe("CryptoFiatInput gasAppliedToMax guard", () => {
     const expected2 = expectedMaxAfterGas(balanceRaw, gasRaw2);
     await waitFor(() => {
       expect(onChangeCryptoInput).toHaveBeenCalledWith(expected2);
+    });
+  });
+
+  it("subtracts an additive transfer fee in addition to gas on max", async () => {
+    const balanceRaw = "2000000";
+    const gasRaw = "5000";
+    const feeRaw = "30000";
+    const onChangeCryptoInput = jest.fn();
+
+    renderInput({
+      isMax: true,
+      cryptoInput: makeBalance(balanceRaw).toDec().toString(),
+      transferGasCost: makeGasCost(gasRaw),
+      additiveTransferFee: new CoinPretty(ATOM_CURRENCY, feeRaw),
+      balanceRaw,
+      onChangeCryptoInput,
+    });
+
+    const expected = trimPlaceholderZeros(
+      makeBalance(balanceRaw)
+        .toDec()
+        .sub(makeGasCost(gasRaw).toDec().mul(MUL_GAS_SLIPPAGE))
+        .sub(new CoinPretty(ATOM_CURRENCY, feeRaw).toDec())
+        .toString()
+    );
+
+    await waitFor(() => {
+      expect(onChangeCryptoInput).toHaveBeenCalledWith(expected);
+    });
+  });
+
+  it("subtracts an additive transfer fee even when gas is unknown", async () => {
+    const balanceRaw = "2000000";
+    const feeRaw = "30000";
+    const onChangeCryptoInput = jest.fn();
+
+    renderInput({
+      isMax: true,
+      cryptoInput: makeBalance(balanceRaw).toDec().toString(),
+      transferGasCost: undefined,
+      additiveTransferFee: new CoinPretty(ATOM_CURRENCY, feeRaw),
+      balanceRaw,
+      onChangeCryptoInput,
+    });
+
+    const expected = trimPlaceholderZeros(
+      makeBalance(balanceRaw)
+        .toDec()
+        .sub(new CoinPretty(ATOM_CURRENCY, feeRaw).toDec())
+        .toString()
+    );
+
+    await waitFor(() => {
+      expect(onChangeCryptoInput).toHaveBeenCalledWith(expected);
     });
   });
 

--- a/packages/web/components/control/__tests__/crypto-fiat-input-max-guard.spec.tsx
+++ b/packages/web/components/control/__tests__/crypto-fiat-input-max-guard.spec.tsx
@@ -352,6 +352,134 @@ describe("CryptoFiatInput gasAppliedToMax guard", () => {
     });
   });
 
+  it("clamps max to zero when gas plus the additive fee exceed the balance", async () => {
+    // Reproduces the dust-balance Skip deposit that failed on-chain: the
+    // additive bridge fee plus gas head-room cost more than the whole balance,
+    // so there is no fundable amount. The input must clamp to zero instead of
+    // leaving the full balance (which builds a tx whose value exceeds the
+    // balance and fails at signing).
+    const balanceRaw = "82750538726230";
+    const gasRaw = "16746229134611";
+    const feeRaw = "63381527751084";
+    const onChangeCryptoInput = jest.fn();
+
+    const ETH_CURRENCY = {
+      coinDecimals: 18,
+      coinDenom: "ETH",
+      coinMinimalDenom: "wei",
+    };
+    const balance = new CoinPretty(ETH_CURRENCY, balanceRaw);
+
+    const { queryByText } = render(
+      <CryptoFiatInput
+        currentUnit="crypto"
+        setCurrentUnit={jest.fn()}
+        isMax={true}
+        setIsMax={jest.fn()}
+        canSetMax={true}
+        transferGasCost={new CoinPretty(ETH_CURRENCY, gasRaw)}
+        additiveTransferFee={new CoinPretty(ETH_CURRENCY, feeRaw)}
+        transferGasChain={{ prettyName: "Ethereum" }}
+        assetPrice={undefined}
+        assetWithBalance={{
+          denom: "ETH",
+          address: "wei",
+          decimals: 18,
+          amount: balance,
+        }}
+        cryptoInput={balance.toDec().toString()}
+        onChangeCryptoInput={onChangeCryptoInput}
+        fiatInput=""
+        onChangeFiatInput={jest.fn()}
+        isInsufficientBal={false}
+        isInsufficientFee={false}
+      />
+    );
+
+    await waitFor(() => {
+      expect(onChangeCryptoInput).toHaveBeenCalledWith("0");
+    });
+
+    // the user is told why max resolved to zero
+    await waitFor(() => {
+      expect(
+        queryByText("components.cryptoFiatInput.feesExceedBalance")
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("keeps max at zero when quoting drops out after a fees-exceed-balance clamp", async () => {
+    // After clamping to zero the input stops quoting, so gas/fee go undefined.
+    // The no-quote branch must NOT restore the full balance — doing so would
+    // re-enable the unfundable transfer and oscillate the input.
+    const balanceRaw = "82750538726230";
+    const gasRaw = "16746229134611";
+    const feeRaw = "63381527751084";
+    const onChangeCryptoInput = jest.fn();
+
+    const ETH_CURRENCY = {
+      coinDecimals: 18,
+      coinDenom: "ETH",
+      coinMinimalDenom: "wei",
+    };
+    const balance = new CoinPretty(ETH_CURRENCY, balanceRaw);
+
+    const baseProps = {
+      currentUnit: "crypto" as const,
+      setCurrentUnit: jest.fn(),
+      setIsMax: jest.fn(),
+      canSetMax: true,
+      transferGasChain: { prettyName: "Ethereum" },
+      assetPrice: undefined,
+      assetWithBalance: {
+        denom: "ETH",
+        address: "wei",
+        decimals: 18,
+        amount: balance,
+      },
+      fiatInput: "",
+      onChangeFiatInput: jest.fn(),
+      isInsufficientBal: false,
+      isInsufficientFee: false,
+    };
+
+    // 1) Quote present, fees exceed balance -> clamp to zero
+    const { rerender } = render(
+      <CryptoFiatInput
+        {...baseProps}
+        isMax={true}
+        transferGasCost={new CoinPretty(ETH_CURRENCY, gasRaw)}
+        additiveTransferFee={new CoinPretty(ETH_CURRENCY, feeRaw)}
+        cryptoInput={balance.toDec().toString()}
+        onChangeCryptoInput={onChangeCryptoInput}
+      />
+    );
+
+    await waitFor(() => {
+      expect(onChangeCryptoInput).toHaveBeenCalledWith("0");
+    });
+
+    onChangeCryptoInput.mockClear();
+
+    // 2) Input is now zero so quoting stops: gas and fee go undefined
+    rerender(
+      <CryptoFiatInput
+        {...baseProps}
+        isMax={true}
+        transferGasCost={undefined}
+        additiveTransferFee={undefined}
+        cryptoInput="0"
+        onChangeCryptoInput={onChangeCryptoInput}
+      />
+    );
+
+    // The full balance must NOT be restored.
+    await new Promise((r) => setTimeout(r, 100));
+    expect(onChangeCryptoInput).not.toHaveBeenCalledWith(
+      trimPlaceholderZeros(balance.toDec().toString())
+    );
+  });
+
   it("leaves the full balance usable when the additive fee denom differs from the input", async () => {
     // the common ERC-20 deposit path: input in the token (here ATOM stands in
     // for WETH/USDC), while gas and the additive bridge fee are native ETH

--- a/packages/web/components/control/__tests__/crypto-fiat-input-max-guard.spec.tsx
+++ b/packages/web/components/control/__tests__/crypto-fiat-input-max-guard.spec.tsx
@@ -352,6 +352,33 @@ describe("CryptoFiatInput gasAppliedToMax guard", () => {
     });
   });
 
+  it("leaves the full balance usable when the additive fee denom differs from the input", async () => {
+    // the common ERC-20 deposit path: input in the token (here ATOM stands in
+    // for WETH/USDC), while gas and the additive bridge fee are native ETH
+    const balanceRaw = "2000000";
+    const onChangeCryptoInput = jest.fn();
+
+    const ETH_CURRENCY = {
+      coinDecimals: 18,
+      coinDenom: "ETH",
+      coinMinimalDenom: "wei",
+    };
+
+    renderInput({
+      isMax: true,
+      cryptoInput: makeBalance(balanceRaw).toDec().toString(),
+      transferGasCost: new CoinPretty(ETH_CURRENCY, "840000000000000"),
+      additiveTransferFee: new CoinPretty(ETH_CURRENCY, "73924361079993"),
+      balanceRaw,
+      onChangeCryptoInput,
+    });
+
+    // Neither the gas nor the fee is payable in the input denom, so the
+    // max input must remain the full balance (no deduction fires).
+    await new Promise((r) => setTimeout(r, 100));
+    expect(onChangeCryptoInput).not.toHaveBeenCalled();
+  });
+
   it("sets full balance when transferGasCost is undefined", async () => {
     const balanceRaw = "2000000";
     const onChangeCryptoInput = jest.fn();

--- a/packages/web/components/control/__tests__/crypto-fiat-input.spec.tsx
+++ b/packages/web/components/control/__tests__/crypto-fiat-input.spec.tsx
@@ -103,7 +103,7 @@ describe.each(testCases)(
 
       const expectedMax = balanceCoin
         .toDec()
-        .sub(transferGasCost.toDec().mul(new Dec("1.1")));
+        .sub(transferGasCost.toDec().mul(new Dec("2")));
       const expectedValue = trimPlaceholderZeros(expectedMax.toString());
 
       const onChangeCryptoInput = jest.fn();

--- a/packages/web/components/control/crypto-fiat-input.tsx
+++ b/packages/web/components/control/crypto-fiat-input.tsx
@@ -40,6 +40,10 @@ export const CryptoFiatInput: FunctionComponent<{
   setIsMax?: (nextValue: boolean) => void;
   canSetMax?: boolean;
   transferGasCost: CoinPretty | undefined;
+  /** Bridge/transfer fee charged on top of the input amount (e.g. Axelar fees
+   *  on EVM-source transfers). Like gas, it must be subtracted from the
+   *  balance when selecting max. Omit for fees deducted from the amount. */
+  additiveTransferFee?: CoinPretty;
   transferGasChain: { prettyName: string } | undefined;
 
   assetPrice: PricePretty | undefined;
@@ -69,6 +73,7 @@ export const CryptoFiatInput: FunctionComponent<{
   setIsMax: setIsMaxProp,
   canSetMax = true,
   transferGasCost,
+  additiveTransferFee,
   transferGasChain,
 
   assetPrice,
@@ -248,10 +253,11 @@ export const CryptoFiatInput: FunctionComponent<{
     pendingRatioUpdate,
   ]);
 
-  // Subtract gas cost and adjust input when selecting max amount.
-  // Uses gasAppliedToMax ref to prevent a feedback loop: without it,
-  // each quote response returns a slightly different gas estimate which
-  // re-triggers this effect, adjusts the input, fires a new quote, etc.
+  // Subtract gas cost and any additive bridge fee from the input when
+  // selecting max amount. Uses gasAppliedToMax ref to prevent a feedback
+  // loop: without it, each quote response returns a slightly different gas
+  // estimate which re-triggers this effect, adjusts the input, fires a new
+  // quote, etc.
   useEffect(() => {
     if (!isMax) {
       gasAppliedToMax.current = false;
@@ -264,23 +270,27 @@ export const CryptoFiatInput: FunctionComponent<{
       gasAppliedToMax.current = false;
     }
 
-    if (transferGasCost) {
+    const additiveFeeMatchesInputDenom = Boolean(
+      additiveTransferFee &&
+        isSameCoinDenom(additiveTransferFee, assetWithBalance.amount)
+    );
+
+    if (transferGasCost || additiveFeeMatchesInputDenom) {
       if (gasAppliedToMax.current) return;
 
-      let maxTransferAmount = new Dec(0);
+      let deduction = new Dec(0);
 
-      const gasFeeMatchesInputDenom = isSameCoinDenom(
-        transferGasCost,
-        assetWithBalance.amount
-      );
-
-      if (gasFeeMatchesInputDenom) {
-        maxTransferAmount = assetWithBalance.amount
-          .toDec()
-          .sub(transferGasCost.toDec().mul(mulGasSlippage));
-      } else {
-        maxTransferAmount = assetWithBalance.amount.toDec();
+      if (
+        transferGasCost &&
+        isSameCoinDenom(transferGasCost, assetWithBalance.amount)
+      ) {
+        deduction = deduction.add(transferGasCost.toDec().mul(mulGasSlippage));
       }
+      if (additiveFeeMatchesInputDenom) {
+        deduction = deduction.add(additiveTransferFee!.toDec());
+      }
+
+      const maxTransferAmount = assetWithBalance.amount.toDec().sub(deduction);
 
       if (
         maxTransferAmount.isPositive() &&
@@ -289,8 +299,12 @@ export const CryptoFiatInput: FunctionComponent<{
         onInput("crypto")(trimPlaceholderZeros(maxTransferAmount.toString()));
       }
 
-      gasAppliedToMax.current = true;
-      gasAppliedForAsset.current = assetWithBalance.address;
+      // Only latch the guard once gas is known; a fee-only application
+      // should re-run when a later quote delivers the gas estimate.
+      if (transferGasCost) {
+        gasAppliedToMax.current = true;
+        gasAppliedForAsset.current = assetWithBalance.address;
+      }
     } else {
       // Reset the guard so gas deduction runs when transferGasCost arrives.
       // This covers both the initial render (ref starts false) and the case
@@ -301,6 +315,7 @@ export const CryptoFiatInput: FunctionComponent<{
       );
     }
   }, [
+    additiveTransferFee,
     assetWithBalance?.address,
     assetWithBalance?.amount,
     canSetMax,

--- a/packages/web/components/control/crypto-fiat-input.tsx
+++ b/packages/web/components/control/crypto-fiat-input.tsx
@@ -123,15 +123,6 @@ export const CryptoFiatInput: FunctionComponent<{
   // an additive fee (e.g. the best provider switches to Skip).
   const feeAppliedToMax = useRef(false);
   const gasAppliedForAsset = useRef<string | undefined>(undefined);
-  // Set when gas plus the additive fee cost more than the entire balance, so
-  // there is no fundable max and the input is clamped to zero. It stops the
-  // no-quote branch below from restoring the full (unfundable) balance, which
-  // would otherwise let the user submit a transfer that fails at signing and
-  // oscillate the input as quoting switches off at zero.
-  const feesExceedBalance = useRef(false);
-  // Render mirror of feesExceedBalance (a ref, to keep it out of the effect's
-  // dependencies) so the "balance too low" message can react to it.
-  const [showFeesExceedBalance, setShowFeesExceedBalance] = useState(false);
 
   // Check if price is available for fiat input
   const isPriceAvailable = Boolean(assetPrice?.fiatCurrency);
@@ -281,8 +272,6 @@ export const CryptoFiatInput: FunctionComponent<{
     if (!isMax) {
       gasAppliedToMax.current = false;
       feeAppliedToMax.current = false;
-      feesExceedBalance.current = false;
-      setShowFeesExceedBalance(false);
       return;
     }
 
@@ -291,8 +280,6 @@ export const CryptoFiatInput: FunctionComponent<{
     if (assetWithBalance.address !== gasAppliedForAsset.current) {
       gasAppliedToMax.current = false;
       feeAppliedToMax.current = false;
-      feesExceedBalance.current = false;
-      setShowFeesExceedBalance(false);
     }
 
     const additiveFeeMatchesInputDenom = Boolean(
@@ -325,23 +312,15 @@ export const CryptoFiatInput: FunctionComponent<{
 
       const maxTransferAmount = assetWithBalance.amount.toDec().sub(deduction);
 
-      if (maxTransferAmount.isPositive()) {
-        feesExceedBalance.current = false;
-        setShowFeesExceedBalance(false);
-        if (inputCoin.toDec().gt(maxTransferAmount)) {
-          onInput("crypto")(trimPlaceholderZeros(maxTransferAmount.toString()));
-        }
-      } else {
-        // Gas plus the additive fee cost more than the whole balance, so there
-        // is no fundable amount to bridge. Clamp to zero (blocking a transfer
-        // that would fail at signing), surface the reason to the user, and
-        // latch so the no-quote branch keeps it there instead of restoring the
-        // full balance.
-        feesExceedBalance.current = true;
-        setShowFeesExceedBalance(true);
-        if (!inputCoin.toDec().isZero()) {
-          onInput("crypto")("0");
-        }
+      // When gas plus the additive fee cost more than the whole balance the max
+      // is non-positive; leave the input at the full balance so the quote (and
+      // its fee breakdown) still renders. useBridgeQuotes flags this as
+      // insufficient and blocks the transfer.
+      if (
+        maxTransferAmount.isPositive() &&
+        inputCoin.toDec().gt(maxTransferAmount)
+      ) {
+        onInput("crypto")(trimPlaceholderZeros(maxTransferAmount.toString()));
       }
 
       // Only latch the guard once gas is known; a fee-only application
@@ -352,11 +331,6 @@ export const CryptoFiatInput: FunctionComponent<{
       }
       feeAppliedToMax.current = additiveFeeMatchesInputDenom;
     } else {
-      // No quote yet, or quoting is disabled because the input was clamped to
-      // zero. If we already determined fees exceed the balance, keep the input
-      // at zero — restoring the full balance here would reintroduce the
-      // unfundable transfer and oscillate with the clamp above.
-      if (feesExceedBalance.current) return;
       // Reset the guard so gas deduction runs when transferGasCost arrives.
       // This covers both the initial render (ref starts false) and the case
       // where quotes temporarily fail after gas was previously applied.
@@ -378,6 +352,9 @@ export const CryptoFiatInput: FunctionComponent<{
   ]);
 
   const insufficientFunds = isInsufficientBal || isInsufficientFee;
+  // On additive-fee routes the shortfall is the fee charged on top of the
+  // input, so name it explicitly rather than the generic "insufficient funds".
+  const showFeeShortfall = Boolean(isInsufficientFee && additiveTransferFee);
 
   return (
     <div className="relative flex flex-col items-center">
@@ -389,9 +366,9 @@ export const CryptoFiatInput: FunctionComponent<{
             inputRef.current?.focus();
           }}
         >
-          {(insufficientFunds || showFeesExceedBalance) && (
+          {insufficientFunds && (
             <p className="body1 animate-[fadeIn_0.25s] text-rust-400">
-              {showFeesExceedBalance
+              {showFeeShortfall
                 ? t("components.cryptoFiatInput.feesExceedBalance")
                 : t("components.cryptoFiatInput.insufficientFunds")}
             </p>

--- a/packages/web/components/control/crypto-fiat-input.tsx
+++ b/packages/web/components/control/crypto-fiat-input.tsx
@@ -118,6 +118,10 @@ export const CryptoFiatInput: FunctionComponent<{
   });
 
   const gasAppliedToMax = useRef(false);
+  // Whether the latched max adjustment included the additive transfer fee.
+  // A gas-only application must re-run if the selected quote later reports
+  // an additive fee (e.g. the best provider switches to Skip).
+  const feeAppliedToMax = useRef(false);
   const gasAppliedForAsset = useRef<string | undefined>(undefined);
 
   // Check if price is available for fiat input
@@ -267,6 +271,7 @@ export const CryptoFiatInput: FunctionComponent<{
   useEffect(() => {
     if (!isMax) {
       gasAppliedToMax.current = false;
+      feeAppliedToMax.current = false;
       return;
     }
 
@@ -274,6 +279,7 @@ export const CryptoFiatInput: FunctionComponent<{
 
     if (assetWithBalance.address !== gasAppliedForAsset.current) {
       gasAppliedToMax.current = false;
+      feeAppliedToMax.current = false;
     }
 
     const additiveFeeMatchesInputDenom = Boolean(
@@ -282,7 +288,15 @@ export const CryptoFiatInput: FunctionComponent<{
     );
 
     if (transferGasCost || additiveFeeMatchesInputDenom) {
-      if (gasAppliedToMax.current) return;
+      // Skip only if the latched application already covered everything
+      // currently known: a gas-only application must re-run when an
+      // additive fee shows up later so the fee also gets reserved.
+      if (
+        gasAppliedToMax.current &&
+        (feeAppliedToMax.current || !additiveFeeMatchesInputDenom)
+      ) {
+        return;
+      }
 
       let deduction = new Dec(0);
 
@@ -311,11 +325,13 @@ export const CryptoFiatInput: FunctionComponent<{
         gasAppliedToMax.current = true;
         gasAppliedForAsset.current = assetWithBalance.address;
       }
+      feeAppliedToMax.current = additiveFeeMatchesInputDenom;
     } else {
       // Reset the guard so gas deduction runs when transferGasCost arrives.
       // This covers both the initial render (ref starts false) and the case
       // where quotes temporarily fail after gas was previously applied.
       gasAppliedToMax.current = false;
+      feeAppliedToMax.current = false;
       onInput("crypto")(
         trimPlaceholderZeros(assetWithBalance.amount.toDec().toString())
       );

--- a/packages/web/components/control/crypto-fiat-input.tsx
+++ b/packages/web/components/control/crypto-fiat-input.tsx
@@ -123,6 +123,15 @@ export const CryptoFiatInput: FunctionComponent<{
   // an additive fee (e.g. the best provider switches to Skip).
   const feeAppliedToMax = useRef(false);
   const gasAppliedForAsset = useRef<string | undefined>(undefined);
+  // Set when gas plus the additive fee cost more than the entire balance, so
+  // there is no fundable max and the input is clamped to zero. It stops the
+  // no-quote branch below from restoring the full (unfundable) balance, which
+  // would otherwise let the user submit a transfer that fails at signing and
+  // oscillate the input as quoting switches off at zero.
+  const feesExceedBalance = useRef(false);
+  // Render mirror of feesExceedBalance (a ref, to keep it out of the effect's
+  // dependencies) so the "balance too low" message can react to it.
+  const [showFeesExceedBalance, setShowFeesExceedBalance] = useState(false);
 
   // Check if price is available for fiat input
   const isPriceAvailable = Boolean(assetPrice?.fiatCurrency);
@@ -272,6 +281,8 @@ export const CryptoFiatInput: FunctionComponent<{
     if (!isMax) {
       gasAppliedToMax.current = false;
       feeAppliedToMax.current = false;
+      feesExceedBalance.current = false;
+      setShowFeesExceedBalance(false);
       return;
     }
 
@@ -280,6 +291,8 @@ export const CryptoFiatInput: FunctionComponent<{
     if (assetWithBalance.address !== gasAppliedForAsset.current) {
       gasAppliedToMax.current = false;
       feeAppliedToMax.current = false;
+      feesExceedBalance.current = false;
+      setShowFeesExceedBalance(false);
     }
 
     const additiveFeeMatchesInputDenom = Boolean(
@@ -312,11 +325,23 @@ export const CryptoFiatInput: FunctionComponent<{
 
       const maxTransferAmount = assetWithBalance.amount.toDec().sub(deduction);
 
-      if (
-        maxTransferAmount.isPositive() &&
-        inputCoin.toDec().gt(maxTransferAmount)
-      ) {
-        onInput("crypto")(trimPlaceholderZeros(maxTransferAmount.toString()));
+      if (maxTransferAmount.isPositive()) {
+        feesExceedBalance.current = false;
+        setShowFeesExceedBalance(false);
+        if (inputCoin.toDec().gt(maxTransferAmount)) {
+          onInput("crypto")(trimPlaceholderZeros(maxTransferAmount.toString()));
+        }
+      } else {
+        // Gas plus the additive fee cost more than the whole balance, so there
+        // is no fundable amount to bridge. Clamp to zero (blocking a transfer
+        // that would fail at signing), surface the reason to the user, and
+        // latch so the no-quote branch keeps it there instead of restoring the
+        // full balance.
+        feesExceedBalance.current = true;
+        setShowFeesExceedBalance(true);
+        if (!inputCoin.toDec().isZero()) {
+          onInput("crypto")("0");
+        }
       }
 
       // Only latch the guard once gas is known; a fee-only application
@@ -327,6 +352,11 @@ export const CryptoFiatInput: FunctionComponent<{
       }
       feeAppliedToMax.current = additiveFeeMatchesInputDenom;
     } else {
+      // No quote yet, or quoting is disabled because the input was clamped to
+      // zero. If we already determined fees exceed the balance, keep the input
+      // at zero — restoring the full balance here would reintroduce the
+      // unfundable transfer and oscillate with the clamp above.
+      if (feesExceedBalance.current) return;
       // Reset the guard so gas deduction runs when transferGasCost arrives.
       // This covers both the initial render (ref starts false) and the case
       // where quotes temporarily fail after gas was previously applied.
@@ -359,9 +389,11 @@ export const CryptoFiatInput: FunctionComponent<{
             inputRef.current?.focus();
           }}
         >
-          {insufficientFunds && (
+          {(insufficientFunds || showFeesExceedBalance) && (
             <p className="body1 animate-[fadeIn_0.25s] text-rust-400">
-              {t("components.cryptoFiatInput.insufficientFunds")}
+              {showFeesExceedBalance
+                ? t("components.cryptoFiatInput.feesExceedBalance")
+                : t("components.cryptoFiatInput.insufficientFunds")}
             </p>
           )}
 

--- a/packages/web/components/control/crypto-fiat-input.tsx
+++ b/packages/web/components/control/crypto-fiat-input.tsx
@@ -21,7 +21,13 @@ import { replaceAt } from "~/utils/array";
 import { isSameCoinDenom } from "~/utils/denom";
 import { trimPlaceholderZeros } from "~/utils/number";
 
-const mulGasSlippage = new Dec("1.1");
+// Head-room multiplier on the quoted gas cost when clamping a max-amount
+// input. Must absorb base-fee drift between quote time and signing time
+// plus wallet-side padding: the EIP-1559 base fee moves up to ±12.5% per
+// block and wallets budget their own worst-case fee when the user signs,
+// so a thin margin fails the signature with "insufficient funds".
+// Over-reserving only leaves ~one gas fee of dust in the wallet.
+const mulGasSlippage = new Dec("2");
 
 /** Safely converts a raw input string to a Dec value.
  * Returns "0" for empty strings or lone decimals that can't be parsed.

--- a/packages/web/localizations/de.json
+++ b/packages/web/localizations/de.json
@@ -238,7 +238,8 @@
   "buyTokens": "Kaufen Sie Token",
   "components": {
     "cryptoFiatInput": {
-      "insufficientFunds": "Unzureichende Mittel"
+      "insufficientFunds": "Unzureichende Mittel",
+      "feesExceedBalance": "Guthaben zu niedrig, um die Transfergebühr zu decken"
     },
     "fiatOnrampSelection": {
       "chooseOnramp": "Krypto kaufen",

--- a/packages/web/localizations/en.json
+++ b/packages/web/localizations/en.json
@@ -238,7 +238,8 @@
   "buyTokens": "Buy tokens",
   "components": {
     "cryptoFiatInput": {
-      "insufficientFunds": "Insufficient funds"
+      "insufficientFunds": "Insufficient funds",
+      "feesExceedBalance": "Balance too low to cover the transfer fee"
     },
     "fiatOnrampSelection": {
       "chooseOnramp": "Buy crypto",

--- a/packages/web/localizations/es.json
+++ b/packages/web/localizations/es.json
@@ -238,7 +238,8 @@
   "buyTokens": "Comprar fichas",
   "components": {
     "cryptoFiatInput": {
-      "insufficientFunds": "Fondos insuficientes"
+      "insufficientFunds": "Fondos insuficientes",
+      "feesExceedBalance": "Saldo insuficiente para cubrir la comisión de transferencia"
     },
     "fiatOnrampSelection": {
       "chooseOnramp": "Comprar criptomonedas",

--- a/packages/web/localizations/fa.json
+++ b/packages/web/localizations/fa.json
@@ -238,7 +238,8 @@
   "buyTokens": "خرید توکن",
   "components": {
     "cryptoFiatInput": {
-      "insufficientFunds": "بودجه ناکافی"
+      "insufficientFunds": "بودجه ناکافی",
+      "feesExceedBalance": "موجودی برای پوشش کارمزد انتقال بسیار کم است"
     },
     "fiatOnrampSelection": {
       "chooseOnramp": "کریپتو بخر",

--- a/packages/web/localizations/fr.json
+++ b/packages/web/localizations/fr.json
@@ -238,7 +238,8 @@
   "buyTokens": "Acheter jetons",
   "components": {
     "cryptoFiatInput": {
-      "insufficientFunds": "Fonds insuffisants"
+      "insufficientFunds": "Fonds insuffisants",
+      "feesExceedBalance": "Solde trop faible pour couvrir les frais de transfert"
     },
     "fiatOnrampSelection": {
       "chooseOnramp": "Acheter des crypto-monnaies",

--- a/packages/web/localizations/gu.json
+++ b/packages/web/localizations/gu.json
@@ -238,7 +238,8 @@
   "buyTokens": "ટોકન્સ ખરીદો",
   "components": {
     "cryptoFiatInput": {
-      "insufficientFunds": "અપૂરતું ભંડોળ"
+      "insufficientFunds": "અપૂરતું ભંડોળ",
+      "feesExceedBalance": "ટ્રાન્સફર ફી આવરી લેવા માટે બેલેન્સ ખૂબ ઓછું છે"
     },
     "fiatOnrampSelection": {
       "chooseOnramp": "ક્રિપ્ટો ખરીદો",

--- a/packages/web/localizations/hi.json
+++ b/packages/web/localizations/hi.json
@@ -238,7 +238,8 @@
   "buyTokens": "टोकन खरीदें",
   "components": {
     "cryptoFiatInput": {
-      "insufficientFunds": "अपर्याप्त कोष"
+      "insufficientFunds": "अपर्याप्त कोष",
+      "feesExceedBalance": "ट्रांसफ़र शुल्क को कवर करने के लिए बैलेंस बहुत कम है"
     },
     "fiatOnrampSelection": {
       "chooseOnramp": "क्रिप्टो खरीदें",

--- a/packages/web/localizations/ja.json
+++ b/packages/web/localizations/ja.json
@@ -238,7 +238,8 @@
   "buyTokens": "トークンを購入する",
   "components": {
     "cryptoFiatInput": {
-      "insufficientFunds": "残高不足"
+      "insufficientFunds": "残高不足",
+      "feesExceedBalance": "残高が不足しており、送金手数料を賄えません"
     },
     "fiatOnrampSelection": {
       "chooseOnramp": "暗号通貨を購入する",

--- a/packages/web/localizations/ko.json
+++ b/packages/web/localizations/ko.json
@@ -238,7 +238,8 @@
   "buyTokens": "토큰 구매",
   "components": {
     "cryptoFiatInput": {
-      "insufficientFunds": "자금 부족"
+      "insufficientFunds": "자금 부족",
+      "feesExceedBalance": "잔액이 부족하여 전송 수수료를 충당할 수 없습니다"
     },
     "fiatOnrampSelection": {
       "chooseOnramp": "암호화폐를 구매하세요",

--- a/packages/web/localizations/pl.json
+++ b/packages/web/localizations/pl.json
@@ -238,7 +238,8 @@
   "buyTokens": "Kup tokeny",
   "components": {
     "cryptoFiatInput": {
-      "insufficientFunds": "Niewystarczające środki"
+      "insufficientFunds": "Niewystarczające środki",
+      "feesExceedBalance": "Saldo zbyt niskie, aby pokryć opłatę za transfer"
     },
     "fiatOnrampSelection": {
       "chooseOnramp": "Kup kryptowalutę",

--- a/packages/web/localizations/pt-br.json
+++ b/packages/web/localizations/pt-br.json
@@ -238,7 +238,8 @@
   "buyTokens": "Comprar tokens",
   "components": {
     "cryptoFiatInput": {
-      "insufficientFunds": "Fundos insuficientes"
+      "insufficientFunds": "Fundos insuficientes",
+      "feesExceedBalance": "Saldo muito baixo para cobrir a taxa de transferência"
     },
     "fiatOnrampSelection": {
       "chooseOnramp": "Comprar cripto",

--- a/packages/web/localizations/ro.json
+++ b/packages/web/localizations/ro.json
@@ -238,7 +238,8 @@
   "buyTokens": "Cumpărați jetoane",
   "components": {
     "cryptoFiatInput": {
-      "insufficientFunds": "Fonduri insuficiente"
+      "insufficientFunds": "Fonduri insuficiente",
+      "feesExceedBalance": "Sold prea mic pentru a acoperi taxa de transfer"
     },
     "fiatOnrampSelection": {
       "chooseOnramp": "Cumpărați cripto",

--- a/packages/web/localizations/ru.json
+++ b/packages/web/localizations/ru.json
@@ -238,7 +238,8 @@
   "buyTokens": "Купить токены",
   "components": {
     "cryptoFiatInput": {
-      "insufficientFunds": "Недостаточно средств"
+      "insufficientFunds": "Недостаточно средств",
+      "feesExceedBalance": "Недостаточно средств для покрытия комиссии за перевод"
     },
     "fiatOnrampSelection": {
       "chooseOnramp": "Купить криптовалюту",

--- a/packages/web/localizations/tr.json
+++ b/packages/web/localizations/tr.json
@@ -238,7 +238,8 @@
   "buyTokens": "jeton satın al",
   "components": {
     "cryptoFiatInput": {
-      "insufficientFunds": "Yetersiz bakiye"
+      "insufficientFunds": "Yetersiz bakiye",
+      "feesExceedBalance": "Bakiye, transfer ücretini karşılamak için çok düşük"
     },
     "fiatOnrampSelection": {
       "chooseOnramp": "Kripto satın al",

--- a/packages/web/localizations/zh-cn.json
+++ b/packages/web/localizations/zh-cn.json
@@ -238,7 +238,8 @@
   "buyTokens": "购买代币",
   "components": {
     "cryptoFiatInput": {
-      "insufficientFunds": "不充足的资金"
+      "insufficientFunds": "不充足的资金",
+      "feesExceedBalance": "余额不足以支付转账手续费"
     },
     "fiatOnrampSelection": {
       "chooseOnramp": "购买加密货币",

--- a/packages/web/localizations/zh-hk.json
+++ b/packages/web/localizations/zh-hk.json
@@ -238,7 +238,8 @@
   "buyTokens": "購買代幣",
   "components": {
     "cryptoFiatInput": {
-      "insufficientFunds": "不充足的資金"
+      "insufficientFunds": "不充足的資金",
+      "feesExceedBalance": "餘額不足以支付轉賬手續費"
     },
     "fiatOnrampSelection": {
       "chooseOnramp": "購買加密貨幣",

--- a/packages/web/localizations/zh-tw.json
+++ b/packages/web/localizations/zh-tw.json
@@ -238,7 +238,8 @@
   "buyTokens": "購買代幣",
   "components": {
     "cryptoFiatInput": {
-      "insufficientFunds": "不充足的資金"
+      "insufficientFunds": "不充足的資金",
+      "feesExceedBalance": "餘額不足以支付轉帳手續費"
     },
     "fiatOnrampSelection": {
       "chooseOnramp": "購買加密貨幣",

--- a/packages/web/server/api/routers/bridge-transfer.ts
+++ b/packages/web/server/api/routers/bridge-transfer.ts
@@ -152,11 +152,11 @@ export const bridgeTransferRouter = createTRPCRouter({
       }
 
       /**
-       * Since transfer fee is deducted from input amount,
-       * we overwrite the transfer fee asset to be the input
-       * asset if it's the same variant.
-       * This allows us to easily deduct fees from input amount
-       * and find prices on Osmosis.
+       * When the transfer fee is the same variant as the input asset,
+       * we overwrite the fee asset to be the input asset so we can find
+       * prices on Osmosis. Note the fee is not necessarily deducted from
+       * the input amount: additive fees (`transferFee.isAdditive`, e.g.
+       * Axelar fees on EVM-source Skip transfers) are charged on top of it.
        */
       const feeCoin = isSameVariant(
         ctx.assetLists,
@@ -300,6 +300,7 @@ export const bridgeTransferRouter = createTRPCRouter({
         fiatValue: feeAssetPrice
           ? priceFromBridgeCoin(feeCoin, feeAssetPrice)
           : undefined,
+        isAdditive: quote.transferFee.isAdditive === true,
       };
 
       const estimatedGasFee = quote.estimatedGasFee


### PR DESCRIPTION
## What is the purpose of the change:

Make max-amount EVM deposits via Skip quotable and fundable. Skip charges EVM-source Axelar bridge fees on top of the input amount, so quoting the full wallet balance built a transaction the wallet couldn't fund: gas estimation failed, the error was swallowed to a fee-less quote, and the max button never subtracted the bridge fee.

### Linear Task

[MTN-214](https://linear.app/osmosis/issue/MTN-214/bridge-deposits-max-amount-skip-quotes-fail-because-axelar-bridge-fee)

## Brief Changelog

- Override the sender's balance (value + 1 native token) during Skip EVM gas estimation so max-amount quotes still get a real gas figure instead of a swallowed "insufficient funds" error.
- Model Skip's `estimated_fees` / `fee_behavior` in `SkipRouteResponse` and flag the quote's `transferFee` as `isAdditive` from the BRIDGE fee entries. Only an explicit `FEE_BEHAVIOR_DEDUCTED` opts an EVM-source fee out of additive treatment — unknown or unspecified values fail toward over-reserving rather than an unfundable transaction.
- Thread the flag through `getQuoteByBridge` and `use-bridge-quotes`, and subtract an additive same-denom transfer fee alongside gas in `CryptoFiatInput`'s max-amount deduction.
- Price Skip EVM gas at the wallet's worst-case EIP-1559 `maxFeePerGas`. Note: this also makes the gas figure shown in quote details conservative (worst-case) on Skip EVM quotes — intentional, since over-reserving is the safe failure direction for max flows.
- Correct the stale "fee is deducted from input" comment in `getQuoteByBridge`.

## Testing and Verifying

Added spec coverage: Skip provider flags additive fees (explicit ADDITIONAL/DEDUCTED, UNSPECIFIED fallback, non-bridge entries ignored) and passes the balance state override to `estimateGas`; `CryptoFiatInput` subtracts fee + gas (and fee alone when gas is unknown) on max and leaves the full balance usable when the fee denom differs from the input. Both suites pass (24 + 14 tests). The state-override estimation and the additive-fee failure mode were verified against Skip's live API and a mainnet RPC — evidence in MTN-214.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches fundability logic for bridge deposits (fee semantics, max amount, gas pricing); wrong additive/deducted handling could over- or under-reserve balance but changes bias toward over-reserving and include broad test coverage.
> 
> **Overview**
> Fixes **max-amount EVM deposits via Skip** where Axelar bridge fees sit on top of the input, so quoting the full balance produced unfundable txs and broken gas estimates.
> 
> The **Skip provider** now reads `estimated_fees` / `fee_behavior` on **BRIDGE** entries and sets `transferFee.isAdditive` (EVM default additive unless explicitly deducted). EVM gas estimation uses a **sender balance `stateOverride`** so estimates succeed at max input, and gas is priced at **EIP-1559 `maxFeePerGas`** instead of legacy `getGasPrice`. The bridge quote type and API layer thread `isAdditive` through to the UI.
> 
> **Bridge UI** treats additive fees like extra balance headroom: `use-bridge-quotes` validates `input + fee + gas` against balance; `CryptoFiatInput` subtracts same-denom additive fees on MAX (with a **2× gas slippage** multiplier), avoids clamping to zero when fees exceed balance, and shows a dedicated **fees exceed balance** message. Locales add the new string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f202d721fa0ebc88e796f09edec809074b50eeb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->