### PR TITLE
ci(e2e): weekly/monthly fleet balance report to Slack

### DIFF
--- a/.github/workflows/e2e-fleet-balance-report.yml
+++ b/.github/workflows/e2e-fleet-balance-report.yml
@@ -1,0 +1,161 @@
+name: "E2E: Fleet Balance Report"
+
+# Posts a periodic Slack report of total assets across all five E2E accounts
+# (US/EU/SG monitoring, preview, topup/holding), valued in USD at SQS prices.
+# Read-only — no transactions.
+#
+# Cadence: weekly compact report (Mondays 09:00 UTC, an hour after the sweep
+# so it reflects post-sweep state) and a monthly full report (1st, 09:30 UTC).
+# When the 1st lands on a Monday, the weekly is skipped in favor of the
+# monthly.
+#
+# Trend/burn-rate math never assumes a fixed interval: each scheduled run
+# uploads its numbers as a `fleet-balance-state` artifact, and the next run
+# picks the prior artifact *closest to its target window* (7 days for weekly,
+# 30 for monthly) — so extra manual runs neither skew the window nor pollute
+# the baseline history (manual dispatches don't upload state unless
+# `save_state` is checked).
+
+run-name: "Fleet balance report — ${{ github.event_name == 'schedule' && (github.event.schedule == '30 9 1 * *' && 'monthly' || 'weekly') || format('manual ({0})', inputs.mode) }}"
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Report detail level"
+        type: choice
+        options:
+          - full
+          - compact
+        default: full
+      save_state:
+        description: "Save this run's numbers as a trend baseline (scheduled runs always do)"
+        type: boolean
+        default: false
+  schedule:
+    - cron: "0 9 * * 1" # weekly compact, Monday 09:00 UTC (post-sweep)
+    - cron: "30 9 1 * *" # monthly full, 1st of month 09:30 UTC
+
+concurrency:
+  group: e2e-fleet-report
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  actions: read # list/download prior state artifacts
+
+jobs:
+  report:
+    name: "Fleet balance report"
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Plan run (mode, window, state saving)
+        id: plan
+        env:
+          EVENT: ${{ github.event_name }}
+          SCHEDULE: ${{ github.event.schedule }}
+          INPUT_MODE: ${{ inputs.mode }}
+          INPUT_SAVE: ${{ inputs.save_state }}
+        run: |
+          SKIP=false
+          if [ "$EVENT" = "schedule" ]; then
+            SAVE=true
+            if [ "$SCHEDULE" = "30 9 1 * *" ]; then
+              MODE=full; LABEL=monthly; WINDOW_DAYS=30
+            else
+              MODE=compact; LABEL=weekly; WINDOW_DAYS=7
+              # Skip the weekly when the monthly fires the same morning.
+              if [ "$(date -u +%d)" = "01" ]; then
+                echo "1st of the month — monthly report supersedes the weekly."
+                SKIP=true
+              fi
+            fi
+          else
+            MODE="${INPUT_MODE:-full}"; LABEL=manual
+            SAVE="${INPUT_SAVE:-false}"
+            if [ "$MODE" = "full" ]; then WINDOW_DAYS=30; else WINDOW_DAYS=7; fi
+          fi
+          {
+            echo "skip=$SKIP"
+            echo "mode=$MODE"
+            echo "label=$LABEL"
+            echo "save=$SAVE"
+            echo "window_days=$WINDOW_DAYS"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Check out repository
+        if: steps.plan.outputs.skip != 'true'
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            packages/e2e
+
+      - name: Setup Node.js
+        if: steps.plan.outputs.skip != 'true'
+        uses: actions/setup-node@v6
+        with:
+          package-manager-cache: false
+          node-version: 22.x
+
+      - name: Cache dependencies
+        if: steps.plan.outputs.skip != 'true'
+        uses: actions/cache@v5
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.OS }}-22.x-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.OS }}-22.x-
+
+      - name: Install dependencies
+        if: steps.plan.outputs.skip != 'true'
+        run: yarn --cwd packages/e2e install --frozen-lockfile
+
+      - name: Download baseline state (closest to target window)
+        if: steps.plan.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          WINDOW_DAYS: ${{ steps.plan.outputs.window_days }}
+        run: |
+          TARGET=$(date -u -d "-${WINDOW_DAYS} days" +%s)
+          # Pick the non-expired fleet-balance-state artifact whose creation
+          # time is closest to the target window, so extra runs in between
+          # never shrink the trend window.
+          ARTIFACT_ID=$(gh api "repos/$GH_REPO/actions/artifacts?name=fleet-balance-state&per_page=100" |
+            jq -r --argjson target "$TARGET" '
+              [.artifacts[] | select(.expired | not)]
+              | map(. + {diff: (((.created_at | fromdateiso8601) - $target) | if . < 0 then -. else . end)})
+              | sort_by(.diff)
+              | .[0].id // empty')
+          if [ -n "$ARTIFACT_ID" ]; then
+            echo "Using baseline artifact $ARTIFACT_ID (target: $WINDOW_DAYS days ago)."
+            gh api "repos/$GH_REPO/actions/artifacts/$ARTIFACT_ID/zip" > baseline.zip
+            mkdir -p baseline && unzip -o baseline.zip -d baseline
+            echo "BASELINE_STATE_PATH=$PWD/baseline/fleet-state.json" >> "$GITHUB_ENV"
+          else
+            echo "No prior state artifact — snapshot-only report."
+          fi
+
+      - name: Generate and post report
+        if: steps.plan.outputs.skip != 'true'
+        env:
+          MODE: ${{ steps.plan.outputs.mode }}
+          REPORT_LABEL: ${{ steps.plan.outputs.label }}
+          OUTPUT_STATE_PATH: ${{ github.workspace }}/fleet-state.json
+          E2E_PRIVATE_KEY_TOPUP: ${{ secrets.E2E_PRIVATE_KEY_TOPUP }}
+          E2E_PRIVATE_KEY_PREVIEW: ${{ secrets.E2E_PRIVATE_KEY_PREVIEW }}
+          TEST_PRIVATE_KEY_SG: ${{ secrets.TEST_PRIVATE_KEY_SG }}
+          TEST_PRIVATE_KEY_EU: ${{ secrets.TEST_PRIVATE_KEY_EU }}
+          TEST_PRIVATE_KEY_US: ${{ secrets.TEST_PRIVATE_KEY_US }}
+          SLACK_WEBHOOK_URL: ${{ secrets.E2E_SLACK_WEBHOOK_BALANCE_ALERTS }}
+        run: npx tsx packages/e2e/scripts/report-fleet-balances.ts
+
+      - name: Upload state artifact (trend baseline)
+        if: steps.plan.outputs.skip != 'true' && steps.plan.outputs.save == 'true'
+        uses: actions/upload-artifact@v6
+        with:
+          name: fleet-balance-state
+          path: ${{ github.workspace }}/fleet-state.json
+          retention-days: 90

--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -405,10 +405,12 @@ on-chain balances) and only sends the remainder — no double-sends will occur.
 | **E2E: Migrate Funds** | `e2e-migrate-funds.yml` | One-time extract/distribute for wallet rotation |
 | **E2E: Topup Test Accounts** | `e2e-topup-accounts.yml` | Ongoing topup when accounts run low |
 | **E2E: Sweep Account Surplus** | `e2e-sweep-accounts.yml` | Weekly (+ manual) sweep of surplus tokens back to the topup account |
