### PR TITLE
fix(web): explain timed-out Wormhole packets instead of telling users to wait (MTN-257)

### DIFF
--- a/packages/web/components/bridge/__tests__/wormhole-redeem.spec.tsx
+++ b/packages/web/components/bridge/__tests__/wormhole-redeem.spec.tsx
@@ -579,6 +579,42 @@ describe("checkOsmosisPacketFate", () => {
     ).resolves.toEqual({ status: "acknowledged" });
   });
 
+  it("keeps asking after an empty timeout search, so a pruned LCD can't fake an ack", async () => {
+    const fetchMock = jest
+      .fn()
+      // Pruned LCD: commitment gone, but it cannot see the timeout tx.
+      .mockResolvedValueOnce({ ok: false, status: 404 })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ tx_responses: [] }),
+      })
+      // Healthy LCD: the refund is right there.
+      .mockResolvedValueOnce({ ok: false, status: 404 })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          tx_responses: [
+            { txhash: "TIMEOUTHASH", timestamp: "2026-08-09T17:21:51Z" },
+          ],
+        }),
+      });
+    global.fetch = fetchMock;
+
+    await expect(
+      checkOsmosisPacketFate({
+        sequence: "43411",
+        srcChannel: "channel-2186",
+        lcds: ["https://lcd-pruned.example", "https://lcd-healthy.example"],
+      })
+    ).resolves.toEqual({
+      status: "timed_out",
+      txHash: "TIMEOUTHASH",
+      timestamp: "2026-08-09T17:21:51Z",
+    });
+  });
+
   it("degrades to unknown rather than throwing when every LCD fails", async () => {
     global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 503 });
 
@@ -687,44 +723,43 @@ describe("resolveOperation", () => {
     );
   });
 
-  // Regression for the real support case: Osmosis tx A1F5976E… (packet 43579)
-  // was never relayed, timed out, and was refunded on 2026-08-09. The widget
-  // used to tell the user to wait a minute for a packet that no longer existed.
+  // Every Wormchain RPC agrees there is no receive and the packet commitment
+  // is gone; only the timeout search separates a refund from an ack. Routed by
+  // URL rather than call order so these tests do not silently break when a
+  // provider is added to `OSMOSIS_LCDS` or `WORMCHAIN_RPCS`.
+  const mockNoWormchainReceive = (timeoutTxs: unknown[]) =>
+    jest.fn(async (url: string) => {
+      if (url.includes("/tx_search")) {
+        return { ok: true, json: async () => ({ result: { txs: [] } }) };
+      }
+      if (url.includes("/packet_commitments/")) {
+        return { ok: false, status: 404 };
+      }
+      if (url.includes("/txs?query=")) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ tx_responses: timeoutTxs }),
+        };
+      }
+      // Osmosis tx lookup by hash.
+      return { ok: true, json: async () => OSMOSIS_TX_EVENTS_FIXTURE };
+    }) as unknown as typeof fetch;
+
+  const REFUND_TX =
+    "9488C16915D31303460B949B62B3FF8483136EED3C2E1ED059E88A88D561A218";
+
+  // Regression for the real support case: a transfer that was never relayed
+  // timed out and was refunded on 2026-08-09 by tx 9488C169…, and the widget
+  // told the user to wait a minute for a packet that no longer existed. The
+  // send packet is the shared fixture's (sequence 43411) rather than the
+  // incident's 43579 — the refund tx is the part that reproduces the bug.
   it("explains the refund instead of telling the user to wait when the packet timed out", async () => {
     mockedApiClient.mockResolvedValueOnce({ operations: [] });
 
-    global.fetch = jest
-      .fn()
-      // Osmosis LCD: the send packet.
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => OSMOSIS_TX_EVENTS_FIXTURE,
-      })
-      // Both Wormchain RPCs agree there is no receive.
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ result: { txs: [] } }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ result: { txs: [] } }),
-      })
-      // The packet commitment is gone...
-      .mockResolvedValueOnce({ ok: false, status: 404 })
-      // ...because it timed out and was refunded.
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        json: async () => ({
-          tx_responses: [
-            {
-              txhash:
-                "9488C16915D31303460B949B62B3FF8483136EED3C2E1ED059E88A88D561A218",
-              timestamp: "2026-08-09T17:21:51Z",
-            },
-          ],
-        }),
-      });
+    global.fetch = mockNoWormchainReceive([
+      { txhash: REFUND_TX, timestamp: "2026-08-09T17:21:51Z" },
+    ]);
 
     const error = await resolveOperation(OSMOSIS_HASH).catch((e) => e);
     expect(error.message).toMatch(/timed out/i);
@@ -741,8 +776,23 @@ describe("resolveOperation", () => {
           month: "long",
           day: "numeric",
         }),
-        txHash:
-          "9488C16915D31303460B949B62B3FF8483136EED3C2E1ED059E88A88D561A218",
+        txHash: REFUND_TX,
+      })
+    );
+  });
+
+  it("drops the date rather than printing 'Invalid Date' when the LCD timestamp is junk", async () => {
+    mockedApiClient.mockResolvedValueOnce({ operations: [] });
+
+    global.fetch = mockNoWormchainReceive([
+      { txhash: REFUND_TX, timestamp: "not a date" },
+    ]);
+
+    const error = await resolveOperation(OSMOSIS_HASH).catch((e) => e);
+    expect(error.message).not.toMatch(/invalid date/i);
+    expect(error.message).toBe(
+      t("transfer.wormholeRedeem.packetTimedOutRefundedNoDate", {
+        txHash: REFUND_TX,
       })
     );
   });
@@ -750,26 +800,7 @@ describe("resolveOperation", () => {
   it("points at Wormholescan when Osmosis acked a receive we cannot locate", async () => {
     mockedApiClient.mockResolvedValueOnce({ operations: [] });
 
-    global.fetch = jest
-      .fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => OSMOSIS_TX_EVENTS_FIXTURE,
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ result: { txs: [] } }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ result: { txs: [] } }),
-      })
-      .mockResolvedValueOnce({ ok: false, status: 404 })
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        json: async () => ({ tx_responses: [] }),
-      });
+    global.fetch = mockNoWormchainReceive([]);
 
     await expect(resolveOperation(OSMOSIS_HASH)).rejects.toThrow(
       /received on Wormchain, but the receive transaction could not be located/i

--- a/packages/web/components/bridge/__tests__/wormhole-redeem.spec.tsx
+++ b/packages/web/components/bridge/__tests__/wormhole-redeem.spec.tsx
@@ -731,6 +731,20 @@ describe("resolveOperation", () => {
     expect(error.message).toMatch(/refunded/i);
     expect(error.message).toContain("9488C169");
     expect(error.message).not.toMatch(/try again in a minute/i);
+
+    // Comes from the translation catalogue, not a hardcoded literal, so the
+    // message is localized like the rest of the widget.
+    expect(error.message).toBe(
+      t("transfer.wormholeRedeem.packetTimedOutRefunded", {
+        date: new Date("2026-08-09T17:21:51Z").toLocaleDateString(undefined, {
+          year: "numeric",
+          month: "long",
+          day: "numeric",
+        }),
+        txHash:
+          "9488C16915D31303460B949B62B3FF8483136EED3C2E1ED059E88A88D561A218",
+      })
+    );
   });
 
   it("points at Wormholescan when Osmosis acked a receive we cannot locate", async () => {

--- a/packages/web/components/bridge/__tests__/wormhole-redeem.spec.tsx
+++ b/packages/web/components/bridge/__tests__/wormhole-redeem.spec.tsx
@@ -51,6 +51,7 @@ import { MultiLanguageProvider, t } from "~/hooks/language";
 
 import {
   checkIfRedeemed,
+  checkOsmosisPacketFate,
   fetchGovernorDelay,
   findWormchainRecvTx,
   formatGovernorReleaseCountdown,
@@ -476,6 +477,119 @@ describe("findWormchainRecvTx", () => {
       })
     ).rejects.toThrow(/Could not query Wormchain RPC/);
   });
+
+  it("keeps asking after an empty result, so a pruned node can't fake a miss", async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: { txs: [], total_count: "0" } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: { txs: [{ hash: WORMCHAIN_HASH }] } }),
+      });
+    global.fetch = fetchMock;
+
+    const hash = await findWormchainRecvTx({
+      sequence: "43411",
+      srcChannel: "channel-2186",
+      wormchainRpcs: [
+        "https://wormchain-rpc-pruned.example",
+        "https://wormchain-rpc-healthy.example",
+      ],
+    });
+    expect(hash).toBe(WORMCHAIN_HASH);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("checkOsmosisPacketFate", () => {
+  const originalFetch = global.fetch;
+  const LCDS = ["https://lcd.example"];
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("reports in_flight while the packet commitment is still live", async () => {
+    global.fetch = jest.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ commitment: "Y29tbWl0bWVudA==" }),
+    });
+
+    await expect(
+      checkOsmosisPacketFate({
+        sequence: "43411",
+        srcChannel: "channel-2186",
+        lcds: LCDS,
+      })
+    ).resolves.toEqual({ status: "in_flight" });
+  });
+
+  it("reports timed_out with the refund tx once the commitment is cleared", async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 404 })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          tx_responses: [
+            { txhash: "TIMEOUTHASH", timestamp: "2026-08-09T17:21:51Z" },
+          ],
+        }),
+      });
+    global.fetch = fetchMock;
+
+    await expect(
+      checkOsmosisPacketFate({
+        sequence: "43411",
+        srcChannel: "channel-2186",
+        lcds: LCDS,
+      })
+    ).resolves.toEqual({
+      status: "timed_out",
+      txHash: "TIMEOUTHASH",
+      timestamp: "2026-08-09T17:21:51Z",
+    });
+
+    expect(decodeURIComponent(fetchMock.mock.calls[1][0] as string)).toContain(
+      "timeout_packet.packet_sequence='43411' AND timeout_packet.packet_src_channel='channel-2186'"
+    );
+  });
+
+  it("reports acknowledged when the commitment cleared without a timeout", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 404 })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ tx_responses: [] }),
+      });
+
+    await expect(
+      checkOsmosisPacketFate({
+        sequence: "43411",
+        srcChannel: "channel-2186",
+        lcds: LCDS,
+      })
+    ).resolves.toEqual({ status: "acknowledged" });
+  });
+
+  it("degrades to unknown rather than throwing when every LCD fails", async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 503 });
+
+    await expect(
+      checkOsmosisPacketFate({
+        sequence: "43411",
+        srcChannel: "channel-2186",
+        lcds: ["https://lcd-a.example", "https://lcd-b.example"],
+      })
+    ).resolves.toEqual({ status: "unknown" });
+  });
 });
 
 describe("resolveOperation", () => {
@@ -570,6 +684,81 @@ describe("resolveOperation", () => {
 
     await expect(resolveOperation(OSMOSIS_HASH)).rejects.toThrow(
       /has not been relayed yet/i
+    );
+  });
+
+  // Regression for the real support case: Osmosis tx A1F5976E… (packet 43579)
+  // was never relayed, timed out, and was refunded on 2026-08-09. The widget
+  // used to tell the user to wait a minute for a packet that no longer existed.
+  it("explains the refund instead of telling the user to wait when the packet timed out", async () => {
+    mockedApiClient.mockResolvedValueOnce({ operations: [] });
+
+    global.fetch = jest
+      .fn()
+      // Osmosis LCD: the send packet.
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => OSMOSIS_TX_EVENTS_FIXTURE,
+      })
+      // Both Wormchain RPCs agree there is no receive.
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: { txs: [] } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: { txs: [] } }),
+      })
+      // The packet commitment is gone...
+      .mockResolvedValueOnce({ ok: false, status: 404 })
+      // ...because it timed out and was refunded.
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          tx_responses: [
+            {
+              txhash:
+                "9488C16915D31303460B949B62B3FF8483136EED3C2E1ED059E88A88D561A218",
+              timestamp: "2026-08-09T17:21:51Z",
+            },
+          ],
+        }),
+      });
+
+    const error = await resolveOperation(OSMOSIS_HASH).catch((e) => e);
+    expect(error.message).toMatch(/timed out/i);
+    expect(error.message).toMatch(/refunded/i);
+    expect(error.message).toContain("9488C169");
+    expect(error.message).not.toMatch(/try again in a minute/i);
+  });
+
+  it("points at Wormholescan when Osmosis acked a receive we cannot locate", async () => {
+    mockedApiClient.mockResolvedValueOnce({ operations: [] });
+
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => OSMOSIS_TX_EVENTS_FIXTURE,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: { txs: [] } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ result: { txs: [] } }),
+      })
+      .mockResolvedValueOnce({ ok: false, status: 404 })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ tx_responses: [] }),
+      });
+
+    await expect(resolveOperation(OSMOSIS_HASH)).rejects.toThrow(
+      /received on Wormchain, but the receive transaction could not be located/i
     );
   });
 

