### PR TITLE
ci(e2e): run US market + limit monitoring suites 12-hourly

### DIFF
--- a/.github/workflows/monitoring-limit-geo-e2e-tests.yml
+++ b/.github/workflows/monitoring-limit-geo-e2e-tests.yml
@@ -1,9 +1,16 @@
 name: Synthetic Geo Monitoring Frontend tests
 
+# Two-tier cadence (cost control): the stablecoin swap suites are near-free
+# (round-trips net to ~0 USDC), so they run every hour in all regions. The US
+# market + limit suites cause almost all of the wallet drain (~25x the swap
+# suites' burn), so they only run on the 12-hourly ticks below. The two cron
+# entries don't overlap — every hour still fires exactly one run, and the
+# preflight/topup jobs keep their hourly rhythm.
 on:
   workflow_dispatch:
   schedule:
-    - cron: "1 * * * *"
+    - cron: "1 1-11,13-23 * * *" # hourly ticks: swap suites only
+    - cron: "1 0,12 * * *" # 12-hourly ticks: swap + market + limit
 
 permissions:
   actions: write
@@ -328,6 +335,10 @@ jobs:
   # Each `needs:` its region's preflight and skips when preflight reports
   # a critical (`fail`) balance shortage. Per-job balance checks have moved
   # to the preflight; these jobs only run the playwright tests.
+  #
+  # The swap jobs run on every tick; fe-trade-us and fe-limit-us are
+  # additionally gated to the 12-hourly schedule (see the cadence note on
+  # the schedule trigger).
   # -------------------------------------------------------------------------
 
   fe-swap-us:
@@ -481,7 +492,11 @@ jobs:
   fe-trade-us:
     timeout-minutes: 10
     needs: [preflight-us, fe-swap-us]
-    if: always() && needs.preflight-us.outputs.outcome != 'fail'
+    # Only on the 12-hourly ticks (or manual dispatch) — see the cadence note
+    # on the schedule trigger above.
+    if: >-
+      always() && needs.preflight-us.outputs.outcome != 'fail' &&
+      (github.event_name == 'workflow_dispatch' || github.event.schedule == '1 0,12 * * *')
     name: prod-fe-trade-us
     runs-on: macos-14
     outputs:
@@ -534,7 +549,11 @@ jobs:
   fe-limit-us:
     timeout-minutes: 15
     needs: [preflight-us, fe-trade-us]
-    if: always() && needs.preflight-us.outputs.outcome != 'fail'
+    # Only on the 12-hourly ticks (or manual dispatch) — see the cadence note
+    # on the schedule trigger above.
+    if: >-
+      always() && needs.preflight-us.outputs.outcome != 'fail' &&
+      (github.event_name == 'workflow_dispatch' || github.event.schedule == '1 0,12 * * *')
     name: prod-fe-limit-us
     runs-on: macos-14
     outputs:

--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -453,11 +453,13 @@ is capped, so all funds are utilized.
 rule**: top up only when `current < warnAmount`, and when topping up, refill
 all the way to `warnAmount × topup_multiplier` (the "target", default
 `3 × warnAmount`). When `warnAmount ≤ current < target`, the script reports
-`✓ ok (above warn, below target — no topup)` and skips the token. With the
-default multiplier and the observed monitoring-wallet drain rate (~5 USDC/hr
-on US, less on EU/SG), an auto-cron topup fires roughly every ~3.4 hours and
-refills the account back to ~5 hours of headroom — striking a balance between
-alert frequency and the size of stranded reserves.
+`✓ ok (above warn, below target — no topup)` and skips the token. Measured
+on-chain (Mar–Jul 2026), the US monitoring wallet drained ~0.4 USDC/hr
+(~10/day) with the market + limit suites running hourly — a ~17 USDC topup
+every ~2 days — while EU/SG (stablecoin swaps only) drain almost nothing.
+Since the market + limit suites moved to a 12-hourly cadence (Jul 2026), the
+expected US drain is ~34 USDC/month, so an auto-cron topup fires roughly
+every two weeks.
 
 The hysteresis matters because the monitoring tests are cyclic (each cron tick
 runs Buy then Sell pairs that *should* net to ~0 USDC). Mid-cycle, between a


### PR DESCRIPTION
## What is the purpose of the change:

Cut the e2e monitoring wallets' USDC burn by running the two expensive US suites twice a day instead of hourly. On-chain flow accounting (Mar–Jul 2026, topups netted out) measured ~297 USDC/month consumed by the US monitoring wallet, almost all of it from the market-order and limit-order suites; the stablecoin swap suites net to ~0 (EU/SG burn ~10–15/month combined). Expected result: US drops to ~34 USDC/month and total e2e spend to ~100–120 USDC/month, while the swap heartbeat stays hourly in all three regions.

### Linear Task

N/A

## Brief Changelog

- Split the geo-monitoring cron into two non-overlapping schedules: `1 1-11,13-23 * * *` (hourly) and `1 0,12 * * *` (12-hourly).
- Gate `fe-trade-us` and `fe-limit-us` on the 12-hourly schedule; `workflow_dispatch` still runs the full suite. Preflights and `topup-dispatch` keep running every tick, so the 45-min topup cooldown logic is unchanged.
- Replace the stale "~5 USDC/hr on US" drain figure in the e2e README with the measured rates.

## Testing and Verifying

Workflow YAML validated locally. Skipped jobs don't count as failed, so `fe-bot-alert` (`failure()` gate) and `retry-e2e-test.yml` (reruns failed jobs only) are unaffected on hourly ticks. After merge to `stage` (default branch, so the schedule change takes effect immediately): hourly-tick runs should show `prod-fe-trade-us`/`prod-fe-limit-us` skipped, the 00:01/12:01 UTC runs should execute them, and US topups (~17 USDC each) should stretch from every ~2 days to roughly every two weeks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
