### PR TITLE
fix(assets): exclude alloy variants from the New category

### DIFF
--- a/packages/server/src/queries/__tests__/mock-asset-lists.ts
+++ b/packages/server/src/queries/__tests__/mock-asset-lists.ts
@@ -374,7 +374,8 @@ export const AssetLists: AssetList[] = [
             },
           },
         ],
-        variantGroupKey: "BTC",
+        variantGroupKey:
+          "factory/osmo1z6r6qdknhgsc0zeracktgpcxf43j6sekq07nw8sxduc9lg0qjjlqfu25e3/alloyed/allBTC",
         name: "Wrapped Bitcoin",
         isAlloyed: false,
         verified: true,

--- a/packages/server/src/queries/complex/assets/__tests__/assets.spec.ts
+++ b/packages/server/src/queries/complex/assets/__tests__/assets.spec.ts
@@ -1,5 +1,37 @@
 import { AssetLists as MockAssetLists } from "../../../__tests__/mock-asset-lists";
+import { queryAllTokenData } from "../../../data-services";
 import { getAsset, getAssets, getAssetWithVariants } from "../index";
+import { mapGetMarketAssets } from "../market";
+
+jest.mock("../../../data-services", () => {
+  const actual = jest.requireActual("../../../data-services");
+
+  return {
+    ...actual,
+    queryAllTokenData: jest.fn(),
+  };
+});
+
+const mockedQueryAllTokenData = jest.mocked(queryAllTokenData);
+
+const makeTokenData = (denom: string, symbol: string) => ({
+  price: 1,
+  denom,
+  symbol,
+  main: true,
+  liquidity: 1_000,
+  liquidity_24h_change: 0,
+  volume_24h: 1_000,
+  volume_24h_change: 0,
+  name: symbol,
+  price_1h_change: 0,
+  price_24h_change: 0,
+  price_7d_change: 0,
+  exponent: 6,
+  display: symbol,
+  coingecko_id: null,
+  coingecko_mcap: null,
+});
 
 describe("getAssets", () => {
   describe("search", () => {
@@ -107,21 +139,27 @@ describe("getAssets", () => {
         expect(assets.some((asset) => asset.coinDenom === "OSMO")).toBeFalsy();
       });
 
-      it("should still return alloy variants, which callers filter out themselves", () => {
-        const assets = getAssets({
+      it("should exclude variants from the new assets table when requested", async () => {
+        const wbtc = getAsset({ assetLists: MockAssetLists, anyDenom: "WBTC" });
+        const badkid = getAsset({
           assetLists: MockAssetLists,
-          categories: ["new"],
+          anyDenom: "BADKID",
         });
 
-        // WBTC is a variant (variantGroupKey "BTC" !== its coinMinimalDenom).
-        // The category filter is date-only; dropping variants so a newly listed
-        // constituent doesn't appear next to its alloy is the caller's job, via
-        // getTopNewAssets' canonical filter and getMarketAssets' excludeVariants.
-        const wbtc = assets.find((asset) => asset.coinDenom === "WBTC");
+        mockedQueryAllTokenData.mockResolvedValueOnce([
+          makeTokenData(wbtc.coinMinimalDenom, wbtc.coinDenom),
+          makeTokenData(badkid.coinMinimalDenom, badkid.coinDenom),
+        ]);
 
-        expect(wbtc).toBeDefined();
-        expect(wbtc?.variantGroupKey).toBe("BTC");
-        expect(wbtc?.variantGroupKey).not.toBe(wbtc?.coinMinimalDenom);
+        const assets = await mapGetMarketAssets({
+          assetLists: MockAssetLists,
+          chainList: [],
+          categories: ["new"],
+          excludeVariants: true,
+        });
+
+        expect(assets.map(({ coinDenom }) => coinDenom)).toContain("BADKID");
+        expect(assets.map(({ coinDenom }) => coinDenom)).not.toContain("WBTC");
       });
     });
   });

--- a/packages/server/src/queries/complex/assets/__tests__/assets.spec.ts
+++ b/packages/server/src/queries/complex/assets/__tests__/assets.spec.ts
@@ -106,6 +106,23 @@ describe("getAssets", () => {
 
         expect(assets.some((asset) => asset.coinDenom === "OSMO")).toBeFalsy();
       });
+
+      it("should still return alloy variants, which callers filter out themselves", () => {
+        const assets = getAssets({
+          assetLists: MockAssetLists,
+          categories: ["new"],
+        });
+
+        // WBTC is a variant (variantGroupKey "BTC" !== its coinMinimalDenom).
+        // The category filter is date-only; dropping variants so a newly listed
+        // constituent doesn't appear next to its alloy is the caller's job, via
+        // getTopNewAssets' canonical filter and getMarketAssets' excludeVariants.
+        const wbtc = assets.find((asset) => asset.coinDenom === "WBTC");
+
+        expect(wbtc).toBeDefined();
+        expect(wbtc?.variantGroupKey).toBe("BTC");
+        expect(wbtc?.variantGroupKey).not.toBe(wbtc?.coinMinimalDenom);
+      });
     });
   });
 });

