### PR TITLE
fix(pools): demand exact output only for genuinely 1:1 conversion routes

### DIFF
--- a/packages/server/src/queries/complex/pools/env.ts
+++ b/packages/server/src/queries/complex/pools/env.ts
@@ -11,6 +11,21 @@ const WhitewhalePoolCodeIds = IS_TESTNET ? ["?"] : ["503", "641"];
 /** Cosmwasm Code Ids confirmed to be orderbook pools in current env. */
 export const OrderbookPoolCodeIds = IS_TESTNET ? ["?"] : ["885"];
 
+/** Pool types that swap at a fixed 1:1 ratio with no price movement, so a quote
+ *  against them cannot drift between quote and execution. Deliberately excludes
+ *  `cosmwasm-astroport-pcl` (a concentrated AMM, with a dynamic spread factor),
+ *  `cosmwasm-whitewhale` (an AMM), `cosmwasm-orderbook` (fills at book prices),
+ *  and bare `cosmwasm` (unrecognised code id, unknown semantics). */
+const OneToOnePoolTypes = ["cosmwasm-transmuter", "cosmwasm-alloyed"];
+
+/** Whether a quoted pool swaps 1:1, so callers may demand the exact quoted
+ *  amount out instead of allowing a slippage tolerance. Takes the pool `type`
+ *  as it appears on a quote, which `getCosmwasmPoolTypeFromCodeId` has already
+ *  narrowed to a CosmWasm subtype. */
+export function isOneToOnePoolType(type: string): boolean {
+  return OneToOnePoolTypes.includes(type);
+}
+
 export function getCosmwasmPoolTypeFromCodeId(
   codeId: string
 ):

--- a/packages/web/hooks/__tests__/use-convert-variant.test.ts
+++ b/packages/web/hooks/__tests__/use-convert-variant.test.ts
@@ -1,6 +1,20 @@
-import { Dec } from "@osmosis-labs/unit";
+import type { AssetVariant } from "@osmosis-labs/server";
+import { getSwapMessages, type QuoteOutGivenIn } from "@osmosis-labs/tx";
+import { CoinPretty, Dec, Int, PricePretty } from "@osmosis-labs/unit";
 
