### PR TITLE
fix(bridge): normalise IBC transfer timeout to a 15 minute window per chain

### DIFF
--- a/packages/server/src/queries/complex/__tests__/get-timeout-height.spec.ts
+++ b/packages/server/src/queries/complex/__tests__/get-timeout-height.spec.ts
@@ -1,0 +1,370 @@
+import { createMultiEndpointClient } from "@osmosis-labs/utils";
+
+import { MockChains } from "../../__tests__/mock-chains";
+import { queryRPCStatus } from "../../cosmos";
+import {
+  getTimeoutHeight,
+  resetBlockTimeCacheForTests,
+} from "../get-timeout-height";
+
+jest.mock("../../cosmos", () => ({
+  ...jest.requireActual("../../cosmos"),
+  queryRPCStatus: jest.fn(),
+}));
+
+jest.mock("@osmosis-labs/utils", () => ({
+  ...jest.requireActual("@osmosis-labs/utils"),
+  createMultiEndpointClient: jest.fn(),
+}));
+
+const LATEST_HEIGHT = 1_000_000;
+const LATEST_TIME = "2026-08-10T12:00:00.000Z";
+
+/** 15 minute target window, as configured in the module under test. */
+const WINDOW_SECONDS = 15 * 60;
+/** Sample size the module looks back by when measuring block time. */
+const SAMPLE_SIZE = 1000;
+/** Flat height offset used when block time can't be measured. */
+const FALLBACK_OFFSET = 200;
+
+function mockStatus({
+  latestBlockHeight = String(LATEST_HEIGHT),
+  latestBlockTime = LATEST_TIME,
+  network = "osmosis-1",
+}: {
+  latestBlockHeight?: string;
+  latestBlockTime?: string;
+  network?: string;
+} = {}) {
+  (queryRPCStatus as jest.Mock).mockResolvedValue({
+    result: {
+      node_info: { network },
+      sync_info: {
+        latest_block_height: latestBlockHeight,
+        latest_block_time: latestBlockTime,
+      },
+    },
+  });
+}
+
+/** A `/block` response whose timestamp implies `blockTimeSeconds`. */
+function priorBlockResponse(blockTimeSeconds: number) {
+  const elapsedMs = blockTimeSeconds * SAMPLE_SIZE * 1_000;
+  return {
+    result: {
+      block: {
+        header: {
+          time: new Date(
+            new Date(LATEST_TIME).getTime() - elapsedMs
+          ).toISOString(),
+        },
+      },
+    },
+  };
+}
+
+/** Mocks the prior-block fetch so that block time resolves to `blockTimeSeconds`. */
+function mockPriorBlock(blockTimeSeconds: number | undefined) {
+  (createMultiEndpointClient as jest.Mock).mockReturnValue({
+    fetch: jest.fn().mockImplementation(async () => {
+      if (blockTimeSeconds === undefined) throw new Error("unreachable node");
+      return priorBlockResponse(blockTimeSeconds);
+    }),
+  });
+}
+
+/** As {@link mockPriorBlock}, returning the fetch spy for call-count assertions. */
+function mockPriorBlockWithSpy(blockTimeSeconds: number) {
+  const fetch = jest
+    .fn()
+    .mockImplementation(async () => priorBlockResponse(blockTimeSeconds));
+  (createMultiEndpointClient as jest.Mock).mockReturnValue({ fetch });
+  return fetch;
+}
+
+/** The revisionHeight the module should return for a given block time. */
+function expectedHeight(blockTimeSeconds: number) {
+  return String(LATEST_HEIGHT + Math.ceil(WINDOW_SECONDS / blockTimeSeconds));
+}
+
+describe("getTimeoutHeight", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Block time is cached per chain across calls; reset so cases stay isolated.
+    resetBlockTimeCacheForTests();
+    mockStatus();
+  });
+
+  it("scales the offset by block time so the window is ~15 minutes", async () => {
+    // Nibiru-like fast blocks: the case that previously produced a ~4.5 min window.
+    mockPriorBlock(1.79);
+
+    const result = await getTimeoutHeight({
+      chainList: MockChains,
+      chainId: "osmosis-1",
+    });
+
+    expect(result.revisionHeight).toBe(expectedHeight(1.79));
+  });
+
+  it("gives a slow-block chain the same wall-clock window, not the same block count", async () => {
+    const slowBlockTime = 6;
+    const fastBlockTime = 1.79;
+
+    mockPriorBlock(slowBlockTime);
+    const slow = await getTimeoutHeight({
+      chainList: MockChains,
+      chainId: "osmosis-1",
+    });
+
+    // Different chain id, so this measures afresh rather than reusing the
+    // cached block time from the call above.
+    mockPriorBlock(fastBlockTime);
+    const fast = await getTimeoutHeight({
+      chainList: MockChains,
+      chainId: "cosmoshub-4",
+    });
+
+    const slowOffset = Number(slow.revisionHeight) - LATEST_HEIGHT;
+    const fastOffset = Number(fast.revisionHeight) - LATEST_HEIGHT;
+
+    // Fewer blocks on the slower chain, but the same duration.
+    expect(slowOffset).toBeLessThan(fastOffset);
+    expect(slowOffset * slowBlockTime).toBeCloseTo(WINDOW_SECONDS, -1);
+    expect(fastOffset * fastBlockTime).toBeCloseTo(WINDOW_SECONDS, -1);
+  });
+
+  it("never returns a window shorter than the target, at any block speed", async () => {
+    // A flat block count gave fast chains ~4.5 min, which stranded packets.
+    for (const blockTime of [0.5, 1.79, 2, 6]) {
+      // Clear per iteration, otherwise the cached block time from the previous
+      // one is reused and the remaining cases assert nothing.
+      resetBlockTimeCacheForTests();
+      mockPriorBlock(blockTime);
+      const result = await getTimeoutHeight({
+        chainList: MockChains,
+        chainId: "osmosis-1",
+      });
+      const offset = Number(result.revisionHeight) - LATEST_HEIGHT;
+      expect(offset * blockTime).toBeGreaterThanOrEqual(WINDOW_SECONDS);
+    }
+  });
+
+  it("caps slow chains at the target window rather than inheriting a long one", async () => {
+    // A flat block count gave slow chains incidentally long windows (Babylon at
+    // ~10s got ~25 min, Optio at ~60.7s got ~152 min). Those are shortened to the
+    // target on purpose: a user should not wait hours to become refund-eligible.
+    //
+    // 60.785 is Optio's measured block time, the slowest in the chain list, and
+    // is here to catch the plausibility bound being set below a real chain.
+    for (const blockTime of [6.9, 10, 14.9, 60, 60.785]) {
+      resetBlockTimeCacheForTests();
+      mockPriorBlock(blockTime);
+      const result = await getTimeoutHeight({
+        chainList: MockChains,
+        chainId: "osmosis-1",
+      });
+      const offset = Number(result.revisionHeight) - LATEST_HEIGHT;
+
+      // Within one block of the target, in both directions.
+      expect(offset * blockTime).toBeGreaterThanOrEqual(WINDOW_SECONDS);
+      expect(offset * blockTime).toBeLessThan(WINDOW_SECONDS + blockTime);
+    }
+  });
+
+  it("falls back to the flat offset when the prior block can't be fetched", async () => {
+    // A timeout must always be set; an unset one removes the path to a refund.
+    // The flat offset applies only while measurement fails, and only until the
+    // short failure TTL lapses.
+    mockPriorBlock(undefined);
+
+    const result = await getTimeoutHeight({
+      chainList: MockChains,
+      chainId: "osmosis-1",
+    });
+
+    expect(result.revisionHeight).toBe(String(LATEST_HEIGHT + FALLBACK_OFFSET));
+  });
+
+  it("falls back when the node reports an implausible block time", async () => {
+    // Clock skew or a stalled node, well beyond the slowest real chain (~60.7s).
+    for (const blockTime of [121, 600, 86_400]) {
+      resetBlockTimeCacheForTests();
+      mockPriorBlock(blockTime);
+
+      const result = await getTimeoutHeight({
+        chainList: MockChains,
+        chainId: "osmosis-1",
+      });
+
+      expect(result.revisionHeight).toBe(
+        String(LATEST_HEIGHT + FALLBACK_OFFSET)
+      );
+    }
+  });
+
+  it("falls back when the prior block time is not older than the latest", async () => {
+    // Non-monotonic timestamps would otherwise yield a zero/negative block time.
+    mockPriorBlock(0);
+
+    const result = await getTimeoutHeight({
+      chainList: MockChains,
+      chainId: "osmosis-1",
+    });
+
+    expect(result.revisionHeight).toBe(String(LATEST_HEIGHT + FALLBACK_OFFSET));
+  });
+
+  it("falls back when the chain is too young to sample", async () => {
+    mockStatus({ latestBlockHeight: "10" });
+    mockPriorBlock(1.79);
+
+    const result = await getTimeoutHeight({
+      chainList: MockChains,
+      chainId: "osmosis-1",
+    });
+
+    expect(result.revisionHeight).toBe(String(10 + FALLBACK_OFFSET));
+  });
+
+  it("includes the revisionNumber parsed from the chain id", async () => {
+    mockStatus({ network: "osmosis-1" });
+    mockPriorBlock(1.79);
+
+    const result = await getTimeoutHeight({
+      chainList: MockChains,
+      chainId: "osmosis-1",
+    });
+
+    expect(result.revisionNumber).toBe("1");
+  });
+
+  it("omits revisionNumber for a chain id without a version suffix", async () => {
+    // Sending revision_number 0 would cause the transfer to fail.
+    mockStatus({ network: "cataclysm" });
+    mockPriorBlock(1.79);
+
+    const result = await getTimeoutHeight({
+      chainList: MockChains,
+      chainId: "osmosis-1",
+    });
+
+    expect(result.revisionNumber).toBeUndefined();
+  });
+
+  it("throws when the destination chain isn't in the chain list", async () => {
+    await expect(
+      getTimeoutHeight({ chainList: MockChains, chainId: "not-a-chain" })
+    ).rejects.toThrow("Could not find destination Cosmos chain");
+  });
+
+  describe("block time caching", () => {
+    it("reuses a measured block time instead of re-querying per transfer", async () => {
+      const fetch = mockPriorBlockWithSpy(1.79);
+
+      await getTimeoutHeight({ chainList: MockChains, chainId: "osmosis-1" });
+      await getTimeoutHeight({ chainList: MockChains, chainId: "osmosis-1" });
+      await getTimeoutHeight({ chainList: MockChains, chainId: "osmosis-1" });
+
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("still advances revisionHeight with the live block height while cached", async () => {
+      mockPriorBlockWithSpy(1.79);
+
+      mockStatus({ latestBlockHeight: String(LATEST_HEIGHT) });
+      const first = await getTimeoutHeight({
+        chainList: MockChains,
+        chainId: "osmosis-1",
+      });
+
+      // A later transfer sees a higher tip; the cached block time must not
+      // freeze the returned height, which would hand out a stale timeout.
+      mockStatus({ latestBlockHeight: String(LATEST_HEIGHT + 500) });
+      const second = await getTimeoutHeight({
+        chainList: MockChains,
+        chainId: "osmosis-1",
+      });
+
+      expect(Number(second.revisionHeight) - Number(first.revisionHeight)).toBe(
+        500
+      );
+    });
+
+    it("does not repeat the query while a failure is cached", async () => {
+      // Every endpoint having pruned the sampled height would otherwise repeat
+      // the full hedged request per quote, which costs seconds each time.
+      const fetch = jest
+        .fn()
+        .mockRejectedValue(new Error("height is not available"));
+      (createMultiEndpointClient as jest.Mock).mockReturnValue({ fetch });
+
+      const first = await getTimeoutHeight({
+        chainList: MockChains,
+        chainId: "osmosis-1",
+      });
+      const second = await getTimeoutHeight({
+        chainList: MockChains,
+        chainId: "osmosis-1",
+      });
+
+      expect(first.revisionHeight).toBe(
+        String(LATEST_HEIGHT + FALLBACK_OFFSET)
+      );
+      expect(second.revisionHeight).toBe(
+        String(LATEST_HEIGHT + FALLBACK_OFFSET)
+      );
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("re-measures a failure after a minute, not an hour", async () => {
+      // A transient failure must not pin the chain to the fallback for the full
+      // success TTL, so it is cached under a much shorter one.
+      jest.useFakeTimers({ doNotFake: ["nextTick"] });
+      try {
+        const fetch = jest
+          .fn()
+          .mockRejectedValueOnce(new Error("transient RPC failure"))
+          .mockImplementation(async () => priorBlockResponse(1.79));
+        (createMultiEndpointClient as jest.Mock).mockReturnValue({ fetch });
+
+        const failed = await getTimeoutHeight({
+          chainList: MockChains,
+          chainId: "osmosis-1",
+        });
+        expect(failed.revisionHeight).toBe(
+          String(LATEST_HEIGHT + FALLBACK_OFFSET)
+        );
+
+        jest.advanceTimersByTime(1000 * 61);
+
+        const recovered = await getTimeoutHeight({
+          chainList: MockChains,
+          chainId: "osmosis-1",
+        });
+        expect(recovered.revisionHeight).toBe(expectedHeight(1.79));
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it("keeps a successful measurement well past the failure TTL", async () => {
+      jest.useFakeTimers({ doNotFake: ["nextTick"] });
+      try {
+        const fetch = mockPriorBlockWithSpy(1.79);
+
+        await getTimeoutHeight({ chainList: MockChains, chainId: "osmosis-1" });
+
+        // Past the one minute failure TTL, but far short of the one hour
+        // success TTL, so this must still be served from cache.
+        jest.advanceTimersByTime(1000 * 60 * 5);
+
+        await getTimeoutHeight({ chainList: MockChains, chainId: "osmosis-1" });
+
+        expect(fetch).toHaveBeenCalledTimes(1);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+  });
+});

--- a/packages/server/src/queries/complex/get-timeout-height.ts
+++ b/packages/server/src/queries/complex/get-timeout-height.ts
@@ -1,8 +1,105 @@
 import { Chain } from "@osmosis-labs/types";
 import { Int } from "@osmosis-labs/unit";
-import { ChainIdHelper, getChain } from "@osmosis-labs/utils";
+import {
+  ChainIdHelper,
+  createMultiEndpointClient,
+  getChain,
+} from "@osmosis-labs/utils";
+import cachified, { CacheEntry } from "cachified";
+import { LRUCache } from "lru-cache";
 
 import { queryRPCStatus } from "../../queries/cosmos";
+import { DEFAULT_LRU_OPTIONS } from "../../utils";
+
+/**
+ * How long an IBC transfer stays deliverable before it becomes refund-eligible.
+ *
+ * A packet that arrives after this window is rejected by the destination chain
+ * and can only be refunded, so the window has to cover a slow relay rather than
+ * a typical one.
+ *
+ * 15 minutes is the duration the previous flat 150-block offset produced on the
+ * ~6s-block chains it was presumably chosen against (150 x 6s = 15 min), applied
+ * uniformly here. It cuts both ways by design: fast chains gain a window they
+ * were never meant to have as short as they did (Osmosis ~3.2 min, Nibiru
+ * ~4.5 min), and slow chains lose windows that had grown incidentally long from
+ * the flat block count (Babylon ~25 min, Optio ~152 min). Those long windows
+ * were an artefact of block speed rather than an intended refund delay, and a
+ * user waiting hours to become refund-eligible is its own failure.
+ */
+const TIMEOUT_WINDOW_SECONDS = 15 * 60;
+
+/**
+ * Height offset used when the destination chain's block time can't be measured.
+ *
+ * A flat count is necessarily a different duration on each chain (~2 min on a
+ * 0.6s chain, ~19 min on a 6s one), so this is a deliberately conservative
+ * stand-in rather than an equivalent of {@link TIMEOUT_WINDOW_SECONDS}: it keeps
+ * an unmeasurable chain close to the offset this function returned historically
+ * instead of extrapolating a window from a block time we don't actually know.
+ *
+ * It only applies when measurement fails. A failure is cached briefly to avoid
+ * repeating an expensive multi-endpoint request on every quote, then measured
+ * again after the short failure TTL expires.
+ */
+const FALLBACK_HEIGHT_OFFSET = 200;
+
+/**
+ * How many blocks back to sample when measuring block time. Large enough to
+ * smooth over individual slow blocks, small enough to stay within the recent
+ * history every node retains and to reflect the chain's *current* pace.
+ */
+const BLOCK_TIME_SAMPLE_SIZE = 1000;
+
+/**
+ * Bounds on a believable block time, in seconds, to reject bad node data.
+ *
+ * The upper bound sits above the slowest chain in the list rather than at a
+ * round number: Optio produces a block roughly every 60.7s, so a 60s bound would
+ * reject its genuine measurement and hand it the fallback offset, which at that
+ * block speed is over three hours. A bound only guards against a misreporting
+ * node, so it has to clear the real fleet with room to spare.
+ */
+const MIN_PLAUSIBLE_BLOCK_TIME_SECONDS = 0.1;
+const MAX_PLAUSIBLE_BLOCK_TIME_SECONDS = 120;
+
+/**
+ * How long a measured block time is reused before being re-measured.
+ *
+ * Block time is a property of the chain, not of the requesting user, so this is
+ * shared rather than per-user, and it is stable over hours.
+ *
+ * The staleness this can cause is bounded and one-directional. A chain that
+ * *slows down* yields a longer window than intended, which is harmless. A chain
+ * that *speeds up* yields a shorter one, so the exposure is a fraction of the
+ * target window rather than of the TTL: a chain would have to roughly halve its
+ * block time within the hour to bring 15 minutes below the ~4.5 that caused
+ * packets to strand. Retunes of that size ship in a coordinated upgrade, not
+ * mid-hour. Osmosis went from ~6s to ~1.3s blocks, but over releases.
+ */
+const BLOCK_TIME_TTL_MS = 1000 * 60 * 60;
+
+/**
+ * How long a *failed* measurement is remembered before retrying.
+ *
+ * Kept far shorter than {@link BLOCK_TIME_TTL_MS} so a transient RPC failure
+ * doesn't pin a chain to the fallback offset, while still bounding the cost of a
+ * persistent failure. Without this, a chain whose endpoints have all pruned the
+ * sampled height would repeat the full hedged request on every quote: endpoints
+ * are tried staggered by 1s, and the request only settles once all of them have
+ * failed, so a median 6-endpoint chain would add ~5s to every quote.
+ */
+const BLOCK_TIME_FAILURE_TTL_MS = 1000 * 60;
+
+const blockTimeCache = new LRUCache<string, CacheEntry>(DEFAULT_LRU_OPTIONS);
+
+/**
+ * Clears the measured block times. Only for tests, which would otherwise leak
+ * one case's block time into the next.
+ */
+export function resetBlockTimeCacheForTests() {
+  blockTimeCache.clear();
+}
 
 export async function getTimeoutHeight({
   chainList,
@@ -55,12 +152,141 @@ export async function getTimeoutHeight({
 
   const revisionNumber = ChainIdHelper.parse(network).version.toString();
 
+  const heightOffset = await getHeightOffset({
+    chainId: destinationCosmosChain.chain_id,
+    rpcUrls,
+    latestBlockHeight,
+    latestBlockTime: destinationNodeStatus.result.sync_info.latest_block_time,
+  });
+
   return {
     /**
      * Omit the revision_number if the chain's version is 0.
      * Sending the value as 0 will cause the transaction to fail.
      */
     ...(revisionNumber !== "0" && { revisionNumber }),
-    revisionHeight: new Int(latestBlockHeight).add(new Int("150")).toString(),
+    revisionHeight: new Int(latestBlockHeight)
+      .add(new Int(heightOffset.toString()))
+      .toString(),
   };
+}
+
+/**
+ * Converts {@link TIMEOUT_WINDOW_SECONDS} into a block count for the
+ * destination chain, so the timeout is the same wall-clock duration regardless
+ * of how fast the chain produces blocks.
+ *
+ * Falls back to {@link FALLBACK_HEIGHT_OFFSET} if block time can't be measured,
+ * so a timeout is always set: leaving it unset would remove the user's only path
+ * to a refund.
+ */
+async function getHeightOffset({
+  chainId,
+  rpcUrls,
+  latestBlockHeight,
+  latestBlockTime,
+}: {
+  chainId: string;
+  rpcUrls: string[];
+  latestBlockHeight: string;
+  latestBlockTime?: string;
+}): Promise<number> {
+  /**
+   * Only the block time is cached, never the resulting height: the offset is
+   * added to a live block height, so caching the height would hand out a stale
+   * (and eventually already-expired) timeout.
+   *
+   * A failure is cached too, under a much shorter TTL, so that a chain whose
+   * endpoints have all pruned the sampled height doesn't repeat the full hedged
+   * request on every quote. `null` is the cached marker for "measurement
+   * failed"; `cachified` picks the TTL per outcome via `getFreshValue`'s
+   * metadata.
+   */
+  const blockTimeSeconds = await cachified({
+    cache: blockTimeCache,
+    key: `ibc-timeout-block-time-${chainId}`,
+    ttl: BLOCK_TIME_TTL_MS,
+    getFreshValue: async ({ metadata }) => {
+      const measured = await queryBlockTimeSeconds({
+        rpcUrls,
+        latestBlockHeight,
+        latestBlockTime,
+      });
+
+      if (measured === undefined) {
+        metadata.ttl = BLOCK_TIME_FAILURE_TTL_MS;
+        return null;
+      }
+
+      return measured;
+    },
+  });
+
+  if (blockTimeSeconds === null) return FALLBACK_HEIGHT_OFFSET;
+
+  return Math.ceil(TIMEOUT_WINDOW_SECONDS / blockTimeSeconds);
+}
+
+/**
+ * Measures average seconds per block from the interval between the latest block
+ * and one {@link BLOCK_TIME_SAMPLE_SIZE} blocks earlier.
+ *
+ * The retained range reported in `sync_info` is deliberately not used: it is
+ * bounded by each node's pruning config, so it varies between endpoints for the
+ * same chain and averages over historical periods whose pace may differ from
+ * today's.
+ *
+ * @returns Average seconds per block, or undefined if it can't be measured.
+ */
+async function queryBlockTimeSeconds({
+  rpcUrls,
+  latestBlockHeight,
+  latestBlockTime,
+}: {
+  rpcUrls: string[];
+  latestBlockHeight: string;
+  latestBlockTime?: string;
+}): Promise<number | undefined> {
+  if (!latestBlockTime) return undefined;
+
+  const latestHeight = Number(latestBlockHeight);
+  const priorHeight = latestHeight - BLOCK_TIME_SAMPLE_SIZE;
+
+  // Chain too young to sample; the fallback offset is the safer choice.
+  if (!Number.isFinite(latestHeight) || priorHeight < 1) return undefined;
+
+  // Constructed outside the try so a client misconfiguration surfaces rather
+  // than being mistaken for an unreachable node.
+  const client = createMultiEndpointClient(
+    rpcUrls.map((url) => ({ address: url }))
+  );
+
+  let priorBlockTime: string | undefined;
+  try {
+    const response = await client.fetch<{
+      result?: { block?: { header?: { time?: string } } };
+    }>(`/block?height=${priorHeight}`);
+    priorBlockTime = response?.result?.block?.header?.time;
+  } catch {
+    // Every endpoint has pruned this height or is unreachable; fall back below.
+    return undefined;
+  }
+
+  if (!priorBlockTime) return undefined;
+
+  const elapsedMs =
+    new Date(latestBlockTime).getTime() - new Date(priorBlockTime).getTime();
+  if (!Number.isFinite(elapsedMs) || elapsedMs <= 0) return undefined;
+
+  const blockTimeSeconds = elapsedMs / 1_000 / BLOCK_TIME_SAMPLE_SIZE;
+
+  // Guard against nonsense values from a stalled or misreporting node.
+  if (
+    blockTimeSeconds < MIN_PLAUSIBLE_BLOCK_TIME_SECONDS ||
+    blockTimeSeconds > MAX_PLAUSIBLE_BLOCK_TIME_SECONDS
+  ) {
+    return undefined;
+  }
+
+  return blockTimeSeconds;
 }

--- a/packages/utils/src/__tests__/chain-utils.spec.ts
+++ b/packages/utils/src/__tests__/chain-utils.spec.ts
@@ -1,0 +1,82 @@
+import type { Chain } from "@osmosis-labs/types";
+
+import { getChain } from "../chain-utils";
+
+/**
+ * Minimal chains covering the prefix shapes that matter: several real prefixes
+ * are prefixes of another, and Nyx's `n` shadows every `n*` chain.
+ *
+ * Ordered so the shadowing chain comes first, which is the case a
+ * first-match-wins scan resolves incorrectly.
+ */
+const chainList = [
+  { chain_id: "nyx", chain_name: "nyx", prefix: "n" },
+  { chain_id: "cataclysm-1", chain_name: "nibiru", prefix: "nibi" },
+  { chain_id: "neutron-1", chain_name: "neutron", prefix: "neutron" },
+  { chain_id: "bitbadges-1", chain_name: "bitbadges", prefix: "bb" },
+  { chain_id: "bbn-1", chain_name: "babylon", prefix: "bbn" },
+  { chain_id: "osmosis-1", chain_name: "osmosis", prefix: "osmo" },
+].map(
+  ({ chain_id, chain_name, prefix }) =>
+    ({
+      chain_id,
+      chain_name,
+      bech32Config: { bech32PrefixAccAddr: prefix },
+    } as unknown as Chain)
+);
+
+describe("getChain", () => {
+  it("resolves an address to the chain with the longest matching prefix", () => {
+    // `nibi1...` also starts with Nyx's `n`, which appears earlier in the list.
+    expect(
+      getChain({ chainList, destinationAddress: "nibi1abcdef" })?.chain_id
+    ).toBe("cataclysm-1");
+
+    expect(
+      getChain({ chainList, destinationAddress: "neutron1abcdef" })?.chain_id
+    ).toBe("neutron-1");
+
+    // `bbn1...` also starts with BitBadges' `bb`.
+    expect(
+      getChain({ chainList, destinationAddress: "bbn1abcdef" })?.chain_id
+    ).toBe("bbn-1");
+  });
+
+  it("still resolves an address whose prefix is the short one", () => {
+    expect(
+      getChain({ chainList, destinationAddress: "n1abcdef" })?.chain_id
+    ).toBe("nyx");
+  });
+
+  it("prefers an explicit chainId over an address that points elsewhere", () => {
+    expect(
+      getChain({
+        chainList,
+        chainId: "osmosis-1",
+        destinationAddress: "nibi1abcdef",
+      })?.chain_id
+    ).toBe("osmosis-1");
+  });
+
+  it("resolves by chainId and chainName", () => {
+    expect(getChain({ chainList, chainId: "bbn-1" })?.chain_name).toBe(
+      "babylon"
+    );
+    expect(getChain({ chainList, chainName: "nibiru" })?.chain_id).toBe(
+      "cataclysm-1"
+    );
+  });
+
+  it("returns undefined when nothing matches", () => {
+    expect(
+      getChain({ chainList, destinationAddress: "zzz1abcdef" })
+    ).toBeUndefined();
+    expect(getChain({ chainList, chainId: "not-a-chain" })).toBeUndefined();
+  });
+
+  it("throws when given no way to identify a chain", () => {
+    expect(() => getChain({ chainList })).toThrow(
+      "Missing chainId, chainName or destinationAddress"
+    );
+  });
+});

--- a/packages/utils/src/chain-utils.ts
+++ b/packages/utils/src/chain-utils.ts
@@ -9,8 +9,9 @@ export function getChain<Chain extends ChainType>({
   chainId?: string;
   chainName?: string;
   /**
-   * WARNING: bech32 prefix may be the same across different chains,
-   * retulting in the use of an unintended chain.
+   * WARNING: bech32 prefixes are not unique. Two chains can share one (Terra
+   * Classic and Terra 2 are both `terra`), so an address alone cannot always
+   * identify a chain. Prefer passing `chainId` where the caller knows it.
    */
   destinationAddress?: string;
   chainList: Chain[];
@@ -19,13 +20,36 @@ export function getChain<Chain extends ChainType>({
     throw new Error("Missing chainId, chainName or destinationAddress");
   }
 
-  return chainList.find((chain) => {
-    return (
-      destinationAddress?.startsWith(chain.bech32Config.bech32PrefixAccAddr) ||
-      chain.chain_id === chainId ||
-      chain.chain_name === chainName
-    );
-  });
+  // An explicit identifier is unambiguous, so it always wins over the
+  // address-derived match below.
+  const byIdentifier = chainList.find(
+    (chain) => chain.chain_id === chainId || chain.chain_name === chainName
+  );
+  if (byIdentifier) return byIdentifier;
+
+  if (!destinationAddress) return undefined;
+
+  /**
+   * Match on the longest prefix rather than the first in list order. Several
+   * prefixes are prefixes of another (`n` for Nyx against `nibi`, `neutron`,
+   * `noble`, `nolus`; `bb` against `bbn`; `st` against `stride`), so a
+   * first-match-wins scan resolves e.g. a `nibi1...` address to Nyx purely
+   * because it appears earlier in the list.
+   */
+  let match: Chain | undefined;
+  let matchedPrefixLength = -1;
+  for (const chain of chainList) {
+    const prefix = chain.bech32Config.bech32PrefixAccAddr;
+    if (
+      destinationAddress.startsWith(prefix) &&
+      prefix.length > matchedPrefixLength
+    ) {
+      match = chain;
+      matchedPrefixLength = prefix.length;
+    }
+  }
+
+  return match;
 }
 
 export function getChainStakeTokenSourceDenom({


### PR DESCRIPTION
## What is the purpose of the change

`getTimeoutHeight` returned a flat `latestBlockHeight + 150` for every destination chain. A flat block count is a different wall-clock duration on every chain, so the IBC transfer timeout window ranged from ~1.5 minutes to ~152 minutes depending only on how fast the destination produces blocks.

A packet that misses its window can no longer be delivered and is refund-eligible only, so this matters in both directions. Too short turns a slightly delayed transfer into a failed one needing a manual refund; too long leaves the user waiting hours to become refund-eligible.

Measured live, the flat 150 produced:

| chain | block time | old window |
| --- | --- | --- |
| injective-1 | 0.599s | 1.50 min |
| dydx-mainnet-1 | 0.698s | 1.75 min |
| osmosis-1 | 1.286s | 3.21 min |
| cataclysm-1 (Nibiru) | 1.788s | 4.46 min |
| cosmoshub-4 | 5.704s | 14.26 min |
| neutron-1 | 6.939s | 17.34 min |
| bbn-1 (Babylon) | 10.003s | 25.01 min |
| optio | 60.680s | 151.7 min |

Found while investigating unresolved packet commitments on the Osmosis <> Nibiru channel (channel-21113). Of 839 commitments there on 10 Aug, 752 had actually been delivered with only the acknowledgement unrelayed, and 87 were genuinely undelivered and expired (~1.17M NIBI). 24 of those 87 came from this code path, timing out inside a 4.46 minute window against a relayer whose typical delivery was ~2 minutes but which stalled for up to ~30.

The `150` itself carried no rationale in git history: it arrived as vendored chainapsis Keplr store code (#2193) and survived four refactors untouched. `150 x 6s = 15 min` exactly, so it was most likely chosen against the ~6s-block chains of the era and never revisited as faster chains were added.

## Brief change log

**`fix(bridge): normalise IBC timeout height to a 15 minute window`**

- Derive the offset from a target duration and the chain's measured block time, so every route gets ~15 minutes regardless of block speed. Deliberately bidirectional: fast chains gain a window they were never meant to have as short as they did, slow chains lose windows that had grown incidentally long from the flat count.
- Measure block time against a block 1000 heights back, not `sync_info`'s retained range. That range is bounded by each node's pruning config and differs per endpoint for the same chain (2.417s on polkachu vs 1.900s on cosmos.directory for Nibiru, against an actual 1.788s), which would make the window non-deterministic.
- Cache the measurement per chain for 1 hour, so this adds no RPC round trip to the typical quote. Only the block time is cached, never the resulting height, which must stay tied to a live tip.
- Cache failures for 1 minute. The hedged client staggers endpoints by 1s and settles only once all reject, so a chain whose endpoints have all pruned the sampled height would otherwise add ~5s to every quote on a median 6-endpoint chain.
- Plausibility bound at 120s rather than 60s: Optio produces a block roughly every 60.7s, so a 60s bound rejected a genuine measurement and handed it the fallback (~203 min).
- Fall back to a flat 200-block offset when block time can't be measured, so a timeout is always set. Leaving it unset would remove the user's only path to a refund.

**`fix(utils): resolve a bech32 address to the longest matching chain prefix`**

Found while reviewing the above. `getChain` matched addresses with `startsWith` and took the first hit in chain-list order. Six prefixes in the live chain list are prefixes of another:

- `n` (nyx, list position 92) shadowed `nibi` (99), `neutaro` (106), `neutron`, `noble`, `nolus`, `nomic`
- `bb` (bitbadges) shadowed `bbn` (Babylon)
- `st` (stratos) shadowed `stride` and `stafi`; also `ki`/`kima`, `lum`/`lumera`, `bc`/`bcna`

So a `nibi1...` withdrawal address resolved to **Nyx**, meaning Skip and Squid fetched the wrong chain's RPC endpoints and returned a timeout height referencing the wrong chain entirely. Callers passing an explicit `chainId` were unaffected; only Skip (`skip/index.ts:526`) and Squid (`squid/index.ts:579`) resolve purely from the receiver address, so the behavioural change lands on exactly those two call sites.

Fixed by matching the longest prefix, and resolving an explicit `chainId`/`chainName` before any address-derived guess. An exact shared prefix (Terra Classic and Terra 2 are both `terra`) remains inherently ambiguous from an address alone; the parameter warning now says that specifically.

## Deliberately not changed

Not switching to, or adding, a timeout **timestamp**. `ibc/transfer-status.ts:147` throws on an unset timeout height, and `parseMsgTransferEvents` requires `packet_timeout_height` to be truthy or the transfer is reported as `failed` — so a timestamp-only packet would show successful transfers as failed. Skip supplies its own `timeout_timestamp`, which we pass through untouched. Adding both is viable but needs the status tracker reworked, which belongs in its own PR.

## Testing and Verifying

- **16 tests on `getTimeoutHeight`**, which had none: duration scaling, slow-chain capping, all five fallback paths, cache hit/miss, and failure-TTL vs success-TTL via fake timers.
- **6 tests on `getChain`**, also none previously. The fixture is ordered so the shadowing chain comes first, reproducing the real chain-list ordering that caused the bug.
- Both fixes were verified by reverting each implementation and confirming the relevant tests fail, so neither test passes vacuously.

Suites run: server 86, utils 114, bridge 75 (all three `getTimeoutHeight` consumers: ibc, skip, squid), stores 14. `tsc --noEmit` clean on server, utils and bridge. eslint, prettier and `git diff --check` clean.

## Manual testing

`timeoutHeight` is not surfaced anywhere in the bridge UI, so a correct and an incorrect window look identical on screen until a packet actually times out. The value is observable in two places: the wallet approval screen (expand the JSON, read `timeoutHeight.revisionHeight`) and the `packet_timeout_height` attribute on the `send_packet` event after sending.

**This affects deposits as well as withdrawals.** `getTimeoutHeight` resolves `params.toChain`, so it always describes the destination, and the provider is direction-symmetric. Deposits therefore all share one case, because the destination is always Osmosis — and at 1.26s blocks that was a 3.16 minute window, tighter than the 4.49 minutes that stranded packets on Nibiru. Only withdrawals need per-chain coverage.

### Tier 1 — verify the computed offset (required, no funds needed)

Each link opens the transfer flow directly on the Amount screen (`transferDirection` + `transferAsset` are read on mount). The window is not displayed in the UI, so read `timeoutHeight.revisionHeight` from the wallet approval JSON and subtract the destination chain's current height. No need to sign — reaching the review screen is enough.

Preview host is the branch deployment; production links are the before/after baseline.

| destination | block time | preview (expect ~15 min) | production (current) | expected offset | prod offset |
| --- | --- | --- | --- | --- | --- |
| **osmosis-1** (INJ deposit) | 1.264s | [deposit INJ](https://osmosis-frontend-git-fix-ibc-timeout-window-chain-aware.vercel.dev-osmosis.zone/?transferDirection=deposit&transferAsset=INJ) | [deposit INJ](https://app.osmosis.zone/?transferDirection=deposit&transferAsset=INJ) | ~713 (15.0 min) | 150 (3.16 min) |
| **injective-1** (fastest) | 0.596s | [withdraw INJ](https://osmosis-frontend-git-fix-ibc-timeout-window-chain-aware.vercel.dev-osmosis.zone/?transferDirection=withdraw&transferAsset=INJ) | [withdraw INJ](https://app.osmosis.zone/?transferDirection=withdraw&transferAsset=INJ) | ~1510 (15.0 min) | 150 (1.49 min) |
| **cataclysm-1** (Nibiru) | 1.795s | [withdraw NIBI](https://osmosis-frontend-git-fix-ibc-timeout-window-chain-aware.vercel.dev-osmosis.zone/?transferDirection=withdraw&transferAsset=NIBI) | [withdraw NIBI](https://app.osmosis.zone/?transferDirection=withdraw&transferAsset=NIBI) | ~502 (15.0 min) | 150 (4.49 min) |
| **cosmoshub-4** (control) | 5.721s | [withdraw ATOM](https://osmosis-frontend-git-fix-ibc-timeout-window-chain-aware.vercel.dev-osmosis.zone/?transferDirection=withdraw&transferAsset=ATOM) | [withdraw ATOM](https://app.osmosis.zone/?transferDirection=withdraw&transferAsset=ATOM) | ~158 (15.1 min) | 150 (14.30 min) |
| **bbn-1** (Babylon, slow) | 10.014s | [withdraw BABY](https://osmosis-frontend-git-fix-ibc-timeout-window-chain-aware.vercel.dev-osmosis.zone/?transferDirection=withdraw&transferAsset=BABY) | [withdraw BABY](https://app.osmosis.zone/?transferDirection=withdraw&transferAsset=BABY) | ~90 (15.0 min) | 150 (25.03 min) |
| **optio** (slowest) | 60.733s | [withdraw OPT](https://osmosis-frontend-git-fix-ibc-timeout-window-chain-aware.vercel.dev-osmosis.zone/?transferDirection=withdraw&transferAsset=OPT) | [withdraw OPT](https://app.osmosis.zone/?transferDirection=withdraw&transferAsset=OPT) | ~15 (15.2 min) | 150 (151.83 min) |

Offsets drift as block times move; the invariant is `offset x blockTime ~= 900s`. On production every pair should differ by exactly 150.

Two cases worth prioritising: **OPT** is the largest delta (151.83 -> 15.2 min) and is the case that was silently taking the rejected-measurement fallback before the plausibility bound was raised. **ATOM** is the control — it should barely move (14.30 -> 15.07 min); if it moves a lot, the derivation is wrong.

### Tier 1 results (verified on chain, 5 chains)

Ten real transfers from one wallet across production and this branch. Offsets are derived from `packet_timeout_height` in each send tx against the destination chain's height at that moment, so these are measured rather than predicted.

| sequence | destination | block time | offset | window | build | delivered |
| --- | --- | --- | --- | --- | --- | --- |
| 768869 | injective-1 | 0.597s | 1546 | 15.38 min | branch | yes |
| 768871 | injective-1 | 0.597s | 184 | 1.83 min | production | yes |
| 768873 | injective-1 | 0.597s | 1518 | 15.11 min | branch | yes |
| 37759 | cataclysm-1 | 1.794s | 493 | 14.73 min | branch | **no, expired** |
| 4599491 | cosmoshub-4 | 5.708s | 156 | 14.86 min | branch | yes |
| 4599493 | cosmoshub-4 | 5.708s | 147 | 14.03 min | production | yes |
| 78925 | bbn-1 | 10.012s | 91 | 15.17 min | branch | yes |
| 78926 | bbn-1 | 10.012s | 149 | 24.92 min | production | yes |
| 802 | optio | 60.733s | 14 | 13.96 min | branch | yes |
| 803 | optio | 60.733s | 148 | 150.12 min | production | yes |

The before/after pairs on the same route:

- **injective-1**: 1.83 -> 15.11 min
- **bbn-1**: 24.92 -> 15.17 min (correctly shortened)
- **optio**: 150.12 -> 13.96 min, the largest delta, and the case that took the rejected-measurement fallback on production before the plausibility bound was raised
- **cosmoshub-4**: 14.03 -> 14.86 min, the control, barely moves as expected. At 5.7s blocks the flat 150 and the derived ~158 are nearly identical, so this route cannot distinguish the two builds — useful as a sanity check, not as a discriminator

Every branch transfer landed in a 14.0-15.4 minute band across block times spanning 0.597s to 60.733s, a ~100x range. That is the invariant this PR is trying to establish.

Nibiru's 493 blocks is slightly under the 15 minute target because the block-time cache still held an earlier 1.828s measurement while the chain had drifted to 1.794s. That is the 1 hour TTL behaving as designed, and the drift is well inside tolerance.

**Sequence 37759 to Nibiru timed out and has not been refunded.** It received a correct 14.73 minute window and the relayer simply did not deliver inside it. This is not a defect in this change — it is the same channel whose relayer stopped submitting `MsgTimeout` on 17 July 2026, so nothing will refund it automatically. It is an unintentionally direct demonstration that a correct timeout window cannot rescue a route whose relayer is not clearing timeouts, which is why the relayer config gap is tracked separately rather than here.

The "taking longer than expected" toast appeared during several of these. That is unrelated to this change: it fires when the cosmetic `estimatedArrivalUnix` countdown reaches zero (`stores/transfer-history.tsx:444-471`), derived from block times via `estimateTransferTime`, not from the packet timeout. On fast chains that estimate is a few seconds, so any real relay latency trips it while the packet still has its full window.

### Tier 2 — one real transfer each way (spot check)

Small amounts. Confirm `packet_timeout_height` in the send tx matches Tier 1, the transfer is delivered, and the UI reaches `success`.

- One **deposit** (destination Osmosis, covers every deposit route)
- One **withdrawal** to a fast chain

### Tier 3 — the aggregator paths (optional, and awkward to force)

These exercise the `getChain` commit rather than the timeout maths, because Skip and Squid are the only callers that resolve the destination from the receiver address instead of passing a `chainId`.

They are genuinely hard to trigger deliberately: the provider is chosen by whichever quote wins, not by the user. To reach a non-IBC provider on a Cosmos route, open the transfer, expand the quote details, and use the **Provider** dropdown (`quote-detail.tsx:15`, visible only when more than one provider returned a successful quote). If the IBC provider is the only quote for a route, there is nothing to switch to and this tier cannot be run for that pair.

If you can get a Skip or Squid quote to Nibiru, that is the clearest case: pre-fix, a `nibi1...` receiver resolved to **Nyx**, so the quote used Nyx's RPC endpoints and returned a timeout height on the wrong chain entirely. Post-fix it should resolve to `cataclysm-1`, and the offset should match the Nibiru row in Tier 1 (~502 blocks).

If forcing an aggregator quote is impractical, the unit tests in `packages/utils/src/__tests__/chain-utils.spec.ts` cover the resolution directly, including a fixture ordered so the shadowing chain comes first. That was verified by reverting the implementation and confirming the collision cases fail. Skipping this tier is reasonable; it is a belt-and-braces check on a path the unit tests already pin.

### Not manually testable

The five fallback paths (all endpoints pruned, unreachable node, implausible block time, non-monotonic timestamps, chain younger than the sample size) and the cache TTLs cannot be triggered on demand against live chains. Those are covered by the unit tests above, including the failure-vs-success TTL distinction via fake timers.

## Reviewer notes

- The 15 minute target is a product decision, not a derived constant. It was picked so it matches what the flat offset produced on ~6s chains, but it does shorten the window on chains slower than that (Babylon 25.0 -> 15.0 min, Optio 151.7 -> 15.2 min). That is intended: those long windows were an artefact of block speed rather than a deliberate refund delay.
- The chain-utils commit changes resolution behaviour for a shared util. Only 2 real call sites pass an address, but it is worth a second opinion on whether it should land separately.
- This does **not** clear the 87 stuck packets on channel-21113, and does not address Skip's own ~5 minute timestamp window, which is the binding constraint on 47 of them. Both tracked in the issue.



