### PR TITLE
feat(navbar): denom-gated asset alert banners

### DIFF
--- a/packages/server/src/queries/complex/portfolio/__tests__/assets.spec.ts
+++ b/packages/server/src/queries/complex/portfolio/__tests__/assets.spec.ts
@@ -1,7 +1,7 @@
 import { AssetLists as assetLists } from "../../../__tests__/mock-asset-lists";
 import { PortfolioAssetsResponse } from "../../../sidecar";
 import { calculatePercentAndFiatValues, getAllocations } from "../assets";
-import { checkAssetVariants } from "../assets";
+import { checkAssetVariants, getHeldAssets } from "../assets";
 
 const MOCK_DATA: PortfolioAssetsResponse = {
   categories: {
@@ -252,6 +252,65 @@ describe("calculatePercentAndFiatValues", () => {
         fiatValue: "$0",
       },
     ]);
+  });
+});
+
+describe("getHeldAssets", () => {
+  it("should return denoms and symbols from the total-assets breakdown, including pooled-only holdings", () => {
+    // The ibc/7ED9... denom is only present in total-assets (not user-balances),
+    // representing a holding that only exists in a pool or lock.
+    expect(getHeldAssets(MOCK_DATA.categories, assetLists)).toEqual([
+      {
+        denom: "factory/osmo1pfyxruwvtwk00y8z06dh2lqjdj82ldvy74wzm3/WOSMO",
+        coinDenom: "WOSMO",
+      },
+      {
+        denom:
+          "factory/osmo1rckme96ptawr4zwexxj5g5gej9s2dmud8r2t9j0k0prn5mch5g4snzzwjv/sail",
+        coinDenom: "SAIL",
+      },
+      {
+        denom:
+          "ibc/7ED954CFFFC06EE8419387F3FC688837FF64EF264DE14219935F724EEEDBF8D3",
+        coinDenom: "CTK",
+      },
+    ]);
+  });
+
+  it("should leave coinDenom undefined for unlisted denoms", () => {
+    expect(
+      getHeldAssets(
+        {
+          ...MOCK_DATA.categories,
+          "total-assets": {
+            capitalization: "1",
+            account_coins_result: [
+              {
+                coin: { denom: "factory/osmo1notlisted/spam", amount: "1" },
+                cap_value: "1",
+              },
+            ],
+            is_best_effort: false,
+          },
+        },
+        assetLists
+      )
+    ).toEqual([{ denom: "factory/osmo1notlisted/spam", coinDenom: undefined }]);
+  });
+
+  it("should return an empty array when the breakdown is missing", () => {
+    expect(
+      getHeldAssets(
+        {
+          ...MOCK_DATA.categories,
+          "total-assets": {
+            capitalization: "0",
+            is_best_effort: true,
+          },
+        },
+        assetLists
+      )
+    ).toEqual([]);
   });
 });
 

--- a/packages/server/src/queries/complex/portfolio/assets.ts
+++ b/packages/server/src/queries/complex/portfolio/assets.ts
@@ -143,12 +143,25 @@ export function calculatePercentAndFiatValues(
   return [...assets, other];
 }
 
+export type HeldAsset = {
+  /** Minimal denom, e.g. `ibc/HASH`. */
+  denom: string;
+  /** Display symbol from the asset list, when the asset is listed. */
+  coinDenom?: string;
+};
+
 export type PortfolioAssets = {
   all: Allocation[];
   assets: Allocation[];
   available: Allocation[];
   totalCap: PricePretty;
   assetVariants: AssetVariant[];
+  /**
+   * Assets the user holds across all categories (bank balances, staked,
+   * unstaking, in-locks, unclaimed rewards, and pooled — GAMM shares and
+   * CL positions are broken down to underlying denoms by sidecar).
+   */
+  heldAssets: HeldAsset[];
 };
 
 /**
@@ -201,13 +214,38 @@ export async function getPortfolioAssets({
   // check for asset variants, alloys and canonical assets such as USDC
   const assetVariants = checkAssetVariants(userBalanceDenoms, assetLists);
 
+  const heldAssets = getHeldAssets(categories, assetLists);
+
   return {
     all: allocations,
     assets,
     available,
     totalCap,
     assetVariants,
+    heldAssets,
   };
+}
+
+/**
+ * Extracts the assets the user holds from the total-assets category, which
+ * sidecar composes from every category (bank balances, staked, unstaking,
+ * in-locks, unclaimed rewards, and pooled) in underlying denoms, and pairs
+ * each denom with its asset list display symbol when listed.
+ */
+export function getHeldAssets(
+  categories: Categories,
+  assetLists: AssetList[]
+): HeldAsset[] {
+  const assetListAssets = assetLists.flatMap((list) => list.assets);
+
+  return (
+    categories["total-assets"]?.account_coins_result?.map(({ coin }) => ({
+      denom: coin.denom,
+      coinDenom: assetListAssets.find(
+        (asset) => asset.coinMinimalDenom === coin.denom
+      )?.symbol,
+    })) ?? []
+  );
 }
 
 export function checkAssetVariants(

--- a/packages/types/src/feature-flags-types.ts
+++ b/packages/types/src/feature-flags-types.ts
@@ -21,6 +21,7 @@ export type AvailableFlags =
   | "inGivenOut"
   | "sqsActiveOrders"
   | "alloyedAssets"
+  | "assetAlerts"
   | "bridgeDepositAddress"
   | "nomicWithdrawAmount"
   | "swapToolTopGainers"

--- a/packages/web/components/navbar/index.tsx
+++ b/packages/web/components/navbar/index.tsx
@@ -34,6 +34,7 @@ import { Button } from "~/components/ui/button";
 import { useDisclosure, useTranslation } from "~/hooks";
 import { useOneClickTradingSession } from "~/hooks/one-click-trading/use-one-click-trading-session";
 import { useICNSName } from "~/hooks/queries/osmosis/use-icns-name";
+import { useAssetAlerts } from "~/hooks/use-asset-alerts";
 import { useFeatureFlags } from "~/hooks/use-feature-flags";
 import { usePreviousConnectedCosmosAccount } from "~/hooks/use-previous-connected-cosmos-account";
 import { useWalletSelect } from "~/hooks/use-wallet-select";
@@ -48,6 +49,11 @@ import { useNavBarStore } from "~/stores/nav-bar-store";
 import { useProfileStore } from "~/stores/profile-store";
 import { useUserSettingsStore } from "~/stores/user-settings-store";
 import { theme } from "~/tailwind.config";
+import {
+  CMSBannerFields,
+  getMatchedSymbolsText,
+  interpolateBannerText,
+} from "~/utils/asset-alerts";
 import { api } from "~/utils/trpc";
 import { removeQueryParam } from "~/utils/url";
 
@@ -72,7 +78,12 @@ export const NavBar: FunctionComponent<
       },
       accountStore,
     } = useStore();