-import { checkLargeAmountDiff } from "../use-convert-variant";
+import {
+  checkLargeAmountDiff,
+  getConvertVariantMessages,
+} from "../use-convert-variant";
+
+jest.mock("@osmosis-labs/tx", () => ({
+  ...jest.requireActual("@osmosis-labs/tx"),
+  getSwapMessages: jest.fn().mockResolvedValue([]),
+}));
+
+const mockGetSwapMessages = getSwapMessages as jest.MockedFunction<
+  typeof getSwapMessages
+>;
 
 describe("isLargeAmountDiff", () => {
   test("returns false when input amount is zero", () => {
@@ -17,5 +31,139 @@ describe("isLargeAmountDiff", () => {
     expect(checkLargeAmountDiff(new Dec("100"), new Dec("94"))).toBe(true);
     expect(checkLargeAmountDiff(new Dec("100"), new Dec("90"))).toBe(true);
     expect(checkLargeAmountDiff(new Dec("100"), new Dec("50"))).toBe(true);
+  });
+});
+
+describe("getConvertVariantMessages slippage", () => {
+  const VARIANT_DENOM = "ibc/VARIANT";
+  const ALLOY_DENOM = "factory/osmo1alloycontract/alloyed/allTEST";
+
+  const currency = {
+    coinDenom: "TEST.variant",
+    coinMinimalDenom: VARIANT_DENOM,
+    coinDecimals: 6,
+  };
+
+  const variant = {
+    name: "Test Variant",
+    amount: new CoinPretty(currency, new Dec("1000000")),
+    fiatValue: new PricePretty(
+      { currency: "usd", symbol: "$", maxDecimals: 2, locale: "en-US" },
+      new Dec("1")
+    ),
+    canonicalAsset: {
+      coinDenom: "TEST",
+      coinMinimalDenom: ALLOY_DENOM,
+      coinDecimals: 6,
+    },
+  } as unknown as AssetVariant;
+
+  /** Minimal quote shaped like the tRPC route output. Pool `type` here is the
+   *  CosmWasm *subtype*, because `makeDisplayableOutGivenInSplit` rewrites the
+   *  raw type via `getCosmwasmPoolTypeFromCodeId` whenever a codeId is present
+   *  (which it is for every CosmWasm pool). Fixtures using a bare "cosmwasm"
+   *  would assert a shape production does not emit. */
+  const makeQuote = (split: { poolTypes: string[] }[]): QuoteOutGivenIn =>
+    ({
+      amount: new Int("1000000"),
+      split: split.map(({ poolTypes }) => ({
+        initialAmount: new Int("1000000"),
+        pools: poolTypes.map((type, i) => ({
+          id: String(i + 1),
+          type,
+          codeId: "996",
+          swapFee: new Dec(0),
+        })),
+        tokenInDenom: VARIANT_DENOM,
+        tokenOutDenoms: poolTypes.map(() => ALLOY_DENOM),
+      })),
+    } as unknown as QuoteOutGivenIn);
+
+  const slippageForQuote = async (quote: QuoteOutGivenIn) => {
+    await getConvertVariantMessages(variant, quote, "osmo1address");
+    return mockGetSwapMessages.mock.calls.at(-1)?.[0].maxSlippage;
+  };
+
+  beforeEach(() => {
+    mockGetSwapMessages.mockClear();
+  });
+
+  test("uses zero slippage for a single-hop alloyed pool", async () => {
+    // The regression this guards: the condition previously required
+    // pools.length === 0, so this case fell through to 5%.
+    expect(
+      await slippageForQuote(makeQuote([{ poolTypes: ["cosmwasm-alloyed"] }]))
+    ).toBe("0");
+  });
+
+  test("uses zero slippage for a single-hop transmuter pool", async () => {
+    expect(
+      await slippageForQuote(
+        makeQuote([{ poolTypes: ["cosmwasm-transmuter"] }])
+      )
+    ).toBe("0");
+  });
+
+  // The CosmWasm subtypes below are NOT 1:1. A prefix test on "cosmwasm" would
+  // wrongly demand the exact quoted amount out and revert on normal price drift.
+  test("keeps slippage for a single-hop Astroport PCL pool", async () => {
+    expect(
+      await slippageForQuote(
+        makeQuote([{ poolTypes: ["cosmwasm-astroport-pcl"] }])
+      )
+    ).toBe("0.05");
+  });
+
+  test("keeps slippage for a single-hop WhiteWhale pool", async () => {
+    expect(
+      await slippageForQuote(
+        makeQuote([{ poolTypes: ["cosmwasm-whitewhale"] }])
+      )
+    ).toBe("0.05");
+  });
+
+  test("keeps slippage for a single-hop orderbook pool", async () => {
+    expect(
+      await slippageForQuote(makeQuote([{ poolTypes: ["cosmwasm-orderbook"] }]))
+    ).toBe("0.05");
+  });
+
+  test("keeps slippage for an unrecognised bare cosmwasm pool", async () => {
+    // Unknown code id means unknown semantics; do not assume 1:1.
+    expect(
+      await slippageForQuote(makeQuote([{ poolTypes: ["cosmwasm"] }]))
+    ).toBe("0.05");
+  });
+
+  test("allows slippage when the route is not a CosmWasm pool", async () => {
+    expect(
+      await slippageForQuote(makeQuote([{ poolTypes: ["concentrated"] }]))
+    ).toBe("0.05");
+  });
+
+  test("allows slippage on a multi-hop route even via an alloyed pool", async () => {
+    // Second hop is a real swap that can move against the user.
+    expect(
+      await slippageForQuote(
+        makeQuote([{ poolTypes: ["cosmwasm-alloyed", "concentrated"] }])
+      )
+    ).toBe("0.05");
+  });
+
+  test("allows slippage on a split route", async () => {
+    expect(
+      await slippageForQuote(
+        makeQuote([
+          { poolTypes: ["cosmwasm-alloyed"] },
+          { poolTypes: ["cosmwasm-alloyed"] },
+        ])
+      )
+    ).toBe("0.05");
+  });
+
+  test("falls back to slippage when the route has no pools", async () => {
+    // An empty pool list is malformed; it must not be read as a 1:1 alloy hop.
+    // This is the exact shape the old `pools.length === 0` condition tested for.
+    expect(await slippageForQuote(makeQuote([{ poolTypes: [] }]))).toBe("0.05");
   });
 });

--- a/packages/web/hooks/__tests__/use-convert-variant.test.ts
+++ b/packages/web/hooks/__tests__/use-convert-variant.test.ts
@@ -1,6 +1,12 @@
 import type { AssetVariant } from "@osmosis-labs/server";
 import { getSwapMessages, type QuoteOutGivenIn } from "@osmosis-labs/tx";
-import { CoinPretty, Dec, Int, PricePretty } from "@osmosis-labs/unit";
+import {
+  CoinPretty,
+  Dec,
+  Int,
+  PricePretty,
+  RatePretty,
+} from "@osmosis-labs/unit";
 
 import {
   checkLargeAmountDiff,
@@ -38,31 +44,37 @@ describe("getConvertVariantMessages slippage", () => {
   const VARIANT_DENOM = "ibc/VARIANT";
   const ALLOY_DENOM = "factory/osmo1alloycontract/alloyed/allTEST";
 
-  const currency = {
+  const variantCurrency = {
     coinDenom: "TEST.variant",
     coinMinimalDenom: VARIANT_DENOM,
     coinDecimals: 6,
   };
 
+  const alloyCurrency = {
+    coinDenom: "TEST",
+    coinMinimalDenom: ALLOY_DENOM,
+    coinDecimals: 6,
+  };
+
   const variant = {
     name: "Test Variant",
-    amount: new CoinPretty(currency, new Dec("1000000")),
+    amount: new CoinPretty(variantCurrency, new Dec("1000000")),
     fiatValue: new PricePretty(
       { currency: "usd", symbol: "$", maxDecimals: 2, locale: "en-US" },
       new Dec("1")
     ),
-    canonicalAsset: {
-      coinDenom: "TEST",
-      coinMinimalDenom: ALLOY_DENOM,
-      coinDecimals: 6,
-    },
+    canonicalAsset: alloyCurrency,
   } as unknown as AssetVariant;
 
-  /** Minimal quote shaped like the tRPC route output. Pool `type` here is the
-   *  CosmWasm *subtype*, because `makeDisplayableOutGivenInSplit` rewrites the
-   *  raw type via `getCosmwasmPoolTypeFromCodeId` whenever a codeId is present
-   *  (which it is for every CosmWasm pool). Fixtures using a bare "cosmwasm"
-   *  would assert a shape production does not emit. */
+  /** Quote shaped like the tRPC route output, i.e. post-
+   *  `makeDisplayableOutGivenInSplit`. Two details matter:
+   *
+   *  - `type` is the CosmWasm *subtype*. That transform rewrites the raw type
+   *    via `getCosmwasmPoolTypeFromCodeId`, so a bare "cosmwasm" would assert a
+   *    shape production does not emit.
+   *  - the displayable pool carries `spreadFactor` / `dynamicSpreadFactor` /
+   *    `inCurrency` / `outCurrency`, and NOT `codeId` or `swapFee`; the code id
+   *    is consumed by the transform and dropped. */
   const makeQuote = (split: { poolTypes: string[] }[]): QuoteOutGivenIn =>
     ({
       amount: new Int("1000000"),
@@ -71,8 +83,10 @@ describe("getConvertVariantMessages slippage", () => {
         pools: poolTypes.map((type, i) => ({
           id: String(i + 1),
           type,
-          codeId: "996",
-          swapFee: new Dec(0),
+          spreadFactor: new RatePretty(new Dec(0)),
+          dynamicSpreadFactor: type === "cosmwasm-astroport-pcl",
+          inCurrency: variantCurrency,
+          outCurrency: alloyCurrency,
         })),
         tokenInDenom: VARIANT_DENOM,
         tokenOutDenoms: poolTypes.map(() => ALLOY_DENOM),

--- a/packages/web/hooks/__tests__/use-convert-variant.test.ts
+++ b/packages/web/hooks/__tests__/use-convert-variant.test.ts
@@ -10,7 +10,9 @@ import {
 
 import {
   checkLargeAmountDiff,
+  DEFAULT_CONVERT_MAX_SLIPPAGE,
   getConvertVariantMessages,
+  ONE_TO_ONE_MAX_SLIPPAGE,
 } from "../use-convert-variant";
 
 jest.mock("@osmosis-labs/tx", () => ({
@@ -102,20 +104,31 @@ describe("getConvertVariantMessages slippage", () => {
     mockGetSwapMessages.mockClear();
   });
 
-  test("uses zero slippage for a single-hop alloyed pool", async () => {
-    // The regression this guards: the condition previously required
-    // pools.length === 0, so this case fell through to 5%.
+  test("the 1:1 tolerance is small but non-zero", () => {
+    // Non-zero so a unit of chain-side truncation cannot revert the tx; small
+    // enough to be economically irrelevant (0.01% = 100 base units on a 1M USDC
+    // conversion). Exact "0" would demand byte-exact output.
+    expect(ONE_TO_ONE_MAX_SLIPPAGE).toBe("0.0001");
+    expect(new Dec(ONE_TO_ONE_MAX_SLIPPAGE).isPositive()).toBe(true);
     expect(
-      await slippageForQuote(makeQuote([{ poolTypes: ["cosmwasm-alloyed"] }]))
-    ).toBe("0");
+      new Dec(ONE_TO_ONE_MAX_SLIPPAGE).lt(new Dec(DEFAULT_CONVERT_MAX_SLIPPAGE))
+    ).toBe(true);
   });
 
-  test("uses zero slippage for a single-hop transmuter pool", async () => {
+  test("uses the near-zero tolerance for a single-hop alloyed pool", async () => {
+    // The regression this guards: the condition previously required
+    // pools.length === 0, so this case fell through to the full 5%.
+    expect(
+      await slippageForQuote(makeQuote([{ poolTypes: ["cosmwasm-alloyed"] }]))
+    ).toBe(ONE_TO_ONE_MAX_SLIPPAGE);
+  });
+
+  test("uses the near-zero tolerance for a single-hop transmuter pool", async () => {
     expect(
       await slippageForQuote(
         makeQuote([{ poolTypes: ["cosmwasm-transmuter"] }])
       )
-    ).toBe("0");
+    ).toBe(ONE_TO_ONE_MAX_SLIPPAGE);
   });
 
   // The CosmWasm subtypes below are NOT 1:1. A prefix test on "cosmwasm" would
@@ -125,7 +138,7 @@ describe("getConvertVariantMessages slippage", () => {
       await slippageForQuote(
         makeQuote([{ poolTypes: ["cosmwasm-astroport-pcl"] }])
       )
-    ).toBe("0.05");
+    ).toBe(DEFAULT_CONVERT_MAX_SLIPPAGE);
   });
 
   test("keeps slippage for a single-hop WhiteWhale pool", async () => {
@@ -133,26 +146,26 @@ describe("getConvertVariantMessages slippage", () => {
       await slippageForQuote(
         makeQuote([{ poolTypes: ["cosmwasm-whitewhale"] }])
       )
-    ).toBe("0.05");
+    ).toBe(DEFAULT_CONVERT_MAX_SLIPPAGE);
   });
 
   test("keeps slippage for a single-hop orderbook pool", async () => {
     expect(
       await slippageForQuote(makeQuote([{ poolTypes: ["cosmwasm-orderbook"] }]))
-    ).toBe("0.05");
+    ).toBe(DEFAULT_CONVERT_MAX_SLIPPAGE);
   });
 
   test("keeps slippage for an unrecognised bare cosmwasm pool", async () => {
     // Unknown code id means unknown semantics; do not assume 1:1.
     expect(
       await slippageForQuote(makeQuote([{ poolTypes: ["cosmwasm"] }]))
-    ).toBe("0.05");
+    ).toBe(DEFAULT_CONVERT_MAX_SLIPPAGE);
   });
 
   test("allows slippage when the route is not a CosmWasm pool", async () => {
     expect(
       await slippageForQuote(makeQuote([{ poolTypes: ["concentrated"] }]))
-    ).toBe("0.05");
+    ).toBe(DEFAULT_CONVERT_MAX_SLIPPAGE);
   });
 
   test("allows slippage on a multi-hop route even via an alloyed pool", async () => {
@@ -161,7 +174,7 @@ describe("getConvertVariantMessages slippage", () => {
       await slippageForQuote(
         makeQuote([{ poolTypes: ["cosmwasm-alloyed", "concentrated"] }])
       )
-    ).toBe("0.05");
+    ).toBe(DEFAULT_CONVERT_MAX_SLIPPAGE);
   });
 
   test("allows slippage on a split route", async () => {
@@ -172,12 +185,14 @@ describe("getConvertVariantMessages slippage", () => {
           { poolTypes: ["cosmwasm-alloyed"] },
         ])
       )
-    ).toBe("0.05");
+    ).toBe(DEFAULT_CONVERT_MAX_SLIPPAGE);
   });
 
   test("falls back to slippage when the route has no pools", async () => {
     // An empty pool list is malformed; it must not be read as a 1:1 alloy hop.
     // This is the exact shape the old `pools.length === 0` condition tested for.
-    expect(await slippageForQuote(makeQuote([{ poolTypes: [] }]))).toBe("0.05");
+    expect(await slippageForQuote(makeQuote([{ poolTypes: [] }]))).toBe(
+      DEFAULT_CONVERT_MAX_SLIPPAGE
+    );
   });
 });

--- a/packages/web/hooks/use-convert-variant.ts
+++ b/packages/web/hooks/use-convert-variant.ts
@@ -1,4 +1,4 @@
-import type { AssetVariant } from "@osmosis-labs/server";
+import { type AssetVariant, isOneToOnePoolType } from "@osmosis-labs/server";
 import { getSwapMessages, type QuoteOutGivenIn } from "@osmosis-labs/tx";
 import { Dec } from "@osmosis-labs/unit";
 import { useCallback, useMemo } from "react";
@@ -201,16 +201,28 @@ export async function getConvertVariantMessages(
     throw new Error("No quote found");
   }
 
-  // if it's an alloy, or CW pool, let's assume it's a 1:1 swap
-  // so, let's remove slippage to convert more of the asset
-  const isAlloyPoolSwap =
+  // A conversion routing through a single 1:1 pool (transmuter or alloyed) has a
+  // fixed ratio, so we demand the exact quoted amount out rather than silently
+  // accepting less. Any other shape (a split, a multi-hop, or a price-moving
+  // pool) can drift between quote and execution and keeps a slippage allowance.
+  //
+  // Not every variant conversion is an alloy conversion: `variantGroupKey` also
+  // groups non-alloy canonical assets, whose conversions route through ordinary
+  // AMMs. The pool-type check, not the caller, is what makes this safe.
+  //
+  // NOTE: match the exact CosmWasm subtypes. On the quote path
+  // `getCosmwasmPoolTypeFromCodeId` has already narrowed `type`, so a
+  // `startsWith("cosmwasm")` prefix test would also catch Astroport PCL,
+  // WhiteWhale and orderbook pools, which are not 1:1.
+  const [singleRoute] = quote.split;
+  const isOneToOneSwap =
     quote.split.length === 1 &&
-    quote.split[0].pools.length === 0 &&
-    quote.split[0].pools[0].type.startsWith("cosmwasm");
+    singleRoute.pools.length === 1 &&
+    isOneToOnePoolType(singleRoute.pools[0].type);
 
   return await getSwapMessages({
     coinAmount: amount,
-    maxSlippage: isAlloyPoolSwap ? "0" : "0.05",
+    maxSlippage: isOneToOneSwap ? "0" : "0.05",
     quote,
     tokenInCoinMinimalDenom: tokenInDenom,
     tokenOutCoinMinimalDenom: tokenOutDenom,

--- a/packages/web/hooks/use-convert-variant.ts
+++ b/packages/web/hooks/use-convert-variant.ts
@@ -10,6 +10,21 @@ import { api } from "~/utils/trpc";
 import { useCoinFiatValue } from "./queries/assets/use-coin-fiat-value";
 import { useAmplitudeAnalytics } from "./use-amplitude-analytics";
 
+/** Slippage tolerance for a conversion through a single fixed-ratio pool
+ *  (transmuter / alloyed), as a decimal fraction: 0.01%.
+ *
+ *  Deliberately not "0". `maxSlippage` sets `tokenOutMinAmount` to
+ *  `quoted * (1 - maxSlippage)`, so exact zero demands byte-exact output and one
+ *  unit of chain-side truncation reverts the tx. This is small enough to be
+ *  economically irrelevant (100 base units on a 1M USDC conversion) while still
+ *  absorbing rounding. */
+export const ONE_TO_ONE_MAX_SLIPPAGE = "0.0001";
+
+/** Slippage tolerance for any conversion that can genuinely move against the
+ *  user between quote and execution: splits, multi-hops, and price-moving pools
+ *  (AMMs, orderbooks). Unchanged long-standing default. */
+export const DEFAULT_CONVERT_MAX_SLIPPAGE = "0.05";
+
 /**
  * Hook to convert a variant asset to its canonical form.
  *
@@ -202,9 +217,15 @@ export async function getConvertVariantMessages(
   }
 
   // A conversion routing through a single 1:1 pool (transmuter or alloyed) has a
-  // fixed ratio, so we demand the exact quoted amount out rather than silently
-  // accepting less. Any other shape (a split, a multi-hop, or a price-moving
-  // pool) can drift between quote and execution and keeps a slippage allowance.
+  // fixed ratio, so it gets a near-zero tolerance instead of silently accepting
+  // up to 5% less. Any other shape (a split, a multi-hop, or a price-moving
+  // pool) can drift between quote and execution and keeps the full allowance.
+  //
+  // Not exactly zero: `maxSlippage` becomes `tokenOutMinAmount` via
+  // `quoted * (1 - maxSlippage)`, so "0" demands byte-exact output and a single
+  // unit of chain-side truncation reverts the tx. ONE_TO_ONE_MAX_SLIPPAGE is the
+  // smallest tolerance that absorbs rounding while still capping loss at 0.01%
+  // (100 base units on a 1M USDC conversion, against 50,000 under the old 5%).
   //
   // Not every variant conversion is an alloy conversion: `variantGroupKey` also
   // groups non-alloy canonical assets, whose conversions route through ordinary
@@ -222,7 +243,9 @@ export async function getConvertVariantMessages(
 
   return await getSwapMessages({
     coinAmount: amount,
-    maxSlippage: isOneToOneSwap ? "0" : "0.05",
+    maxSlippage: isOneToOneSwap
+      ? ONE_TO_ONE_MAX_SLIPPAGE
+      : DEFAULT_CONVERT_MAX_SLIPPAGE,
     quote,
     tokenInCoinMinimalDenom: tokenInDenom,
     tokenOutCoinMinimalDenom: tokenOutDenom,


### PR DESCRIPTION
## What

The variant-conversion slippage guard in `getConvertVariantMessages` was dead code:

```ts
quote.split[0].pools.length === 0 &&
quote.split[0].pools[0].type.startsWith("cosmwasm")
```

`&&` short-circuits before the out-of-bounds index, so it never threw, but it also never evaluated true. Every conversion used the 5% allowance instead of the intended 0.

`maxSlippage` feeds `tokenOutMinAmount` directly (`packages/tx/src/message-composers/complex/swap.ts`), so a 1:1 transmuter conversion was signing a transaction willing to accept 95% of the quoted output. The transmuter returns 1:1 in practice so this cost nobody anything, but the protection was absent rather than merely loose.

## Why the obvious fix would have been worse

Correcting the length check to `=== 1` and keeping `startsWith("cosmwasm")` is actively dangerous. On the tRPC quote path `makeDisplayableOutGivenInSplit` rewrites `pool.type` via `getCosmwasmPoolTypeFromCodeId`, so the value is a CosmWasm **subtype**. A prefix test also matches:

- `cosmwasm-astroport-pcl` — a concentrated AMM, which this codebase itself flags `dynamicSpreadFactor: true`
- `cosmwasm-whitewhale` — an AMM
- `cosmwasm-orderbook` — fills at book prices

Because the condition had never fired, activating it would have demanded exact output from price-moving pools and reverted on ordinary quote drift.

The check now matches the two subtypes that are 1:1 by construction, via a new `isOneToOnePoolType` exported from `pools/env.ts` beside the code-id mappings it depends on. Everything else keeps the 5% allowance: splits, multi-hops, non-CosmWasm pools, and unrecognised bare `cosmwasm`.

## This is not an alloy-only path

`variantGroupKey` groups non-alloy canonical assets too — 34 of 65 live groups, including today's ibc-denom USDC with ten bridged variants — and those conversions route through ordinary AMMs. The pool-type check, not the caller, is what makes zero slippage safe.

## Testing

`packages/web/hooks/__tests__/use-convert-variant.test.ts` now asserts the `maxSlippage` actually handed to `getSwapMessages`, with a case per subtype (13 tests, all passing).

I verified the tests catch the regressions rather than merely passing: reverting to the prefix match fails exactly the four AMM/orderbook cases, and reverting the length check fails the alloy cases.

Fixtures carry `codeId` and use real subtype strings, since a bare `"cosmwasm"` type asserts a shape the tRPC path does not emit.

Web and server typecheck clean (web matches the pre-existing baseline of unrelated spec errors); ESLint clean.

## Tolerance is 0.01%, not exact zero

Resolved in review. `maxSlippage` sets `tokenOutMinAmount` to `quoted * (1 - maxSlippage)`, so `"0"` demands byte-exact output and one unit of chain-side truncation reverts the tx, a failure mode that would show up at volume at USDC-alloy scale.

`ONE_TO_ONE_MAX_SLIPPAGE = "0.0001"` is the smallest tolerance that absorbs rounding while staying economically irrelevant: 100 base units on a 1M USDC conversion, against 50,000 under the 5% the dead condition was silently applying. Both values are named constants with the reasoning attached, the tests assert against them, and one test pins the literal so a careless edit is caught.

The `env.ts` transmuter code-id pin (`148`) is confirmed as known and the reliable approach; no change needed.

---

Linear: MTN-256
