### PR TITLE
fix(pools): drop liquidity floor when searching the pools table

### DIFF
--- a/packages/web/components/complex/pools-table.tsx
+++ b/packages/web/components/complex/pools-table.tsx
@@ -178,7 +178,10 @@ export const PoolsTable = (props: PropsWithChildren<PoolsTableProps>) => {
             direction: sortParams.allPoolsSortDir,
           }
         : undefined,
-      minLiquidityUsd,
+      // Drop the liquidity floor while searching, mirroring the assets table:
+      // a pool the user asks for by name should be findable even below the
+      // browsing threshold (orderbook pools also report 0 liquidity to SQS).
+      minLiquidityUsd: filters.searchQuery ? 0 : minLiquidityUsd,
     },
     {
       getNextPageParam: (lastPage) => lastPage.nextCursor,


### PR DESCRIPTION
## What is the purpose of the change:

Searching the pools page currently keeps the $1k browsing liquidity floor, so a pool below it returns no results even when searched for by exact name or ID. This also hides orderbook pools, which report 0 liquidity to SQS. The assets table already solves this (`asset-info.tsx` drops `minLiquidity` to 0 while a search query is active); this applies the same pattern to the pools table.

### Linear Task

None (picked up from closed #4029 / FE-1308; this is the narrow search-only variant rather than removing the floor outright).

## Brief Changelog

- `packages/web/components/complex/pools-table.tsx`: pass `minLiquidityUsd: 0` to the pools query while `filters.searchQuery` is set; keep the existing floor (default $1k) for browsing.

## Testing and Verifying

- prettier and eslint clean on the touched file.
- Behavior scope: browsing is byte-identical (floor unchanged, 327 pools today). Only searches change: SQS reports 3,499 pools at floor 0, so search results can now include dust pools, but they appear only when the query matches them and sorting is already relevance-based while searching.
- The asset-info page pool list already passes `minLiquidityUsd={0}` explicitly and is unaffected.

## Trade-off

Same one the assets table accepted: low-liquidity scam/dust pools become reachable via explicit search. They remain excluded from all browsing views.
