### PR TITLE
fix(pools): hide add-liquidity quick action for cosmwasm pools

### DIFF
--- a/packages/web/components/complex/pools-table.tsx
+++ b/packages/web/components/complex/pools-table.tsx
@@ -38,6 +38,15 @@ export type PoolIncentiveFilter = NonNullable<
   NonNullable<Pool["incentives"]>["incentiveTypes"]
 >[number];
 
+/** Pool types supported by the add liquidity modal. The modal has no
+ *  cosmwasm support, so cosmwasm pools get no quick action; their liquidity
+ *  is managed through dedicated UIs linked from the pool row instead. */
+const quickAddLiquidityPoolTypes: readonly PoolType[] = [
+  "weighted",
+  "stable",
+  "concentrated",
+];
+
 // These are the options for filtering the pools.
 export const poolFilterTypes: PoolTypeFilter[] = [
   "concentrated",
@@ -322,7 +331,7 @@ export const PoolsTable = (props: PropsWithChildren<PoolsTableProps>) => {
             <PoolQuickActionCell
               poolId={row.original.id}
               onAddLiquidity={
-                quickAddLiquidity
+                quickAddLiquidityPoolTypes.includes(row.original.type)
                   ? () => quickAddLiquidity(row.original.id, row.original.type)
                   : undefined
               }


### PR DESCRIPTION
Hides the `+` (add liquidity) quick-action button on the pools table for cosmwasm pools (transmuter/alloyed, orderbook, Astroport PCL, WhiteWhale, generic cosmwasm).

<img width="821" height="725" alt="image" src="https://github.com/user-attachments/assets/4978ef60-5eca-4782-88d6-d7d58fd57753" />
(CL Pools show +, omitted for screenshot ability to capture a range of pools)

## Why

The button rendered for every pool row, but the add-liquidity modal only supports weighted, stable, and concentrated pools. For cosmwasm pool types the modal falls through to the share-pool (weighted) UI in a broken state. Liquidity for those pools is managed through their own dedicated UIs, which the pool rows already link out to.

## How

A `quickAddLiquidityPoolTypes` whitelist (`weighted`, `stable`, `concentrated`) in `packages/web/components/complex/pools-table.tsx` gates the `onAddLiquidity` callback per row. `PoolQuickActionCell` already renders nothing when the callback is undefined, so the button is simply absent for unsupported types. Whitelisting (rather than excluding `cosmwasm*`) means any future pool type shows no quick action until it is confirmed to work with the modal.

Pool detail pages are intentionally out of scope; cosmwasm pools have their own flows there.

Linear: [MTN-242](https://linear.app/osmosis/issue/MTN-242/pools-table-hide-the-add-liquidity-quick-action-for-cosmwasm-pools)