### PR TITLE
fix(bridge): flag Squid EVM transfer fees as additive

### DIFF
--- a/packages/bridge/src/squid/__tests__/squid-bridge-provider.spec.ts
+++ b/packages/bridge/src/squid/__tests__/squid-bridge-provider.spec.ts
@@ -181,6 +181,7 @@ describe("SquidBridgeProvider", () => {
         address: "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
         decimals: 18,
         coinGeckoId: "ethereum",
+        isAdditive: true,
       },
       estimatedTime: 960,
       estimatedGasFee: {
@@ -293,6 +294,7 @@ describe("SquidBridgeProvider", () => {
           "ibc/EA1D43981D5C9A1C4AAEA9C23BB1D4FA126BA9BC7020A25E0AE4AA841EA25DC5",
         decimals: 18,
         coinGeckoId: "weth",
+        isAdditive: false,
       },
       estimatedTime: 60,
       estimatedGasFee: {

--- a/packages/bridge/src/squid/index.ts
+++ b/packages/bridge/src/squid/index.ts
@@ -259,6 +259,12 @@ export class SquidBridgeProvider implements BridgeProvider {
                   decimals: feeCosts[0].token.decimals,
                   address: feeCosts[0].token.address,
                   coinGeckoId: feeCosts[0].token.coingeckoId,
+                  // Squid (Axelar) charges its cross-chain fee on top of the
+                  // input on EVM-source deposits: the tx value is amount + fee.
+                  // Flag it additive so a max-amount input reserves it and the
+                  // affordability check funds input + fee instead of deducting
+                  // it from the input (which fails the wallet signature).
+                  isAdditive: isEvmTransaction,
                 }
               : {
                   ...fromAsset,


### PR DESCRIPTION
## What is the purpose of the change

Extend the additive-fee handling from #4406 (Skip) to the Squid provider. Squid (Axelar) charges its cross-chain fee on top of the input on EVM-source deposits — the tx value is `amount + fee` — but the provider never set `transferFee.isAdditive`, so a max-amount deposit reserved only gas and the affordability check treated the fee as deducted. The wallet was then asked to fund `input + fee` and rejected it with "insufficient funds for gas * price + value".

### Linear Task

MTN-214

## Brief Changelog

- Set `transferFee.isAdditive = true` for EVM-source Squid quotes (reusing the existing `isEvmTransaction` flag), mirroring Skip's EVM default, so the max guard reserves the fee and `useBridgeQuotes` funds `input + fee + gas` against the balance.
- Update the two Squid quote-shape assertions (EVM-source → `true`, Cosmos-source → `false`).

Same-denom coverage only; cross-denom native-fee coverage (ERC-20 input, native ETH fee) remains tracked in MTN-216.

## Testing and Verifying

`yarn jest squid-bridge-provider` passes (16/16); eslint + prettier clean. Reproduced the original failure with a real Squid ETH→Osmosis max deposit (overshoot equal to the unreserved additive fee); with this change the fee is reserved and the transfer is blocked client-side instead of failing at signing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes bridge fee accounting for real EVM deposits; wrong `isAdditive` would still break max sends or over-restrict amounts, but scope is limited to Squid quote mapping and aligned with existing Skip behavior.
> 
> **Overview**
> Squid quotes now set **`transferFee.isAdditive`** on EVM-source routes so cross-chain fees are treated as charged **on top of** the input (tx value = amount + fee), matching the additive-fee handling already used for Skip.
> 
> When `fromChain` is EVM, `isAdditive` is `true`; Cosmos-source quotes keep the default non-additive behavior (`false` in tests). Downstream max-amount and affordability logic can reserve the bridge fee instead of deducting it from the input, avoiding wallet signing failures on max deposits.
> 
> Spec expectations for Ethereum→Avalanche and Osmosis→Ethereum quote shapes were updated to assert the new flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38dabf1bd61bd354816b77f3521494f22dc7453d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->