--- a/packages/web/components/bridge/wormhole-redeem.tsx
+++ b/packages/web/components/bridge/wormhole-redeem.tsx
@@ -9,7 +9,7 @@ import type {
 import { FunctionComponent, useCallback, useEffect, useState } from "react";
 
 import { Spinner } from "~/components/loaders";
-import { type MultiLanguageT, useTranslation } from "~/hooks/language";
+import { type MultiLanguageT, t, useTranslation } from "~/hooks/language";
 import { formatPretty } from "~/utils/formatter";
 
 import {
@@ -327,6 +327,15 @@ function parseGatewayMemo(
 }
 
 /**
+ * Every configured LCD reported the tx as missing.
+ *
+ * Identified by class rather than by matching the message text, because the
+ * message is translated and a substring check would silently stop matching in
+ * every non-English locale.
+ */
+export class OsmosisTxNotFoundError extends Error {}
+
+/**
  * Look up an Osmosis transaction and extract the Wormhole gateway IBC packet
  * (sequence + channels + memo). Returns null if no Wormhole gateway transfer
  * was found in the tx. Tries multiple LCD providers because individual
@@ -402,15 +411,16 @@ export async function lookupOsmosisIbcPacket(
   // it). Surface a tx-not-found error rather than a generic provider
   // outage so the user can correct the hash.
   if (!lastError && seenNotFound) {
-    throw new Error(
-      "Osmosis transaction not found. Double-check the hash and that it was broadcast on Osmosis mainnet."
+    throw new OsmosisTxNotFoundError(
+      t("transfer.wormholeRedeem.osmosisTxNotFound")
     );
   }
   if (lastError) {
     throw new Error(
-      `Could not fetch Osmosis tx from any LCD: ${
-        lastError instanceof Error ? lastError.message : String(lastError)
-      }`
+      t("transfer.wormholeRedeem.osmosisLcdUnavailable", {
+        error:
+          lastError instanceof Error ? lastError.message : String(lastError),
+      })
     );
   }
   return null;
@@ -460,9 +470,9 @@ export async function findWormchainRecvTx({
   // At least one provider gave us a clean "no such packet" and none found it.
   if (sawEmptyResult) return null;
   throw new Error(
-    `Could not query Wormchain RPC: ${
-      lastError instanceof Error ? lastError.message : String(lastError)
-    }`
+    t("transfer.wormholeRedeem.wormchainRpcUnavailable", {
+      error: lastError instanceof Error ? lastError.message : String(lastError),
+    })
   );
 }
 
@@ -556,9 +566,7 @@ export async function resolveOperation(
   }
 
   if (!COSMOS_TX_HASH_RE.test(userHash)) {
-    throw new Error(
-      "Transaction not found. Make sure this is a Wormhole bridge transaction hash."
-    );
+    throw new Error(t("transfer.wormholeRedeem.notAWormholeTx"));
   }
 
   // The hash format alone can't tell us whether this is an Osmosis tx or
@@ -570,20 +578,15 @@ export async function resolveOperation(
   try {
     packet = await lookupOsmosisIbcPacket(userHash);
   } catch (err) {
-    if (
-      err instanceof Error &&
-      err.message.startsWith("Osmosis transaction not found")
-    ) {
+    if (err instanceof OsmosisTxNotFoundError) {
       throw new Error(
-        "Transaction not found on Wormholescan and no matching Osmosis transaction was located. If this is a Wormchain receive hash, the guardians may still be signing — try again in a minute. Otherwise, double-check the hash."
+        t("transfer.wormholeRedeem.notFoundOnWormholescanOrOsmosis")
       );
     }
     throw err;
   }
   if (!packet) {
-    throw new Error(
-      "Transaction not found on Wormholescan and no Wormhole gateway IBC transfer was found in this Osmosis transaction."
-    );
+    throw new Error(t("transfer.wormholeRedeem.noGatewayTransferInTx"));
   }
 
   const wormchainHash = await findWormchainRecvTx({
@@ -599,33 +602,35 @@ export async function resolveOperation(
     });
 
     if (fate.status === "timed_out") {
-      const when = fate.timestamp
-        ? ` on ${new Date(fate.timestamp).toLocaleDateString(undefined, {
-            year: "numeric",
-            month: "long",
-            day: "numeric",
-          })}`
-        : "";
+      // Two whole sentences rather than splicing the date into one, so
+      // translators get a complete sentence in both cases.
       throw new Error(
-        `This transfer timed out before it reached Wormchain, so it was automatically refunded to your Osmosis address${when} (tx ${fate.txHash}). There is nothing to redeem — the tokens are already back in your wallet, and you can bridge again from the Wormhole page.`
+        fate.timestamp
+          ? t("transfer.wormholeRedeem.packetTimedOutRefunded", {
+              date: new Date(fate.timestamp).toLocaleDateString(undefined, {
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+              }),
+              txHash: fate.txHash,
+            })
+          : t("transfer.wormholeRedeem.packetTimedOutRefundedNoDate", {
+              txHash: fate.txHash,
+            })
       );
     }
 
     if (fate.status === "acknowledged") {
-      throw new Error(
-        "Osmosis confirms this packet was received on Wormchain, but the receive transaction could not be located. Look this transfer up directly on Wormholescan."
-      );
+      throw new Error(t("transfer.wormholeRedeem.packetReceivedButTxNotFound"));
     }
 
-    throw new Error(
-      "Found the Osmosis send packet but the corresponding Wormchain receive has not been relayed yet. Try again in a minute."
-    );
+    throw new Error(t("transfer.wormholeRedeem.wormchainReceiveNotRelayedYet"));
   }
 
   const op = await fetchOperation(wormchainHash);
   if (!op) {
     throw new Error(
-      `Found the Wormchain receive (${wormchainHash}) but Wormholescan has not indexed a VAA for it yet. The guardians may still be signing — try again in a minute.`
+      t("transfer.wormholeRedeem.vaaNotIndexedYet", { txHash: wormchainHash })
     );
   }
 

--- a/packages/web/components/bridge/wormhole-redeem.tsx
+++ b/packages/web/components/bridge/wormhole-redeem.tsx
@@ -492,6 +492,7 @@ export async function checkOsmosisPacketFate({
   srcChannel: string;
   lcds?: readonly string[];
 }): Promise<OsmosisPacketFate> {
+  let sawEmptyTimeoutSearch = false;
   for (const lcd of lcds) {
     try {
       const commitmentRes = await fetchWithTimeout(
@@ -517,17 +518,22 @@ export async function checkOsmosisPacketFate({
       if (!txRes.ok) continue;
       const txJson = (await txRes.json()) as CosmosTxSearchResponse;
       const timeoutTx = txJson.tx_responses?.[0];
-      return timeoutTx
-        ? {
-            status: "timed_out",
-            txHash: timeoutTx.txhash,
-            timestamp: timeoutTx.timestamp,
-          }
-        : { status: "acknowledged" };
+      if (timeoutTx) {
+        return {
+          status: "timed_out",
+          txHash: timeoutTx.txhash,
+          timestamp: timeoutTx.timestamp,
+        };
+      }
+      // A provider that pruned the block or does not index transactions
+      // answers empty for a packet that did time out. Claiming acknowledgement
+      // on that would send a refunded user to Wormholescan for nothing.
+      sawEmptyTimeoutSearch = true;
     } catch {
       // Try the next provider.
     }
   }
+  if (sawEmptyTimeoutSearch) return { status: "acknowledged" };
   return { status: "unknown" };
 }
 
@@ -603,11 +609,13 @@ export async function resolveOperation(
 
     if (fate.status === "timed_out") {
       // Two whole sentences rather than splicing the date into one, so
-      // translators get a complete sentence in both cases.
+      // translators get a complete sentence in both cases. An LCD timestamp we
+      // cannot parse falls back to the undated sentence, never "Invalid Date".
+      const refundedAt = fate.timestamp ? new Date(fate.timestamp) : null;
       throw new Error(
-        fate.timestamp
+        refundedAt && !Number.isNaN(refundedAt.getTime())
           ? t("transfer.wormholeRedeem.packetTimedOutRefunded", {
-              date: new Date(fate.timestamp).toLocaleDateString(undefined, {
+              date: refundedAt.toLocaleDateString(undefined, {
                 year: "numeric",
                 month: "long",
                 day: "numeric",

--- a/packages/web/components/bridge/wormhole-redeem.tsx
+++ b/packages/web/components/bridge/wormhole-redeem.tsx
@@ -58,6 +58,11 @@ const OSMOSIS_LCDS = [
 
 // Wormchain RPC fallbacks. Same rationale as `OSMOSIS_LCDS`: a single
 // provider going down would otherwise break recovery for every user.
+//
+// `wormchain-rpc.publicnode.com` was verified down on 2026-08-12 (404 on
+// every path, including `/status`), leaving polkachu as the only working
+// provider. It is kept deliberately in case it returns: `findWormchainRecvTx`
+// skips non-200 responses, so a dead entry costs nothing.
 const WORMCHAIN_RPCS = [
   "https://wormchain-rpc.polkachu.com",
   "https://wormchain-rpc.publicnode.com",
@@ -273,6 +278,28 @@ interface WormchainTxSearchResponse {
   };
 }
 
+interface PacketCommitmentResponse {
+  commitment?: string;
+}
+
+interface CosmosTxSearchResponse {
+  tx_responses?: { txhash: string; timestamp?: string }[];
+}
+
+/**
+ * What Osmosis says became of a send_packet we couldn't find on Wormchain.
+ *
+ * Osmosis is authoritative here: it clears the packet commitment on either an
+ * acknowledgement or a timeout, so the commitment plus the presence of a
+ * timeout tx tell us which case we're in. `unknown` means the probe itself
+ * failed and the caller should fall back to the neutral "still pending" copy.
+ */
+type OsmosisPacketFate =
+  | { status: "in_flight" }
+  | { status: "timed_out"; txHash: string; timestamp?: string }
+  | { status: "acknowledged" }
+  | { status: "unknown" };
+
 const getAttr = (event: CosmosTxEvent, key: string): string | undefined =>
   event.attributes.find((a) => a.key === key)?.value;
 
@@ -410,6 +437,10 @@ export async function findWormchainRecvTx({
   // Tendermint RPC requires the query value to be a quoted string.
   const query = `"recv_packet.packet_sequence='${sequence}' AND recv_packet.packet_src_channel='${srcChannel}'"`;
   let lastError: unknown = null;
+  // A provider answering with zero results may simply have pruned the block
+  // or be lagging behind. Treat an empty answer as non-authoritative and keep
+  // asking, so one stale node can't manufacture a "not relayed yet" verdict.
+  let sawEmptyResult = false;
   for (const rpc of wormchainRpcs) {
     try {
       const url = `${rpc}/tx_search?query=${encodeURIComponent(query)}`;
@@ -419,16 +450,75 @@ export async function findWormchainRecvTx({
         continue;
       }
       const json = (await res.json()) as WormchainTxSearchResponse;
-      return json.result?.txs?.[0]?.hash ?? null;
+      const hash = json.result?.txs?.[0]?.hash;
+      if (hash) return hash;
+      sawEmptyResult = true;
     } catch (err) {
       lastError = err;
     }
   }
+  // At least one provider gave us a clean "no such packet" and none found it.
+  if (sawEmptyResult) return null;
   throw new Error(
     `Could not query Wormchain RPC: ${
       lastError instanceof Error ? lastError.message : String(lastError)
     }`
   );
+}
+
+/**
+ * Ask Osmosis what happened to a send_packet that has no Wormchain receive.
+ *
+ * Purely diagnostic: it only ever refines the error message we show, so every
+ * failure path degrades to `unknown` rather than throwing and turning a
+ * recoverable transfer into a hard error.
+ */
+export async function checkOsmosisPacketFate({
+  sequence,
+  srcChannel,
+  lcds = OSMOSIS_LCDS,
+}: {
+  sequence: string;
+  srcChannel: string;
+  lcds?: readonly string[];
+}): Promise<OsmosisPacketFate> {
+  for (const lcd of lcds) {
+    try {
+      const commitmentRes = await fetchWithTimeout(
+        `${lcd}/ibc/core/channel/v1/channels/${encodeURIComponent(
+          srcChannel
+        )}/ports/transfer/packet_commitments/${encodeURIComponent(sequence)}`
+      );
+      if (commitmentRes.ok) {
+        const json = (await commitmentRes.json()) as PacketCommitmentResponse;
+        // A live commitment means the packet really is still pending.
+        if (json.commitment) return { status: "in_flight" };
+      } else if (commitmentRes.status !== 404) {
+        // Provider trouble rather than an answer — ask the next one.
+        continue;
+      }
+
+      // The commitment is gone, so the packet was either acknowledged or
+      // timed out. Only the presence of a timeout tx separates the two.
+      const query = `timeout_packet.packet_sequence='${sequence}' AND timeout_packet.packet_src_channel='${srcChannel}'`;
+      const txRes = await fetchWithTimeout(
+        `${lcd}/cosmos/tx/v1beta1/txs?query=${encodeURIComponent(query)}`
+      );
+      if (!txRes.ok) continue;
+      const txJson = (await txRes.json()) as CosmosTxSearchResponse;
+      const timeoutTx = txJson.tx_responses?.[0];
+      return timeoutTx
+        ? {
+            status: "timed_out",
+            txHash: timeoutTx.txhash,
+            timestamp: timeoutTx.timestamp,
+          }
+        : { status: "acknowledged" };
+    } catch {
+      // Try the next provider.
+    }
+  }
+  return { status: "unknown" };
 }
 
 interface ResolvedOperation {
@@ -501,6 +591,32 @@ export async function resolveOperation(
     srcChannel: packet.srcChannel,
   });
   if (!wormchainHash) {
+    // "No receive on Wormchain" has three very different causes, and telling
+    // a user to wait for a packet that timed out days ago is a dead end.
+    const fate = await checkOsmosisPacketFate({
+      sequence: packet.sequence,
+      srcChannel: packet.srcChannel,
+    });
+
+    if (fate.status === "timed_out") {
+      const when = fate.timestamp
+        ? ` on ${new Date(fate.timestamp).toLocaleDateString(undefined, {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+          })}`
+        : "";
+      throw new Error(
+        `This transfer timed out before it reached Wormchain, so it was automatically refunded to your Osmosis address${when} (tx ${fate.txHash}). There is nothing to redeem — the tokens are already back in your wallet, and you can bridge again from the Wormhole page.`
+      );
+    }
+
+    if (fate.status === "acknowledged") {
+      throw new Error(
+        "Osmosis confirms this packet was received on Wormchain, but the receive transaction could not be located. Look this transfer up directly on Wormholescan."
+      );
+    }
+
     throw new Error(
       "Found the Osmosis send packet but the corresponding Wormchain receive has not been relayed yet. Try again in a minute."
     );

--- a/packages/web/localizations/de.json
+++ b/packages/web/localizations/de.json
@@ -1097,7 +1097,18 @@
       "connectedNamedAccount": "Verbundenes {wallet}-Konto",
       "confirmInNamed": "In {wallet} bestätigen...",
       "submittingOnSui": "Wird auf Sui übermittelt...",
-      "redeemOnSui": "Auf Sui einlösen"
+      "redeemOnSui": "Auf Sui einlösen",
+      "osmosisTxNotFound": "Osmosis-Transaktion nicht gefunden. Überprüfe den Hash und ob sie im Osmosis-Mainnet gesendet wurde.",
+      "osmosisLcdUnavailable": "Osmosis-Transaktion konnte von keinem LCD abgerufen werden: {error}",
+      "wormchainRpcUnavailable": "Wormchain-RPC konnte nicht abgefragt werden: {error}",
+      "notAWormholeTx": "Transaktion nicht gefunden. Stelle sicher, dass dies der Hash einer Wormhole-Bridge-Transaktion ist.",
+      "notFoundOnWormholescanOrOsmosis": "Transaktion wurde nicht auf Wormholescan gefunden und es konnte keine passende Osmosis-Transaktion ermittelt werden. Falls dies ein Wormchain-Empfangs-Hash ist, signieren die Guardians möglicherweise noch — versuche es in einer Minute erneut. Andernfalls überprüfe den Hash.",
+      "noGatewayTransferInTx": "Transaktion wurde nicht auf Wormholescan gefunden und in dieser Osmosis-Transaktion wurde kein Wormhole-Gateway-IBC-Transfer gefunden.",
+      "packetTimedOutRefunded": "Diese Überweisung ist abgelaufen, bevor sie Wormchain erreicht hat, und wurde am {date} automatisch an deine Osmosis-Adresse zurückerstattet (Tx {txHash}). Es gibt nichts einzulösen — die Token sind bereits in deiner Wallet, und du kannst die Überweisung auf der Wormhole-Seite erneut starten.",
+      "packetTimedOutRefundedNoDate": "Diese Überweisung ist abgelaufen, bevor sie Wormchain erreicht hat, und wurde automatisch an deine Osmosis-Adresse zurückerstattet (Tx {txHash}). Es gibt nichts einzulösen — die Token sind bereits in deiner Wallet, und du kannst die Überweisung auf der Wormhole-Seite erneut starten.",
+      "packetReceivedButTxNotFound": "Osmosis bestätigt, dass dieses Paket auf Wormchain empfangen wurde, aber die Empfangstransaktion konnte nicht gefunden werden. Sieh dir diese Überweisung direkt auf Wormholescan an.",
+      "wormchainReceiveNotRelayedYet": "Das Osmosis-Sendepaket wurde gefunden, aber der zugehörige Wormchain-Empfang wurde noch nicht weitergeleitet. Versuche es in einer Minute erneut.",
+      "vaaNotIndexedYet": "Der Wormchain-Empfang ({txHash}) wurde gefunden, aber Wormholescan hat dafür noch keine VAA indexiert. Die Guardians signieren möglicherweise noch — versuche es in einer Minute erneut."
     }
   },
   "unknownError": "Unbekannter Fehler",

--- a/packages/web/localizations/en.json
+++ b/packages/web/localizations/en.json
@@ -1097,7 +1097,18 @@
       "connectedNamedAccount": "Connected {wallet} account",
       "confirmInNamed": "Confirm in {wallet}...",
       "submittingOnSui": "Submitting on Sui...",
-      "redeemOnSui": "Redeem on Sui"
+      "redeemOnSui": "Redeem on Sui",
+      "osmosisTxNotFound": "Osmosis transaction not found. Double-check the hash and that it was broadcast on Osmosis mainnet.",
+      "osmosisLcdUnavailable": "Could not fetch Osmosis tx from any LCD: {error}",
+      "wormchainRpcUnavailable": "Could not query Wormchain RPC: {error}",
+      "notAWormholeTx": "Transaction not found. Make sure this is a Wormhole bridge transaction hash.",
+      "notFoundOnWormholescanOrOsmosis": "Transaction not found on Wormholescan and no matching Osmosis transaction was located. If this is a Wormchain receive hash, the guardians may still be signing — try again in a minute. Otherwise, double-check the hash.",
+      "noGatewayTransferInTx": "Transaction not found on Wormholescan and no Wormhole gateway IBC transfer was found in this Osmosis transaction.",
+      "packetTimedOutRefunded": "This transfer timed out before it reached Wormchain, so it was automatically refunded to your Osmosis address on {date} (tx {txHash}). There is nothing to redeem — the tokens are already back in your wallet, and you can bridge again from the Wormhole page.",
+      "packetTimedOutRefundedNoDate": "This transfer timed out before it reached Wormchain, so it was automatically refunded to your Osmosis address (tx {txHash}). There is nothing to redeem — the tokens are already back in your wallet, and you can bridge again from the Wormhole page.",
+      "packetReceivedButTxNotFound": "Osmosis confirms this packet was received on Wormchain, but the receive transaction could not be located. Look this transfer up directly on Wormholescan.",
+      "wormchainReceiveNotRelayedYet": "Found the Osmosis send packet but the corresponding Wormchain receive has not been relayed yet. Try again in a minute.",
+      "vaaNotIndexedYet": "Found the Wormchain receive ({txHash}) but Wormholescan has not indexed a VAA for it yet. The guardians may still be signing — try again in a minute."
     }
   },
   "unknownError": "Unknown error",

--- a/packages/web/localizations/es.json
+++ b/packages/web/localizations/es.json
@@ -1097,7 +1097,18 @@
       "connectedNamedAccount": "Cuenta de {wallet} conectada",
       "confirmInNamed": "Confirma en {wallet}...",
       "submittingOnSui": "Enviando en Sui...",
-      "redeemOnSui": "Reclamar en Sui"
+      "redeemOnSui": "Reclamar en Sui",
+      "osmosisTxNotFound": "No se encontró la transacción de Osmosis. Verifica el hash y que se haya transmitido en la mainnet de Osmosis.",
+      "osmosisLcdUnavailable": "No se pudo obtener la transacción de Osmosis desde ningún LCD: {error}",
+      "wormchainRpcUnavailable": "No se pudo consultar el RPC de Wormchain: {error}",
+      "notAWormholeTx": "No se encontró la transacción. Asegúrate de que sea un hash de transacción del puente Wormhole.",
+      "notFoundOnWormholescanOrOsmosis": "No se encontró la transacción en Wormholescan ni se localizó una transacción de Osmosis correspondiente. Si este es un hash de recepción de Wormchain, es posible que los guardianes aún estén firmando: inténtalo de nuevo en un minuto. De lo contrario, verifica el hash.",
+      "noGatewayTransferInTx": "No se encontró la transacción en Wormholescan y no se encontró ninguna transferencia IBC del gateway de Wormhole en esta transacción de Osmosis.",
+      "packetTimedOutRefunded": "Esta transferencia expiró antes de llegar a Wormchain, por lo que se reembolsó automáticamente a tu dirección de Osmosis el {date} (tx {txHash}). No hay nada que canjear: los tokens ya están de vuelta en tu billetera y puedes volver a usar el puente desde la página de Wormhole.",
+      "packetTimedOutRefundedNoDate": "Esta transferencia expiró antes de llegar a Wormchain, por lo que se reembolsó automáticamente a tu dirección de Osmosis (tx {txHash}). No hay nada que canjear: los tokens ya están de vuelta en tu billetera y puedes volver a usar el puente desde la página de Wormhole.",
+      "packetReceivedButTxNotFound": "Osmosis confirma que este paquete se recibió en Wormchain, pero no se pudo localizar la transacción de recepción. Consulta esta transferencia directamente en Wormholescan.",
+      "wormchainReceiveNotRelayedYet": "Se encontró el paquete de envío de Osmosis, pero la recepción correspondiente en Wormchain aún no se ha retransmitido. Inténtalo de nuevo en un minuto.",
+      "vaaNotIndexedYet": "Se encontró la recepción de Wormchain ({txHash}), pero Wormholescan aún no ha indexado un VAA para ella. Es posible que los guardianes aún estén firmando: inténtalo de nuevo en un minuto."
     }
   },
   "unknownError": "Error desconocido",