--- a/packages/trpc/src/__tests__/assets-new.spec.ts
+++ b/packages/trpc/src/__tests__/assets-new.spec.ts
@@ -1,0 +1,109 @@
+import {
+  DEFAULT_VS_CURRENCY,
+  getAssetListingDate,
+  getAssetMarketActivity,
+  getAssets,
+} from "@osmosis-labs/server";
+import type { MinimalAsset } from "@osmosis-labs/types";
+import { Dec, PricePretty, RatePretty } from "@osmosis-labs/unit";
+
+import {
+  createCallerFactory,
+  createInnerTRPCContext,
+  createTRPCRouter,
+} from "..";
+import { assetsRouter } from "../assets";
+
+jest.mock("@osmosis-labs/server", () => {
+  const actual = jest.requireActual("@osmosis-labs/server");
+
+  return {
+    ...actual,
+    getAssetListingDate: jest.fn(),
+    getAssetMarketActivity: jest.fn(),
+    getAssets: jest.fn(),
+  };
+});
+
+const mockedGetAssetListingDate = jest.mocked(getAssetListingDate);
+const mockedGetAssetMarketActivity = jest.mocked(getAssetMarketActivity);
+const mockedGetAssets = jest.mocked(getAssets);
+
+const makeAsset = ({
+  coinMinimalDenom,
+  variantGroupKey,
+}: {
+  coinMinimalDenom: string;
+  variantGroupKey?: string;
+}): MinimalAsset => ({
+  coinDenom: coinMinimalDenom,
+  coinMinimalDenom,
+  coinDecimals: 6,
+  coinGeckoId: undefined,
+  coinName: coinMinimalDenom,
+  isUnstable: false,
+  areTransfersDisabled: false,
+  areDepositsHalted: false,
+  areWithdrawalsHalted: false,
+  isVerified: true,
+  isAlloyed: variantGroupKey === coinMinimalDenom,
+  variantGroupKey,
+});
+
+const makeCaller = () => {
+  const router = createTRPCRouter({ assets: assetsRouter });
+  return createCallerFactory(router)(
+    createInnerTRPCContext({ assetLists: [], chainList: [] })
+  );
+};
+
+describe("getTopNewAssets", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("excludes non-canonical variants before fetching market activity", async () => {
+    const canonicalAsset = makeAsset({
+      coinMinimalDenom: "factory/alloy",
+      variantGroupKey: "factory/alloy",
+    });
+    const variantAsset = makeAsset({
+      coinMinimalDenom: "ibc/variant",
+      variantGroupKey: canonicalAsset.coinMinimalDenom,
+    });
+
+    mockedGetAssets.mockReturnValue([canonicalAsset, variantAsset]);
+    mockedGetAssetMarketActivity.mockResolvedValue({
+      price: new PricePretty(DEFAULT_VS_CURRENCY, new Dec(1)),
+      denom: canonicalAsset.coinMinimalDenom,
+      symbol: canonicalAsset.coinDenom,
+      liquidity: new PricePretty(DEFAULT_VS_CURRENCY, new Dec(1_000)),
+      liquidity24hChange: undefined,
+      marketCap: undefined,
+      volume24h: new PricePretty(DEFAULT_VS_CURRENCY, new Dec(1_000)),
+      volume24hChange: undefined,
+      name: canonicalAsset.coinName,
+      price1hChange: undefined,
+      price24hChange: new RatePretty(new Dec("0.1")),
+      price7dChange: undefined,
+      exponent: canonicalAsset.coinDecimals,
+      display: canonicalAsset.coinDenom,
+    });
+    mockedGetAssetListingDate.mockReturnValue(
+      new Date("2026-08-01T00:00:00.000Z")
+    );
+
+    const result = await makeCaller().assets.getTopNewAssets({ topN: 3 });
+
+    expect(result.map(({ coinMinimalDenom }) => coinMinimalDenom)).toEqual([
+      canonicalAsset.coinMinimalDenom,
+    ]);
+    expect(mockedGetAssetMarketActivity).toHaveBeenCalledTimes(1);
+    expect(mockedGetAssetMarketActivity).toHaveBeenCalledWith(canonicalAsset);
+    expect(mockedGetAssetListingDate).toHaveBeenCalledTimes(1);
+    expect(mockedGetAssetListingDate).toHaveBeenCalledWith({
+      assetLists: [],
+      coinMinimalDenom: canonicalAsset.coinMinimalDenom,
+    });
+  });
+});

