### PR TITLE
feat: add Vultisig extension to wallet selector

### DIFF
--- a/packages/web/config/generate-cosmos-kit-wallet-list.ts
+++ b/packages/web/config/generate-cosmos-kit-wallet-list.ts
@@ -10,6 +10,7 @@ import { keplrMobileInfo } from "@cosmos-kit/keplr-mobile";
 import { OkxwalletExtensionInfo as okxWalletExtensionInfo } from "@cosmos-kit/okxwallet-extension";
 import { stationExtensionInfo } from "@cosmos-kit/station-extension";
 import { trustExtensionInfo } from "@cosmos-kit/trust-extension";
+import { vultisigExtensionInfo } from "@cosmos-kit/vultisig-extension";
 import { xdefiExtensionInfo } from "@cosmos-kit/xdefi-extension";
 import { isFunction } from "@osmosis-labs/utils";
 import * as prettier from "prettier";
@@ -34,6 +35,7 @@ const CosmosKitWalletList: Wallet[] = [
   cosmostationExtensionInfo,
   stationExtensionInfo,
   cdcwalletExtensionInfo,
+  vultisigExtensionInfo,
 ];
 
 function isObject(value: any): value is Record<any, any> {

--- a/packages/web/config/wallet-registry.ts
+++ b/packages/web/config/wallet-registry.ts
@@ -244,4 +244,14 @@ export const CosmosWalletRegistry: CosmosRegistryWallet[] = [
     },
     features: [],
   },
+  {
+    ...CosmosKitWalletList["vultisig-extension"],
+    logo: "/wallets/vultisig.svg",
+    lazyInstall: () =>
+      import("@cosmos-kit/vultisig-extension").then(
+        (m) => m.VultisigExtensionWallet
+      ),
+    windowPropertyName: "vultisig",
+    features: [],
+  },
 ];

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -35,6 +35,7 @@
     "@cosmos-kit/okxwallet": "^2.14.1",
     "@cosmos-kit/station": "^2.15.1",
     "@cosmos-kit/trust": "^2.16.1",
+    "@cosmos-kit/vultisig": "^2.16.1",
     "@cosmos-kit/xdefi": "^2.12.0",
     "@headlessui/react": "^2.1.1",
     "@keplr-wallet/common": "0.10.24-ibc.go.v7.hot.fix",