--- a/packages/web/localizations/fa.json
+++ b/packages/web/localizations/fa.json
@@ -1097,7 +1097,18 @@
       "connectedNamedAccount": "حساب {wallet} متصل",
       "confirmInNamed": "در {wallet} تأیید کنید...",
       "submittingOnSui": "در حال ارسال در Sui...",
-      "redeemOnSui": "بازخرید در Sui"
+      "redeemOnSui": "بازخرید در Sui",
+      "osmosisTxNotFound": "تراکنش Osmosis پیدا نشد. هش را بررسی کنید و مطمئن شوید که در شبکه اصلی Osmosis ارسال شده است.",
+      "osmosisLcdUnavailable": "دریافت تراکنش Osmosis از هیچ LCD ممکن نشد: {error}",
+      "wormchainRpcUnavailable": "امکان جست‌وجو در RPC وُرم‌چین وجود نداشت: {error}",
+      "notAWormholeTx": "تراکنش پیدا نشد. مطمئن شوید که این هش یک تراکنش پل Wormhole است.",
+      "notFoundOnWormholescanOrOsmosis": "تراکنش در Wormholescan پیدا نشد و هیچ تراکنش متناظری در Osmosis یافت نشد. اگر این هش دریافت وُرم‌چین است، ممکن است نگهبانان هنوز در حال امضا باشند — یک دقیقه دیگر دوباره تلاش کنید. در غیر این صورت، هش را بررسی کنید.",
+      "noGatewayTransferInTx": "تراکنش در Wormholescan پیدا نشد و هیچ انتقال IBC از دروازه Wormhole در این تراکنش Osmosis یافت نشد.",
+      "packetTimedOutRefunded": "این انتقال پیش از رسیدن به وُرم‌چین منقضی شد، بنابراین در تاریخ {date} به‌طور خودکار به آدرس Osmosis شما بازگردانده شد (تراکنش {txHash}). چیزی برای دریافت وجود ندارد — توکن‌ها هم‌اکنون در کیف پول شما هستند و می‌توانید دوباره از صفحه Wormhole انتقال دهید.",
+      "packetTimedOutRefundedNoDate": "این انتقال پیش از رسیدن به وُرم‌چین منقضی شد، بنابراین به‌طور خودکار به آدرس Osmosis شما بازگردانده شد (تراکنش {txHash}). چیزی برای دریافت وجود ندارد — توکن‌ها هم‌اکنون در کیف پول شما هستند و می‌توانید دوباره از صفحه Wormhole انتقال دهید.",
+      "packetReceivedButTxNotFound": "Osmosis تأیید می‌کند که این بسته در وُرم‌چین دریافت شده است، اما تراکنش دریافت پیدا نشد. این انتقال را مستقیماً در Wormholescan بررسی کنید.",
+      "wormchainReceiveNotRelayedYet": "بسته ارسال Osmosis پیدا شد اما دریافت متناظر در وُرم‌چین هنوز رله نشده است. یک دقیقه دیگر دوباره تلاش کنید.",
+      "vaaNotIndexedYet": "دریافت وُرم‌چین ({txHash}) پیدا شد اما Wormholescan هنوز VAA آن را ایندکس نکرده است. ممکن است نگهبانان هنوز در حال امضا باشند — یک دقیقه دیگر دوباره تلاش کنید."
     }
   },
   "unknownError": "خطای نا شناس",

