### PR TITLE
feat(bridge): stamp warn-accept flags into the tx auth memo (MTN-137)

### DIFF
--- a/packages/stores/src/account/__tests__/memo.spec.ts
+++ b/packages/stores/src/account/__tests__/memo.spec.ts
@@ -1,0 +1,98 @@
+import { Dec } from "@osmosis-labs/unit";
+
+import {
+  appendFeMemoTag,
+  FeMemoTag,
+  formatWarnPct,
+  OneClickFeMemoTag,
+} from "../memo";
+
+describe("formatWarnPct", () => {
+  it.each([
+    ["0", "0.00"],
+    ["0.0001", "0.01"],
+    ["0.124", "12.40"],
+    ["1", "100.00"],
+    // half-up rounding at the 2nd decimal place
+    ["0.99895", "99.90"],
+    ["0.99894", "99.89"],
+    ["0.12405", "12.41"],
+  ])("formats fraction %s as %s", (fraction, expected) => {
+    expect(formatWarnPct(new Dec(fraction))).toBe(expected);
+  });
+});
+
+describe("appendFeMemoTag", () => {
+  describe("without flags (unwarned txs)", () => {
+    it("produces exactly the bare base tag on an empty memo", () => {
+      expect(appendFeMemoTag("", FeMemoTag)).toBe("OsmosisFE");
+      expect(appendFeMemoTag("", OneClickFeMemoTag)).toBe("1CT");
+    });
+
+    it("appends the tag after a non-empty memo exactly as before", () => {
+      expect(appendFeMemoTag("user memo", FeMemoTag)).toBe(
+        "user memo \nOsmosisFE"
+      );
+      expect(appendFeMemoTag("user memo", OneClickFeMemoTag)).toBe(
+        "user memo \n1CT"
+      );
+    });
+
+    it("treats an empty flags object as no flags", () => {
+      expect(appendFeMemoTag("", FeMemoTag, {})).toBe("OsmosisFE");
+    });
+  });
+
+  describe("with warn-accept flags", () => {
+    it("stamps an acknowledged total-loss as slip=", () => {
+      expect(
+        appendFeMemoTag("", FeMemoTag, { slippage: new Dec("0.9989") })
+      ).toBe("OsmosisFE/warn:slip=99.89");
+    });
+
+    it("stamps an acknowledged price impact as pi=", () => {
+      expect(
+        appendFeMemoTag("", FeMemoTag, { priceImpact: new Dec("0.124") })
+      ).toBe("OsmosisFE/warn:pi=12.40");
+    });
+
+    it("stamps both flags in fixed order: slip before pi", () => {
+      expect(
+        appendFeMemoTag("", FeMemoTag, {
+          slippage: new Dec("0.9989"),
+          priceImpact: new Dec("0.124"),
+        })
+      ).toBe("OsmosisFE/warn:slip=99.89,pi=12.40");
+    });
+
+    it("stamps the 1CT variant for one-click sessions", () => {
+      expect(
+        appendFeMemoTag("", OneClickFeMemoTag, {
+          priceImpact: new Dec("0.124"),
+        })
+      ).toBe("1CT/warn:pi=12.40");
+    });
+
+    it("stamps a zero acknowledged figure (presence, not truthiness)", () => {
+      expect(appendFeMemoTag("", FeMemoTag, { slippage: new Dec(0) })).toBe(
+        "OsmosisFE/warn:slip=0.00"
+      );
+    });
+
+    it("appends the flagged tag after a non-empty memo", () => {
+      expect(
+        appendFeMemoTag("user memo", FeMemoTag, {
+          slippage: new Dec("0.9989"),
+        })
+      ).toBe("user memo \nOsmosisFE/warn:slip=99.89");
+    });
+
+    it("stays well under the 100-byte memo budget", () => {
+      const worstCase = appendFeMemoTag("", FeMemoTag, {
+        slippage: new Dec("9.99895"),
+        priceImpact: new Dec("9.99895"),
+      });
+      expect(new TextEncoder().encode(worstCase).length).toBeLessThan(100);
+    });
+  });
+});

