### PR TITLE
fix(web): cross-platform lint-staged paths for the Windows pre-commit hook, plus gitignore .claude/ (MTN-246)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ packages/e2e/keplr-extension-manifest/
 packages/e2e/playwright-report/
 packages/e2e/test-results/
 packages/e2e/.env
+
+# Local agent config: skills and settings are personal and may carry credentials
+.claude/

--- a/packages/web/.lintstagedrc.js
+++ b/packages/web/.lintstagedrc.js
@@ -1,14 +1,14 @@
+const path = require("path");
+
 module.exports = {
   "**/*.{js,ts,jsx,tsx}": (filenames) => {
-    const filePaths = filenames.map((file) => {
-      // Current working directory
-      let cwd = process.cwd();
-      if (cwd[cwd.length - 1] !== "/") {
-        cwd = cwd + "/";
-      }
-
-      return file.split(cwd)[1];
-    });
+    // Make paths relative to the package cwd. Uses path.relative so this
+    // works on Windows too, where cwd has backslashes and the previous
+    // string-split approach produced empty paths (prettier then hung
+    // waiting on stdin).
+    const filePaths = filenames.map((file) =>
+      path.relative(process.cwd(), file).split(path.sep).join("/")
+    );
 
     return [
       `prettier --check ${filePaths.join(" ")}`,


### PR DESCRIPTION
### Purpose

Two small dev-experience fixes, no product code:

1. **Pre-commit hook hung on Windows.** `packages/web/.lintstagedrc.js` made lint-staged's absolute paths relative by string-splitting on `process.cwd()`, which never matches on Windows (cwd has backslashes, lint-staged supplies forward slashes). Paths came back `undefined`, so `prettier --check` got no files and blocked on stdin, and `next lint --file` got the same empty list. Now derives the path with `path.relative()` and normalises separators back to `/`.
2. **Ignore `.claude/`** (separate commit `3c4a82a`, droppable on its own) so local Claude Code agent config can't be committed by a stray `git add -A`.

Linear: MTN-246

### Changes

- `packages/web/.lintstagedrc.js`: map with `path.relative(process.cwd(), file).split(path.sep).join("/")`. The `/` normalisation is load-bearing — it's what keeps Linux/macOS argv byte-identical to before.
- `.gitignore`: ignore `.claude/` (nothing under it is tracked today, so this untracks nothing).
- Other packages (`math`, `pools`, `proto-codecs`, `stores`) use lint-staged's array form and never had the bug.

### Testing

Verified by real commits and byte-for-byte argv comparison. `prettier --check` and `next lint --file` always receive the same relative file list.

| Platform | How | Result |
|---|---|---|
| **Windows** | real hook | mis-formatted file fails the commit; clean file passes; no hang, no `--no-verify` |
| **Linux** (Ubuntu 24.04, Node 22, lint-staged 12.1.7) | real lint-staged with argv-recording shims, incl. symlinked cwd | new config == old config, byte-identical |
| **macOS** (Darwin 25.1) | real commit | mis-formatted file fails fast with a Prettier error (no hang); clean file commits; both commands get the identical relative path |
| all three | config loaded with `path.win32` / `path.posix` | emitted commands byte-identical |

Confirmed the old string-split was correct on posix and broken **only** on Windows — this is a Windows-only fix, not a behaviour change elsewhere.

> **Reviewers:** green CI/Vercel says nothing about this change. The pre-commit hook is a local git hook (`git commit` only) — nothing in `.github/workflows/` or the Vercel build ever invokes lint-staged.