--- a/packages/web/localizations/fr.json
+++ b/packages/web/localizations/fr.json
@@ -1097,7 +1097,18 @@
       "connectedNamedAccount": "Compte {wallet} connecté",
       "confirmInNamed": "Confirmez dans {wallet}...",
       "submittingOnSui": "Envoi sur Sui...",
-      "redeemOnSui": "Récupérer sur Sui"
+      "redeemOnSui": "Récupérer sur Sui",
+      "osmosisTxNotFound": "Transaction Osmosis introuvable. Vérifiez le hash et qu'elle a bien été diffusée sur le mainnet Osmosis.",
+      "osmosisLcdUnavailable": "Impossible de récupérer la transaction Osmosis depuis un LCD : {error}",
+      "wormchainRpcUnavailable": "Impossible d'interroger le RPC Wormchain : {error}",
+      "notAWormholeTx": "Transaction introuvable. Assurez-vous qu'il s'agit d'un hash de transaction du pont Wormhole.",
+      "notFoundOnWormholescanOrOsmosis": "Transaction introuvable sur Wormholescan et aucune transaction Osmosis correspondante n'a été trouvée. S'il s'agit d'un hash de réception Wormchain, les gardiens sont peut-être encore en train de signer — réessayez dans une minute. Sinon, vérifiez le hash.",
+      "noGatewayTransferInTx": "Transaction introuvable sur Wormholescan et aucun transfert IBC via la passerelle Wormhole n'a été trouvé dans cette transaction Osmosis.",
+      "packetTimedOutRefunded": "Ce transfert a expiré avant d'atteindre Wormchain ; il a donc été automatiquement remboursé sur votre adresse Osmosis le {date} (tx {txHash}). Il n'y a rien à réclamer — les jetons sont déjà de retour dans votre portefeuille et vous pouvez relancer le transfert depuis la page Wormhole.",
+      "packetTimedOutRefundedNoDate": "Ce transfert a expiré avant d'atteindre Wormchain ; il a donc été automatiquement remboursé sur votre adresse Osmosis (tx {txHash}). Il n'y a rien à réclamer — les jetons sont déjà de retour dans votre portefeuille et vous pouvez relancer le transfert depuis la page Wormhole.",
+      "packetReceivedButTxNotFound": "Osmosis confirme que ce paquet a été reçu sur Wormchain, mais la transaction de réception est introuvable. Consultez ce transfert directement sur Wormholescan.",
+      "wormchainReceiveNotRelayedYet": "Le paquet d'envoi Osmosis a été trouvé, mais la réception Wormchain correspondante n'a pas encore été relayée. Réessayez dans une minute.",
+      "vaaNotIndexedYet": "La réception Wormchain ({txHash}) a été trouvée, mais Wormholescan n'a pas encore indexé de VAA pour celle-ci. Les gardiens sont peut-être encore en train de signer — réessayez dans une minute."
     }
   },
   "unknownError": "Erreur inconnue",