--- a/packages/stores/src/account/base.ts
+++ b/packages/stores/src/account/base.ts
@@ -60,6 +60,12 @@ import { OsmosisQueries } from "../queries";
 import { InsufficientBalanceForFeeError } from "../ui-config";
 import { getAminoConverters } from "./amino-converters";
 import {
+  appendFeMemoTag,
+  FeMemoTag,
+  OneClickFeMemoTag,
+  TxFeMemoFlags,
+} from "./memo";
+import {
   AccountStoreWallet,
   CosmosRegistryWallet,
   DeliverTxResponse,
@@ -518,6 +524,7 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
    *   - `onBroadcastFailed`: Invoked when the broadcast fails.
    *   - `onBroadcasted`: Invoked when the transaction is successfully broadcasted.
    *   - `onFulfill`: Invoked when the transaction is successfully fulfilled.
+   * @param memoFlags - Optional warn-accept flags stamped into the auth memo's frontend tag (see `memo.ts`).
    *
    * @throws Throws an error if:
    *   - Wallet for the given chain is not provided or not connected.
@@ -541,7 +548,8 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
           onBroadcasted?: (txHash: Uint8Array) => void;
           onFulfill?: (tx: DeliverTxResponse) => void;
           onSign?: () => Promise<void> | void;
-        }
+        },
+    memoFlags?: TxFeMemoFlags
   ) {
     runInAction(() => {
       this.txTypeInProgressByChain.set(chainNameOrId, type);
@@ -617,6 +625,7 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
         memo: memo || "",
         messages: msgs,
         signOptions: mergedSignOptions,
+        memoFlags,
       });
       const { TxRaw } = await import("cosmjs-types/cosmos/tx/v1beta1/tx");
       const encodedTx = TxRaw.encode(txRaw).finish();
@@ -807,12 +816,14 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
     fee,
     memo,
     signOptions,
+    memoFlags,
   }: {
     wallet: AccountStoreWallet;
     messages: readonly EncodeObject[];
     fee: StdFee;
     memo: string;
     signOptions?: SignOptions;
+    memoFlags?: TxFeMemoFlags;
   }): Promise<TxRaw> {
     const { accountNumber, sequence } = await this.getSequence(wallet);
     const chainId = wallet?.chainId;
@@ -863,6 +874,7 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
         fee,
         memo,
         signerData,
+        memoFlags,
       });
     }
 
@@ -916,6 +928,7 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
           memo,
           signerData,
           signOptions,
+          memoFlags,
         })
       : this.signDirect({
           wallet,
@@ -925,6 +938,7 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
           memo,
           signerData,
           signOptions,
+          memoFlags,
         });
   }
 
@@ -935,6 +949,7 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
     fee,
     memo,
     signerData: { accountNumber, sequence, chainId },
