### PR TITLE
fix(e2e): repair the failing scheduled monitoring jobs

### DIFF
--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -286,8 +286,8 @@ suite, so their USDC floor is lower:
 
 | Token | Min (US) | Warn (US) | Min (EU/SG) | Warn (EU/SG) | Unit | Used By |
 |-------|----------|-----------|-------------|--------------|------|---------|
-| USDC | 2.9 | 5.5 | 1.2 | 2.3 | token | market buys ($0.55 x2) + limit buy ($0.52) + swap stables (1.10) |
-| OSMO | $1.20 | $2.40 | $1.20 | $2.40 | USD | market sell + limit sell OSMO ($0.54 each) + gas |
+| USDC | 3.5 | 6.6 | 1.2 | 2.3 | token | market buys ($0.55 x2) + limit buy ($1.10) + swap stables (1.10) |
+| OSMO | $1.80 | $3.60 | $1.20 | $2.40 | USD | market sell ($0.54) + limit sell ($1.10) OSMO + gas |
 | BTC | $0.60 | $1.50 | $0.60 | $1.50 | USD | market sell BTC (~$0.54) |
 | USDC.eth.axl | 1 | 2 | 1 | 2 | token | swap stables |
 | USDT | 1 | 1.2 | 1 | 1.2 | token | swap stables |

--- a/packages/e2e/pages/keplr-helper.ts
+++ b/packages/e2e/pages/keplr-helper.ts
@@ -71,7 +71,9 @@ export async function openKeplrPopupDirect(
  *   1. Check `context.pages()` for an already-open Keplr popup (handles
  *      fast-opening popups when the helper is called after the click).
  *   2. `context.waitForEvent("page")` (headed mode on macOS).
- *   3. Direct `chrome-extension://` navigation (headless Linux fallback).
+ *   3. Re-scan `context.pages()` once that wait times out, since the predicate
+ *      can miss a popup whose URL was not set yet when the event fired.
+ *   4. Direct `chrome-extension://` navigation (headless Linux fallback).
  *
  * Returns null if no popup could be obtained.
  *
@@ -99,6 +101,19 @@ export async function getKeplrPopupPage(
     });
   } catch {
     console.log("Keplr popup did not appear as a page event.");
+  }
+
+  // The page event can fire before the popup has navigated, so the predicate
+  // gets an empty URL and rejects a real sign popup; Playwright tests the
+  // predicate once per event and never re-checks. Loosening it is not the fix —
+  // Keplr's self-opened `register.html` tabs are equally URL-less at that
+  // moment, which is exactly what the predicate is there to reject. By the time
+  // the wait has timed out the navigation has committed, so a re-scan is
+  // unambiguous.
+  const late = context.pages().find(isKeplrPopupPage);
+  if (late) {
+    console.log(`Found Keplr popup on re-scan after timeout: ${late.url()}`);
+    return late;
   }
 
   // Headless-only by design. Bare `popup.html` renders Keplr Home whether or not
@@ -150,7 +165,8 @@ const hasApproveButton = (p: Page) =>
  * So when the direct-navigation fallback beats a slow sign popup, reloading it
  * just yields Home again — the only useful move is to go find the real popup.
  * Prefers an already-open popup showing Approve. Failing that, returns the next
- * Keplr popup to arrive as a page event without re-checking it: this is only
+ * Keplr popup to arrive as a page event — or, if that wait times out, one found
+ * by re-scanning afterwards — without re-checking it: this is only
  * called once the current popup has already failed, so any other popup is at
  * worst an equal starting point, and the retry loop re-tests Approve anyway.
  * Callers must not treat the result as guaranteed to be a sign request.
@@ -174,8 +190,20 @@ async function reacquireSignPopup(
       predicate: isKeplrPopupPage,
     })
     .catch(() => null);