--- a/packages/web/localizations/gu.json
+++ b/packages/web/localizations/gu.json
@@ -1097,7 +1097,18 @@
       "connectedNamedAccount": "કનેક્ટેડ {wallet} એકાઉન્ટ",
       "confirmInNamed": "{wallet} માં પુષ્ટિ કરો...",
       "submittingOnSui": "Sui પર સબમિટ કરવામાં આવી રહ્યું છે...",
-      "redeemOnSui": "Sui પર રિડીમ કરો"
+      "redeemOnSui": "Sui પર રિડીમ કરો",
+      "osmosisTxNotFound": "Osmosis ટ્રાન્ઝેક્શન મળ્યું નથી. હેશ તપાસો અને ખાતરી કરો કે તે Osmosis મેઇનનેટ પર બ્રોડકાસ્ટ થયું હતું.",
+      "osmosisLcdUnavailable": "કોઈ પણ LCD પરથી Osmosis ટ્રાન્ઝેક્શન મેળવી શકાયું નથી: {error}",
+      "wormchainRpcUnavailable": "Wormchain RPC ને ક્વેરી કરી શકાયું નથી: {error}",
+      "notAWormholeTx": "ટ્રાન્ઝેક્શન મળ્યું નથી. ખાતરી કરો કે આ Wormhole બ્રિજ ટ્રાન્ઝેક્શન હેશ છે.",
+      "notFoundOnWormholescanOrOsmosis": "Wormholescan પર ટ્રાન્ઝેક્શન મળ્યું નથી અને કોઈ મેળ ખાતું Osmosis ટ્રાન્ઝેક્શન પણ મળ્યું નથી. જો આ Wormchain રિસીવ હેશ હોય, તો ગાર્ડિયન કદાચ હજી સહી કરી રહ્યા હોય — એક મિનિટમાં ફરી પ્રયાસ કરો. અન્યથા, હેશ તપાસો.",
+      "noGatewayTransferInTx": "Wormholescan પર ટ્રાન્ઝેક્શન મળ્યું નથી અને આ Osmosis ટ્રાન્ઝેક્શનમાં કોઈ Wormhole ગેટવે IBC ટ્રાન્સફર મળ્યું નથી.",
+      "packetTimedOutRefunded": "આ ટ્રાન્સફર Wormchain સુધી પહોંચે તે પહેલાં સમય સમાપ્ત થઈ ગયો, તેથી {date} ના રોજ તે આપોઆપ તમારા Osmosis સરનામે પરત કરવામાં આવ્યું (tx {txHash}). રિડીમ કરવા માટે કંઈ નથી — ટોકન પહેલેથી જ તમારા વૉલેટમાં છે, અને તમે Wormhole પેજ પરથી ફરી બ્રિજ કરી શકો છો.",
+      "packetTimedOutRefundedNoDate": "આ ટ્રાન્સફર Wormchain સુધી પહોંચે તે પહેલાં સમય સમાપ્ત થઈ ગયો, તેથી તે આપોઆપ તમારા Osmosis સરનામે પરત કરવામાં આવ્યું (tx {txHash}). રિડીમ કરવા માટે કંઈ નથી — ટોકન પહેલેથી જ તમારા વૉલેટમાં છે, અને તમે Wormhole પેજ પરથી ફરી બ્રિજ કરી શકો છો.",
+      "packetReceivedButTxNotFound": "Osmosis પુષ્ટિ કરે છે કે આ પેકેટ Wormchain પર પ્રાપ્ત થયું હતું, પરંતુ રિસીવ ટ્રાન્ઝેક્શન શોધી શકાયું નથી. આ ટ્રાન્સફર સીધું Wormholescan પર જુઓ.",
+      "wormchainReceiveNotRelayedYet": "Osmosis સેન્ડ પેકેટ મળ્યું પરંતુ તેને અનુરૂપ Wormchain રિસીવ હજી રિલે થયું નથી. એક મિનિટમાં ફરી પ્રયાસ કરો.",
+      "vaaNotIndexedYet": "Wormchain રિસીવ ({txHash}) મળ્યું પરંતુ Wormholescan એ હજી તેના માટે VAA ઇન્ડેક્સ કર્યું નથી. ગાર્ડિયન કદાચ હજી સહી કરી રહ્યા હોય — એક મિનિટમાં ફરી પ્રયાસ કરો."
     }
   },
   "unknownError": "અજાણી ભૂલ",

--- a/packages/web/localizations/hi.json
+++ b/packages/web/localizations/hi.json
@@ -1097,7 +1097,18 @@
       "connectedNamedAccount": "कनेक्टेड {wallet} खाता",
       "confirmInNamed": "{wallet} में पुष्टि करें...",
       "submittingOnSui": "Sui पर सबमिट किया जा रहा है...",
-      "redeemOnSui": "Sui पर रिडीम करें"
+      "redeemOnSui": "Sui पर रिडीम करें",
+      "osmosisTxNotFound": "Osmosis ट्रांज़ैक्शन नहीं मिला। हैश जाँचें और सुनिश्चित करें कि यह Osmosis मेननेट पर ब्रॉडकास्ट हुआ था।",
+      "osmosisLcdUnavailable": "किसी भी LCD से Osmosis ट्रांज़ैक्शन प्राप्त नहीं किया जा सका: {error}",
+      "wormchainRpcUnavailable": "Wormchain RPC से क्वेरी नहीं की जा सकी: {error}",
+      "notAWormholeTx": "ट्रांज़ैक्शन नहीं मिला। सुनिश्चित करें कि यह एक Wormhole ब्रिज ट्रांज़ैक्शन हैश है।",
+      "notFoundOnWormholescanOrOsmosis": "Wormholescan पर ट्रांज़ैक्शन नहीं मिला और कोई मेल खाता Osmosis ट्रांज़ैक्शन भी नहीं मिला। यदि यह Wormchain रिसीव हैश है, तो हो सकता है गार्डियन अभी भी साइन कर रहे हों — एक मिनट में फिर कोशिश करें। अन्यथा, हैश जाँचें।",
+      "noGatewayTransferInTx": "Wormholescan पर ट्रांज़ैक्शन नहीं मिला और इस Osmosis ट्रांज़ैक्शन में कोई Wormhole गेटवे IBC ट्रांसफ़र नहीं मिला।",
+      "packetTimedOutRefunded": "यह ट्रांसफ़र Wormchain तक पहुँचने से पहले टाइम आउट हो गया, इसलिए {date} को यह अपने आप आपके Osmosis पते पर वापस कर दिया गया (tx {txHash})। रिडीम करने के लिए कुछ नहीं है — टोकन पहले से ही आपके वॉलेट में हैं, और आप Wormhole पेज से दोबारा ब्रिज कर सकते हैं।",
+      "packetTimedOutRefundedNoDate": "यह ट्रांसफ़र Wormchain तक पहुँचने से पहले टाइम आउट हो गया, इसलिए यह अपने आप आपके Osmosis पते पर वापस कर दिया गया (tx {txHash})। रिडीम करने के लिए कुछ नहीं है — टोकन पहले से ही आपके वॉलेट में हैं, और आप Wormhole पेज से दोबारा ब्रिज कर सकते हैं।",
+      "packetReceivedButTxNotFound": "Osmosis पुष्टि करता है कि यह पैकेट Wormchain पर प्राप्त हुआ था, लेकिन रिसीव ट्रांज़ैक्शन नहीं मिल सका। इस ट्रांसफ़र को सीधे Wormholescan पर देखें।",
+      "wormchainReceiveNotRelayedYet": "Osmosis सेंड पैकेट मिल गया लेकिन उससे संबंधित Wormchain रिसीव अभी तक रिले नहीं हुआ है। एक मिनट में फिर कोशिश करें।",
+      "vaaNotIndexedYet": "Wormchain रिसीव ({txHash}) मिल गया लेकिन Wormholescan ने अभी तक इसके लिए VAA इंडेक्स नहीं किया है। हो सकता है गार्डियन अभी भी साइन कर रहे हों — एक मिनट में फिर कोशिश करें।"
     }
   },
   "unknownError": "अज्ञात त्रुटि",

--- a/packages/web/localizations/ja.json
+++ b/packages/web/localizations/ja.json
@@ -1097,7 +1097,18 @@
       "connectedNamedAccount": "接続済みの {wallet} アカウント",
       "confirmInNamed": "{wallet} で確認してください...",
       "submittingOnSui": "Sui に送信しています...",