+    memoFlags,
   }: {
     wallet: AccountStoreWallet;
     signerAddress: string;
@@ -942,6 +957,7 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
     fee: StdFee;
     memo: string;
     signerData: SignerData;
+    memoFlags?: TxFeMemoFlags;
   }): Promise<TxRaw> {
     if (!wallet.offlineSigner) {
       throw new Error("offlineSigner is not available in wallet");
@@ -959,14 +975,9 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
       throw new Error("One click trading info is not available");
     }
 
-    if (memo === "") {
-      // If the memo is empty, set it to "1CT" so we know it originated from the frontend for
-      // QA purposes.
-      memo = "1CT";
-    } else {
-      // Otherwise, tack on "1CT" to the end of the memo.
-      memo += " \n1CT";
-    }
+    // Tag the memo so we know the tx originated from the frontend (QA), plus
+    // any warn-accept flags the user acknowledged.
+    memo = appendFeMemoTag(memo, OneClickFeMemoTag, memoFlags);
 
     const [
       { encodeSecp256k1Pubkey, encodeSecp256k1Signature },
@@ -1067,6 +1078,7 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
     memo,
     signerData: { accountNumber, sequence, chainId },
     signOptions,
+    memoFlags,
   }: {
     wallet: AccountStoreWallet;
     signerAddress: string;
@@ -1075,6 +1087,7 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
     memo: string;
     signerData: SignerData;
     signOptions?: SignOptions;
+    memoFlags?: TxFeMemoFlags;
   }): Promise<TxRaw> {
     if (!wallet.offlineSigner) {
       throw new Error("offlineSigner is not available in wallet");
@@ -1095,14 +1108,11 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
       throw new Error("Failed to retrieve account from signer");
     }
 
-    if (memo === "") {
-      // If the memo is empty, set it to "OsmosisFE" so we know it originated from the frontend for
-      // QA purposes.
-      memo = "OsmosisFE";
-    } else {
-      // Otherwise, tack on "OsmosisFE" to the end of the memo.
-      memo += " \nOsmosisFE";
-    }
+    // Tag the memo so we know the tx originated from the frontend (QA), plus
+    // any warn-accept flags the user acknowledged. On this path the wallet
+    // can return an edited memo (`signed.memo` below is what gets encoded) —
+    // callers stamping flags should set `preferNoSetMemo`.
+    memo = appendFeMemoTag(memo, FeMemoTag, memoFlags);
 
     const [
       { encodeSecp256k1Pubkey },
@@ -1239,6 +1249,7 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
     memo,
     signerData: { accountNumber, sequence, chainId },
     signOptions,
+    memoFlags,
   }: {
     wallet: AccountStoreWallet;
     signerAddress: string;
@@ -1247,6 +1258,7 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
     memo: string;
     signerData: SignerData;
     signOptions?: SignOptions;
+    memoFlags?: TxFeMemoFlags;
   }): Promise<TxRaw> {
     if (!wallet.offlineSigner) {
       throw new Error("offlineSigner is not available in wallet");
@@ -1295,14 +1307,9 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
 
     pubkey.typeUrl = pubKeyTypeUrl;
 
-    if (memo === "") {
-      // If the memo is empty, set it to "OsmosisFE" so we know it originated from the frontend for
-      // QA purposes.
-      memo = "OsmosisFE";
-    } else {
-      // Otherwise, tack on "OsmosisFE" to the end of the memo.
-      memo += " \nOsmosisFE";
-    }
+    // Tag the memo so we know the tx originated from the frontend (QA), plus
+    // any warn-accept flags the user acknowledged.
+    memo = appendFeMemoTag(memo, FeMemoTag, memoFlags);
 
     const txBodyEncodeObject = {
       typeUrl: "/cosmos.tx.v1beta1.TxBody",

--- a/packages/stores/src/account/index.ts
+++ b/packages/stores/src/account/index.ts
@@ -2,6 +2,7 @@ export * from "./amino-converters";
 export * from "./base";
 export * from "./cosmos";
 export * from "./cosmwasm";
+export * from "./memo";
 export * from "./osmosis";
 export * from "./types";
 export * from "./utils";

--- a/packages/stores/src/account/memo.ts
+++ b/packages/stores/src/account/memo.ts
@@ -1,0 +1,92 @@
+import { Dec } from "@osmosis-labs/unit";
+
+/**
+ * Single writer of the frontend's tx auth-memo tag. This tags the top-level
+ * `TxBody.memo` (the auth memo) only — never the IBC forwarding memo inside
+ * `MsgTransfer.value.memo`, which carries bridge routing data.
+ *
+ * Grammar (canonical spec — MTN-137):
+ *
+ * ```
+ * <BASE>                              # default — no acknowledgement happened
+ * <BASE>/warn:pi=12.40                # user acknowledged the price-impact warning
+ * <BASE>/warn:slip=99.89              # user acknowledged the total-loss warning
+ * <BASE>/warn:slip=99.89,pi=12.40     # both (fixed order: slip before pi)
+ * ```
+ *
+ * where `<BASE>` is `OsmosisFE` (normal sign) or `1CT` (one-click session).
+ *
+ * Format rules:
+ * - Percentages at 2 decimal places, half-up rounding, no `%` sign
+ *   (`99.895` → `99.90`).
+ * - A flag appears only for a warning that was actually shown and
+ *   acknowledged; unwarned transactions carry the bare base tag.
+ * - The total memo stays well under 100 bytes.
+ * - A non-empty caller memo keeps the historical behavior: the tag is
+ *   appended after `" \n"`.
+ * - Amino caveat: wallets can let the user edit the memo before signing;
+ *   callers stamping flags should set `preferNoSetMemo` so the proof
+ *   survives signing untouched.
+ */
+
+/** Base tag appended to every frontend-originated tx for QA purposes. */
+export const FeMemoTag = "OsmosisFE";
+/** Base tag for transactions signed by a one-click trading session. */
+export const OneClickFeMemoTag = "1CT";
+
+export type FeMemoBaseTag = typeof FeMemoTag | typeof OneClickFeMemoTag;
+
+/**
+ * Warn-accept flags stamped into the auth memo (MTN-137). Values are the
+ * figures the user explicitly acknowledged (the frozen basis), never live
+ * sign-time values. A field is present iff its warning was shown and the
+ * user ticked the acknowledgement checkbox for it.
+ */
+export interface TxFeMemoFlags {
+  /** Acknowledged total-loss fraction (0..1) — stamped as `slip=<pct>`. */
+  slippage?: Dec;
+  /**
+   * Acknowledged bundled-swap price impact as a positive magnitude fraction
+   * (0..1) — stamped as `pi=<pct>`.
+   */
+  priceImpact?: Dec;
+}
+
+/**
+ * Formats a non-negative loss fraction as a percentage with exactly 2 decimal
+ * places, rounded half-up, without a `%` sign: `0.99895` → `"99.90"`.
+ */
+export function formatWarnPct(fraction: Dec): string {
+  // Work in hundredths of a percent so half-up rounding is a +0.5 truncate.
+  const hundredths = fraction
+    .mul(new Dec(10000))
+    .add(new Dec("0.5"))
+    .truncate()
+    .toString()
+    .padStart(3, "0");
+  return `${hundredths.slice(0, -2)}.${hundredths.slice(-2)}`;
+}
+
+/**
+ * Appends the frontend base tag — plus the `warn:` suffix when flags are
+ * present — to a tx auth memo, preserving the historical behavior for
+ * non-empty caller memos.
+ */
+export function appendFeMemoTag(
+  memo: string,
+  baseTag: FeMemoBaseTag,
+  flags?: TxFeMemoFlags
+): string {
+  const warnParts: string[] = [];
+  if (flags?.slippage !== undefined) {
+    warnParts.push(`slip=${formatWarnPct(flags.slippage)}`);
+  }
+  if (flags?.priceImpact !== undefined) {
+    warnParts.push(`pi=${formatWarnPct(flags.priceImpact)}`);
+  }
+
+  const tag =
+    warnParts.length > 0 ? `${baseTag}/warn:${warnParts.join(",")}` : baseTag;
+
+  return memo === "" ? tag : `${memo} \n${tag}`;
+}

--- a/packages/web/components/bridge/__tests__/loss-acknowledgement.spec.ts
+++ b/packages/web/components/bridge/__tests__/loss-acknowledgement.spec.ts
@@ -1,6 +1,7 @@
 import { Dec } from "@osmosis-labs/unit";
 
 import {
+  deriveMemoFlags,
   hasActiveWarning,
   needsAcknowledgement,
   normalizePriceImpact,
@@ -196,5 +197,51 @@ describe("needsAcknowledgement", () => {
       slippage: warnedSlippage.add(AckReArmTolerance).add(new Dec(0.0001)),
     });
     expect(needsAcknowledgement(baseFigures(), worse)).toBe(true);
+  });
+});
+
+describe("deriveMemoFlags", () => {
+  it("is undefined when nothing was acknowledged", () => {
+    expect(deriveMemoFlags(null)).toBeUndefined();
+  });
+
+  it("stamps only the slippage figure when only the total-loss warning fired", () => {
+    const flags = deriveMemoFlags(baseFigures());
+    expect(flags?.slippage).toEqual(warnedSlippage);
+    expect(flags?.priceImpact).toBeUndefined();
+  });
+
+  it("stamps only the price-impact figure when only its warning fired", () => {
+    const impact = new Dec("0.124");
+    const flags = deriveMemoFlags(
+      baseFigures({
+        warnSlippage: false,
+        warnPriceImpact: true,
+        priceImpact: impact,
+      })
+    );
+    expect(flags?.priceImpact).toEqual(impact);
+    expect(flags?.slippage).toBeUndefined();
+  });
+
+  it("stamps both acknowledged figures when both warnings fired", () => {
+    const impact = new Dec("0.124");
+    const flags = deriveMemoFlags(
+      baseFigures({ warnPriceImpact: true, priceImpact: impact })
+    );
+    expect(flags?.slippage).toEqual(warnedSlippage);
+    expect(flags?.priceImpact).toEqual(impact);
+  });
+
+  it("yields no flags for an unknown-impact-only acknowledgement (no figure to stamp)", () => {
+    expect(
+      deriveMemoFlags(
+        baseFigures({
+          warnSlippage: false,
+          warnPriceImpact: false,
+          swapImpactUnknown: true,
+        })
+      )
+    ).toBeUndefined();
   });
 });

