### PR TITLE
fix(utils): bound the EVM RPC fallback chain and drop the hanging merkle endpoint

### DIFF
--- a/packages/bridge/src/skip/index.ts
+++ b/packages/bridge/src/skip/index.ts
@@ -565,7 +565,10 @@ export class SkipBridgeProvider implements BridgeProvider {
 
     const provider = createPublicClient({
       chain: evmChain,
-      transport: getEvmRpcTransport(evmChain),
+      transport: getEvmRpcTransport(evmChain, {
+        timeout: 3_000,
+        retryCount: 0,
+      }),
     });
 
     return provider;
@@ -812,7 +815,10 @@ export class SkipBridgeProvider implements BridgeProvider {
 
       const provider = createPublicClient({
         chain: evmChain,
-        transport: getEvmRpcTransport(evmChain),
+        transport: getEvmRpcTransport(evmChain, {
+          timeout: 3_000,
+          retryCount: 0,
+        }),
       });
 
       const estimatedGas = await this.estimateEvmGasWithStateOverrides(

--- a/packages/bridge/src/squid/index.ts
+++ b/packages/bridge/src/squid/index.ts
@@ -479,7 +479,10 @@ export class SquidBridgeProvider implements BridgeProvider {
 
       const fromTokenContract = createPublicClient({
         chain: evmChain,
-        transport: getEvmRpcTransport(evmChain),
+        transport: getEvmRpcTransport(evmChain, {
+          timeout: 3_000,
+          retryCount: 0,
+        }),
       });
 
       approvalTx = await this.getApprovalTx({

--- a/packages/utils/src/ethereum.ts
+++ b/packages/utils/src/ethereum.ts
@@ -180,20 +180,24 @@ export const EthereumChainInfo = [
  * Builds a viem fallback transport from a chain's default RPC URLs.
  * Falls through each URL in order on failure.
  *
- * Each attempt is bounded (short timeout, no retries) so a degraded RPC
- * can't stall the chain: server-side bridge quotes run under a 12s tRPC
- * procedure timeout, and viem's defaults (10s timeout, 3 retries per
- * transport plus fallback-level retries) let one hanging endpoint consume
- * the entire budget before the remaining URLs are tried.
+ * By default each attempt uses viem's timeout/retry behavior, which suits
+ * long-lived client-side calls like waiting for a transaction receipt —
+ * failing fast there mislabels an in-flight transaction as failed. Server-side
+ * bridge quotes run under a 12s tRPC procedure timeout, where those same
+ * defaults (10s timeout, 3 retries per transport plus fallback-level retries)
+ * let one hanging endpoint consume the entire budget before the remaining
+ * URLs are tried — those call sites should pass a short timeout and zero
+ * retries.
  */
-export function getEvmRpcTransport(chain: {
-  rpcUrls: { default: { http: readonly string[] } };
-}) {
+export function getEvmRpcTransport(
+  chain: {
+    rpcUrls: { default: { http: readonly string[] } };
+  },
+  opts?: { timeout?: number; retryCount?: number }
+) {
   return fallback(
-    chain.rpcUrls.default.http.map((url) =>
-      http(url, { timeout: 3_000, retryCount: 0 })
-    ),
-    { retryCount: 0 }
+    chain.rpcUrls.default.http.map((url) => http(url, opts)),
+    { retryCount: opts?.retryCount }
   );
 }
 

--- a/packages/utils/src/ethereum.ts
+++ b/packages/utils/src/ethereum.ts
@@ -48,8 +48,11 @@ function mapChainInfo<Chain>({
 }
 
 export const EthereumChainInfo = [
-  // Override viem's default mainnet RPC (eth.merkle.io, 25 req/s free-tier cap)
-  // with more reliable public endpoints. Order matters: first URL is primary.
+  // Override viem's default mainnet RPC (eth.merkle.io) with more reliable
+  // public endpoints. Order matters: first URL is primary. Every URL must
+  // support eth_estimateGas with state overrides (the bridge quote flow
+  // relies on it) and answer that method promptly — merkle was dropped
+  // because its eth_estimateGas hangs ~15s while other methods stay fast.
   mapChainInfo({
     chain: {
       ...mainnet,
@@ -60,7 +63,7 @@ export const EthereumChainInfo = [
           http: [
             "https://ethereum-rpc.publicnode.com",
             "https://evm-1.keplr.app",
-            "https://eth.merkle.io",
+            "https://eth.drpc.org",
           ],
         },
       },
@@ -176,11 +179,22 @@ export const EthereumChainInfo = [
 /**
  * Builds a viem fallback transport from a chain's default RPC URLs.
  * Falls through each URL in order on failure.
+ *
+ * Each attempt is bounded (short timeout, no retries) so a degraded RPC
+ * can't stall the chain: server-side bridge quotes run under a 12s tRPC
+ * procedure timeout, and viem's defaults (10s timeout, 3 retries per
+ * transport plus fallback-level retries) let one hanging endpoint consume
+ * the entire budget before the remaining URLs are tried.
  */
 export function getEvmRpcTransport(chain: {
   rpcUrls: { default: { http: readonly string[] } };
 }) {
-  return fallback(chain.rpcUrls.default.http.map((url) => http(url)));
+  return fallback(
+    chain.rpcUrls.default.http.map((url) =>
+      http(url, { timeout: 3_000, retryCount: 0 })
+    ),
+    { retryCount: 0 }
+  );
 }
 
 export function getEvmExplorerUrl({


### PR DESCRIPTION
## What is the purpose of the change:

Stop degraded Ethereum RPCs from timing out bridge quotes. One hanging endpoint could consume the whole 12s tRPC procedure budget under viem's default timeouts/retries, turning a recoverable estimate failure into a user-visible "something went wrong". Independently shippable hardening per the investigation in MTN-214 (Johnny's comment).

### Linear Task

[MTN-214](https://linear.app/osmosis/issue/MTN-214/bridge-deposits-max-amount-skip-quotes-fail-because-axelar-bridge-fee)

## Brief Changelog

- Bound each `http()` transport in `getEvmRpcTransport` to a 3s timeout with no retries, and disable fallback-level retries, so the worst-case walk of the URL list stays well inside the 12s procedure budget.
- Replace `eth.merkle.io` (currently hangs ~15s on `eth_estimateGas` while answering other methods fast) with `eth.drpc.org` in the mainnet RPC list, and document that listed endpoints must support state-override gas estimation.

## Testing and Verifying

Endpoint behavior measured 2026-07-08: merkle `eth_estimateGas` hangs 15.5s (its `eth_blockNumber` answers in 0.3s); publicnode, keplr, and drpc all answer the same estimate — including with state overrides — in 0.2–1.8s. Utils package builds and all 108 tests pass. Full measurements in MTN-214.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes RPC failover behavior and mainnet endpoint list for bridge quoting; mis-tuned timeouts could cause more estimate failures, but client-side receipt polling keeps viem defaults.
> 
> **Overview**
> **Hardens bridge quotes** against slow or stuck Ethereum RPCs by making server-side viem clients fail over quickly instead of burning the whole tRPC budget on one URL.
> 
> `getEvmRpcTransport` now accepts optional **`timeout`** and **`retryCount`**, applied to each `http()` transport and to fallback-level retries. **Skip** and **Squid** pass **3s timeout** and **zero retries** wherever they build public clients for EVM gas estimation and ERC-20 approval checks.
> 
> On Ethereum mainnet, **`eth.merkle.io` is removed** from the RPC list (its `eth_estimateGas` was hanging ~15s) and **`eth.drpc.org` is added**. Comments note listed endpoints must support state-override gas estimation and respond promptly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 595027ad5c1864d6235b2d9180d4a38d90c35936. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->