--- a/packages/web/public/wallets/vultisig.svg
+++ b/packages/web/public/wallets/vultisig.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120" viewBox="0 0 1024 1024" fill="none">
+<rect width="1024" height="1024" rx="512" fill="#061B3A" />
+<path d="M502.487 560.085L263.176 698.603L228.016 663.443L437.804 522.477L502.487 560.085Z" fill="url(#paint0_linear_6897_19996)" />
+<path d="M507.896 569.454L268.281 707.444L281.15 755.474L508.124 644.274L507.896 569.454Z" fill="url(#paint1_linear_6897_19996)" />
+<path d="M517.409 569.454L757.024 707.444L744.154 755.473L517.18 644.274L517.409 569.454Z" fill="url(#paint2_linear_6897_19996)" />
+<path d="M522.818 560.085L762.128 698.602L797.288 663.443L587.5 522.477L522.818 560.085Z" fill="url(#paint3_linear_6897_19996)" />
+<path d="M517.409 549.849L517.104 273.341L565.134 260.471L582.32 512.636L517.409 549.849Z" fill="url(#paint4_linear_6897_19996)" />
+<path d="M506.591 549.849L506.895 273.341L458.866 260.471L441.68 512.636L506.591 549.849Z" fill="url(#paint5_linear_6897_19996)" />
+<path d="M502.487 560.085L263.176 698.603L228.016 663.443L437.804 522.477L502.487 560.085Z" stroke="url(#paint6_linear_6897_19996)" />
+<path d="M507.896 569.454L268.281 707.444L281.15 755.474L508.124 644.274L507.896 569.454Z" stroke="url(#paint7_linear_6897_19996)" />
+<path d="M517.409 569.454L757.024 707.444L744.154 755.473L517.18 644.274L517.409 569.454Z" stroke="url(#paint8_linear_6897_19996)" />
+<path d="M522.818 560.085L762.128 698.602L797.288 663.443L587.5 522.477L522.818 560.085Z" stroke="url(#paint9_linear_6897_19996)" />
+<path d="M517.409 549.849L517.104 273.341L565.134 260.471L582.32 512.636L517.409 549.849Z" stroke="url(#paint10_linear_6897_19996)" />
+<path d="M506.591 549.849L506.895 273.341L458.866 260.471L441.68 512.636L506.591 549.849Z" stroke="url(#paint11_linear_6897_19996)" />
+<defs>
+<linearGradient id="paint0_linear_6897_19996" x1="512.652" y1="260.471" x2="512.652" y2="755.474" gradientUnits="userSpaceOnUse">
+<stop stop-color="#33E6BF" />
+<stop offset="1" stop-color="#0439C7" />
+</linearGradient>
+<linearGradient id="paint1_linear_6897_19996" x1="512.652" y1="260.471" x2="512.652" y2="755.474" gradientUnits="userSpaceOnUse">
+<stop stop-color="#33E6BF" />
+<stop offset="1" stop-color="#0439C7" />
+</linearGradient>
+<linearGradient id="paint2_linear_6897_19996" x1="512.652" y1="260.471" x2="512.652" y2="755.474" gradientUnits="userSpaceOnUse">
+<stop stop-color="#33E6BF" />
+<stop offset="1" stop-color="#0439C7" />
+</linearGradient>
+<linearGradient id="paint3_linear_6897_19996" x1="512.652" y1="260.471" x2="512.652" y2="755.474" gradientUnits="userSpaceOnUse">
+<stop stop-color="#33E6BF" />
+<stop offset="1" stop-color="#0439C7" />
+</linearGradient>
+<linearGradient id="paint4_linear_6897_19996" x1="512.652" y1="260.471" x2="512.652" y2="755.474" gradientUnits="userSpaceOnUse">
+<stop stop-color="#33E6BF" />
+<stop offset="1" stop-color="#0439C7" />
+</linearGradient>
+<linearGradient id="paint5_linear_6897_19996" x1="512.652" y1="260.471" x2="512.652" y2="755.474" gradientUnits="userSpaceOnUse">
+<stop stop-color="#33E6BF" />
+<stop offset="1" stop-color="#0439C7" />
+</linearGradient>
+<linearGradient id="paint6_linear_6897_19996" x1="512.652" y1="260.471" x2="512.652" y2="755.474" gradientUnits="userSpaceOnUse">
+<stop stop-color="#33E6BF" />
+<stop offset="1" stop-color="#0439C7" />
+</linearGradient>
+<linearGradient id="paint7_linear_6897_19996" x1="512.652" y1="260.471" x2="512.652" y2="755.474" gradientUnits="userSpaceOnUse">
+<stop stop-color="#33E6BF" />
+<stop offset="1" stop-color="#0439C7" />
+</linearGradient>
+<linearGradient id="paint8_linear_6897_19996" x1="512.652" y1="260.471" x2="512.652" y2="755.474" gradientUnits="userSpaceOnUse">
+<stop stop-color="#33E6BF" />
+<stop offset="1" stop-color="#0439C7" />
+</linearGradient>
+<linearGradient id="paint9_linear_6897_19996" x1="512.652" y1="260.471" x2="512.652" y2="755.474" gradientUnits="userSpaceOnUse">
+<stop stop-color="#33E6BF" />
+<stop offset="1" stop-color="#0439C7" />
+</linearGradient>
+<linearGradient id="paint10_linear_6897_19996" x1="512.652" y1="260.471" x2="512.652" y2="755.474" gradientUnits="userSpaceOnUse">
+<stop stop-color="#33E6BF" />
+<stop offset="1" stop-color="#0439C7" />
+</linearGradient>
+<linearGradient id="paint11_linear_6897_19996" x1="512.652" y1="260.471" x2="512.652" y2="755.474" gradientUnits="userSpaceOnUse">
+<stop stop-color="#33E6BF" />
+<stop offset="1" stop-color="#0439C7" />
+</linearGradient>
+</defs>
+</svg>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3057,6 +3057,20 @@
     "@cosmos-kit/trust-extension" "^2.15.1"
     "@cosmos-kit/trust-mobile" "^2.15.1"
 
