### PR TITLE
fix(chart): fit price y-axis gutter to widest label

### DIFF
--- a/packages/web/components/chart/price-historical.tsx
+++ b/packages/web/components/chart/price-historical.tsx
@@ -159,7 +159,7 @@ export const HistoricalPriceChart: FunctionComponent<{
               const datum = tooltipData.datum as any;
               const close = datum.close;
 
-              if (close && onPointerHover) {
+              if (close != null && onPointerHover) {
                 onPointerHover(close);
               }
             }}
@@ -280,7 +280,7 @@ export const HistoricalPriceChart: FunctionComponent<{
                 const close = tooltipData?.nearestDatum?.datum?.close;
                 const time = tooltipData?.nearestDatum?.datum?.time;
 
-                if (showTooltip && time && close) {
+                if (showTooltip && time != null && close != null) {
                   const date = dayjs(time).format("MMM Do, hh:mma");
                   const minimumDecimals = 2;
                   const maxDecimals = Math.max(

--- a/packages/web/components/chart/price-historical.tsx
+++ b/packages/web/components/chart/price-historical.tsx
@@ -2,6 +2,7 @@ import { Dec } from "@osmosis-labs/unit";
 import { curveNatural } from "@visx/curve";
 import { LinearGradient } from "@visx/gradient";
 import { ParentSize } from "@visx/responsive";
+import { scaleLinear } from "@visx/scale";
 import {
   AnimatedAreaSeries,
   AnimatedAxis,
@@ -31,6 +32,66 @@ import {
   getPriceExtendedFormatOptions,
 } from "~/utils/formatter";
 import { getDecimalCount } from "~/utils/number";
+
+const NUM_Y_TICKS = 5;
+
+/**
+ * Derives the y-axis tick formatter and the left margin needed to fit the
+ * widest tick label, both keyed off the chart's domain.
+ *
+ * `formatYTick` builds on d3's own linear tick formatter (via @visx/scale),
+ * matching the tick count the axis uses, so tight or sub-cent ranges get the
+ * same decimal precision the axis would pick; it then adds thousands separators
+ * the raw d3 formatter omits. The margin is measured from the actual rendered
+ * pixel width of those labels (canvas, using the axis font Inter 12px/500 per
+ * the chart theme's svgLabelSmall), so the gutter fits six-figure prices
+ * (e.g. "118,000") without clipping and stays snug for cheap pairs, with no
+ * hand-tuned per-char guess. Falls back to a generous char estimate when canvas
+ * is unavailable (SSR).
+ */
+function useYAxisTickLayout(domain: [number, number]) {
+  const formatYTick = useMemo(() => {
+    const scale = scaleLinear({ domain, range: [0, 1] });
+    const d3Format = scale.tickFormat(NUM_Y_TICKS);
+    return (value: number) => {
+      // Keep d3's chosen decimal precision (it varies with tick spacing), then
+      // add thousands separators to the integer part, which d3 omits.
+      const formatted = d3Format(value);
+      const negative = formatted.startsWith("-");
+      const [intPart, decPart] = formatted.replace(/^-/, "").split(".");
+      const withCommas = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+      return (
+        (negative ? "-" : "") + withCommas + (decPart ? `.${decPart}` : "")
+      );
+    };
+  }, [domain]);
+
+  const leftMargin = useMemo(() => {
+    const scale = scaleLinear({ domain, range: [0, 1] });
+    const ticks = scale.ticks(NUM_Y_TICKS);
+    // A dead pool with a flat price series yields a zero-width domain and no
+    // ticks; fall back to a representative label so the gutter is still sized.
+    const labels = ticks.length ? ticks.map(formatYTick) : ["0.00"];
+    const tickGap = 8; // tick line + label padding
+
+    let widestPx: number | null = null;
+    if (typeof document !== "undefined") {
+      const ctx = document.createElement("canvas").getContext("2d");
+      if (ctx) {
+        ctx.font = "500 12px Inter, ui-sans-serif, system-ui";
+        widestPx = Math.max(...labels.map((l) => ctx.measureText(l).width));
+      }
+    }
+    // Fallback: 8px per char is a safe upper bound for Inter digits at 12px.
+    if (widestPx == null) {
+      widestPx = Math.max(...labels.map((l) => l.length)) * 8;
+    }
+
+    return Math.max(36, Math.ceil(widestPx + tickGap));
+  }, [domain, formatYTick]);
+
+  return { formatYTick, leftMargin };
+}
 
 export const HistoricalPriceChart: FunctionComponent<{
   data: { close: number; time: number }[];
@@ -65,184 +126,197 @@ export const HistoricalPriceChart: FunctionComponent<{
     xNumTicks = 4,
     showTooltip = false,
     fiatSymbol,
-  }) => (
-    <ParentSize
-      className={`flex-shrink-1 flex-1 ${
-        !minimal ? "overflow-hidden" : "[&>svg]:overflow-visible"
-      }`}
-    >
-      {({ height, width }) => (
-        <XYChart
-          key="line-chart"
-          margin={
-            minimal
-              ? { top: 0, right: 0, bottom: 24, left: 0 }
-              : { top: 0, right: 0, bottom: 24, left: 36 }
-          }
-          height={height}
-          width={width}
-          xScale={{
-            type: "time",
-            paddingInner: 0.5,
-          }}
-          yScale={{
-            type: "linear",
-            domain,
-            zero: false,
-          }}
-          onPointerOut={onPointerOut}
-          onPointerMove={(tooltipData) => {
-            const datum = tooltipData.datum as any;
-            const close = datum.close;
+  }) => {
+    const { formatYTick, leftMargin } = useYAxisTickLayout(domain);
 
-            if (close && onPointerHover) {
-              onPointerHover(close);
+    return (
+      <ParentSize
+        className={`flex-shrink-1 flex-1 ${
+          !minimal ? "overflow-hidden" : "[&>svg]:overflow-visible"
+        }`}
+      >
+        {({ height, width }) => (
+          <XYChart
+            key="line-chart"
+            margin={
+              minimal
+                ? { top: 0, right: 0, bottom: 24, left: 0 }
+                : { top: 0, right: 0, bottom: 24, left: leftMargin }
             }
-          }}
-          theme={buildChartTheme({
-            backgroundColor: "transparent",
-            colors: showGradient ? [theme.colors.wosmongton["300"]] : ["white"],
-            gridColor: theme.colors.osmoverse["600"],
-            gridColorDark: theme.colors.osmoverse["300"],
-            svgLabelSmall: {
-              fill: theme.colors.osmoverse["300"],
-              fontSize: 12,
-              fontWeight: 500,
-            },
-            svgLabelBig: {
-              fill: theme.colors.osmoverse["300"],
-              fontSize: 12,
-              fontWeight: 500,
-            },
-            tickLength: 1,
-            xAxisLineStyles: {
-              strokeWidth: 0,
-            },
-            xTickLineStyles: {
-              strokeWidth: 0,
-            },
-            yAxisLineStyles: {
-              strokeWidth: 0,
-            },
-          })}
-        >
-          <AnimatedAxis
-            orientation="bottom"
-            numTicks={xNumTicks}
-            hideTicks={minimal}
-            hideZero={minimal}
-          />
-          {!minimal && (
-            <AnimatedAxis orientation="left" numTicks={5} strokeWidth={0} />
-          )}
-          {!minimal && <AnimatedGrid columns={false} numTicks={5} />}
+            height={height}
+            width={width}
+            xScale={{
+              type: "time",
+              paddingInner: 0.5,
+            }}
+            yScale={{
+              type: "linear",
+              domain,
+              zero: false,
+            }}
+            onPointerOut={onPointerOut}
+            onPointerMove={(tooltipData) => {
+              const datum = tooltipData.datum as any;
+              const close = datum.close;
 
-          {showGradient ? (
-            <>
-              <AnimatedAreaSeries
+              if (close && onPointerHover) {
+                onPointerHover(close);
+              }
+            }}
+            theme={buildChartTheme({
+              backgroundColor: "transparent",
+              colors: showGradient
+                ? [theme.colors.wosmongton["300"]]
+                : ["white"],
+              gridColor: theme.colors.osmoverse["600"],
+              gridColorDark: theme.colors.osmoverse["300"],
+              svgLabelSmall: {
+                fill: theme.colors.osmoverse["300"],
+                fontSize: 12,
+                fontWeight: 500,
+              },
+              svgLabelBig: {
+                fill: theme.colors.osmoverse["300"],
+                fontSize: 12,
+                fontWeight: 500,
+              },
+              tickLength: 1,
+              xAxisLineStyles: {
+                strokeWidth: 0,
+              },
+              xTickLineStyles: {
+                strokeWidth: 0,
+              },
+              yAxisLineStyles: {
+                strokeWidth: 0,
+              },
+            })}
+          >
+            <AnimatedAxis
+              orientation="bottom"
+              numTicks={xNumTicks}
+              hideTicks={minimal}
+              hideZero={minimal}
+            />
+            {!minimal && (
+              <AnimatedAxis
+                orientation="left"
+                numTicks={NUM_Y_TICKS}
+                strokeWidth={0}
+                tickFormat={formatYTick}
+              />
+            )}
+            {!minimal && (
+              <AnimatedGrid columns={false} numTicks={NUM_Y_TICKS} />
+            )}
+
+            {showGradient ? (
+              <>
+                <AnimatedAreaSeries
+                  dataKey="close"
+                  data={data}
+                  xAccessor={(d: { time: number; close: number }) => d?.time}
+                  yAccessor={(d: { time: number; close: number }) => d?.close}
+                  fillOpacity={0.4}
+                  curve={curveNatural}
+                  fill="url(#gradient)"
+                />
+                <LinearGradient
+                  id="gradient"
+                  from={theme.colors.chartGradientPrimary}
+                  to={theme.colors.chartGradientSecondary}
+                  rotate={-8}
+                  fromOffset="13.08%"
+                  fromOpacity={1}
+                  toOpacity={0}
+                  toOffset="85.36%"
+                />
+              </>
+            ) : (
+              <AnimatedLineSeries
+                key={data.length}
                 dataKey="close"
                 data={data}
+                curve={curveNatural}
                 xAccessor={(d: { time: number; close: number }) => d?.time}
                 yAccessor={(d: { time: number; close: number }) => d?.close}
-                fillOpacity={0.4}
-                curve={curveNatural}
-                fill="url(#gradient)"
-              />
-              <LinearGradient
-                id="gradient"
-                from={theme.colors.chartGradientPrimary}
-                to={theme.colors.chartGradientSecondary}
-                rotate={-8}
-                fromOffset="13.08%"
-                fromOpacity={1}
-                toOpacity={0}
-                toOffset="85.36%"
-              />
-            </>
-          ) : (
-            <AnimatedLineSeries
-              key={data.length}
-              dataKey="close"
-              data={data}
-              curve={curveNatural}
-              xAccessor={(d: { time: number; close: number }) => d?.time}
-              yAccessor={(d: { time: number; close: number }) => d?.close}
-              stroke={theme.colors.wosmongton["200"]}
-            />
-          )}
-          {annotations.map((dec, i) => (
-            <Annotation
-              key={i}
-              dataKey="depth"
-              xAccessor={(d: { close: number; time: number }) => d.time}
-              yAccessor={(d: { close: number; time: number }) => d.close}
-              datum={{ close: Number(dec.toString()), time: 0 }}
-            >
-              <AnnotationConnector />
-              <AnnotationLineSubject
-                orientation="horizontal"
                 stroke={theme.colors.wosmongton["200"]}
-                strokeWidth={2}
-                strokeDasharray={4}
               />
-            </Annotation>
-          ))}
-          <Tooltip
-            detectBounds
-            showDatumGlyph
-            horizontalCrosshairStyle={{
-              strokeWidth: 2,
-              strokeDasharray: "5 5",
-              opacity: 0.17,
-              stroke: theme.colors.osmoverse[300],
-            }}
-            verticalCrosshairStyle={{
-              strokeWidth: 2,
-              strokeDasharray: "5 5",
-              opacity: 0.17,
-              stroke: theme.colors.osmoverse[300],
-            }}
-            showVerticalCrosshair={true}
-            renderTooltip={({ tooltipData }: any) => {
-              const close = tooltipData?.nearestDatum?.datum?.close;
-              const time = tooltipData?.nearestDatum?.datum?.time;
+            )}
+            {annotations.map((dec, i) => (
+              <Annotation
+                key={i}
+                dataKey="depth"
+                xAccessor={(d: { close: number; time: number }) => d.time}
+                yAccessor={(d: { close: number; time: number }) => d.close}
+                datum={{ close: Number(dec.toString()), time: 0 }}
+              >
+                <AnnotationConnector />
+                <AnnotationLineSubject
+                  orientation="horizontal"
+                  stroke={theme.colors.wosmongton["200"]}
+                  strokeWidth={2}
+                  strokeDasharray={4}
+                />
+              </Annotation>
+            ))}
+            <Tooltip
+              detectBounds
+              showDatumGlyph
+              horizontalCrosshairStyle={{
+                strokeWidth: 2,
+                strokeDasharray: "5 5",
+                opacity: 0.17,
+                stroke: theme.colors.osmoverse[300],
+              }}
+              verticalCrosshairStyle={{
+                strokeWidth: 2,
+                strokeDasharray: "5 5",
+                opacity: 0.17,
+                stroke: theme.colors.osmoverse[300],
+              }}
+              showVerticalCrosshair={true}
+              renderTooltip={({ tooltipData }: any) => {
+                const close = tooltipData?.nearestDatum?.datum?.close;
+                const time = tooltipData?.nearestDatum?.datum?.time;
 
-              if (showTooltip && time && close) {
-                const date = dayjs(time).format("MMM Do, hh:mma");
-                const minimumDecimals = 2;
-                const maxDecimals = Math.max(
-                  getDecimalCount(close),
-                  minimumDecimals
-                );
+                if (showTooltip && time && close) {
+                  const date = dayjs(time).format("MMM Do, hh:mma");
+                  const minimumDecimals = 2;
+                  const maxDecimals = Math.max(
+                    getDecimalCount(close),
+                    minimumDecimals
+                  );
 
-                const closeDec = new Dec(close);
+                  const closeDec = new Dec(close);
 
-                const formatOpts = getPriceExtendedFormatOptions(closeDec);
+                  const formatOpts = getPriceExtendedFormatOptions(closeDec);
 
-                return (
-                  <div className="relative flex flex-col gap-1 rounded-xl bg-osmoverse-1000 p-3 shadow-md">
-                    <h6 className="text-h6 font-semibold text-white-full">
-                      {fiatSymbol}
-                      {formatPretty(closeDec, {
-                        maxDecimals,
-                        ...formatOpts,
-                      }) || ""}
-                    </h6>
+                  return (
+                    <div className="relative flex flex-col gap-1 rounded-xl bg-osmoverse-1000 p-3 shadow-md">
+                      <h6 className="text-h6 font-semibold text-white-full">
+                        {fiatSymbol}
+                        {formatPretty(closeDec, {
+                          maxDecimals,
+                          ...formatOpts,
+                        }) || ""}
+                      </h6>
 
-                    <p className="text-caption font-medium text-osmoverse-200">
-                      {date}
-                    </p>
-                  </div>
-                );
-              }
+                      <p className="text-caption font-medium text-osmoverse-200">
+                        {date}
+                      </p>
+                    </div>
+                  );
+                }
 
-              return <div></div>;
-            }}
-          />
-        </XYChart>
-      )}
-    </ParentSize>
-  )
+                return <div></div>;
+              }}
+            />
+          </XYChart>
+        )}
+      </ParentSize>
+    );
+  }
 );
 
 export const PriceChartHeader: FunctionComponent<{


### PR DESCRIPTION
## Problem

The historical price chart's left y-axis used a hardcoded `left: 36` margin. That gutter is too narrow for wide price labels, so the leading digit was clipped: on the allBTC/USDC pool (1943, ~$118k) the axis showed `18,000` / `20,000` instead of `118,000` / `120,000`.

## Fix

Extracted a `useYAxisTickLayout(domain)` hook that:

- **Measures the widest rendered tick label's actual pixel width** via canvas `measureText`, using the axis font (Inter 12px/500, matching the theme's `svgLabelSmall`), and sizes the left gutter to fit it. Floors at the original `36px`, so cheap pairs are unchanged; grows for six-figure prices. Falls back to an 8px/char upper bound when canvas is unavailable (SSR/tests); the component is `dynamic(ssr: false)` so the canvas path is client-only.
- **Uses one shared formatter** for both the measurement and the axis itself (passed via `tickFormat`), so the measured width always matches what renders.

The result scales to any price magnitude (verified against BTC-scale, tight sub-cent, and 7-figure domains) and no longer clips.

## Why a bespoke formatter (not `formatPretty`)

The axis needs d3 to choose the tick **count and decimal precision** together (`scale.tickFormat(numTicks)` from `@visx/scale`), so labels stay consistent across the tick series. `formatPretty`/`PricePretty` format a single value and don't select precision to match tick spacing, so they'd desync from the axis. The hook builds on d3's formatter and only adds the thousands separators d3 omits.

## Notes

- The `useMemo`s key on `[domain]`. This is honest because the only `domain` source, the `yRange` `@computed` in `use-historical-and-depth-data.ts`, returns a fresh `[min, max]` array on every recompute (never mutates-and-reuses a tuple).
- The `["0.00"]` empty-tick fallback is intentional: a dead pool with a flat price series yields a zero-width domain and no ticks, and the gutter still needs sizing.

## Review feedback

- **Copilot** flagged that the hover callback and tooltip guard used truthy checks on `close`/`time`, which would suppress a valid `0` price or `0` timestamp. Fixed in a follow-up commit with explicit `!= null` checks (these were pre-existing lines, tightened while here since the fix is trivial).

## Diff note

The raw diff is 393 changed lines, but 314 of them are a 2-space reindent: converting the component's implicit-return arrow to a block body (to host the hook call) shifted the whole JSX tree. Review with **Hide whitespace**. The remaining 79 lines are the ~60-line `useYAxisTickLayout` hook (d3-matched tick formatter plus canvas label measurement and its fallbacks) and five wiring lines on the margin, axis, and grid.

Example Before and after:
<img width="845" height="323" alt="image" src="https://github.com/user-attachments/assets/28b26458-7495-4bef-88b6-77a97183b858" />
<img width="827" height="336" alt="image" src="https://github.com/user-attachments/assets/af18b7b9-2325-4014-be6b-199b92026c33" />

<img width="825" height="329" alt="image" src="https://github.com/user-attachments/assets/2dcc9207-768f-4151-b228-7c059a4fc031" />
<img width="809" height="329" alt="image" src="https://github.com/user-attachments/assets/fe0c8f0c-cc32-4eab-859b-8326a400d879" />







