### PR TITLE
chore(deps): replace es5-ext with a fork that has no postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "@keplr-wallet/ens/axios": "^0.33.0",
     "@keplr-wallet/types/axios": "^0.33.0",
     "@0xsquid/sdk/axios": "^0.33.0",
-    "@terra-money/feather.js/axios": "^0.33.0"
+    "@terra-money/feather.js/axios": "^0.33.0",
+    "es5-ext": "npm:@unes/es5-ext@0.10.64-1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12631,10 +12631,10 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-es5-ext@^0.10.35, es5-ext@^0.10.46, es5-ext@^0.10.50, es5-ext@^0.10.53, es5-ext@^0.10.61, es5-ext@^0.10.62, es5-ext@~0.10.14, es5-ext@~0.10.2, es5-ext@~0.10.46:
-  version "0.10.64"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.64.tgz#12e4ffb48f1ba2ea777f1fcdd1918ef73ea21714"
-  integrity sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==
+es5-ext@^0.10.35, es5-ext@^0.10.46, es5-ext@^0.10.50, es5-ext@^0.10.53, es5-ext@^0.10.61, es5-ext@^0.10.62, "es5-ext@npm:@unes/es5-ext@0.10.64-1", es5-ext@~0.10.14, es5-ext@~0.10.2, es5-ext@~0.10.46:
+  version "0.10.64-1"
+  resolved "https://registry.yarnpkg.com/@unes/es5-ext/-/es5-ext-0.10.64-1.tgz#4364fd5a1431f70c42e538982318a184b99992b0"
+  integrity sha512-nZSbffWxU0SleuK9kPrC9zwsbNmzkrSxQSa0+UOR8ghBQSlnj1wmtZZA5+ZRtgk8Xn+kaoAYPT9aOBwFZzXfFA==
   dependencies:
     es6-iterator "^2.0.3"
     es6-symbol "^3.1.3"


### PR DESCRIPTION
## What is the purpose of the change:

Resolves the High-severity **protestware** alert Socket raised on #4427, where the release bumped `es5-ext` 0.10.62 → 0.10.64.

Upstream `es5-ext` ships:

```
"postinstall": " node -e \"try{require('./_postinstall')}catch(e){}\" || exit 0"
```

`_postinstall.js` geolocates the host by timezone and prints a lengthy anti-war message for matching locations. The `try/catch` plus `|| exit 0` means it fails silently by design. This is a documented, widely-known incident: it is why some antivirus tools flag builds that include the package, and why Nexus Firewall quarantines it under advisory sonatype-2022-2248.

## What changed

One resolution, following the community fix used downstream (coder/code-server#7788), adapted to this repo's yarn 1 `resolutions` block rather than the npm `overrides` syntax in that thread:

```json
"es5-ext": "npm:@unes/es5-ext@0.10.64-1"
```

`@unes/es5-ext` is a community fork that strips the postinstall and rebases daily against upstream.

## Verification

Checked against the npm registry rather than taken on trust:

- Upstream `es5-ext@0.10.64` has the `postinstall` entry above.
- `@unes/es5-ext@0.10.64-1` has **`"scripts": {}`**, no scripts at all.
- After install, **`node_modules/es5-ext/_postinstall.js` does not exist**, and the installed package identifies as `@unes/es5-ext@0.10.64-1`. The script is removed, not merely disabled.

Drop-in equivalence:

- All **ten** `es5-ext` ranges in the lockfile resolve to the single forked entry. No duplicate copies.
- `require('es5-ext/object/assign')` and `es5-ext/array/#/uniq` load and behave correctly.
- **Full web build passes, 14/14 tasks.**
- `proto-codecs` tests pass 12/12, and that package builds clean (it is the one that pulls es5-ext in).

## Blast radius

`es5-ext` reaches this repo only via `@cosmology/telescope`, which is a **devDependency** of `packages/proto-codecs` (proto codegen tooling). It never shipped in the web bundle, so **production users were never exposed**. What this removes is a script that made a network call and executed undisclosed code at install time on developer machines and CI runners.

## The other Socket alert: node-forge is a verified false positive

Socket raised a second High alert on the same release: `node-forge` 1.3.1 → 1.4.0, "90% likely obfuscated". **No override is applied for it, and none should be.** Rather than reason about it, both published tarballs were pulled and diffed.

The 1.4.0 tarball's SHA-512 matches the release lockfile's integrity hash exactly, so the audit covers the precise artifact that would ship.

**Not obfuscated, not even minified.** `jsbn.js`, the file responsible for the large diff, averages **~27 characters per line** in both versions. Obfuscated or minified code runs to hundreds or thousands of characters per line. It is plainly readable source.

**The big diff is a code-style reformat.** `jsbn.js` shows 902 changed lines, which collapses to **64** under `diff -w -B`. The bulk is `} else {` rewritten as `}\nelse {`. The likely trigger for Socket's heuristic is that reformatting churn plus the natural density of a bignum library, which is full of bit-shifts and hex constants.

**Every substantive change is a security or bug fix:**

- `ed25519.js` — rejects non-canonical signature scalars (requires S < L). A **signature malleability fix**.
- `x509.js` — rejects certificates used as a CA when `basicConstraints` is absent. A **certificate validation fix**.
- `pkcs12.js` — throws `Invalid PKCS#12. macData field present but MAC was not validated.` instead of silently accepting. **Closes a MAC bypass**.
- `rsa.js` — adds an explicitly-documented-as-unsupported `_skipPaddingChecks` test flag, default `false`.
- `jsbn.js` — adds `square()`, a `lowprimes` table, and an infinite-loop guard returning `BigInteger.ZERO` when `signum() == 0`.
- `oids.js` — one added OID mapping (`2.5.4.65` → `pseudonym`).
- `aes`, `pbe`, `tls`, `util`, `xhr`, `prime.worker` — **comment typo corrections only** ("algebriac", "renegotation", "trunacted", "asychronous").

**No exfiltration surface added.** Every added line across all 13 changed files was grepped for `eval`, `new Function`, `fetch`, `XMLHttpRequest`, http/https URLs, `child_process`, `process.env`, base64 decoding, WebSocket, and `.send(`. **Zero hits.**

**No install-time scripts** in either version (only `prepublish`, which never runs on consumers). That is the opposite of es5-ext, where the postinstall was the entire problem.

1.4.0 also only **removes** files (CHANGELOG and the legacy Flash socket-pool shim) and adds none.

So 1.4.0 is strictly *more* secure than 1.3.1. Pinning back to silence the heuristic would have removed three real cryptographic fixes, and it sits four levels deep in the wallet stack (`@cosmos-kit/core` → WalletConnect → wagmi → node-forge) on the real user fund path. The appropriate handling is marking it acceptable risk in the Socket dashboard, which is a policy decision rather than a code change.

## Risks

Low, but not zero: this swaps a transitive build-tool dependency for a third-party fork, so we now trust `@unes/es5-ext`'s publisher in place of `medikoo`'s. The mitigation is that it is build-time only, never reaches users, and the full build plus test suite pass on it. If the fork ever stops tracking upstream, reverting is a one-line change.