-  if (arrived) console.log("Sign popup arrived late as a page event.");
-  return arrived;
+  if (arrived) {
+    console.log("Sign popup arrived late as a page event.");
+    return arrived;
+  }
+
+  // Same blind spot as `getKeplrPopupPage`, and it bites hardest here: the scan
+  // at the top of the next call would catch a popup this wait rejected, but only
+  // while a next attempt remains. On the final re-acquisition there is none, so
+  // the miss costs the whole spec.
+  const late = context
+    .pages()
+    .find((p) => p !== current && !p.isClosed() && isKeplrPopupPage(p));
+  if (late) console.log(`Re-acquired Keplr popup on re-scan: ${late.url()}`);
+  return late ?? null;
 }
 
 /**

--- a/packages/e2e/pages/keplr-helper.ts
+++ b/packages/e2e/pages/keplr-helper.ts
@@ -37,6 +37,10 @@ export async function getKeplrExtensionId(
   return null;
 }
 
+/** True for any Keplr popup page — including Home, which is not a sign request. */
+export const isKeplrPopupPage = (p: Page) =>
+  p.url().includes("chrome-extension://") && p.url().includes("/popup.html");
+
 /**
  * Opens the Keplr extension popup directly via chrome-extension:// URL.
  *
@@ -44,6 +48,9 @@ export async function getKeplrExtensionId(
  * `context.waitForEvent("page")`. In headless mode on Linux these popups
  * often don't fire that event. This function opens the popup page manually
  * so the pending approval request can be acted on.
+ *
+ * Only meaningful when an approval is actually pending: with no queued request
+ * this URL renders Keplr Home, which has no Approve button.
  */
 export async function openKeplrPopupDirect(
   context: BrowserContext,
@@ -77,26 +84,36 @@ export async function getKeplrPopupPage(
 ): Promise<Page | null> {
   const { timeout = 15_000 } = opts;
 
-  const existing = context
-    .pages()
-    .find(
-      (p) =>
-        p.url().includes("chrome-extension://") &&
-        p.url().includes("/popup.html")
-    );
+  const existing = context.pages().find(isKeplrPopupPage);
   if (existing) {
     console.log(`Found already-open Keplr popup: ${existing.url()}`);
     return existing;
   }
 
   try {
-    return await context.waitForEvent("page", { timeout });
+    // The predicate matters: Keplr re-opens `register.html` tabs of its own
+    // accord, and an unfiltered wait hands one back as though it were the popup.
+    return await context.waitForEvent("page", {
+      timeout,
+      predicate: isKeplrPopupPage,
+    });
   } catch {
-    console.log(
-      "Keplr popup did not appear as page event; trying direct navigation."
-    );
+    console.log("Keplr popup did not appear as a page event.");
   }
 
+  // Headless-only by design. Bare `popup.html` renders Keplr Home whether or not
+  // a request is pending, so in headed mode this fallback manufactures a popup
+  // with no Approve button and hides the real one — a slow sign popup becomes a
+  // hard failure. Headed Chrome fires the page event reliably, so if we got here
+  // without one, there is genuinely no approval to act on.
+  if (process.env.HEADLESS !== "true") {
+    console.log(
+      "Headed mode: no Keplr popup appeared, treating as no approval needed."
+    );
+    return null;
+  }
+
+  console.log("Headless mode: trying direct navigation.");
   const extensionId = await getKeplrExtensionId(context);
   if (extensionId) {
     try {
@@ -114,6 +131,48 @@ export async function getKeplrPopupPage(
 // step that actually timed out (popup load vs Approve button).
 const APPROVE_LOAD_TIMEOUT_MS = 10_000;
 const APPROVE_BUTTON_TIMEOUT_MS = 10_000;
+// Short window to catch a genuine sign popup that lost the race to the
+// direct-navigation fallback. Kept well under the per-attempt budgets so a
+// re-acquisition attempt cannot dominate the retry loop.
+const REACQUIRE_TIMEOUT_MS = 5_000;
+
+/** Non-blocking probe: is this page currently showing a sign request? */
+const hasApproveButton = (p: Page) =>
+  p
+    .getByRole("button", { name: "Approve" })
+    .isVisible()
+    .catch(() => false);
+
+/**
+ * Finds a Keplr popup that is actually showing a sign request.
+ *
+ * Bare `popup.html` renders Keplr Home, which never grows an "Approve" button.
+ * So when the direct-navigation fallback beats a slow sign popup, reloading it
+ * just yields Home again — the only useful move is to go find the real popup.
+ * Prefers an already-open popup showing Approve, then waits briefly for one to
+ * arrive as a page event. Returns null if neither turns up.
+ */
+async function reacquireSignPopup(
+  context: BrowserContext,
+  current: Page
+): Promise<Page | null> {
+  for (const p of context.pages()) {
+    if (p === current || p.isClosed() || !isKeplrPopupPage(p)) continue;
+    if (await hasApproveButton(p)) {
+      console.log("Re-acquired an open Keplr popup showing a sign request.");
+      return p;
+    }
+  }
+
+  const arrived = await context
+    .waitForEvent("page", {
+      timeout: REACQUIRE_TIMEOUT_MS,
+      predicate: isKeplrPopupPage,
+    })
+    .catch(() => null);
+  if (arrived) console.log("Sign popup arrived late as a page event.");
+  return arrived;
+}
 
 /**
  * Waits for a Keplr approval popup and clicks "Approve".
@@ -139,9 +198,6 @@ export async function waitForKeplrApproval(
   opts: { timeout?: number; attempts?: number } = {}
 ): Promise<Page | null> {
   const { timeout = 15_000, attempts = 3 } = opts;
-
-  const isPopup = (p: Page) =>
-    p.url().includes("chrome-extension://") && p.url().includes("/popup.html");
 
   // A null result here means no approval popup ever appeared (1CT /
   // pre-approved) — a no-op success, not a failure.
@@ -190,14 +246,18 @@ export async function waitForKeplrApproval(
     );
 
     if (attempt < attempts) {
-      // Reload to re-render a blank/stuck popup; the pending request persists
-      // in the service worker. If the popup was re-emitted as a new page,
-      // switch to the freshest open popup.
-      await popupPage.reload({ waitUntil: "domcontentloaded" }).catch(() => {});
-      await popupPage.waitForTimeout(1_500);
-      const popups = context.pages().filter(isPopup);
-      const fresh = popups[popups.length - 1];
-      if (fresh) popupPage = fresh;
+      const fresh = await reacquireSignPopup(context, popupPage);
+      if (fresh) {
+        popupPage = fresh;
+      } else {
+        // No better popup to switch to, so fall back to reloading this one:
+        // a blank/stuck popup re-reads the still-pending approval from the
+        // background service worker, which survives the reload.
+        await popupPage
+          .reload({ waitUntil: "domcontentloaded" })
+          .catch(() => {});
+        await popupPage.waitForTimeout(1_500);
+      }
     }
   }
 

--- a/packages/e2e/pages/keplr-helper.ts
+++ b/packages/e2e/pages/keplr-helper.ts
@@ -144,13 +144,17 @@ const hasApproveButton = (p: Page) =>
     .catch(() => false);
 
 /**
- * Finds a Keplr popup that is actually showing a sign request.
+ * Finds a better Keplr popup to retry the approval against.
  *
  * Bare `popup.html` renders Keplr Home, which never grows an "Approve" button.
  * So when the direct-navigation fallback beats a slow sign popup, reloading it
  * just yields Home again — the only useful move is to go find the real popup.
- * Prefers an already-open popup showing Approve, then waits briefly for one to
- * arrive as a page event. Returns null if neither turns up.
+ * Prefers an already-open popup showing Approve. Failing that, returns the next
+ * Keplr popup to arrive as a page event without re-checking it: this is only
+ * called once the current popup has already failed, so any other popup is at
+ * worst an equal starting point, and the retry loop re-tests Approve anyway.
+ * Callers must not treat the result as guaranteed to be a sign request.
+ * Returns null if nothing turns up.
  */
 async function reacquireSignPopup(
   context: BrowserContext,

--- a/packages/e2e/tests/monitoring.limit.wallet.spec.ts
+++ b/packages/e2e/tests/monitoring.limit.wallet.spec.ts
@@ -10,6 +10,12 @@ test.describe("Test Filled Limit Order feature", () => {
   const privateKey = process.env.PRIVATE_KEY ?? "private_key";
   let tradePage: TradePage;
 
+  // Prod rejects limit orders below $1 (NEXT_PUBLIC_LIMIT_ORDER_MIN_AMOUNT, enforced
+  // in use-place-limit.ts) by disabling the trade button. Size just above the floor:
+  // the check runs on a live fiat price, so an order sized at exactly $1 can round
+  // under it. Market/swap legs are exempt from the minimum and stay smaller.
+  const ORDER_AMOUNT = "1.10";
+
   test.beforeAll(async () => {
     context = await new SetupKeplr().setupWallet(privateKey);
 
@@ -17,8 +23,8 @@ test.describe("Test Filled Limit Order feature", () => {
     await ensureBalances(address, [
       // Sell-tab amounts are fiat-mode in prod (inGivenOut flag, see MTN-157
       // note in balance-config.ts), so both requirements are USD-denominated.
-      { token: "OSMO", amount: 0.6, unit: "usd" }, // For limit sell OSMO ($0.54)
-      { token: "USDC", amount: 0.55, unit: "usd" }, // For limit buy OSMO ($0.52)
+      { token: "OSMO", amount: 1.2, unit: "usd" }, // For limit sell OSMO ($1.10)
+      { token: "USDC", amount: 1.15, unit: "usd" }, // For limit buy OSMO ($1.10)
     ]);
 
     tradePage = new TradePage(context.pages()[0]);
@@ -48,7 +54,7 @@ test.describe("Test Filled Limit Order feature", () => {
     await tradePage.openSellTab();
     await tradePage.openLimit();
     await tradePage.selectAsset("OSMO");
-    await tradePage.enterAmount("0.54");
+    await tradePage.enterAmount(ORDER_AMOUNT);
     await tradePage.setLimitPriceChange("Market");
     await tradePage.sellAndApprove(context);
     await tradePage.getTransactionUrl();
@@ -60,7 +66,7 @@ test.describe("Test Filled Limit Order feature", () => {
     await tradePage.openBuyTab();
     await tradePage.openLimit();
     await tradePage.selectAsset("OSMO");
-    await tradePage.enterAmount("0.52");
+    await tradePage.enterAmount(ORDER_AMOUNT);
     await tradePage.setLimitPriceChange("Market");
     const limitPrice = Number(await tradePage.getLimitPrice());
     const highLimitPrice = (limitPrice * PRICE_INCREASE_FACTOR).toFixed(4);

--- a/packages/e2e/utils/balance-config.ts
+++ b/packages/e2e/utils/balance-config.ts
@@ -130,16 +130,16 @@ export const ACCOUNT_REQUIREMENTS: Record<
     // monitoring.swap + monitoring.market + monitoring.limit
     {
       token: "USDC",
-      minAmount: 2.9,
-      warnAmount: 5.5,
-      note: "market buys ($0.55 x2) + limit buy ($0.52) + swap stables (1.10) ≈ 2.72/tick",
+      minAmount: 3.5,
+      warnAmount: 6.6,
+      note: "market buys ($0.55 x2) + limit buy ($1.10) + swap stables (1.10) ≈ 3.30/tick",
     },
     {
       token: "OSMO",
-      minAmount: 1.2,
-      warnAmount: 2.4,
+      minAmount: 1.8,
+      warnAmount: 3.6,
       unit: "usd",
-      note: "market sell ($0.54) + limit sell ($0.54) OSMO + gas",
+      note: "market sell ($0.54) + limit sell ($1.10) OSMO + gas",
     },
     {
       token: "BTC",


### PR DESCRIPTION
## What is the purpose of the change:

Repairs the two failure modes in the scheduled frontend monitoring workflow. The limit job has been failing on every run for a month because its trade sizes sit below prod's $1 limit-order minimum; the SG swap job intermittently mistakes Keplr's Home screen for the transaction approval popup.

### Linear Task

n/a

## Brief Changelog

- Size both monitoring limit legs from one documented `ORDER_AMOUNT` constant at $1.10, above the $1 prod minimum enforced in `use-place-limit.ts`. The minimum applies only to limit orders, so the swap and market legs keep their reduced sizes.
- Raise the `Monitoring US` USDC and OSMO balance floors to match the larger limit legs, and correct the arithmetic in their notes.
- Filter the Keplr page-event wait so self-reopening `register.html` tabs can't be returned as the approval popup.
- On retry, re-acquire a popup that actually shows Approve instead of reloading a dead one three times.
- Restrict the bare `popup.html` direct-navigation fallback to headless mode, the only case it was written for. In headed mode it renders Keplr Home, which has no Approve button, turning a slow popup into a hard failure with a misleading error.

## Testing and Verifying

Verified locally against `stage.osmosis.zone` with a temporary non-signing Playwright spec that drives the real UI: connect the wallet, open the limit tab, and assert the trade button's enabled state either side of the minimum. No transaction is broadcast and no funds move.

```
Swap 0.52 with rate: 1 OSMO ≈ $0.03028
Swap 1.10 with rate: 1 OSMO ≈ $0.03028
  ✓  buy limit: disabled below $1, enabled above (15.7s)
  ✓  sell limit: disabled below $1, enabled above (13.5s)
  2 passed (1.1m)
```

$0.52 (what #4412 shipped) leaves the button disabled, reproducing the failure; $1.10 enables it. Confirmed on both the buy and sell limit tabs. That spec was scaffolding for this check and is deliberately not included in the diff.

The same run exercised the Keplr helper's happy path: the log shows `Found already-open Keplr popup: …#/permission?interaction=true` followed by `Clicking Approve in Keplr popup`, confirming the new URL predicate selects the real permission popup rather than the `register.html` tab that also fires a page event during wallet setup.

Supporting evidence for the limit fix, independent of the local run:

- Both stage and prod inline the guard as `Dec("1")` in the shipped client bundle, so $1.10 clears the floor on either host.
- `prod-fe-limit-us` failed 60 consecutive runs from the day #4412 landed, always with `Buy/Sell button is disabled!`.
- The CI failure screenshot shows a $0.52 order against a widget rendering "$1.0 minimum".

Typecheck produces no new errors (the four existing ones are in untouched files) and Prettier is clean on the changed files.

Not covered: the Keplr change fixes how the suite reacts to a missing popup, but the underlying trigger is intermittent and specific to the SG proxy, so only the scheduled runs can confirm that half. Worth a `workflow_dispatch` run once merged, which exercises the limit legs regardless of the cron tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