+"@cosmos-kit/vultisig-extension@^2.17.1":
+  version "2.17.1"
+  resolved "https://registry.yarnpkg.com/@cosmos-kit/vultisig-extension/-/vultisig-extension-2.17.1.tgz#9c672b038ed0f70972a52a65f1f1d4e9e0ae84b4"
+  integrity sha512-n0uunlCQTtiqFq2UlP7AOlVQ9P4w13tpxWNt0mqajQc/QYX62aCBISGE6qjLi/lBe1CKjXQrhR3Efmami24zgQ==
+  dependencies:
+    "@cosmos-kit/core" "^2.18.1"
+
+"@cosmos-kit/vultisig@^2.16.1":
+  version "2.16.1"
+  resolved "https://registry.yarnpkg.com/@cosmos-kit/vultisig/-/vultisig-2.16.1.tgz#138999f4ef5d5473290fc2a0c3f3d12033245754"
+  integrity sha512-L6yqibdnK2v76uhLgwg8qokEu2lffnhRYDXpLs0p8NKXwcy1AHa9nyKWLuooa9VGLccA+xoFTMzw3iVUoqYG4Q==
+  dependencies:
+    "@cosmos-kit/vultisig-extension" "^2.17.1"
+
 "@cosmos-kit/walletconnect@^2.15.1":
   version "2.15.1"
   resolved "https://registry.yarnpkg.com/@cosmos-kit/walletconnect/-/walletconnect-2.15.1.tgz#7552865ad9670caba0e36d886f7c6436bc6632e4"


### PR DESCRIPTION
## What

Registers the official Vultisig cosmos-kit connector in the wallet selector:

- `packages/web/package.json`: adds `@cosmos-kit/vultisig@^2.16.1` (aggregator; the code imports the `@cosmos-kit/vultisig-extension` implementation it re-exports, same pattern as the other wallets)
- `config/generate-cosmos-kit-wallet-list.ts`: imports and appends `vultisigExtensionInfo`
- `config/wallet-registry.ts`: appends the registry entry (`lazyInstall`, `windowPropertyName: "vultisig"`, `mobileDisabled` inherited from the connector)
- `public/wallets/vultisig.svg`: wallet logo
- `yarn.lock`: regenerated via `yarn install`

## Why

Vultisig is a free, open-source, self-custody multi-chain wallet with no seed phrase. Its Chrome extension ships a Keplr-compatible provider and the connector is published from the cosmos-kit repo (`@cosmos-kit/vultisig-extension`, maintained with the cosmos-kit maintainers). Osmosis is on `@cosmos-kit/core@2.18.1`, which is exactly the connector's required core range — zero new transitive dependencies are introduced (verified: the dep closure beyond the two `@cosmos-kit/vultisig*` packages is already in the lockfile).

## receipts

no runtime changes to existing wallets — additive registration only

Connector resolves and exports verified from the installed workspace (`packages/web`):

```
$ node vultiprobe.mjs   # imports '@cosmos-kit/vultisig-extension' from node_modules
name: vultisig-extension
prettyName: Vultisig
mode: extension
mobileDisabled: true
wallet class loads: true
```

`yarn install` run after the dependency addition: lockfile delta is exactly the two `@cosmos-kit/vultisig*` entries, no other churn. `prettier --check` passes on the three edited config files; import ordering satisfies `simple-import-sort`.

Note: no Linear task link — external contribution; happy to adjust anything to fit your process.