-    const { title: navBarTitle, callToActionButtons } = useNavBarStore();
+    const {
+      title: navBarTitle,
+      callToActionButtons,
+      visibleBannerHeight,
+      setVisibleBannerHeight,
+    } = useNavBarStore();
     const { t } = useTranslation();
 
     const featureFlags = useFeatureFlags();
@@ -90,6 +101,7 @@ export const NavBar: FunctionComponent<
     } = useDisclosure();
 
     const closeMobileMenuRef = useRef(noop);
+    const bannerStackRef = useRef<HTMLDivElement>(null);
     const router = useRouter();
     const { isLoading: isWalletLoading } = useWalletSelect();
 
@@ -154,6 +166,45 @@ export const NavBar: FunctionComponent<
       !!topAnnouncementBannerData &&
       Boolean(topAnnouncementBannerData?.banner) &&
       isBannerWithinDateRange;
+
+    // Denom-gated asset alerts (fe-content cms/asset-alerts.json), shown only
+    // to wallets holding an affected denom. Dismissal is persisted per alert
+    // under its localStorageKey, matching the announcement banner convention.
+    // Keep the global announcement surface bounded. Surplus alerts wait until
+    // an earlier alert is dismissed or expires.
+    const { visibleAlerts, dismissAlert } = useAssetAlerts();
+    const visibleAssetAlerts = visibleAlerts.slice(
+      0,
+      MAX_STACKED_BANNERS - (showBanner ? 1 : 0)
+    );
+
+    // Banners can wrap as copy, locale, and viewport width change. Measure the
+    // rendered stack so both in-flow and fixed page content use its real height.
+    useEffect(() => {
+      const bannerStack = bannerStackRef.current;
+      if (!bannerStack) return;
+
+      const updateBannerHeight = () => {
+        setVisibleBannerHeight(
+          Math.ceil(bannerStack.getBoundingClientRect().height)
+        );
+      };
+
+      updateBannerHeight();
+      window.addEventListener("resize", updateBannerHeight);
+
+      const resizeObserver =
+        typeof ResizeObserver === "undefined"
+          ? undefined
+          : new ResizeObserver(updateBannerHeight);
+      resizeObserver?.observe(bannerStack);
+
+      return () => {
+        resizeObserver?.disconnect();
+        window.removeEventListener("resize", updateBannerHeight);
+        setVisibleBannerHeight(0);
+      };
+    }, [setVisibleBannerHeight]);
 
     const handleTradeClicked = () => {
       // logEvent(EventName.Topnav.tradeClicked);
@@ -279,19 +330,34 @@ export const NavBar: FunctionComponent<
           </div>
         </div>
         {/* Back-layer element to occupy space for the caller */}
+        <div className={classNames("bg-osmoverse-1000", backElementClassNames)}>
+          <div className="h-navbar md:h-navbar-mobile" />
+          <div style={{ height: visibleBannerHeight }} />
+        </div>
         <div
-          className={classNames(
-            "bg-osmoverse-1000",
-            showBanner ? "h-[124px]" : "h-navbar md:h-navbar-mobile",
-            backElementClassNames
+          ref={bannerStackRef}
+          className="fixed top-[71px] z-[51] ml-sidebar flex w-[calc(100vw_-_14.58rem)] flex-col md:top-[57px] md:ml-0 md:w-full"
+        >
+          {showBanner && (
+            <AnnouncementBanner
+              closeBanner={() => setShowBanner(false)}
+              bannerResponse={topAnnouncementBannerData}
+            />
           )}
-        />
-        {showBanner && (
-          <AnnouncementBanner
-            closeBanner={() => setShowBanner(false)}
-            bannerResponse={topAnnouncementBannerData}
-          />
-        )}
+          {visibleAssetAlerts.map((alert) => (
+            <AnnouncementBanner
+              key={alert.banner.localStorageKey}
+              closeBanner={() => dismissAlert(alert.banner.localStorageKey)}
+              bannerResponse={{
+                isChainHalted: false,
+                banner: alert.banner,
+                localization: alert.localization,
+              }}
+              dismissible={!alert.banner.persistent}
+              textInterpolations={{ symbols: getMatchedSymbolsText(alert) }}
+            />
+          ))}
+        </div>
         <ProfileModal
           isOpen={isProfileOpen}
           onRequestClose={onCloseProfile}
@@ -539,28 +605,26 @@ const OneClickTradingRadialProgress = observer(() => {
 
 interface TopAnnouncementBannerResponse {
   isChainHalted: boolean;
-  banner: {
-    enTextOrLocalizationPath: string;
-    localStorageKey?: string;
-    pageRoute?: string;
-    link?: {
-      enTextOrLocalizationKey: string;
-      url: string;
-      isExternal: boolean;
-    };
-    isWarning?: boolean;
-    persistent?: boolean;
-    bg?: string;
-    startDate?: string;
-    endDate?: string;
-  } | null;
+  banner:
+    | (CMSBannerFields & {
+        /** Only show the banner on this page route. */
+        pageRoute?: string;
+      })
+    | null;
   localization?: Record<string, Record<string, any>>;
 }
+
+/** Most banners renderable at once, including the announcement banner. */
+const MAX_STACKED_BANNERS = 3;
 
 const AnnouncementBanner: FunctionComponent<{
   closeBanner: () => void;
   bannerResponse: TopAnnouncementBannerResponse;
-}> = ({ closeBanner, bannerResponse }) => {
+  /** Overrides the default `!persistent && !isWarning` close-button rule. */
+  dismissible?: boolean;
+  /** Values for `{key}` placeholders in the banner text, e.g. `{symbols}`. */
+  textInterpolations?: Record<string, string>;
+}> = ({ closeBanner, bannerResponse, dismissible, textInterpolations }) => {
   const { t, language } = useTranslation();
   const {
     isOpen: isLeavingOsmosisOpen,
@@ -608,7 +672,7 @@ const AnnouncementBanner: FunctionComponent<{
   return (
     <div
       className={classNames(
-        "fixed top-[71px] z-[51] float-right my-auto ml-sidebar flex w-[calc(100vw_-_14.58rem)] items-center px-8 py-[14px] md:top-[57px] md:ml-0 md:w-full sm:gap-3 sm:px-2",
+        "flex min-h-[53px] w-full items-center px-8 py-[14px] sm:gap-3 sm:px-2",
         {
           "bg-gradient-negative": isWarning,
           "bg-gradient-neutral": !isWarning,
@@ -616,14 +680,19 @@ const AnnouncementBanner: FunctionComponent<{
         bg
       )}
     >
-      <div className="flex w-full place-content-center items-center gap-1.5 text-center text-subtitle1 lg:gap-1 lg:text-xs lg:tracking-normal md:text-left md:text-xxs sm:items-start">
-        <span>
+      <div className="flex min-w-0 w-full flex-wrap place-content-center items-center gap-1.5 text-center text-subtitle1 lg:gap-1 lg:text-xs lg:tracking-normal md:text-left md:text-xxs sm:items-start">
+        <span className="min-w-0 [overflow-wrap:anywhere]">
           {isChainHalted
             ? banner?.enTextOrLocalizationPath ?? ""
-            : getDeepValue<string>(
-                currentLanguageTranslations,
-                banner?.enTextOrLocalizationPath
-              ) ?? banner?.enTextOrLocalizationPath}
+            : interpolateBannerText(
+                getDeepValue<string>(
+                  currentLanguageTranslations,
+                  banner?.enTextOrLocalizationPath
+                ) ??
+                  banner?.enTextOrLocalizationPath ??
+                  "",
+                textInterpolations ?? {}
+              )}
         </span>
         {Boolean(link) && (
           <div className="flex cursor-pointer items-center gap-2">
@@ -645,7 +714,7 @@ const AnnouncementBanner: FunctionComponent<{
           </div>
         )}
       </div>
-      {!persistent && !isWarning && (
+      {(dismissible ?? (!persistent && !isWarning)) && (
         <IconButton
           className="flex w-fit cursor-pointer items-center py-0 text-white-full"
           onClick={closeBanner}

--- a/packages/web/hooks/use-asset-alerts.ts
+++ b/packages/web/hooks/use-asset-alerts.ts
@@ -1,0 +1,127 @@
+import { queryOsmosisCMS } from "@osmosis-labs/server";
+import { useQuery } from "@tanstack/react-query";
+import { useCallback, useEffect, useReducer } from "react";
+
+import { useFeatureFlags, useWalletSelect } from "~/hooks";
+import { useStore } from "~/stores";
+import {
+  AssetAlertsResponse,
+  getActiveAssetAlerts,
+} from "~/utils/asset-alerts";
+import { api } from "~/utils/trpc";
+
+/**
+ * Dismissal is persisted under the alert's `localStorageKey` with the same
+ * `"false"` convention as the announcement banner. Read directly (SSR-guarded)
+ * when deriving visibility so previously dismissed alerts never flash.
+ */
+const isAlertDismissed = (localStorageKey: string) =>
+  typeof window !== "undefined" &&
+  window.localStorage.getItem(localStorageKey) === "false";
+
+/**
+ * Returns the asset alerts from the fe-content repo that are live (within
+ * their date range), match a denom the connected wallet holds anywhere on
+ * Osmosis (bank balances, staked, in-locks, unclaimed rewards, or pooled),
+ * and have not been dismissed, plus a `dismissAlert` callback that persists
+ * a dismissal. Returns no alerts when the `assetAlerts` feature flag is off
+ * or no wallet is connected.
+ */
+export const useAssetAlerts = () => {
+  const { accountStore } = useStore();
+  const wallet = accountStore.getWallet(accountStore.osmosisChainId);
+  const { isLoading: isWalletLoading } = useWalletSelect();
+  const { assetAlerts } = useFeatureFlags();
+
+  // Bumped on dismissals and at alert date boundaries: visibility is derived
+  // at render time, so a re-render is all that's needed to re-evaluate it.
+  const [, forceVisibilityUpdate] = useReducer((count: number) => count + 1, 0);
+
+  const isWalletConnected =
+    !isWalletLoading &&
+    Boolean(wallet?.isWalletConnected) &&
+    Boolean(wallet?.address);
+
+  const { data: alertsData } = useQuery({
+    queryKey: ["osmosis-asset-alerts"],
+    queryFn: () =>
+      queryOsmosisCMS<AssetAlertsResponse>({
+        filePath: "cms/asset-alerts.json",
+      }),
+    staleTime: 1000 * 60 * 3, // 3 minutes
+    cacheTime: 1000 * 60 * 3, // 3 minutes
+    enabled: assetAlerts && isWalletConnected,
+  });
+
+  const { data: portfolioAssets } =
+    api.local.portfolio.getPortfolioAssets.useQuery(
+      {
+        address: wallet?.address ?? "",
+      },
+      {
+        enabled:
+          assetAlerts &&
+          isWalletConnected &&
+          (alertsData?.alerts?.length ?? 0) > 0,
+        refetchOnWindowFocus: false,
+      }
+    );
+
+  // Re-render at the next alert start/end boundary so alerts appear and
+  // expire while a session stays open, rescheduling for the boundary after.
+  useEffect(() => {
+    const alerts = alertsData?.alerts;
+    if (!alerts?.length) return;
+
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+
+    const scheduleNextBoundary = () => {
+      const nowMs = Date.now();
+      const futureBoundaries = alerts
+        .flatMap(({ banner: { startDate, endDate } }) => [startDate, endDate])
+        .map((date) => (date ? new Date(date).getTime() : NaN))
+        .filter((time) => !Number.isNaN(time) && time > nowMs);
+
+      if (futureBoundaries.length === 0) return;
+
+      // Clamp to setTimeout's max delay (~24.8 days); the reschedule after
+      // firing covers boundaries further out.
+      const delay = Math.min(
+        Math.min(...futureBoundaries) - nowMs + 1,
+        2 ** 31 - 1
+      );
+      timeout = setTimeout(() => {
+        forceVisibilityUpdate();
+        scheduleNextBoundary();
+      }, delay);
+    };
+
+    scheduleNextBoundary();
+    return () => clearTimeout(timeout);
+  }, [alertsData]);
+
+  // Derived at render time (not memoized): dismissals stored in a previous
+  // session are respected on the very first render that shows alerts (no
+  // flash), each render re-evaluates date bounds against the current time,
+  // and cached query data is ignored the moment the kill switch flips off or
+  // the wallet disconnects (react-query's `enabled` stops fetching but keeps
+  // cached data).
+  const activeAlerts =
+    assetAlerts && isWalletConnected
+      ? getActiveAssetAlerts({
+          alerts: alertsData?.alerts,
+          heldAssets: portfolioAssets?.heldAssets ?? [],
+        })
+      : [];
+
+  const visibleAlerts = activeAlerts.filter(
+    (alert) => !isAlertDismissed(alert.banner.localStorageKey)
+  );
+
+  const dismissAlert = useCallback((localStorageKey: string) => {
+    window.localStorage.setItem(localStorageKey, "false");
+    forceVisibilityUpdate();
+  }, []);
+
+  return { visibleAlerts, dismissAlert };
+};

--- a/packages/web/hooks/use-feature-flags.ts
+++ b/packages/web/hooks/use-feature-flags.ts
@@ -27,6 +27,7 @@ const defaultFlags: Record<AvailableFlags, boolean> = {
   inGivenOut: false,
   sqsActiveOrders: false,
   alloyedAssets: false,
+  assetAlerts: false,
   bridgeDepositAddress: false,
   nomicWithdrawAmount: false,
   swapToolTopGainers: false,

--- a/packages/web/pages/index.tsx
+++ b/packages/web/pages/index.tsx
@@ -2,7 +2,7 @@ import dayjs from "dayjs";
 import { observer } from "mobx-react-lite";
 import Image from "next/image";
 import { useRouter } from "next/router";
-import { useState } from "react";
+import { CSSProperties, useState } from "react";
 import { useLocalStorage } from "react-use";
 
 import { AdBanners } from "~/components/ad-banner";
@@ -21,6 +21,7 @@ import {
   useFeatureFlags,
   useTranslation,
 } from "~/hooks";
+import { useNavBarStore } from "~/stores/nav-bar-store";
 import { api } from "~/utils/trpc";
 
 export const SwapPreviousTradeKey = "swap-previous-trade";
@@ -33,6 +34,9 @@ export type PreviousTrade = {
 
 const Home = () => {
   const featureFlags = useFeatureFlags();
+  const visibleBannerHeight = useNavBarStore(
+    (state) => state.visibleBannerHeight
+  );
 
   const [previousTrade, setPreviousTrade] =
     useLocalStorage<PreviousTrade>(SwapPreviousTradeKey);
@@ -55,7 +59,14 @@ const Home = () => {
             className="absolute bottom-0 max-h-[720px] w-full"
           />
         </div>
-        <div className="absolute inset-0 top-[104px] flex h-auto w-full justify-center md:top-0">
+        <div
+          className="absolute inset-0 top-[calc(104px+var(--visible-banner-height))] flex h-auto w-full justify-center md:top-0"
+          style={
+            {
+              "--visible-banner-height": `${visibleBannerHeight}px`,
+            } as CSSProperties
+          }
+        >
           <div className="flex w-[512px] flex-col gap-4 lg:mx-auto md:mt-5 md:w-full md:px-5">
             {featureFlags.swapsAdBanner && <SwapAdsBanner />}
             {/** Hydration issues need to be investigated before this client wrapper can be removed. */}

--- a/packages/web/stores/__tests__/nav-bar-store.spec.ts
+++ b/packages/web/stores/__tests__/nav-bar-store.spec.ts
@@ -12,6 +12,7 @@ describe("NavBarStore (Zustand)", () => {
     useNavBarStore.setState({
       title: undefined,
       callToActionButtons: [],
+      visibleBannerHeight: 0,
     });
   });
 
@@ -95,6 +96,35 @@ describe("NavBarStore (Zustand)", () => {
         result.current.setCallToActionButtons([]);
       });
       expect(result.current.callToActionButtons).toEqual([]);
+    });
+  });
+
+  describe("setVisibleBannerHeight", () => {
+    it("should update visibleBannerHeight", () => {
+      const { result } = renderHook(() => useNavBarStore());
+      expect(result.current.visibleBannerHeight).toBe(0);
+
+      act(() => {
+        result.current.setVisibleBannerHeight(106);
+      });
+
+      expect(result.current.visibleBannerHeight).toBe(106);
+    });
+
+    it("should survive reset, since it is owned by the always-mounted NavBar", () => {
+      const { result } = renderHook(() => useNavBarStore());
+
+      act(() => {
+        result.current.setVisibleBannerHeight(106);
+        result.current.setTitle("Test Title");
+      });
+
+      act(() => {
+        result.current.reset();
+      });
+
+      expect(result.current.title).toBeUndefined();
+      expect(result.current.visibleBannerHeight).toBe(106);
     });
   });
 

--- a/packages/web/stores/nav-bar-store.ts
+++ b/packages/web/stores/nav-bar-store.ts
@@ -16,10 +16,15 @@ interface NavBarState {
   title: ReactNode | undefined;
   /** Call to action buttons displayed in the navbar */
   callToActionButtons: CallToAction[];
+  /** Rendered height of banners visible under the navbar, for pages positioned
+   *  outside normal flow that need to offset themselves. */
+  visibleBannerHeight: number;
   /** Set the navbar title */
   setTitle: (title: ReactNode | undefined) => void;
   /** Set the call to action buttons */
   setCallToActionButtons: (buttons: CallToAction[]) => void;
+  /** Set the rendered height of banners visible under the navbar */
+  setVisibleBannerHeight: (height: number) => void;
   /** Reset the store to initial state */
   reset: () => void;
 }
@@ -27,6 +32,7 @@ interface NavBarState {
 const initialState = {
   title: undefined as ReactNode | undefined,
   callToActionButtons: [] as CallToAction[],
+  visibleBannerHeight: 0,
 };
 
 /**
@@ -67,5 +73,12 @@ export const useNavBarStore = create<NavBarState>()((set) => ({
   ...initialState,
   setTitle: (title) => set({ title }),
   setCallToActionButtons: (buttons) => set({ callToActionButtons: buttons }),
-  reset: () => set(initialState),
+  setVisibleBannerHeight: (height) => set({ visibleBannerHeight: height }),
+  // visibleBannerHeight is owned by the always-mounted NavBar and deliberately
+  // survives reset(): page-level cleanup must not desync banner offsets.
+  reset: () =>
+    set((state) => ({
+      ...initialState,
+      visibleBannerHeight: state.visibleBannerHeight,
+    })),
 }));

--- a/packages/web/utils/__tests__/asset-alerts.spec.ts
+++ b/packages/web/utils/__tests__/asset-alerts.spec.ts
@@ -1,0 +1,254 @@
+import {
+  AssetAlert,
+  getActiveAssetAlerts,
+  getMatchedSymbolsText,
+  HeldAsset,
+  interpolateBannerText,
+  isAlertWithinDateRange,
+} from "../asset-alerts";
+
+const INT3_DOGE =
+  "ibc/B3DFDC2958A2BE482532DA3B6B5729B469BE7475598F7487D98B1B3E085245DE";
+const INT3_BTC =
+  "ibc/2F4258D6E1E01B203D6CA83F2C7E4959615053A21EC2C2FC196F7911CAC832EF";
+const ATOM =
+  "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2";
+
+const HELD_DOGE: HeldAsset = { denom: INT3_DOGE, coinDenom: "DOGE.int3" };
+const HELD_BTC: HeldAsset = { denom: INT3_BTC, coinDenom: "BTC.int3" };
+const HELD_ATOM: HeldAsset = { denom: ATOM, coinDenom: "ATOM" };
+
+const makeAlert = (overrides?: {
+  denoms?: string[];
+  startDate?: string;
+  endDate?: string;
+  localStorageKey?: string;
+}): AssetAlert => ({
+  denoms: overrides?.denoms ?? [INT3_DOGE, INT3_BTC],
+  banner: {
+    enTextOrLocalizationPath: "header",
+    localStorageKey: overrides?.localStorageKey ?? "int3face-sunset",
+    link: {
+      enTextOrLocalizationKey: "link",
+      url: "https://example.com/int3face-sunset",
+      isExternal: true,
+    },
+    isWarning: true,
+    startDate: overrides?.startDate,
+    endDate: overrides?.endDate,
+  },
+  localization: {
+    en: {
+      header: "The Int3face bridge is closing. Bridge out your {symbols}.",
+      link: "Learn more",
+    },
+  },
+});
+
+const NOW = new Date("2026-08-01T12:00:00Z");
+
+describe("getActiveAssetAlerts", () => {
+  it("returns an alert with its matched assets when a held denom matches within range", () => {
+    const alert = makeAlert({
+      startDate: "2026-07-30T00:00:00Z",
+      endDate: "2026-08-15T00:00:00Z",
+    });
+
+    expect(
+      getActiveAssetAlerts({
+        alerts: [alert],
+        heldAssets: [HELD_ATOM, HELD_DOGE],
+        now: NOW,
+      })
+    ).toEqual([{ ...alert, matchedAssets: [HELD_DOGE] }]);
+  });
+
+  it("collects every held asset matching the alert", () => {
+    expect(
+      getActiveAssetAlerts({
+        alerts: [makeAlert()],
+        heldAssets: [HELD_BTC, HELD_ATOM, HELD_DOGE],
+        now: NOW,
+      })[0].matchedAssets
+    ).toEqual([HELD_DOGE, HELD_BTC]); // in the alert's denom order
+  });
+
+  it("excludes alerts whose denoms are not held", () => {
+    expect(
+      getActiveAssetAlerts({
+        alerts: [makeAlert()],
+        heldAssets: [HELD_ATOM],
+        now: NOW,
+      })
+    ).toEqual([]);
+  });
+
+  it("matches on the full minimal denom, not a partial or symbol match", () => {
+    expect(
+      getActiveAssetAlerts({
+        alerts: [makeAlert()],
+        heldAssets: [{ denom: INT3_DOGE.slice(0, 20) }, { denom: "DOGE" }],
+        now: NOW,
+      })
+    ).toEqual([]);
+  });
+
+  it("returns an empty array when nothing is held", () => {
+    expect(
+      getActiveAssetAlerts({
+        alerts: [makeAlert()],
+        heldAssets: [],
+        now: NOW,
+      })
+    ).toEqual([]);
+  });
+
+  it("returns an empty array when alerts are undefined", () => {
+    expect(
+      getActiveAssetAlerts({
+        alerts: undefined,
+        heldAssets: [HELD_DOGE],
+        now: NOW,
+      })
+    ).toEqual([]);
+  });
+
+  it("excludes alerts before their start date and after their end date", () => {
+    const upcoming = makeAlert({ startDate: "2026-08-02T00:00:00Z" });
+    const expired = makeAlert({ endDate: "2026-07-31T00:00:00Z" });
+
+    expect(
+      getActiveAssetAlerts({
+        alerts: [upcoming, expired],
+        heldAssets: [HELD_DOGE],
+        now: NOW,
+      })
+    ).toEqual([]);
+  });
+
+  it("returns multiple matching alerts for stacking", () => {
+    const first = makeAlert({ localStorageKey: "first-alert" });
+    const second = makeAlert({
+      denoms: [INT3_BTC],
+      localStorageKey: "second-alert",
+    });
+
+    expect(
+      getActiveAssetAlerts({
+        alerts: [first, second],
+        heldAssets: [HELD_DOGE, HELD_BTC],
+        now: NOW,
+      })
+    ).toEqual([
+      { ...first, matchedAssets: [HELD_DOGE, HELD_BTC] },
+      { ...second, matchedAssets: [HELD_BTC] },
+    ]);
+  });
+});
+
+describe("getMatchedSymbolsText", () => {
+  it("joins the matched symbols for display", () => {
+    const [alert] = getActiveAssetAlerts({
+      alerts: [makeAlert()],
+      heldAssets: [HELD_DOGE, HELD_BTC],
+      now: NOW,
+    });
+
+    expect(getMatchedSymbolsText(alert)).toBe("DOGE.int3, BTC.int3");
+  });
+
+  it("falls back to a shortened denom when the asset is unlisted", () => {
+    const [alert] = getActiveAssetAlerts({
+      alerts: [makeAlert()],
+      heldAssets: [{ denom: INT3_DOGE }],
+      now: NOW,
+    });
+
+    expect(getMatchedSymbolsText(alert)).toBe("ibc/B3...245DE");
+  });
+
+  it("caps long symbol lists with a +N suffix", () => {
+    const denoms = ["d1", "d2", "d3", "d4", "d5", "d6", "d7"];
+    const heldAssets = denoms.map((denom, i) => ({
+      denom,
+      coinDenom: `SYM${i + 1}`,
+    }));
+
+    const [alert] = getActiveAssetAlerts({
+      alerts: [makeAlert({ denoms })],
+      heldAssets,
+      now: NOW,
+    });
+
+    expect(getMatchedSymbolsText(alert)).toBe(
+      "SYM1, SYM2, SYM3, SYM4, SYM5 +2"
+    );
+    expect(getMatchedSymbolsText(alert, 6)).toBe(
+      "SYM1, SYM2, SYM3, SYM4, SYM5, SYM6 +1"
+    );
+    expect(getMatchedSymbolsText(alert, 7)).toBe(
+      "SYM1, SYM2, SYM3, SYM4, SYM5, SYM6, SYM7"
+    );
+  });
+});
+
+describe("interpolateBannerText", () => {
+  it("replaces every occurrence of a placeholder", () => {
+    expect(
+      interpolateBannerText("Move {symbols}. Your {symbols} expire.", {
+        symbols: "DOGE.int3",
+      })
+    ).toBe("Move DOGE.int3. Your DOGE.int3 expire.");
+  });
+
+  it("returns text without placeholders unchanged", () => {
+    expect(
+      interpolateBannerText("No placeholders here.", { symbols: "DOGE.int3" })
+    ).toBe("No placeholders here.");
+  });
+
+  it("supports multiple interpolation keys", () => {
+    expect(
+      interpolateBannerText("{a} and {b}", { a: "first", b: "second" })
+    ).toBe("first and second");
+  });
+});
+
+describe("isAlertWithinDateRange", () => {
+  it("is always within range without dates", () => {
+    expect(isAlertWithinDateRange(makeAlert(), NOW)).toBe(true);
+  });
+
+  it("treats a missing bound as unbounded", () => {
+    expect(
+      isAlertWithinDateRange(makeAlert({ startDate: "2026-07-30" }), NOW)
+    ).toBe(true);
+    expect(
+      isAlertWithinDateRange(makeAlert({ endDate: "2026-08-15" }), NOW)
+    ).toBe(true);
+  });
+
+  it("is out of range before start or after end", () => {
+    expect(
+      isAlertWithinDateRange(
+        makeAlert({ startDate: "2026-08-02T00:00:00Z" }),
+        NOW
+      )
+    ).toBe(false);
+    expect(
+      isAlertWithinDateRange(
+        makeAlert({ endDate: "2026-07-31T00:00:00Z" }),
+        NOW
+      )
+    ).toBe(false);
+  });
+
+  it("includes the start boundary and excludes the end boundary", () => {
+    expect(
+      isAlertWithinDateRange(makeAlert({ startDate: NOW.toISOString() }), NOW)
+    ).toBe(true);
+    expect(
+      isAlertWithinDateRange(makeAlert({ endDate: NOW.toISOString() }), NOW)
+    ).toBe(false);
+  });
+});

--- a/packages/web/utils/asset-alerts.ts
+++ b/packages/web/utils/asset-alerts.ts
@@ -1,0 +1,135 @@
+import { shorten } from "@osmosis-labs/utils";
+
+/**
+ * Banner fields shared between the top announcement banner and asset alerts,
+ * as authored in the osmosis-labs/fe-content repo.
+ */
+export interface CMSBannerFields {
+  enTextOrLocalizationPath: string;
+  /** Persists dismissal under this key. */
+  localStorageKey?: string;
+  link?: {
+    enTextOrLocalizationKey: string;
+    url: string;
+    isExternal: boolean;
+  };
+  isWarning?: boolean;
+  persistent?: boolean;
+  bg?: string;
+  startDate?: string;
+  endDate?: string;
+}
+
+/**
+ * Asset alerts are urgent, denom-gated announcements (e.g. a bridge or
+ * protocol sunsetting) sourced from the osmosis-labs/fe-content repo.
+ * An alert is only shown to users holding one of its denoms anywhere on
+ * Osmosis (bank balances, staked, in-locks, unclaimed rewards, or pooled),
+ * on every page (unlike the announcement banner, there is no `pageRoute`).
+ * @see https://github.com/osmosis-labs/fe-content/blob/main/cms/asset-alerts.json
+ */
+export interface AssetAlert {
+  /** Minimal denoms (e.g. `ibc/HASH`) that trigger this alert when held. */
+  denoms: string[];
+  banner: CMSBannerFields & {
+    /** Persists dismissal, and must be unique per alert. */
+    localStorageKey: string;
+  };
+  localization?: Record<string, Record<string, any>>;
+}
+
+export interface AssetAlertsResponse {
+  alerts: AssetAlert[];
+}
+
+/** An asset the user holds anywhere on Osmosis, with its display symbol
+ *  when the asset is listed. Shape matches `HeldAsset` from the portfolio
+ *  query in `@osmosis-labs/server`. */
+export interface HeldAsset {
+  denom: string;
+  coinDenom?: string;
+}
+
+export type ActiveAssetAlert = AssetAlert & {
+  /** The held assets that triggered this alert. */
+  matchedAssets: HeldAsset[];
+};
+
+/**
+ * Filters alerts down to those within their date range and matching a denom
+ * the user holds, pairing each with the held assets that triggered it.
+ * Dismissal and feature flag gating are left to the caller.
+ */
+export function getActiveAssetAlerts({
+  alerts,
+  heldAssets,
+  now = new Date(),
+}: {
+  alerts: AssetAlert[] | undefined;
+  heldAssets: HeldAsset[];
+  now?: Date;
+}): ActiveAssetAlert[] {
+  if (!alerts || heldAssets.length === 0) return [];
+
+  const heldByDenom = new Map(heldAssets.map((asset) => [asset.denom, asset]));
+
+  return alerts
+    .map((alert) => ({
+      ...alert,
+      matchedAssets: alert.denoms
+        .map((denom) => heldByDenom.get(denom))
+        .filter((asset): asset is HeldAsset => Boolean(asset)),
+    }))
+    .filter(
+      (alert) =>
+        alert.matchedAssets.length > 0 && isAlertWithinDateRange(alert, now)
+    );
+}
+
+/** Keep urgent banner copy concise when many assets trigger one alert. */
+const DEFAULT_MAX_LISTED_SYMBOLS = 5;
+
+/** Display list of the held symbols that triggered an alert, e.g.
+ *  "DOGE.int3, LTC.int3". Falls back to a shortened denom when unlisted, and
+ *  summarizes beyond `maxListed` with a locale-neutral "+N" suffix so the
+ *  banner text stays near one line. */
+export function getMatchedSymbolsText(
+  alert: ActiveAssetAlert,
+  maxListed = DEFAULT_MAX_LISTED_SYMBOLS
+): string {
+  const symbols = alert.matchedAssets.map(
+    (asset) => asset.coinDenom ?? shorten(asset.denom)
+  );
+
+  if (symbols.length <= maxListed) return symbols.join(", ");
+
+  return `${symbols.slice(0, maxListed).join(", ")} +${
+    symbols.length - maxListed
+  }`;
+}
+
+/**
+ * Replaces `{key}` placeholders in CMS banner text, e.g. a `{symbols}`
+ * placeholder in an alert's localized header. Text without placeholders is
+ * returned unchanged, so interpolation is opt-in per CMS entry.
+ */
+export function interpolateBannerText(
+  text: string,
+  interpolations: Record<string, string>
+): string {
+  return Object.entries(interpolations).reduce(
+    (acc, [key, value]) => acc.split(`{${key}}`).join(value),
+    text
+  );
+}
+
+/** Within range when now is past `startDate` and before `endDate`; a missing
+ *  bound is treated as unbounded. */
+export function isAlertWithinDateRange(
+  { banner: { startDate, endDate } }: AssetAlert,
+  now: Date
+): boolean {
+  if (startDate && now < new Date(startDate)) return false;
+  if (endDate && now >= new Date(endDate)) return false;
+  return true;
+}


### PR DESCRIPTION
## What

Urgent **asset alerts**: top banners shown only to connected wallets holding specific denoms, for deadline-driven actions like a bridge or protocol sunsetting. Alerts are authored in fe-content (`cms/asset-alerts.json`, schema PR: osmosis-labs/fe-content — linked below) and go live from a CMS merge with no frontend release. Everything is gated behind a new `asset-alerts` LaunchDarkly flag (off in prod; needs creating before enablement).

First consumer: the **BitFrost (Int3face) bridge sunset** — withdrawal period ends 2026-08-10, affecting 11 int3-bridged assets.

Linear: MTN-240.

<img width="1917" height="686" alt="image" src="https://github.com/user-attachments/assets/c1509b68-159f-472f-868c-56dab9dcb96c" />


## How it works

- **Holdings**: reuses the portfolio passthrough query the alloy-variants toast already makes. `getPortfolioAssets` now also returns `heldAssets` (denom + assetlist symbol) extracted from the sidecar `total-assets` breakdown, which is composed in underlying denoms across bank, staked, unstaking, in-locks, unclaimed rewards, and pooled (sidecar explodes GAMM shares and CL positions; alloys are deliberately never decomposed — alerting alloy holders requires listing the alloy denom explicitly).
- **Matching**: `getActiveAssetAlerts` does a strict exact-minimal-denom intersection (never symbols) and pairs each alert with the held assets that triggered it.
- **Copy**: localized alert text may use a `{symbols}` placeholder → the matched symbols, capped at 5 with a locale-neutral `+N` suffix; unlisted denoms fall back to a shortened denom.
- **Layout**: banners (announcement + up to `MAX_STACKED_BANNERS` alerts) render in one fixed, measured stack. A ResizeObserver publishes the rendered height through the nav-bar zustand store; the in-flow spacer and the trade page's viewport-fixed content both consume it, so wrapped/multi-line banners can't overlap content. This replaces the previous hardcoded 52px/`h-[124px]` assumption and **also fixes a pre-existing ~19px overlap** where the current prod announcement banner clips the swap ads banner on the trade page.
- **Lifecycle**: per-alert localStorage dismissal (read at derive time — no flash of previously dismissed banners), `startDate`/`endDate` windows re-evaluated via a timer at the next boundary so alerts appear/expire mid-session, and derived visibility ignores cached query data the moment the flag flips off or the wallet disconnects.

## Testing

- 17 specs for the alert utilities (exact-denom matching incl. rejection of symbol/partial matches, date windows incl. boundary semantics, matched-asset collection, `{symbols}` interpolation, symbol cap, shortened-denom fallback).
- 12 nav-bar store specs (banner height setter, reset survival).
- 10 server portfolio specs (`getHeldAssets` symbol pairing, unlisted-denom fallback, pooled-only holding present in total-assets but not user-balances; fixtures match the real sidecar response shape).
- Typecheck, eslint, prettier clean on touched packages.
- Manually verified on a local dev server with stubbed CMS + spoofed holdings: single alert, two simultaneous alerts + announcement banner stacking, dismissal persistence, long symbol lists, trade-page offset.

## Notes for review

- With the flag off (current state) nothing changes; the announcement banner renders as before.
- Date checks in the new util use plain `Date` rather than the navbar's dayjs — deliberate: self-contained and directly unit-testable.
- Deferred with follow-ups: e2e for stacking/dismissal (once the CMS file is live), mobile-specific banner heights (pre-existing).

## Risks

- Alert visibility depends on the sidecar total-assets breakdown; when a sidecar sub-fetch fails (`is_best_effort`) a holder may briefly not see the banner (fails quiet, next refetch recovers).
- Trade-page offset now derives from measured height at runtime; verified locally across banner add/dismiss/resize.