-      "redeemOnSui": "Sui で請求"
+      "redeemOnSui": "Sui で請求",
+      "osmosisTxNotFound": "Osmosis のトランザクションが見つかりません。ハッシュと、Osmosis メインネットでブロードキャストされたかを確認してください。",
+      "osmosisLcdUnavailable": "いずれの LCD からも Osmosis のトランザクションを取得できませんでした: {error}",
+      "wormchainRpcUnavailable": "Wormchain RPC に問い合わせできませんでした: {error}",
+      "notAWormholeTx": "トランザクションが見つかりません。Wormhole ブリッジのトランザクションハッシュであることを確認してください。",
+      "notFoundOnWormholescanOrOsmosis": "Wormholescan にトランザクションが見つからず、対応する Osmosis のトランザクションも見つかりませんでした。これが Wormchain の受信ハッシュの場合、ガーディアンがまだ署名中の可能性があります。1 分ほど待って再試行してください。そうでない場合は、ハッシュを確認してください。",
+      "noGatewayTransferInTx": "Wormholescan にトランザクションが見つからず、この Osmosis トランザクションには Wormhole ゲートウェイの IBC 送金が含まれていませんでした。",
+      "packetTimedOutRefunded": "この送金は Wormchain に到達する前にタイムアウトしたため、{date} に Osmosis アドレスへ自動的に返金されました (tx {txHash})。受け取るものはありません。トークンはすでにウォレットに戻っており、Wormhole ページから再度ブリッジできます。",
+      "packetTimedOutRefundedNoDate": "この送金は Wormchain に到達する前にタイムアウトしたため、Osmosis アドレスへ自動的に返金されました (tx {txHash})。受け取るものはありません。トークンはすでにウォレットに戻っており、Wormhole ページから再度ブリッジできます。",
+      "packetReceivedButTxNotFound": "Osmosis はこのパケットが Wormchain で受信されたことを確認していますが、受信トランザクションを特定できませんでした。この送金を Wormholescan で直接確認してください。",
+      "wormchainReceiveNotRelayedYet": "Osmosis の送信パケットは見つかりましたが、対応する Wormchain の受信がまだリレーされていません。1 分ほど待って再試行してください。",
+      "vaaNotIndexedYet": "Wormchain の受信 ({txHash}) は見つかりましたが、Wormholescan がまだ VAA をインデックスしていません。ガーディアンがまだ署名中の可能性があります。1 分ほど待って再試行してください。"
     }
   },
   "unknownError": "不明なエラー",

--- a/packages/web/localizations/ko.json
+++ b/packages/web/localizations/ko.json
@@ -1097,7 +1097,18 @@
       "connectedNamedAccount": "연결된 {wallet} 계정",
       "confirmInNamed": "{wallet}에서 확인하세요...",
       "submittingOnSui": "Sui에서 제출하는 중...",
-      "redeemOnSui": "Sui에서 청구"
+      "redeemOnSui": "Sui에서 청구",
+      "osmosisTxNotFound": "Osmosis 트랜잭션을 찾을 수 없습니다. 해시를 확인하고 Osmosis 메인넷에 브로드캐스트되었는지 확인하세요.",
+      "osmosisLcdUnavailable": "어떤 LCD에서도 Osmosis 트랜잭션을 가져오지 못했습니다: {error}",
+      "wormchainRpcUnavailable": "Wormchain RPC를 조회하지 못했습니다: {error}",
+      "notAWormholeTx": "트랜잭션을 찾을 수 없습니다. Wormhole 브리지 트랜잭션 해시가 맞는지 확인하세요.",
+      "notFoundOnWormholescanOrOsmosis": "Wormholescan에서 트랜잭션을 찾지 못했고 일치하는 Osmosis 트랜잭션도 찾지 못했습니다. 이것이 Wormchain 수신 해시라면 가디언이 아직 서명 중일 수 있습니다. 1분 후에 다시 시도하세요. 그렇지 않다면 해시를 다시 확인하세요.",
+      "noGatewayTransferInTx": "Wormholescan에서 트랜잭션을 찾지 못했고 이 Osmosis 트랜잭션에서 Wormhole 게이트웨이 IBC 전송을 찾지 못했습니다.",
+      "packetTimedOutRefunded": "이 전송은 Wormchain에 도달하기 전에 시간이 초과되어 {date}에 Osmosis 주소로 자동 환불되었습니다 (tx {txHash}). 청구할 것이 없습니다. 토큰은 이미 지갑에 돌아와 있으며 Wormhole 페이지에서 다시 브리지할 수 있습니다.",
+      "packetTimedOutRefundedNoDate": "이 전송은 Wormchain에 도달하기 전에 시간이 초과되어 Osmosis 주소로 자동 환불되었습니다 (tx {txHash}). 청구할 것이 없습니다. 토큰은 이미 지갑에 돌아와 있으며 Wormhole 페이지에서 다시 브리지할 수 있습니다.",
+      "packetReceivedButTxNotFound": "Osmosis는 이 패킷이 Wormchain에서 수신되었음을 확인했지만 수신 트랜잭션을 찾을 수 없습니다. Wormholescan에서 이 전송을 직접 조회하세요.",
+      "wormchainReceiveNotRelayedYet": "Osmosis 전송 패킷을 찾았지만 해당하는 Wormchain 수신이 아직 릴레이되지 않았습니다. 1분 후에 다시 시도하세요.",
+      "vaaNotIndexedYet": "Wormchain 수신 ({txHash})을 찾았지만 Wormholescan이 아직 VAA를 인덱싱하지 않았습니다. 가디언이 아직 서명 중일 수 있습니다. 1분 후에 다시 시도하세요."
     }
   },
   "unknownError": "알 수 없는 에러",

--- a/packages/web/localizations/pl.json
+++ b/packages/web/localizations/pl.json
@@ -1097,7 +1097,18 @@
       "connectedNamedAccount": "Połączone konto {wallet}",
       "confirmInNamed": "Potwierdź w {wallet}...",
       "submittingOnSui": "Wysyłanie na Sui...",
-      "redeemOnSui": "Odbierz na Sui"
+      "redeemOnSui": "Odbierz na Sui",
+      "osmosisTxNotFound": "Nie znaleziono transakcji Osmosis. Sprawdź hash i upewnij się, że została rozgłoszona w sieci głównej Osmosis.",
+      "osmosisLcdUnavailable": "Nie udało się pobrać transakcji Osmosis z żadnego LCD: {error}",
+      "wormchainRpcUnavailable": "Nie udało się odpytać RPC Wormchain: {error}",
+      "notAWormholeTx": "Nie znaleziono transakcji. Upewnij się, że to hash transakcji mostu Wormhole.",
+      "notFoundOnWormholescanOrOsmosis": "Nie znaleziono transakcji w Wormholescan ani odpowiadającej jej transakcji Osmosis. Jeśli to hash odbioru Wormchain, strażnicy mogą wciąż podpisywać — spróbuj ponownie za minutę. W przeciwnym razie sprawdź hash.",
+      "noGatewayTransferInTx": "Nie znaleziono transakcji w Wormholescan, a w tej transakcji Osmosis nie znaleziono transferu IBC przez bramę Wormhole.",
+      "packetTimedOutRefunded": "Ten transfer wygasł, zanim dotarł do Wormchain, więc {date} został automatycznie zwrócony na Twój adres Osmosis (tx {txHash}). Nie ma nic do odebrania — tokeny są już z powrotem w Twoim portfelu, a transfer możesz ponowić ze strony Wormhole.",
+      "packetTimedOutRefundedNoDate": "Ten transfer wygasł, zanim dotarł do Wormchain, więc został automatycznie zwrócony na Twój adres Osmosis (tx {txHash}). Nie ma nic do odebrania — tokeny są już z powrotem w Twoim portfelu, a transfer możesz ponowić ze strony Wormhole.",
+      "packetReceivedButTxNotFound": "Osmosis potwierdza, że ten pakiet został odebrany w Wormchain, ale nie udało się znaleźć transakcji odbioru. Sprawdź ten transfer bezpośrednio w Wormholescan.",
+      "wormchainReceiveNotRelayedYet": "Znaleziono pakiet wysyłki Osmosis, ale odpowiadający mu odbiór w Wormchain nie został jeszcze przekazany. Spróbuj ponownie za minutę.",
+      "vaaNotIndexedYet": "Znaleziono odbiór Wormchain ({txHash}), ale Wormholescan nie zaindeksował jeszcze dla niego VAA. Strażnicy mogą wciąż podpisywać — spróbuj ponownie za minutę."
     }
   },
   "unknownError": "Nieznany błąd",

--- a/packages/web/localizations/pt-br.json
+++ b/packages/web/localizations/pt-br.json
@@ -1097,7 +1097,18 @@
       "connectedNamedAccount": "Conta {wallet} conectada",
       "confirmInNamed": "Confirme na {wallet}...",
       "submittingOnSui": "Enviando na Sui...",