--- a/packages/trpc/src/assets.ts
+++ b/packages/trpc/src/assets.ts
@@ -618,8 +618,16 @@ export const assetsRouter = createTRPCRouter({
         categories: ["new"],
       });
 
+      // Exclude alloy variants (keep only canonical assets), so a newly listed
+      // constituent doesn't show alongside the alloy it backs.
+      const canonicalAssets = assets.filter(
+        (asset) =>
+          !asset.variantGroupKey ||
+          asset.variantGroupKey === asset.coinMinimalDenom
+      );
+
       const marketAssets = await Promise.all(
-        assets.map(async (asset) => {
+        canonicalAssets.map(async (asset) => {
           const marketAsset = await getAssetMarketActivity(asset).catch((e) =>
             captureErrorAndReturn(e, undefined)
           );

--- a/packages/web/components/table/__tests__/asset-info.spec.ts
+++ b/packages/web/components/table/__tests__/asset-info.spec.ts
@@ -1,0 +1,41 @@
+import { getCategoryFilters } from "~/components/table/asset-info";
+
+describe("getCategoryFilters", () => {
+  it("excludes variants for the new category", () => {
+    // The regression this guards: a newly listed alloy constituent (e.g.
+    // cbDOGE.axl, a constituent of allDOGE) otherwise appears on the New
+    // screen next to the alloy it backs.
+    expect(getCategoryFilters("new").excludeVariants).toBe(true);
+  });
+
+  it("excludes variants for top gainers", () => {
+    expect(getCategoryFilters("topGainers").excludeVariants).toBe(true);
+  });
+
+  it("keeps variants for every other category", () => {
+    expect(getCategoryFilters("defi").excludeVariants).toBe(false);
+    expect(getCategoryFilters(undefined).excludeVariants).toBe(false);
+  });
+
+  it("applies the market-quality gates to top gainers only", () => {
+    expect(getCategoryFilters("topGainers")).toEqual({
+      excludeVariants: true,
+      excludeStablecoins: true,
+      minLiquidity: 5000,
+      minVolume24h: 1000,
+      maxPriceChange24h: 1000,
+    });
+  });
+
+  it("leaves the new category ungated apart from variant exclusion", () => {
+    // New is date-ordered, so a liquidity or volume floor would silently hide
+    // legitimately new small listings.
+    expect(getCategoryFilters("new")).toEqual({
+      excludeVariants: true,
+      excludeStablecoins: false,
+      minLiquidity: undefined,
+      minVolume24h: undefined,
+      maxPriceChange24h: undefined,
+    });
+  });
+});

--- a/packages/web/components/table/asset-info.tsx
+++ b/packages/web/components/table/asset-info.tsx
@@ -202,7 +202,8 @@ export const AssetsInfoTable: FunctionComponent<{
       sort,
       watchListDenoms,
       categories,
-      excludeVariants: selectedCategory === "topGainers",
+      excludeVariants:
+        selectedCategory === "topGainers" || selectedCategory === "new",
       excludeStablecoins: selectedCategory === "topGainers",
       minLiquidity:
         selectedCategory === "topGainers" ? 5000 : searchQuery ? 0 : undefined,

--- a/packages/web/components/table/asset-info.tsx
+++ b/packages/web/components/table/asset-info.tsx
@@ -56,6 +56,31 @@ type SortKey =
     >["keyPath"]
   | undefined;
 
+/** Query filters that depend only on which category is selected.
+ *
+ *  Top Gainers needs the market-quality gates because a shallow-pool price blip
+ *  otherwise fabricates a fake gainer. New only needs variant exclusion: it is
+ *  date-ordered, so a liquidity floor would hide legitimately new small
+ *  listings, but a newly listed alloy constituent should not appear next to the
+ *  alloy it backs. */
+export function getCategoryFilters(selectedCategory: string | undefined): {
+  excludeVariants: boolean;
+  excludeStablecoins: boolean;
+  minLiquidity?: number;
+  minVolume24h?: number;
+  maxPriceChange24h?: number;
+} {
+  const isTopGainers = selectedCategory === "topGainers";
+
+  return {
+    excludeVariants: isTopGainers || selectedCategory === "new",
+    excludeStablecoins: isTopGainers,
+    minLiquidity: isTopGainers ? 5000 : undefined,
+    minVolume24h: isTopGainers ? 1000 : undefined,
+    maxPriceChange24h: isTopGainers ? 1000 : undefined,
+  };
+}
+
 export const AssetsInfoTable: FunctionComponent<{
   /** Height of elements above the table in the window. Nav bar is already included. */
   tableTopPadding?: number;
@@ -114,6 +139,10 @@ export const AssetsInfoTable: FunctionComponent<{
       selectedCategory && selectedCategory !== "topGainers"
         ? [selectedCategory]
         : undefined,
+    [selectedCategory]
+  );
+  const categoryFilters = useMemo(
+    () => getCategoryFilters(selectedCategory),
     [selectedCategory]
   );
 
@@ -202,13 +231,9 @@ export const AssetsInfoTable: FunctionComponent<{
       sort,
       watchListDenoms,
       categories,
-      excludeVariants:
-        selectedCategory === "topGainers" || selectedCategory === "new",
-      excludeStablecoins: selectedCategory === "topGainers",
+      ...categoryFilters,
       minLiquidity:
-        selectedCategory === "topGainers" ? 5000 : searchQuery ? 0 : undefined,
-      minVolume24h: selectedCategory === "topGainers" ? 1000 : undefined,
-      maxPriceChange24h: selectedCategory === "topGainers" ? 1000 : undefined,
+        categoryFilters.minLiquidity ?? (searchQuery ? 0 : undefined),
     },
     {
       getNextPageParam: (lastPage) => lastPage.nextCursor,


### PR DESCRIPTION
## What

A newly listed alloy constituent appeared on the **New** screen alongside the alloy it backs. Surfaced by `cbDOGE.axl`, a constituent of `allDOGE`, listed 2026-07-21.

## Why it happened

"New" is not a real assetlist category. It is synthesized from `listingDate` over a 30-day window in `packages/server/src/queries/complex/assets/categories.ts` (`NEW_ASSET_WINDOW_MS`), so the filter is date-only and applied no variant dedupe.

The machinery already existed and simply was not wired up:

- `getTopGainerAssets` already drops non-canonical variants (`variantGroupKey !== coinMinimalDenom`).
- `mapGetMarketAssets` already exposes a generic `excludeVariants` flag.

Neither New path used either one. Both New surfaces are fixed here: the homepage highlights tile (`getTopNewAssets`) and the `?category=new` chip on the assets table.

## User-facing change

The New window currently holds two assets, `cbDOGE.axl` and `NTHR`. Since `cbDOGE.axl` is the variant being filtered, **the New tile and table go from 2 rows to 1**. That is the intended behaviour, and the tile already reflows (it gates on a non-empty list), but it is a visible homepage change rather than a silent one.

## Deliberately not changed

`onlyVerified`, `minLiquidity`, `minVolume24h` and `maxPriceChange24h` are **not** extended to `new`. Those gates exist for Top Gainers because a shallow-pool price blip fabricates a fake gainer. New is date-ordered, so a liquidity floor would silently hide legitimately new small listings, which is the opposite of the screen's purpose.

No assetlists change is needed. `variantGroupKey` and `listingDate` are both correct upstream: `cbDOGE.axl` genuinely is an `allDOGE` constituent and genuinely was listed on that date. The dedupe belongs where the synthesis lives.

## Tests

The first commit's test proved the backend filter but not the UI condition that turns it on, since the server test passes `excludeVariants` itself. Deleting `selectedCategory === "new"` left everything green.

So the category-dependent query filters are extracted into `getCategoryFilters`, a pure function, and tested directly. Removing the `"new"` condition now fails two cases (verified by doing it). The extraction also collapses five scattered `selectedCategory === "topGainers"` ternaries into one place; `minLiquidity` keeps its search-dependent fallback in the query input because that depends on search state, not category.

Two other test improvements:

- **WBTC fixture**: its `variantGroupKey` was the bare symbol `"BTC"` while production keys are denoms (1335/1335). The variant assertion had been passing on a symbol-vs-denom comparison that is trivially true, so it would have held even if the predicate were wrong. It now compares against the real `allBTC` group denom. Verified by neutering the predicate: the test fails with `Received array: ["WBTC", "BADKID"]`.
- **`getTopNewAssets`**: new trpc test asserting the market-activity and listing-date lookups each run exactly once, pinning the filter *before* the fetch loop so it cannot regress to filtering afterwards (which would waste a network call per variant and still pass an output-only test).

## Validation

- Web 5/5, server 15/15, trpc 1/1.
- `asset-info.tsx`: zero type errors. Web package total is 7, identical to a stashed baseline, all pre-existing failures in unrelated test files.
- ESLint, Prettier, `git diff --check` all clean.

## Known follow-up

The canonical-variant predicate now exists in three places (`market.ts`, `getTopGainerAssets`, `getTopNewAssets`) and the phrasings have already diverged stylistically. Extracting a shared `isCanonicalAsset` is worth doing, but it touches code outside this fix's purpose so it is left for a follow-up.