+| **E2E: Fleet Balance Report** | `e2e-fleet-balance-report.yml` | Weekly compact + monthly full Slack report of total assets across all 5 accounts |
 
-All workflows default to **dry run** on manual dispatch (the sweep's weekly
-cron runs live). The `RESERVE_OSMO` / `RESERVE_USDC` inputs control how much
-to keep in the **topup account** during distribute and topup phases.
+All fund-moving workflows default to **dry run** on manual dispatch (the
+sweep's weekly cron runs live; the balance report is read-only). The
+`RESERVE_OSMO` / `RESERVE_USDC` inputs control how much to keep in the
+**topup account** during distribute and topup phases.
 
 The sweep is the topup's inverse: the monitoring tests slowly convert USDC
 into other tokens (buy/sell asymmetry, failed sell legs), so wallets
@@ -424,6 +426,18 @@ live runs post only when something was swept or failed (the weekly cron stays
 silent when there's no surplus). The summary lists per-account swept coins
 with Mintscan links plus the topup account's resulting balances, so the
 manual swap-back can be planned straight from the message.
+
+The fleet balance report (`scripts/report-fleet-balances.ts`) is the
+usage-visibility layer: every Monday it posts a compact per-account USD
+summary, and on the 1st a full per-token breakdown, covering all five
+accounts including topup/holding. Each scheduled run saves its numbers as a
+`fleet-balance-state` artifact; the next run picks the prior artifact
+*closest to its target window* (7 days weekly / 30 days monthly) and scales
+the burn rate by the actual elapsed days — so extra manual runs neither
+shrink the trend window nor pollute the baseline history (manual dispatches
+don't save state unless `save_state` is checked). The trend section shows the
+total USD delta alongside the USDC-only delta (the cleanest burn signal,
+since the total conflates burn with price moves) plus estimated USDC runway.
 
 **Required secrets:**
 

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -9,7 +9,8 @@
     "check-balances": "npx tsx scripts/check-balances.ts",
     "migrate-funds": "npx tsx scripts/migrate-funds.ts",
     "topup-accounts": "npx tsx scripts/topup-accounts.ts",
-    "sweep-surplus": "npx tsx scripts/sweep-surplus.ts"
+    "sweep-surplus": "npx tsx scripts/sweep-surplus.ts",
+    "report-fleet-balances": "npx tsx scripts/report-fleet-balances.ts"
   },
   "dependencies": {
     "@actions/core": "1.11.1",

--- a/packages/e2e/scripts/report-fleet-balances.ts
+++ b/packages/e2e/scripts/report-fleet-balances.ts
@@ -1,0 +1,310 @@
+/**
+ * @file report-fleet-balances.ts
+ * @description Posts a periodic Slack report of total assets across all E2E
+ * accounts (the four test accounts plus the topup holding account), valued in
+ * USD at current SQS prices.
+ *
+ * Read-only: derives addresses from the key secrets and queries balances —
+ * no transactions are ever sent.
+ *
+ * Trend data: the workflow downloads the prior run's state artifact whose
+ * timestamp is closest to the target window (7 days for weekly, 30 for
+ * monthly) and passes it via `BASELINE_STATE_PATH`. The burn rate is scaled
+ * by the *actual* elapsed days from that baseline's stored timestamp — never
+ * by an assumed interval — so extra manual runs can't skew the math. The
+ * report always states which baseline was used. This run's numbers are
+ * written to `OUTPUT_STATE_PATH` for the workflow to upload (scheduled runs
+ * only, unless `save_state` is requested).
+ *
+ * Environment variables:
+ * - `E2E_PRIVATE_KEY_TOPUP`, `E2E_PRIVATE_KEY_PREVIEW`,
+ *   `TEST_PRIVATE_KEY_SG/EU/US` — keys (address derivation only).
+ * - `MODE`                — "full" (per-token tables) or "compact" (one line
+ *                           per account). Default "full".
+ * - `REPORT_LABEL`        — Slack header label ("monthly" / "weekly" /
+ *                           "manual"); defaults to MODE.
+ * - `BASELINE_STATE_PATH` — optional path to a prior run's state JSON.
+ * - `OUTPUT_STATE_PATH`   — where to write this run's state JSON
+ *                           (default "fleet-state.json").
+ * - `SLACK_WEBHOOK_URL`   — optional; same balance-alerts channel as the
+ *                           topup/sweep scripts.
+ */
+
+import * as dotenv from "dotenv";
+import * as fs from "fs";
+import * as path from "path";
+
+import { deriveAddress } from "../utils/order-utils";
+import { fetchTokenPrices } from "../utils/price-utils";
+import {
+  type TokenBalance,
+  fetchAllKnownBalances,
+  validatePrivateKey,
+} from "../utils/fund-utils";
+
+dotenv.config({ path: path.resolve(__dirname, "../.env") });
+
+const ACCOUNTS = [
+  { envVar: "TEST_PRIVATE_KEY_US", label: "Monitoring US" },
+  { envVar: "TEST_PRIVATE_KEY_EU", label: "Monitoring EU" },
+  { envVar: "TEST_PRIVATE_KEY_SG", label: "Monitoring SG" },
+  { envVar: "E2E_PRIVATE_KEY_PREVIEW", label: "E2E Test Account" },
+  { envVar: "E2E_PRIVATE_KEY_TOPUP", label: "Topup / holding" },
+] as const;
+
+interface TokenRow {
+  symbol: string;
+  amount: number;
+  /** USD value, or null when no price was available. */
+  usd: number | null;
+}
+
+interface AccountReport {
+  label: string;
+  address: string;
+  rows: TokenRow[];
+  totalUsd: number;
+  usdc: number;
+  unpricedSymbols: string[];
+}
+
+/** Persisted per-run state used as the baseline for the next report. */
+interface FleetState {
+  timestamp: string;
+  grandTotalUsd: number;
+  grandUsdc: number;
+  accounts: { label: string; totalUsd: number; usdc: number }[];
+}
+
+const fmtUsd = (n: number): string =>
+  `$${n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
+const fmtDelta = (n: number): string => `${n >= 0 ? "+" : "−"}${fmtUsd(Math.abs(n))}`;
+
+async function buildAccountReport(
+  label: string,
+  address: string,
+  prices: Record<string, number>,
+  balances: TokenBalance[]
+): Promise<AccountReport> {
+  const rows: TokenRow[] = [];
+  const unpricedSymbols: string[] = [];
+  let totalUsd = 0;
+  let usdc = 0;
+
+  for (const bal of balances) {
+    const price = prices[bal.denom];
+    const usd = price && price > 0 ? bal.amount * price : null;
+    if (usd === null) {
+      unpricedSymbols.push(bal.symbol);
+    } else {
+      totalUsd += usd;
+    }
+    if (bal.symbol === "USDC") usdc = bal.amount;
+    rows.push({ symbol: bal.symbol, amount: bal.amount, usd });
+  }
+
+  rows.sort((a, b) => (b.usd ?? 0) - (a.usd ?? 0));
+  return { label, address, rows, totalUsd, usdc, unpricedSymbols };
+}
+
+function loadBaseline(): FleetState | null {
+  const p = process.env.BASELINE_STATE_PATH;
+  if (!p || !fs.existsSync(p)) return null;
+  try {
+    const raw = fs.readFileSync(p, "utf8").replace(/^\uFEFF/, "");
+    const state = JSON.parse(raw) as FleetState;
+    if (!state.timestamp || typeof state.grandTotalUsd !== "number") {
+      console.warn("  ⚠ Baseline state file is malformed — ignoring.");
+      return null;
+    }
+    return state;
+  } catch (err) {
+    console.warn(
+      "  ⚠ Could not read baseline state:",
+      err instanceof Error ? err.message : err
+    );
+    return null;
+  }
+}
+
+function trendLines(
+  baseline: FleetState | null,
+  grandTotalUsd: number,
+  grandUsdc: number
+): string[] {
+  if (!baseline) {
+    return ["_No prior report data — snapshot only (trend starts next run)._"];
+  }
+
+  const elapsedMs = Date.now() - new Date(baseline.timestamp).getTime();
+  const elapsedDays = elapsedMs / 86_400_000;
+  if (elapsedDays < 0.04) {
+    return [
+      `_Baseline (${baseline.timestamp.slice(0, 10)}) is less than an hour old — trend skipped._`,
+    ];
+  }
+
+  const deltaUsd = grandTotalUsd - baseline.grandTotalUsd;
+  const deltaUsdc = grandUsdc - baseline.grandUsdc;
+  const lines = [
+    `*Trend* (vs report from ${baseline.timestamp.slice(0, 10)}, ${elapsedDays.toFixed(1)} days ago):`,
+    `  Total: ${fmtDelta(deltaUsd)}  |  USDC only: ${fmtDelta(deltaUsdc)} _(stable — cleanest burn signal; total Δ includes price moves)_`,
+  ];
+
+  const burnUsdc30 = (-deltaUsdc / elapsedDays) * 30;
+  if (burnUsdc30 > 0.01) {
+    const runwayMonths = grandUsdc / burnUsdc30;
+    lines.push(
+      `  USDC burn: ~${fmtUsd(burnUsdc30)}/30d → USDC runway ~${runwayMonths.toFixed(1)} months`
+    );
+  } else {
+    lines.push(
+      `  USDC burn: none over this window (net ${fmtDelta(deltaUsdc)} — inflow or flat)`
+    );
+  }
+  return lines;
+}
+
+async function postSlack(text: string, headerText: string): Promise<void> {
+  const webhookUrl = process.env.SLACK_WEBHOOK_URL;
+  if (!webhookUrl) {
+    console.log("  SLACK_WEBHOOK_URL not set — skipping Slack post.");
+    return;
+  }
+  const payload = {
+    text: headerText,
+    blocks: [
+      {
+        type: "header",
+        text: { type: "plain_text", text: headerText, emoji: true },
+      },
+      { type: "section", text: { type: "mrkdwn", text } },
+    ],
+  };
+  const resp = await fetch(webhookUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!resp.ok) {
+    throw new Error(`Slack webhook responded ${resp.status}: ${await resp.text()}`);
+  }
+  console.log("  Slack report sent.");
+}
+
+async function main(): Promise<void> {
+  const mode = process.env.MODE === "compact" ? "compact" : "full";
+  const outputStatePath = process.env.OUTPUT_STATE_PATH ?? "fleet-state.json";
+
+  console.log(`\n=== E2E Fleet Balance Report (${mode}) ===`);
+
+  // Resolve all accounts and fetch balances first, then price every denom in
+  // one SQS call.
+  const resolved: { label: string; address: string; balances: TokenBalance[] }[] = [];
+  for (const acct of ACCOUNTS) {
+    const key = process.env[acct.envVar];
+    if (!key) {
+      console.error(`❌ ${acct.envVar} is not set.`);
+      process.exit(1);
+    }
+    validatePrivateKey(key, acct.envVar, acct.label);
+    const { address } = await deriveAddress(key);
+    const balances = await fetchAllKnownBalances(address);
+    resolved.push({ label: acct.label, address, balances });
+  }
+
+  const denoms = [
+    ...new Set(resolved.flatMap((r) => r.balances.map((b) => b.denom))),
+  ];
+  let prices: Record<string, number> = {};
+  try {
+    prices = await fetchTokenPrices(denoms);
+  } catch (err) {
+    console.warn(
+      "  ⚠ Price fetch failed — USD totals will be incomplete:",
+      err instanceof Error ? err.message : err
+    );
+  }
+
+  const reports: AccountReport[] = [];
+  for (const r of resolved) {
+    reports.push(await buildAccountReport(r.label, r.address, prices, r.balances));
+  }
+
+  const grandTotalUsd = reports.reduce((s, r) => s + r.totalUsd, 0);
+  const grandUsdc = reports.reduce((s, r) => s + r.usdc, 0);
+  const allUnpriced = [...new Set(reports.flatMap((r) => r.unpricedSymbols))];
+  const baseline = loadBaseline();
+  const baselineByLabel = new Map(
+    (baseline?.accounts ?? []).map((a) => [a.label, a])
+  );
+
+  // Console + Slack body
+  const lines: string[] = [];
+  lines.push(
+    `*Grand total: ${fmtUsd(grandTotalUsd)}*  (USDC across all accounts: ${grandUsdc.toFixed(2)})`
+  );
+  lines.push("");
+
+  for (const r of reports) {
+    const base = baselineByLabel.get(r.label);
+    const delta = base ? `  (Δ ${fmtDelta(r.totalUsd - base.totalUsd)})` : "";
+    lines.push(`*${r.label}*: ${fmtUsd(r.totalUsd)}${delta} — \`${r.address}\``);
+    if (mode === "full" && r.rows.length > 0) {
+      const maxSym = Math.max(...r.rows.map((t) => t.symbol.length), 6);
+      lines.push("```");
+      lines.push(`${"Token".padEnd(maxSym)}  ${"Amount".padStart(16)}  ${"USD".padStart(12)}`);
+      lines.push(`${"─".repeat(maxSym)}  ${"─".repeat(16)}  ${"─".repeat(12)}`);
+      for (const t of r.rows) {
+        const d = t.amount >= 1000 ? 2 : 4;
+        lines.push(
+          `${t.symbol.padEnd(maxSym)}  ${t.amount.toFixed(d).padStart(16)}  ${(t.usd === null ? "n/a" : fmtUsd(t.usd)).padStart(12)}`
+        );
+      }
+      lines.push("```");
+    }
+  }
+
+  lines.push("");
+  lines.push(...trendLines(baseline, grandTotalUsd, grandUsdc));
+  if (allUnpriced.length > 0) {
+    lines.push(
+      `_No price for: ${allUnpriced.join(", ")} — excluded from USD totals._`
+    );
+  }
+
+  const serverUrl = process.env.GITHUB_SERVER_URL;
+  const repo = process.env.GITHUB_REPOSITORY;
+  const runId = process.env.GITHUB_RUN_ID;
+  if (serverUrl && repo && runId) {
+    lines.push(`*Details:* <${serverUrl}/${repo}/actions/runs/${runId}|View run logs>`);
+  }
+
+  const body = lines.join("\n");
+  console.log("\n" + body.replace(/[*_`]/g, "") + "\n");
+
+  // Persist this run's state for future baselines (workflow decides whether
+  // to upload it as an artifact).
+  const state: FleetState = {
+    timestamp: new Date().toISOString(),
+    grandTotalUsd,
+    grandUsdc,
+    accounts: reports.map((r) => ({
+      label: r.label,
+      totalUsd: r.totalUsd,
+      usdc: r.usdc,
+    })),
+  };
+  fs.writeFileSync(outputStatePath, JSON.stringify(state, null, 2));
+  console.log(`  State written to ${outputStatePath}`);
+
+  const label = process.env.REPORT_LABEL || mode;
+  await postSlack(body, `📊 E2E Fleet Balance Report (${label})`);
+}
+
+main().catch((err) => {
+  console.error("❌ Report failed:", err instanceof Error ? err.message : err);
+  process.exit(1);
+});

--- a/packages/e2e/scripts/report-fleet-balances.ts
+++ b/packages/e2e/scripts/report-fleet-balances.ts
@@ -34,7 +34,7 @@ import * as dotenv from "dotenv";
 import * as fs from "fs";
 import * as path from "path";
 
-import { deriveAddress } from "../utils/order-utils";
+import { deriveAddress } from "../utils/wallet-utils";
 import { fetchTokenPrices } from "../utils/price-utils";
 import {
   type TokenBalance,
@@ -100,7 +100,9 @@ async function buildAccountReport(
     } else {
       totalUsd += usd;
     }
-    if (bal.symbol === "USDC") usdc = bal.amount;
+    // Sum every USDC variant (USDC, USDC.eth.axl, …) so the stable-balance
+    // burn signal isn't under-reported or clobbered by whichever appears last.
+    if (bal.symbol.startsWith("USDC")) usdc += bal.amount;
     rows.push({ symbol: bal.symbol, amount: bal.amount, usd });
   }
 
@@ -114,7 +116,16 @@ function loadBaseline(): FleetState | null {
   try {
     const raw = fs.readFileSync(p, "utf8").replace(/^\uFEFF/, "");
     const state = JSON.parse(raw) as FleetState;
-    if (!state.timestamp || typeof state.grandTotalUsd !== "number") {
+    // Validate every field the trend/delta math relies on: an unparsable
+    // timestamp, missing grandUsdc, or non-array accounts would otherwise
+    // surface as NaN totals or throw when building baselineByLabel.
+    if (
+      typeof state.timestamp !== "string" ||
+      Number.isNaN(new Date(state.timestamp).getTime()) ||
+      typeof state.grandTotalUsd !== "number" ||
+      typeof state.grandUsdc !== "number" ||
+      !Array.isArray(state.accounts)
+    ) {
       console.warn("  ⚠ Baseline state file is malformed — ignoring.");
       return null;
     }

--- a/packages/e2e/scripts/report-fleet-balances.ts
+++ b/packages/e2e/scripts/report-fleet-balances.ts
@@ -166,12 +166,19 @@ function trendLines(
   return lines;
 }
 
-async function postSlack(text: string, headerText: string): Promise<void> {
+async function postSlack(
+  sections: string[],
+  headerText: string
+): Promise<void> {
   const webhookUrl = process.env.SLACK_WEBHOOK_URL;
   if (!webhookUrl) {
     console.log("  SLACK_WEBHOOK_URL not set — skipping Slack post.");
     return;
   }
+  // Slack caps section text at 3000 chars, so the full report (5 accounts x
+  // token tables) must be split into one section block per account rather
+  // than a single body. Truncate defensively in case a single section ever
+  // outgrows the cap.
   const payload = {
     text: headerText,
     blocks: [
@@ -179,7 +186,15 @@ async function postSlack(text: string, headerText: string): Promise<void> {
         type: "header",
         text: { type: "plain_text", text: headerText, emoji: true },
       },
-      { type: "section", text: { type: "mrkdwn", text } },
+      ...sections
+        .filter((s) => s.trim().length > 0)
+        .map((s) => ({
+          type: "section",
+          text: {
+            type: "mrkdwn",
+            text: s.length > 2900 ? `${s.slice(0, 2900)}\n_…truncated_` : s,
+          },
+        })),
     ],
   };
   const resp = await fetch(webhookUrl, {
@@ -241,36 +256,38 @@ async function main(): Promise<void> {
     (baseline?.accounts ?? []).map((a) => [a.label, a])
   );
 
-  // Console + Slack body
-  const lines: string[] = [];
-  lines.push(
+  // Console + Slack body. One section per account — Slack caps each section
+  // block at 3000 chars, and the 5 token tables together exceed that.
+  const sections: string[] = [];
+  sections.push(
     `*Grand total: ${fmtUsd(grandTotalUsd)}*  (USDC across all accounts: ${grandUsdc.toFixed(2)})`
   );
-  lines.push("");
 
   for (const r of reports) {
+    const acctLines: string[] = [];
     const base = baselineByLabel.get(r.label);
     const delta = base ? `  (Δ ${fmtDelta(r.totalUsd - base.totalUsd)})` : "";
-    lines.push(`*${r.label}*: ${fmtUsd(r.totalUsd)}${delta} — \`${r.address}\``);
+    acctLines.push(`*${r.label}*: ${fmtUsd(r.totalUsd)}${delta} — \`${r.address}\``);
     if (mode === "full" && r.rows.length > 0) {
       const maxSym = Math.max(...r.rows.map((t) => t.symbol.length), 6);
-      lines.push("```");
-      lines.push(`${"Token".padEnd(maxSym)}  ${"Amount".padStart(16)}  ${"USD".padStart(12)}`);
-      lines.push(`${"─".repeat(maxSym)}  ${"─".repeat(16)}  ${"─".repeat(12)}`);
+      acctLines.push("```");
+      acctLines.push(`${"Token".padEnd(maxSym)}  ${"Amount".padStart(16)}  ${"USD".padStart(12)}`);
+      acctLines.push(`${"─".repeat(maxSym)}  ${"─".repeat(16)}  ${"─".repeat(12)}`);
       for (const t of r.rows) {
         const d = t.amount >= 1000 ? 2 : 4;
-        lines.push(
+        acctLines.push(
           `${t.symbol.padEnd(maxSym)}  ${t.amount.toFixed(d).padStart(16)}  ${(t.usd === null ? "n/a" : fmtUsd(t.usd)).padStart(12)}`
         );
       }
-      lines.push("```");
+      acctLines.push("```");
     }
+    sections.push(acctLines.join("\n"));
   }
 
-  lines.push("");
-  lines.push(...trendLines(baseline, grandTotalUsd, grandUsdc));
+  const tailLines: string[] = [];
+  tailLines.push(...trendLines(baseline, grandTotalUsd, grandUsdc));
   if (allUnpriced.length > 0) {
-    lines.push(
+    tailLines.push(
       `_No price for: ${allUnpriced.join(", ")} — excluded from USD totals._`
     );
   }
@@ -279,10 +296,11 @@ async function main(): Promise<void> {
   const repo = process.env.GITHUB_REPOSITORY;
   const runId = process.env.GITHUB_RUN_ID;
   if (serverUrl && repo && runId) {
-    lines.push(`*Details:* <${serverUrl}/${repo}/actions/runs/${runId}|View run logs>`);
+    tailLines.push(`*Details:* <${serverUrl}/${repo}/actions/runs/${runId}|View run logs>`);
   }
+  sections.push(tailLines.join("\n"));
 
-  const body = lines.join("\n");
+  const body = sections.join("\n\n");
   console.log("\n" + body.replace(/[*_`]/g, "") + "\n");
 
   // Persist this run's state for future baselines (workflow decides whether
@@ -301,7 +319,7 @@ async function main(): Promise<void> {
   console.log(`  State written to ${outputStatePath}`);
 
   const label = process.env.REPORT_LABEL || mode;
-  await postSlack(body, `📊 E2E Fleet Balance Report (${label})`);
+  await postSlack(sections, `📊 E2E Fleet Balance Report (${label})`);
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## What is the purpose of the change:

Adds ongoing visibility of overall e2e wallet usage: a periodic Slack report of total assets across all five accounts (monitoring US/EU/SG, preview, topup/holding), valued in USD at SQS prices, with burn-rate and runway trend data. Read-only — no transactions. Stacked on #4412 (extends the same README section and script patterns); will auto-retarget to `stage` when #4412 merges.

### Linear Task

N/A

## Brief Changelog

- New `scripts/report-fleet-balances.ts`: derives the 5 addresses from existing key secrets, prices every known token via SQS, posts per-account totals + grand total to the balance-alerts channel. `full` mode adds per-token tables.
- New `e2e-fleet-balance-report.yml`: weekly compact (Mon 09:00 UTC, an hour post-sweep) + monthly full (1st 09:30 UTC, supersedes that day's weekly); `workflow_dispatch` with mode picker.
- Trend robustness: scheduled runs upload a `fleet-balance-state` artifact; the next run picks the prior artifact *closest to its target window* (7d weekly / 30d monthly) and scales burn by actual elapsed days — accidental/test runs can't shrink the window, and manual dispatches don't save state unless `save_state` is checked. Reports show USD delta + USDC-only delta (cleanest burn signal) + USDC runway, and always state which baseline was used.
- README: workflow table row + fleet-report docs.

## Testing and Verifying

Ran the script locally end-to-end with throwaway keys: snapshot mode (no baseline), then against a synthetic 7-day-old baseline — verified window-scaled burn math (−42.50 USDC / 7.0d → $182.14/30d), per-account deltas, BOM-tolerant baseline parsing, Slack post to an echo endpoint, and clean exits. `tsc --noEmit` clean for the new script; workflow YAML validated. After merge: dispatch with `save_state` unchecked for a live-data preview, then let the schedules take over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