-      "redeemOnSui": "Resgatar na Sui"
+      "redeemOnSui": "Resgatar na Sui",
+      "osmosisTxNotFound": "Transação Osmosis não encontrada. Verifique o hash e se ela foi transmitida na mainnet da Osmosis.",
+      "osmosisLcdUnavailable": "Não foi possível buscar a transação Osmosis em nenhum LCD: {error}",
+      "wormchainRpcUnavailable": "Não foi possível consultar o RPC da Wormchain: {error}",
+      "notAWormholeTx": "Transação não encontrada. Verifique se este é um hash de transação da ponte Wormhole.",
+      "notFoundOnWormholescanOrOsmosis": "Transação não encontrada no Wormholescan e nenhuma transação Osmosis correspondente foi localizada. Se este for um hash de recebimento da Wormchain, os guardiões podem ainda estar assinando — tente novamente em um minuto. Caso contrário, verifique o hash.",
+      "noGatewayTransferInTx": "Transação não encontrada no Wormholescan e nenhuma transferência IBC pelo gateway da Wormhole foi encontrada nesta transação Osmosis.",
+      "packetTimedOutRefunded": "Esta transferência expirou antes de chegar à Wormchain, então foi reembolsada automaticamente para o seu endereço Osmosis em {date} (tx {txHash}). Não há nada a resgatar — os tokens já estão de volta na sua carteira, e você pode fazer a ponte novamente pela página da Wormhole.",
+      "packetTimedOutRefundedNoDate": "Esta transferência expirou antes de chegar à Wormchain, então foi reembolsada automaticamente para o seu endereço Osmosis (tx {txHash}). Não há nada a resgatar — os tokens já estão de volta na sua carteira, e você pode fazer a ponte novamente pela página da Wormhole.",
+      "packetReceivedButTxNotFound": "A Osmosis confirma que este pacote foi recebido na Wormchain, mas a transação de recebimento não pôde ser localizada. Consulte esta transferência diretamente no Wormholescan.",
+      "wormchainReceiveNotRelayedYet": "O pacote de envio da Osmosis foi encontrado, mas o recebimento correspondente na Wormchain ainda não foi retransmitido. Tente novamente em um minuto.",
+      "vaaNotIndexedYet": "O recebimento na Wormchain ({txHash}) foi encontrado, mas o Wormholescan ainda não indexou um VAA para ele. Os guardiões podem ainda estar assinando — tente novamente em um minuto."
     }
   },
   "unknownError": "Erro desconhecido",

--- a/packages/web/localizations/ro.json
+++ b/packages/web/localizations/ro.json
@@ -1097,7 +1097,18 @@
       "connectedNamedAccount": "Cont {wallet} conectat",
       "confirmInNamed": "Confirmă în {wallet}...",
       "submittingOnSui": "Se trimite pe Sui...",
-      "redeemOnSui": "Revendică pe Sui"
+      "redeemOnSui": "Revendică pe Sui",
+      "osmosisTxNotFound": "Tranzacția Osmosis nu a fost găsită. Verifică hash-ul și dacă a fost transmisă în mainnet-ul Osmosis.",
+      "osmosisLcdUnavailable": "Nu s-a putut prelua tranzacția Osmosis de la niciun LCD: {error}",
+      "wormchainRpcUnavailable": "Nu s-a putut interoga RPC-ul Wormchain: {error}",
+      "notAWormholeTx": "Tranzacția nu a fost găsită. Asigură-te că acesta este un hash de tranzacție al punții Wormhole.",
+      "notFoundOnWormholescanOrOsmosis": "Tranzacția nu a fost găsită pe Wormholescan și nicio tranzacție Osmosis corespunzătoare nu a fost localizată. Dacă acesta este un hash de recepție Wormchain, gardienii ar putea încă semna — încearcă din nou într-un minut. În caz contrar, verifică hash-ul.",
+      "noGatewayTransferInTx": "Tranzacția nu a fost găsită pe Wormholescan și nu s-a găsit niciun transfer IBC prin gateway-ul Wormhole în această tranzacție Osmosis.",
+      "packetTimedOutRefunded": "Acest transfer a expirat înainte de a ajunge la Wormchain, așa că a fost rambursat automat în adresa ta Osmosis pe {date} (tx {txHash}). Nu ai ce revendica — tokenurile sunt deja înapoi în portofel, iar transferul poate fi reluat din pagina Wormhole.",
+      "packetTimedOutRefundedNoDate": "Acest transfer a expirat înainte de a ajunge la Wormchain, așa că a fost rambursat automat în adresa ta Osmosis (tx {txHash}). Nu ai ce revendica — tokenurile sunt deja înapoi în portofel, iar transferul poate fi reluat din pagina Wormhole.",
+      "packetReceivedButTxNotFound": "Osmosis confirmă că acest pachet a fost primit pe Wormchain, dar tranzacția de recepție nu a putut fi localizată. Caută acest transfer direct pe Wormholescan.",
+      "wormchainReceiveNotRelayedYet": "Pachetul de trimitere Osmosis a fost găsit, dar recepția corespunzătoare pe Wormchain nu a fost încă retransmisă. Încearcă din nou într-un minut.",
+      "vaaNotIndexedYet": "Recepția Wormchain ({txHash}) a fost găsită, dar Wormholescan nu a indexat încă un VAA pentru ea. Gardienii ar putea încă semna — încearcă din nou într-un minut."
     }
   },
   "unknownError": "Eroare necunoscuta",

--- a/packages/web/localizations/ru.json
+++ b/packages/web/localizations/ru.json
@@ -1097,7 +1097,18 @@
       "connectedNamedAccount": "Подключённый аккаунт {wallet}",
       "confirmInNamed": "Подтвердите в {wallet}...",
       "submittingOnSui": "Отправка в Sui...",
-      "redeemOnSui": "Получить в Sui"
+      "redeemOnSui": "Получить в Sui",
+      "osmosisTxNotFound": "Транзакция Osmosis не найдена. Проверьте хеш и то, что она была отправлена в основной сети Osmosis.",
+      "osmosisLcdUnavailable": "Не удалось получить транзакцию Osmosis ни с одного LCD: {error}",
+      "wormchainRpcUnavailable": "Не удалось выполнить запрос к RPC Wormchain: {error}",
+      "notAWormholeTx": "Транзакция не найдена. Убедитесь, что это хеш транзакции моста Wormhole.",
+      "notFoundOnWormholescanOrOsmosis": "Транзакция не найдена на Wormholescan, и соответствующая транзакция Osmosis также не обнаружена. Если это хеш получения Wormchain, хранители, возможно, ещё подписывают — попробуйте снова через минуту. В противном случае проверьте хеш.",
+      "noGatewayTransferInTx": "Транзакция не найдена на Wormholescan, и в этой транзакции Osmosis не обнаружен IBC-перевод через шлюз Wormhole.",
+      "packetTimedOutRefunded": "Этот перевод истёк по времени, не достигнув Wormchain, поэтому {date} он был автоматически возвращён на ваш адрес Osmosis (tx {txHash}). Получать нечего — токены уже вернулись в ваш кошелёк, и вы можете повторить перевод на странице Wormhole.",
+      "packetTimedOutRefundedNoDate": "Этот перевод истёк по времени, не достигнув Wormchain, поэтому он был автоматически возвращён на ваш адрес Osmosis (tx {txHash}). Получать нечего — токены уже вернулись в ваш кошелёк, и вы можете повторить перевод на странице Wormhole.",
+      "packetReceivedButTxNotFound": "Osmosis подтверждает, что этот пакет был получен в Wormchain, но найти транзакцию получения не удалось. Посмотрите этот перевод напрямую на Wormholescan.",
+      "wormchainReceiveNotRelayedYet": "Пакет отправки Osmosis найден, но соответствующее получение в Wormchain ещё не ретранслировано. Попробуйте снова через минуту.",
+      "vaaNotIndexedYet": "Получение в Wormchain ({txHash}) найдено, но Wormholescan ещё не проиндексировал VAA для него. Хранители, возможно, ещё подписывают — попробуйте снова через минуту."
     }
   },
   "unknownError": "Неизвестная ошибка",

--- a/packages/web/localizations/tr.json
+++ b/packages/web/localizations/tr.json
@@ -1097,7 +1097,18 @@
       "connectedNamedAccount": "Bağlı {wallet} hesabı",
       "confirmInNamed": "{wallet} içinde onaylayın...",
       "submittingOnSui": "Sui üzerinde gönderiliyor...",
-      "redeemOnSui": "Sui üzerinde geri al"
+      "redeemOnSui": "Sui üzerinde geri al",
+      "osmosisTxNotFound": "Osmosis işlemi bulunamadı. Hash'i ve işlemin Osmosis ana ağında yayınlandığını kontrol edin.",
+      "osmosisLcdUnavailable": "Osmosis işlemi hiçbir LCD'den alınamadı: {error}",
+      "wormchainRpcUnavailable": "Wormchain RPC sorgulanamadı: {error}",
+      "notAWormholeTx": "İşlem bulunamadı. Bunun bir Wormhole köprü işlemi hash'i olduğundan emin olun.",
+      "notFoundOnWormholescanOrOsmosis": "İşlem Wormholescan'de bulunamadı ve eşleşen bir Osmosis işlemi de tespit edilemedi. Bu bir Wormchain alım hash'i ise muhafızlar hâlâ imzalıyor olabilir — bir dakika sonra tekrar deneyin. Aksi hâlde hash'i kontrol edin.",
+      "noGatewayTransferInTx": "İşlem Wormholescan'de bulunamadı ve bu Osmosis işleminde Wormhole ağ geçidi IBC transferi bulunamadı.",
+      "packetTimedOutRefunded": "Bu transfer Wormchain'e ulaşmadan zaman aşımına uğradı ve {date} tarihinde Osmosis adresinize otomatik olarak iade edildi (tx {txHash}). Talep edilecek bir şey yok — tokenlar zaten cüzdanınızda ve Wormhole sayfasından yeniden köprüleme yapabilirsiniz.",
+      "packetTimedOutRefundedNoDate": "Bu transfer Wormchain'e ulaşmadan zaman aşımına uğradı ve Osmosis adresinize otomatik olarak iade edildi (tx {txHash}). Talep edilecek bir şey yok — tokenlar zaten cüzdanınızda ve Wormhole sayfasından yeniden köprüleme yapabilirsiniz.",
+      "packetReceivedButTxNotFound": "Osmosis bu paketin Wormchain'de alındığını doğruluyor, ancak alım işlemi bulunamadı. Bu transferi doğrudan Wormholescan'de arayın.",
+      "wormchainReceiveNotRelayedYet": "Osmosis gönderim paketi bulundu ancak buna karşılık gelen Wormchain alımı henüz aktarılmadı. Bir dakika sonra tekrar deneyin.",
+      "vaaNotIndexedYet": "Wormchain alımı ({txHash}) bulundu ancak Wormholescan bunun için henüz bir VAA indekslemedi. Muhafızlar hâlâ imzalıyor olabilir — bir dakika sonra tekrar deneyin."
     }
   },
   "unknownError": "Bilinmeyen hata",

--- a/packages/web/localizations/zh-cn.json
+++ b/packages/web/localizations/zh-cn.json
@@ -1097,7 +1097,18 @@
       "connectedNamedAccount": "已连接的 {wallet} 账户",
       "confirmInNamed": "请在 {wallet} 中确认...",
       "submittingOnSui": "正在 Sui 上提交...",
