### PR TITLE
feat(pools): gate incentive gauge creation behind a feature flag

### DIFF
--- a/packages/types/src/feature-flags-types.ts
+++ b/packages/types/src/feature-flags-types.ts
@@ -22,6 +22,7 @@ export type AvailableFlags =
   | "sqsActiveOrders"
   | "alloyedAssets"
   | "assetAlerts"
+  | "incentivizePool"
   | "bridgeDepositAddress"
   | "nomicWithdrawAmount"
   | "swapToolTopGainers"

--- a/packages/web/components/pool-detail/base-pool.tsx
+++ b/packages/web/components/pool-detail/base-pool.tsx
@@ -10,13 +10,14 @@ import { Icon, PoolAssetsIcon } from "~/components/assets";
 import { Button } from "~/components/buttons";
 import { AssetBreakdownChart } from "~/components/chart";
 import { Button as UIButton } from "~/components/ui/button";
-import { useTranslation } from "~/hooks";
+import { useFeatureFlags, useTranslation } from "~/hooks";
 import { IncentivizePoolModal } from "~/modals";
 
 export const BasePoolDetails: FunctionComponent<{
   pool: Pool;
 }> = observer(({ pool }) => {
   const { t } = useTranslation();
+  const { incentivizePool } = useFeatureFlags();
 
   const [showPoolDetails, setShowPoolDetails] = useState(true);
   const [showIncentivizeModal, setShowIncentivizeModal] = useState(false);
@@ -42,7 +43,10 @@ export const BasePoolDetails: FunctionComponent<{
   const isUninitializedPool = isSqrtPriceZero && isTickLiquidityZero;
   const isInactivePool = !isUninitializedPool && isTickLiquidityZero && hasTVL;
   const canIncentivize =
-    pool.type === "concentrated" && !isUninitializedPool && !isInactivePool;
+    incentivizePool &&
+    pool.type === "concentrated" &&
+    !isUninitializedPool &&
+    !isInactivePool;
 
   const poolNameAssetLinks = pool.reserveCoins.map(
     ({ denom, currency }, index) => (

--- a/packages/web/components/pool-detail/concentrated.tsx
+++ b/packages/web/components/pool-detail/concentrated.tsx
@@ -61,6 +61,7 @@ export const ConcentratedLiquidityPool: FunctionComponent<{ poolId: string }> =
     const { t } = useTranslation();
     const { logEvent } = useAmplitudeAnalytics();
     const { isLoading: isWalletLoading } = useWalletSelect();
+    const { incentivizePool } = useFeatureFlags();
     const account = accountStore.getWallet(chainStore.osmosis.chainId);
     const openCreatePosition = useSearchParam(OpenCreatePositionSearchParam);
 
@@ -191,7 +192,7 @@ export const ConcentratedLiquidityPool: FunctionComponent<{ poolId: string }> =
             onRequestClose={() => setActiveModal(null)}
           />
         )}
-        {pool && activeModal === "incentivize" && (
+        {pool && incentivizePool && activeModal === "incentivize" && (
           <IncentivizePoolModal
             isOpen={true}
             poolId={pool.id}
@@ -607,9 +608,8 @@ const UserAssetsAndExternalIncentives: FunctionComponent<{
         </div>
       </div>
       {/* Incentivize entry sits to the right of the Total APR card, filling
-          the dead space beside it. Rendered regardless of the aprBreakdown
-          flag so the feature is always reachable (matching the share-pool
-          entry). */}
+          the dead space beside it. Gated on its own incentivizePool flag, not
+          on aprBreakdown, so the two can be toggled independently. */}
       <div className="flex shrink-0 items-center gap-4">
         {featureFlags.aprBreakdown && (
           <SkeletonLoader isLoaded={!isLoadingIncentives}>
@@ -620,14 +620,16 @@ const UserAssetsAndExternalIncentives: FunctionComponent<{
             />
           </SkeletonLoader>
         )}
-        <Button
-          variant="outline"
-          size="sm"
-          className="w-fit"
-          onClick={onIncentivize}
-        >
-          {t("incentivizePool.entry")}
-        </Button>
+        {featureFlags.incentivizePool && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="w-fit"
+            onClick={onIncentivize}
+          >
+            {t("incentivizePool.entry")}
+          </Button>
+        )}
       </div>
 
       {hasIncentives && (

--- a/packages/web/components/pool-detail/share.tsx
+++ b/packages/web/components/pool-detail/share.tsx
@@ -32,6 +32,7 @@ import { EventName } from "~/config";
 import {
   useAmplitudeAnalytics,
   useDailyEpochCountdown,
+  useFeatureFlags,
   useLockTokenConfig,
   useSuperfluidPool,
   useTranslation,
@@ -57,6 +58,7 @@ export const SharePool: FunctionComponent<{ pool: Pool }> = observer(
     const { t } = useTranslation();
     const { isMobile } = useWindowSize();
     const { isLoading: isWalletLoading } = useWalletSelect();
+    const { incentivizePool } = useFeatureFlags();
 
     const [poolDetailsContainerRef, { y: poolDetailsContainerOffset }] =
       useMeasure<HTMLDivElement>();
@@ -322,7 +324,7 @@ export const SharePool: FunctionComponent<{ pool: Pool }> = observer(
             onAddLiquidity={onAddLiquidity}
           />
         )}
-        {pool && showIncentivizeModal && (
+        {pool && incentivizePool && showIncentivizeModal && (
           <IncentivizePoolModal
             isOpen={true}
             poolId={pool.id}
@@ -771,14 +773,16 @@ export const SharePool: FunctionComponent<{ pool: Pool }> = observer(
                         {t("pool.bondShares")}
                       </Button>
                     )}
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="w-fit"
-                      onClick={() => setShowIncentivizeModal(true)}
-                    >
-                      {t("incentivizePool.entry")}
-                    </Button>
+                    {incentivizePool && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="w-fit"
+                        onClick={() => setShowIncentivizeModal(true)}
+                      >
+                        {t("incentivizePool.entry")}
+                      </Button>
+                    )}
                   </div>
                 </div>
                 <div className="grid grid-cols-3 gap-4 1.5xl:grid-cols-1">

--- a/packages/web/hooks/use-feature-flags.ts
+++ b/packages/web/hooks/use-feature-flags.ts
@@ -28,6 +28,7 @@ const defaultFlags: Record<AvailableFlags, boolean> = {
   sqsActiveOrders: false,
   alloyedAssets: false,
   assetAlerts: false,
+  incentivizePool: false,
   bridgeDepositAddress: false,
   nomicWithdrawAmount: false,
   swapToolTopGainers: false,


### PR DESCRIPTION
## What is the purpose of the change:

Adds an `incentivizePool` feature flag (default **off**) and gates the incentive gauge creation entry behind it.

Gauge creation shipped unflagged in #4401. It is a **new signing surface with a 50 OSMO non-refundable fee**, and it is currently reachable by every user the moment the release deploys. Without a flag the only way to withdraw it is to revert the release; with one, it can be turned off from LaunchDarkly without a redeploy.

Every comparable fund-committing or high-risk feature in this codebase already has a flag (`oneClickTrading`, `limitOrders`, `bridgeDepositAddress`, `alloyedAssets`, `assetAlerts`, and others). This brings gauge creation in line.

Surfaced by a release-risk review of #4427.

## What changed

Two lines of plumbing, following the `assetAlerts` pattern exactly:

- `packages/types/src/feature-flags-types.ts` — `incentivizePool` added to `AvailableFlags`.
- `packages/web/hooks/use-feature-flags.ts` — default `false`.

Then all three pool-detail surfaces are gated:

- `components/pool-detail/concentrated.tsx` — desktop concentrated view.
- `components/pool-detail/share.tsx` — weighted / stableswap view.
- `components/pool-detail/base-pool.tsx` — mobile concentrated fallback (folded into the existing `canIncentivize`, which already gated both sites).

**Both the entry button and the modal render are gated in every case.** Gating the button alone is not sufficient: the modal opens off separate state (`activeModal === "incentivize"` and `showIncentivizeModal`), so a stale or deep-linked state could otherwise reach the signing flow with the button hidden.

This also drops a stale comment in `concentrated.tsx` claiming the entry renders regardless of the `aprBreakdown` flag "so the feature is always reachable". That reasoning no longer applies now that it has its own flag, and the comment would have misled the next reader into thinking the entry was deliberately ungated.

## User-facing behaviour

With the flag off (the default, and the state on deploy) the Incentivize entry does not render on any pool page and the modal cannot be opened. Nothing else changes. With it on, behaviour is identical to today.

## Testing and Verifying

- Zero type errors in all four changed TypeScript files. The web package total is **7**, identical to the `stage` baseline (all pre-existing failures in unrelated test files).
- `@osmosis-labs/types` builds clean.
- ESLint and Prettier clean on all five files.
- The one existing test that touches feature flags (`hooks/__tests__/use-swap-wallet-loading.spec.tsx`) passes 2/2.

## Risks

Low. The change only ever removes a render path; it adds no logic to the signing flow itself. The main risk is the opposite of a regression: if the LaunchDarkly flag is not created, or is created and left off, the feature stays invisible. An unknown flag key resolves falsy in the client SDK, which matches the `false` default here, so the fail-safe direction is "hidden" rather than "exposed".