--- a/packages/web/components/bridge/loss-acknowledgement.ts
+++ b/packages/web/components/bridge/loss-acknowledgement.ts
@@ -1,4 +1,5 @@
 import type { Bridge } from "@osmosis-labs/bridge";
+import type { TxFeMemoFlags } from "@osmosis-labs/stores";
 import { Dec } from "@osmosis-labs/unit";
 
 import { AckReArmTolerance } from "~/config/trade-warnings";
@@ -118,4 +119,23 @@ export function shouldResetAcknowledgement(
   }
 
   return false;
+}
+
+/**
+ * Tx auth-memo flags (MTN-137) derived from the acknowledged basis — never
+ * from live sign-time figures, so the memo can only claim acceptance of
+ * numbers the user was actually shown. A figure is stamped iff its warning
+ * fired and was acknowledged; an unknown-impact acknowledgement has no figure
+ * to stamp, so it yields no flags.
+ */
+export function deriveMemoFlags(
+  basis: LossFigures | null
+): TxFeMemoFlags | undefined {
+  if (!basis) return undefined;
+
+  const flags: TxFeMemoFlags = {};
+  if (basis.warnSlippage) flags.slippage = basis.slippage;
+  if (basis.warnPriceImpact) flags.priceImpact = basis.priceImpact;
+
+  return flags.slippage || flags.priceImpact ? flags : undefined;
 }