-      "redeemOnSui": "在 Sui 上领取"
+      "redeemOnSui": "在 Sui 上领取",
+      "osmosisTxNotFound": "未找到 Osmosis 交易。请核对哈希，并确认它已在 Osmosis 主网广播。",
+      "osmosisLcdUnavailable": "无法从任何 LCD 获取 Osmosis 交易：{error}",
+      "wormchainRpcUnavailable": "无法查询 Wormchain RPC：{error}",
+      "notAWormholeTx": "未找到交易。请确认这是 Wormhole 跨链桥交易哈希。",
+      "notFoundOnWormholescanOrOsmosis": "在 Wormholescan 上未找到该交易，也未找到匹配的 Osmosis 交易。如果这是 Wormchain 接收哈希，守护者可能仍在签名——请一分钟后重试。否则，请核对哈希。",
+      "noGatewayTransferInTx": "在 Wormholescan 上未找到该交易，且此 Osmosis 交易中未找到 Wormhole 网关 IBC 转账。",
+      "packetTimedOutRefunded": "此转账在到达 Wormchain 之前已超时，因此已于 {date} 自动退回至您的 Osmosis 地址（交易 {txHash}）。无需赎回——代币已回到您的钱包，您可以在 Wormhole 页面重新发起跨链。",
+      "packetTimedOutRefundedNoDate": "此转账在到达 Wormchain 之前已超时，因此已自动退回至您的 Osmosis 地址（交易 {txHash}）。无需赎回——代币已回到您的钱包，您可以在 Wormhole 页面重新发起跨链。",
+      "packetReceivedButTxNotFound": "Osmosis 确认此数据包已在 Wormchain 上被接收，但无法找到接收交易。请直接在 Wormholescan 上查询此转账。",
+      "wormchainReceiveNotRelayedYet": "已找到 Osmosis 发送数据包，但相应的 Wormchain 接收尚未中继。请一分钟后重试。",
+      "vaaNotIndexedYet": "已找到 Wormchain 接收（{txHash}），但 Wormholescan 尚未为其索引 VAA。守护者可能仍在签名——请一分钟后重试。"
     }
   },
   "unknownError": "未知错误",

--- a/packages/web/localizations/zh-hk.json
+++ b/packages/web/localizations/zh-hk.json
@@ -1097,7 +1097,18 @@
       "connectedNamedAccount": "已連接的 {wallet} 帳戶",
       "confirmInNamed": "請在 {wallet} 中確認...",
       "submittingOnSui": "正在 Sui 上提交...",
-      "redeemOnSui": "在 Sui 上領取"
+      "redeemOnSui": "在 Sui 上領取",
+      "osmosisTxNotFound": "找不到 Osmosis 交易。請核對雜湊，並確認已在 Osmosis 主網廣播。",
+      "osmosisLcdUnavailable": "無法從任何 LCD 取得 Osmosis 交易：{error}",
+      "wormchainRpcUnavailable": "無法查詢 Wormchain RPC：{error}",
+      "notAWormholeTx": "找不到交易。請確認這是 Wormhole 跨鏈橋交易雜湊。",
+      "notFoundOnWormholescanOrOsmosis": "在 Wormholescan 上找不到該交易，亦找不到相符的 Osmosis 交易。如果這是 Wormchain 接收雜湊，守護者可能仍在簽署——請一分鐘後再試。否則，請核對雜湊。",
+      "noGatewayTransferInTx": "在 Wormholescan 上找不到該交易，且此 Osmosis 交易中找不到 Wormhole 閘道 IBC 轉帳。",
+      "packetTimedOutRefunded": "此轉帳在到達 Wormchain 之前已逾時，因此已於 {date} 自動退回至你的 Osmosis 地址（交易 {txHash}）。無需贖回——代幣已回到你的錢包，你可以在 Wormhole 頁面重新發起跨鏈。",
+      "packetTimedOutRefundedNoDate": "此轉帳在到達 Wormchain 之前已逾時，因此已自動退回至你的 Osmosis 地址（交易 {txHash}）。無需贖回——代幣已回到你的錢包，你可以在 Wormhole 頁面重新發起跨鏈。",
+      "packetReceivedButTxNotFound": "Osmosis 確認此封包已在 Wormchain 上接收，但找不到接收交易。請直接在 Wormholescan 上查詢此轉帳。",
+      "wormchainReceiveNotRelayedYet": "已找到 Osmosis 傳送封包，但對應的 Wormchain 接收尚未中繼。請一分鐘後再試。",
+      "vaaNotIndexedYet": "已找到 Wormchain 接收（{txHash}），但 Wormholescan 尚未為其建立 VAA 索引。守護者可能仍在簽署——請一分鐘後再試。"
     }
   },
   "unknownError": "未知錯誤",

--- a/packages/web/localizations/zh-tw.json
+++ b/packages/web/localizations/zh-tw.json
@@ -1097,7 +1097,18 @@
       "connectedNamedAccount": "已連接的 {wallet} 帳戶",
       "confirmInNamed": "請在 {wallet} 中確認...",
       "submittingOnSui": "正在 Sui 上提交...",
-      "redeemOnSui": "在 Sui 上領取"
+      "redeemOnSui": "在 Sui 上領取",
+      "osmosisTxNotFound": "找不到 Osmosis 交易。請核對雜湊，並確認已在 Osmosis 主網廣播。",
+      "osmosisLcdUnavailable": "無法從任何 LCD 取得 Osmosis 交易：{error}",
+      "wormchainRpcUnavailable": "無法查詢 Wormchain RPC：{error}",
+      "notAWormholeTx": "找不到交易。請確認這是 Wormhole 跨鏈橋交易雜湊。",
+      "notFoundOnWormholescanOrOsmosis": "在 Wormholescan 上找不到該交易，也找不到相符的 Osmosis 交易。如果這是 Wormchain 接收雜湊，守護者可能仍在簽署——請一分鐘後再試。否則，請核對雜湊。",
+      "noGatewayTransferInTx": "在 Wormholescan 上找不到該交易，且此 Osmosis 交易中找不到 Wormhole 閘道 IBC 轉帳。",
+      "packetTimedOutRefunded": "此轉帳在到達 Wormchain 之前已逾時，因此已於 {date} 自動退回至您的 Osmosis 地址（交易 {txHash}）。無需贖回——代幣已回到您的錢包，您可以在 Wormhole 頁面重新發起跨鏈。",
+      "packetTimedOutRefundedNoDate": "此轉帳在到達 Wormchain 之前已逾時，因此已自動退回至您的 Osmosis 地址（交易 {txHash}）。無需贖回——代幣已回到您的錢包，您可以在 Wormhole 頁面重新發起跨鏈。",
+      "packetReceivedButTxNotFound": "Osmosis 確認此封包已在 Wormchain 上接收，但找不到接收交易。請直接在 Wormholescan 上查詢此轉帳。",
+      "wormchainReceiveNotRelayedYet": "已找到 Osmosis 傳送封包，但對應的 Wormchain 接收尚未中繼。請一分鐘後再試。",
+      "vaaNotIndexedYet": "已找到 Wormchain 接收（{txHash}），但 Wormholescan 尚未為其建立 VAA 索引。守護者可能仍在簽署——請一分鐘後再試。"
     }
   },
   "unknownError": "未知錯誤",


### PR DESCRIPTION
## What is the purpose of the change:

The `/wormhole` recovery widget told every user with no Wormchain receive to "try again in a minute". That is only true while the packet is still in flight — a packet that timed out was refunded and will never be relayed, so a real support case was told to wait for money that had been back in their wallet for three days. Osmosis can tell the cases apart, so we now ask it before choosing what to say.

Full investigation, evidence and the rejected RPC hypothesis are in the Linear issue.

### Linear Task

[MTN-257](https://linear.app/osmosis/issue/MTN-257/wormhole-recovery-widget-tells-users-to-wait-for-packets-that-timed)

## Brief Changelog

- Add `checkOsmosisPacketFate`, which reads the IBC packet commitment and, once cleared, looks for the timeout tx to tell in-flight from timed-out from acknowledged. Diagnostic only: every failure path degrades to `unknown` and falls back to today's neutral copy, so it can never turn a recoverable transfer into a hard error.
- Branch the `resolveOperation` error three ways. The timed-out case names the refund date and tx and tells the user to bridge again rather than wait.
- Stop trusting a single provider's empty answer, in both `findWormchainRecvTx` and the timeout search: an empty result is non-authoritative, and we conclude "not found" only once every reachable provider agrees. A pruned or lagging node could otherwise manufacture a false verdict.
- Localize all ten thrown error messages into `transfer.wormholeRedeem` across 17 locales. The widget was localized everywhere except its error states, so a non-English user dropped into English the moment anything failed.
- Replace a `err.message.startsWith(...)` check with a typed `OsmosisTxNotFoundError`, which the localization above would otherwise have silently broken in all 16 non-English locales.

## Testing and Verifying

Manually verified on the preview deployment: pasting the real incident hash `A1F5976E6479FFA518005C4B1A482FACD7C6FCCF82398568BD2609239C283FD7` into `/wormhole` now returns

> This transfer timed out before it reached Wormchain, so it was automatically refunded to your Osmosis address on 9 August 2026 (tx 9488C169…). There is nothing to redeem — the tokens are already back in your wallet, and you can bridge again from the Wormhole page.

in place of the old "try again in a minute". The date follows the viewer's locale rather than a hardcoded format.

42 unit tests pass (`components/bridge/__tests__/wormhole-redeem.spec.tsx`), including a regression case pinned to the real incident and an assertion tying the message to its translation key so it cannot be quietly re-hardcoded. Lint, format and typecheck are clean on the changed files, and CI is green. All 17 locales were checked programmatically for key presence and matching `{placeholder}` sets, so no message can lose its tx hash or date in translation.

Two known gaps: the `acknowledged` branch is covered by mocked tests only, as there is no live example of an acked packet our Wormchain lookup misses; and the 16 non-English translations are model-produced and unreviewed by native speakers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
