### PR TITLE
fix(bridge): re-clamp max on fee drift and widen gas head-room to 3x

### DIFF
--- a/packages/web/components/control/__tests__/crypto-fiat-input-max-guard.spec.tsx
+++ b/packages/web/components/control/__tests__/crypto-fiat-input-max-guard.spec.tsx
@@ -25,7 +25,7 @@ function makeGasCost(amount: string) {
   return new CoinPretty(ATOM_CURRENCY, amount);
 }
 
-const MUL_GAS_SLIPPAGE = new Dec("2");
+const MUL_GAS_SLIPPAGE = new Dec("3");
 
 function expectedMaxAfterGas(balanceRaw: string, gasRaw: string) {
   const balance = new CoinPretty(ATOM_CURRENCY, balanceRaw);
@@ -160,6 +160,61 @@ describe("CryptoFiatInput gasAppliedToMax guard", () => {
     // Give effects time to settle — gas should NOT be re-applied
     await new Promise((r) => setTimeout(r, 100));
     expect(onChangeCryptoInput).not.toHaveBeenCalled();
+  });
+
+  it("re-clamps when fee drift exhausts the head-room", async () => {
+    const balanceRaw = "2000000";
+    const gasRaw1 = "5000";
+    // rises enough that the latched input (balance - 3*5000 = 1985000) no
+    // longer covers even face-value gas: 1985000 + 20000 > 2000000
+    const gasRaw2 = "20000";
+    const onChangeCryptoInput = jest.fn();
+
+    const { rerender } = renderInput({
+      isMax: true,
+      cryptoInput: makeBalance(balanceRaw).toDec().toString(),
+      transferGasCost: makeGasCost(gasRaw1),
+      balanceRaw,
+      onChangeCryptoInput,
+    });
+
+    const expected1 = expectedMaxAfterGas(balanceRaw, gasRaw1);
+    await waitFor(() => {
+      expect(onChangeCryptoInput).toHaveBeenCalledWith(expected1);
+    });
+
+    onChangeCryptoInput.mockClear();
+
+    const balance = makeBalance(balanceRaw);
+    rerender(
+      <CryptoFiatInput
+        currentUnit="crypto"
+        setCurrentUnit={jest.fn()}
+        isMax={true}
+        setIsMax={jest.fn()}
+        canSetMax={true}
+        transferGasCost={makeGasCost(gasRaw2)}
+        transferGasChain={{ prettyName: "Cosmos Hub" }}
+        assetPrice={undefined}
+        assetWithBalance={{
+          denom: "ATOM",
+          address: "uatom",
+          decimals: 6,
+          amount: balance,
+        }}
+        cryptoInput={expected1}
+        onChangeCryptoInput={onChangeCryptoInput}
+        fiatInput=""
+        onChangeFiatInput={jest.fn()}
+        isInsufficientBal={false}
+        isInsufficientFee={false}
+      />
+    );
+
+    const expected2 = expectedMaxAfterGas(balanceRaw, gasRaw2);
+    await waitFor(() => {
+      expect(onChangeCryptoInput).toHaveBeenCalledWith(expected2);
+    });
   });
 
   it("resets guard when isMax is toggled off, allowing gas to apply on next Max", async () => {

--- a/packages/web/components/control/__tests__/crypto-fiat-input.spec.tsx
+++ b/packages/web/components/control/__tests__/crypto-fiat-input.spec.tsx
@@ -103,7 +103,7 @@ describe.each(testCases)(
 
       const expectedMax = balanceCoin
         .toDec()
-        .sub(transferGasCost.toDec().mul(new Dec("2")));
+        .sub(transferGasCost.toDec().mul(new Dec("3")));
       const expectedValue = trimPlaceholderZeros(expectedMax.toString());
 
       const onChangeCryptoInput = jest.fn();

--- a/packages/web/components/control/crypto-fiat-input.tsx
+++ b/packages/web/components/control/crypto-fiat-input.tsx
@@ -24,10 +24,11 @@ import { trimPlaceholderZeros } from "~/utils/number";
 // Head-room multiplier on the quoted gas cost when clamping a max-amount
 // input. Must absorb base-fee drift between quote time and signing time
 // plus wallet-side padding: the EIP-1559 base fee moves up to ±12.5% per
-// block and wallets budget their own worst-case fee when the user signs,
-// so a thin margin fails the signature with "insufficient funds".
-// Over-reserving only leaves ~one gas fee of dust in the wallet.
-const mulGasSlippage = new Dec("2");
+// block and wallets budget their own worst-case fee (own gas-limit padding
+// included) when the user signs, so a thin margin fails the signature with
+// "insufficient funds". 2x proved insufficient in field testing; the reserve
+// only strands a couple of gas fees of dust in the wallet, so err high.
+const mulGasSlippage = new Dec("3");
 
 /** Safely converts a raw input string to a Dec value.
  * Returns "0" for empty strings or lone decimals that can't be parsed.
@@ -286,25 +287,44 @@ export const CryptoFiatInput: FunctionComponent<{
       additiveTransferFee &&
         isSameCoinDenom(additiveTransferFee, assetWithBalance.amount)
     );
+    const gasMatchesInputDenom = Boolean(
+      transferGasCost &&
+        isSameCoinDenom(transferGasCost, assetWithBalance.amount)
+    );
 
     if (transferGasCost || additiveFeeMatchesInputDenom) {
       // Skip only if the latched application already covered everything
       // currently known: a gas-only application must re-run when an
       // additive fee shows up later so the fee also gets reserved.
-      if (
+      const alreadyApplied =
         gasAppliedToMax.current &&
-        (feeAppliedToMax.current || !additiveFeeMatchesInputDenom)
-      ) {
-        return;
+        (feeAppliedToMax.current || !additiveFeeMatchesInputDenom);
+
+      if (alreadyApplied) {
+        // Quotes keep refreshing while the user lingers, and the fee market
+        // moves underneath the latched input. Stay latched while the input
+        // still covers the LATEST face-value fee + gas (the head-room from
+        // the original clamp is intact enough); once even face value no
+        // longer fits the balance, fall through and re-clamp with full
+        // head-room instead of letting the signature fail in the wallet.
+        let faceValue = new Dec(0);
+        if (gasMatchesInputDenom) {
+          faceValue = faceValue.add(transferGasCost!.toDec());
+        }
+        if (additiveFeeMatchesInputDenom) {
+          faceValue = faceValue.add(additiveTransferFee!.toDec());
+        }
+        const stillFunded = inputCoin
+          .toDec()
+          .add(faceValue)
+          .lte(assetWithBalance.amount.toDec());
+        if (stillFunded) return;
       }
 
       let deduction = new Dec(0);
 
-      if (
-        transferGasCost &&
-        isSameCoinDenom(transferGasCost, assetWithBalance.amount)
-      ) {
-        deduction = deduction.add(transferGasCost.toDec().mul(mulGasSlippage));
+      if (gasMatchesInputDenom) {
+        deduction = deduction.add(transferGasCost!.toDec().mul(mulGasSlippage));
       }
       if (additiveFeeMatchesInputDenom) {
         deduction = deduction.add(additiveTransferFee!.toDec());


### PR DESCRIPTION
## What is the purpose of the change:

Follow-up to #4406: field-tested max ETH deposits still overshot Keplr's gas reserve with the 2x head-room. This widens the reserve and, more importantly, stops the max clamp from trusting a stale gas quote while the fee market moves underneath it.

### Linear Task

[MTN-214](https://linear.app/osmosis/issue/MTN-214/bridge-deposits-max-amount-skip-quotes-fail-because-axelar-bridge-fee)

## Brief Changelog

- Raise the max-clamp gas head-room multiplier from 2x to 3x (absorbs wallet-side gas padding plus fee-market movement; the reserve only strands a couple of gas fees of dust).
- Re-validate the latched max input against every fresh quote: the latch holds while the input still covers the latest face-value fee + gas (no churn from small estimate wobble), but once even face value no longer fits the balance the clamp re-applies with full head-room instead of letting the wallet reject the signature.

## Testing and Verifying

- Deposit tx submitted successfully on first attempt: https://etherscan.io/tx/0xdc7d8e534e1d25599781db31f1b709998eed4959521d5958c7076afe52783b90

New spec: "re-clamps when fee drift exhausts the head-room" (gas rises past the buffer → input re-clamped to the new max). All 18 input-component tests pass, including the existing feedback-loop guard tests which confirm small gas wobble still does not churn the input.