--- a/packages/web/components/bridge/use-bridge-quotes.ts
+++ b/packages/web/components/bridge/use-bridge-quotes.ts
@@ -23,6 +23,7 @@ import { BaseError } from "wagmi";
 import { displayToast } from "~/components/alert/toast";
 import { ToastType } from "~/components/alert/types";
 import {
+  deriveMemoFlags,
   LossFigures,
   needsAcknowledgement,
   normalizePriceImpact,
@@ -683,6 +684,12 @@ export const useBridgeQuotes = ({
   }, [isTxPending, onRequestClose, transferInitiated]);
 
   const [isApprovingToken, setIsApprovingToken] = useState(false);
+  /**
+   * EVM transactions carry no auth-memo field (`EvmBridgeTransactionRequest`
+   * is only to/data/value/gas), so the warn-accept memo stamp (MTN-137)
+   * cannot be recorded on this path. The acknowledgement gate itself still
+   * applies — only the on-chain forensic proof is unavailable.
+   */
   const signAndBroadcastEvmTx = async (
     quote: NonNullable<typeof selectedQuote>["quote"]
   ) => {
@@ -790,6 +797,11 @@ export const useBridgeQuotes = ({
     const gasFee = transactionRequest.gasFee;
     let nomicCheckpointIndex: number | undefined;
 
+    // Warn-accept flags for the tx auth memo (MTN-137), stamped from the
+    // frozen acknowledged basis — the sign-time guard in `onTransfer` has
+    // already ensured the basis is fresh for the quote being signed.
+    const memoFlags = deriveMemoFlags(acknowledgedBasis);
+
     return accountStore.signAndBroadcast(
       fromChain.chainId,
       `${fromChain.chainId}:${fromAsset?.denom} -> ${toChain?.chainId}:${toAsset?.denom}`,
@@ -811,6 +823,9 @@ export const useBridgeQuotes = ({
         : undefined,
       {
         preferNoSetFee: Boolean(gasFee),
+        // On the amino path the wallet-returned memo is what gets encoded —
+        // don't let wallets offer to edit/drop the warn-accept proof.
+        ...(memoFlags && { preferNoSetMemo: true }),
       },
       {
         /**
@@ -863,7 +878,8 @@ export const useBridgeQuotes = ({
             setIsBroadcastingTx(false);
           }
         },
-      }
+      },
+      memoFlags
     );
   };
 


### PR DESCRIPTION
## What is the purpose of the change

When a user acknowledges a high-loss warning and signs anyway, stamp what they accepted into the transaction's auth memo (e.g. `OsmosisFE/warn:slip=99.89,pi=12.40`), so a tx hash alone can answer "was the user warned, or did the frontend fail to warn?". MTN-199 (#4403) guarantees the acknowledgement this stamp derives from; that has now merged, so this branch is rebased directly on `stage` as a single commit.

### Linear Task

https://linear.app/osmosis/issue/MTN-137/append-warn-accept-flags-to-the-fe-auth-memo

## Brief Changelog

- **`packages/stores/src/account/memo.ts` (new)** — the single writer of the `OsmosisFE`/`1CT` tag and the `warn:` grammar (`slip` before `pi`, 2 d.p., half-up, no `%`). Its module doc block is the canonical spec, so the grammar cannot drift between call sites.
- **Three duplicated tag-append blocks replaced** — the block was byte-identical in `signOneClick`, `signAmino` and `signDirect`; the tag literals now live in one file.
- **Optional `memoFlags` threaded `signAndBroadcast` → `sign` → all three sign functions.** This replaces the original "thread it via `SignOptions`" design, which cannot work: `SignOptions` is forwarded verbatim to wallet clients, never read by the memo code, and never passed to `signOneClick` at all.
- **`deriveMemoFlags` reads MTN-199's frozen acknowledged basis, never live sign-time figures** — the memo is proof of what the user *accepted*, so it must not claim acceptance of numbers they were never shown. A figure is stamped if and only if its warning fired and was acknowledged.
- **`preferNoSetMemo: true` when flags are present** — on the amino path the wallet-returned memo is what gets encoded, so without this a wallet could offer to edit the proof away.
- **EVM sign path documented as unstampable** — EVM transactions have no auth-memo field. The gate still applies there; only the forensic stamp is unavailable.
- **Tests** — the full grammar matrix including half-up rounding edges and a byte-budget assertion, plus `deriveMemoFlags` derivation cases.

## Testing and Verifying

### Automated

- `memo.spec.ts` (17 tests) — the grammar matrix for every flag combination and both base tags, half-up rounding edges (`Dec.round()` is banker's rounding, so it is implemented manually), the sub-100-byte budget, and unwarned transactions producing exactly the bare tags.
- `deriveMemoFlags` (5 tests) — ticked and warned yields the acknowledged figures; unticked yields undefined; `slip` only when its warning fired; an unknown-impact-only acknowledgement stamps nothing.
- 109 web bridge tests across 5 suites pass alongside the `stores` suite. `tsc --noEmit` is clean in every file this branch touches. Note that `packages/stores` and `packages/bridge` must be built before typechecking `packages/web`, and the build must not use `--parallel`.

### Manual QA — 13 tests on the Vercel preview against mainnet, all pass

| # | Test | Result |
|---|---|---|
| 0 | Unit suites green | Baseline for test 12: 17 + 109 passing, typecheck clean |
| 1 | Baseline tag regression | Ordinary swap stamps `OsmosisFE`, Memo field **editable** — the control for test 3 |
| 2 | Benign withdrawal | $60 allETH → Ethereum: no warning, no checkbox, bare tag |
| 3 | Warned and acknowledged | $8 allETH → `OsmosisFE/warn:slip=8.65`, Memo field **read-only**, so `preferNoSetMemo` reaches the amino path. No `pi=` component — a flag is correctly omitted when its warning did not fire |
| 4 | Frozen basis, not sign-time values | Ticked at 7.0566%, let the quote drift to 7.3903% with the box still ticked, memo stamped `slip=7.06` — the tick-time figure |
| 5 | Re-arm then re-tick | Ticked at 7.42%, drift unticked the box, re-ticked at 8.46%, memo stamped `slip=8.47` — the **second** tick's figure |
| 6 | `pi=` alone | ⚠️ **Not reachable on any live route** — see note below |
| 7 | Combined form | 100 allDOGE → `OsmosisFE/warn:slip=93.35,pi=93.06`, fixed order. Each figure verified against an independent source, and they differ by 0.29pp, which proves each lands in its own slot |
| 8 | Unknown swap impact stamps nothing | Cannot fire in production (the router always reports an impact) — unit-tested instead |
| 9 | 1CT bare tag | Broadcast [`BE4FA93A…`](https://www.mintscan.io/osmosis/tx/BE4FA93AB03BE7018E285AB54FFBDEBFD526D4E445AB89E37FD40821B0192653): auth memo reads `1CT`, 3 bytes, no suffix |
| 10 | EVM deposit carries no memo | ✅ **Discharged by construction** — see note below |
| 11 | ✍️ On-chain forensic check | Broadcast [`334F9C3E…`](https://www.mintscan.io/osmosis/tx/334F9C3E9A609882D6BEB7C5B4DB48E546C39E26C046C58D1DB906B4F3818B32) → [`0xa9807b36…`](https://etherscan.io/tx/0xa9807b365a1542c8e9bbb4eb6eb9ede3061f7396d604f9312d9bfbffa36ef3d9): on-chain memo `OsmosisFE/warn:slip=6.03` matches the wallet prompt byte for byte, the provider routing payload is intact, and the funds landed |
| 12 | No knob residue, suites re-run | `config/trade-warnings.ts` is absent from the diff, so no threshold change ever touched this branch; suites match the test 0 baseline |

Tests 9 and 11 are the only ones that broadcast (~$0.75 of real loss in total). Every other test was observe-then-reject, because Keplr renders the auth memo on its approval screen.

**Two tests could not be observed directly.**

- **Test 6 (`pi=` with no `slip=`).** No provider on a route this account can reach reports a nonzero price impact: Skip and IBC hardcode `"0"`; Nomic and int3face only report one when their bundled swap is not a parity transmuter, and allBTC, allETH, allBCH and allLTC all unwind exactly 1:1; Squid computes a real figure but offers no allETH withdrawal targets. The one exception was allDOGE, nonzero only because its redemption leg is drained (MTN-251), where the price impact is inseparable from the slippage — and those withdrawals have since been halted. The property this test uniquely asserts is covered three other ways: test 7 proves the `pi` path end to end with a real value, test 3 proves the mirror case, and `deriveMemoFlags` is two independent `if`s with the pi-only grammar unit-covered.
- **Test 10 (EVM deposit).** `EvmBridgeTransactionRequest` has no memo field at all, and `memoFlags` is derived and passed only in the Cosmos sign branch, so the stamp is structurally impossible rather than merely skipped. An empirical deposit would demonstrate only that MetaMask opens with no memo field.

**On the IBC forwarding memo.** It is untouched by construction — the diff only ever writes the `TxBody.memo` string and no code path reads or rewrites `msgs`. Test 11 confirms that end to end on a real broadcast, and does so on a `MsgExecuteContract` route where the routing data is nested inside the message body, which is a broader result than the `MsgTransfer` case the ticket describes.

Full QA log — routes, amounts, voided attempts, the provider survey, and the behaviours confirmed correct by design — is on MTN-137.

Four pre-existing issues surfaced during this QA and are filed separately, none blocking this change: MTN-246 (lint-staged path mapping, since fixed), MTN-247 (a LaunchDarkly failure takes down the whole bridge provider list), MTN-250 (the requote timer runs through the acknowledgement decision), and MTN-251 (the allDOGE → Dogecoin route is a ~97% loss trap — the June incident pattern live in production, which MTN-199's gate does correctly catch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
