### PR TITLE
feat(swap): allow allUSDC as a selectable quote

### DIFF
--- a/packages/web/components/bridge/use-bridges-supported-assets.ts
+++ b/packages/web/components/bridge/use-bridges-supported-assets.ts
@@ -278,8 +278,10 @@ export const useBridgesSupportedAssets = ({
     // selects the single family member whose halt flags represent the hoisted
     // destination route (undefined => the same predicate as `matchesAsset`, used
     // when the asset and its destination route are the same entry).
+    // `chainId` is a string for Cosmos chains and a number for EVM ones, so it
+    // is compared by identity below rather than assumed to be a string.
     type HoistRule = {
-      chainId: string;
+      chainId: string | number;
       matchesAsset: (asset: MinimalAsset) => boolean | undefined;
       matchesRouteVariant?: (asset: MinimalAsset) => boolean | undefined;
     };
@@ -298,13 +300,14 @@ export const useBridgesSupportedAssets = ({
       asset.coinGeckoId === "cosmos";
 
     const hoistRules: HoistRule[] = [
-      // USDC -> Noble. The destination route is *native Noble* USDC, i.e. the
-      // canonical `USDC` entry (bridged variants are chain-qualified: USDC.eth.grv,
-      // USDC.avax.axl, ...). The route-variant matcher must be narrow: reusing the
-      // broad `isUsdcAsset` would let a halted bridged sibling (e.g. USDC.eth.grv)
-      // wrongly suppress the Noble default even when native Noble USDC is fine.
+      // USDC -> Ethereum, which holds the large majority of USDC supply.
+      // Routing is left to the bridge providers (Skip may use CCTP, Axelar or
+      // another path), so the route variant is the canonical `USDC` alloy that
+      // a routed transfer settles in, not any single bridge's wrapped variant.
+      // Gating on e.g. USDC.eth.axl would suppress the default whenever Axelar
+      // was halted, even with other Ethereum routes healthy.
       {
-        chainId: "noble-1",
+        chainId: 1,
         matchesAsset: isUsdcAsset,
         matchesRouteVariant: (asset) =>
           asset.coinDenom?.toUpperCase() === "USDC",

--- a/packages/web/components/complex/pool/create/cl-pool.tsx
+++ b/packages/web/components/complex/pool/create/cl-pool.tsx
@@ -25,14 +25,14 @@ export type SelectionToken = {
 };
 
 const USDC_ASSET: SelectionToken = {
-  chainName: "noble",
+  chainName: "osmosis",
   token: {
     coinDenom: "USDC",
     coinDecimals: 6,
     // Testnet
     // coinMinimalDenom: "ibc/DE6792CF9E521F6AD6E9A4BDF6225C9571A3B74ACC0A529F92BC5122A39D2E58"
     coinMinimalDenom:
-      "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
+      "factory/osmo147h5x9pcj7lm0cttlaefx6sqq5vdfnmwfcqxkmjd7exqm9gc7grqhr75m0/alloyed/allUSDC",
     coinImageUrl:
       "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.svg",
   },

--- a/packages/web/components/swap-tool/price-selector.tsx
+++ b/packages/web/components/swap-tool/price-selector.tsx
@@ -40,6 +40,8 @@ const UI_DEFAULT_QUOTES: string[] = [USDC_BASE_DENOM, USDT_BASE_DENOM];
 
 const VALID_QUOTES: string[] = [
   ...UI_DEFAULT_QUOTES,
+  // "allUSDC",
+  "factory/osmo147h5x9pcj7lm0cttlaefx6sqq5vdfnmwfcqxkmjd7exqm9gc7grqhr75m0/alloyed/allUSDC",
   // "USDC.sol.wh",
   "ibc/F08DE332018E8070CC4C68FE06E04E254F527556A614F5F8F9A68AF38D367E45",
   // "USDC.eth.grv",


### PR DESCRIPTION
Three additive defaults pointing at the USDC alloy and its constituent. `USDC_BASE_DENOM` and `UI_DEFAULT_QUOTES` are untouched, so **Noble USDC remains the app's default quote** — that flip is #4447, targeted at early September.

## 1. allUSDC selectable as a quote

Adds the alloy to `VALID_QUOTES` in `price-selector.tsx`:

```
factory/osmo147h5x9pcj7lm0cttlaefx6sqq5vdfnmwfcqxkmjd7exqm9gc7grqhr75m0/alloyed/allUSDC
```

Scope is Buy and Limit mode only. Sell mode filters on `UI_DEFAULT_QUOTES` by design (`price-selector.tsx:156`, and the comment on `defaultQuotesWithBalances`: *"Sell trades limited to canonical USDC and alloyed USDT"*), so the alloy correctly does **not** appear there yet.

## 2. Supercharged pool creation defaults to allUSDC

`cl-pool.tsx`'s `USDC_ASSET` pointed at Noble USDC, so new CL pools were created against the asset being migrated away from. Both fields move together: the denom, and `chainName` `noble` → `osmosis`. `chainName` is display metadata only (nothing in the wizard consumes it); the denom is what reaches `MsgCreateConcentratedPool`.

Two sequencing notes until the regenerated assetlist and SQS catch up: the wizard's own 18-decimal ratio guard reads the quote's price from SQS, and production SQS does not price the alloy yet (stage does), so an 18-decimal base against the new default quote is blocked by that guard for now (6-decimal bases are unaffected); and the alloy is still `verified: false`, so it is hidden from the wizard's base-asset list unless "show unverified assets" is on. The pre-filled quote is unaffected by either.

## 3. USDC deposit/withdraw chain defaults to Ethereum

Repoints the USDC entry in `hoistRules` (`use-bridges-supported-assets.ts`) from `noble-1` to Ethereum (`chainId: 1`), so Ethereum is the Recommended route at index 0 — which `amount-screen.tsx:717` reads as `supportedChains[0]` for the deposit default. Ethereum holds the large majority of USDC supply; Noble, which is winding down, stays selectable.

Routing is left to the bridge providers (Skip may use CCTP, Axelar or another path), so `matchesRouteVariant` keys on the canonical `USDC` entry that a routed transfer settles in, not on any single bridge's wrapped variant: gating on e.g. `USDC.eth.axl` would suppress the default whenever Axelar was halted, even with other Ethereum routes healthy. Until the regenerated assetlist hands the `USDC` symbol to the alloy, that gate reads Noble's halt flags; afterwards it reads the alloy's. The hoist still self-suppresses when that variant is halted in the active direction, so a dead route falls back rather than stranding users.

`HoistRule.chainId` widens to `string | number`: Cosmos chain ids are strings and EVM ones are numbers (`BridgeChain`: `z.string()` vs `z.number()`), and a string `"1"` could never have matched Ethereum's numeric `1` under the sort comparator's strict equality, so the hoist would have silently never fired.

Live withdraw measurements from this branch, for reviewer context:

| Route | Cost |
|---|---|
| Injective (transmuter → channel-122) | exact 1:1, no fee |
| Noble → CCTP → Ethereum | 0.183962 on 10 USDC = 1.84% |
| allUSDC → OSMO → USDC.noble → Noble | routed via OSMO rather than the transmuter; landed 1.013689 on 1.0 sent |

Injective is the cheapest exit (USDC.inj is an alloy constituent, so it converts 1:1 with no fee and reaches Injective over the direct channel-122 route); Ethereum is chosen here for supply share and reach. An Injective default is prototyped on the #4447 branch and can be swapped in if reviewers prefer the cheaper route as the recommendation.

## Verified end to end on this branch

Built against an assetlist carrying the identity handover (assetlists#3727, merged 2026-08-25):

- allUSDC appeared as a selectable quote in Buy and Limit mode
- **a TIA/allUSDC orderbook was created through the interface** (pool 3566) — first end-to-end use of the permissionless flow against the alloy
- USDY/allUSDC was correctly refused by the 18-decimal ratio guard
- Withdrawals to Noble, Injective and Ethereum all settled; the Ethereum round-trip returned via Axelar (channel-208) and auto-converted to allUSDC in one atomic tx

## Deliberately not here

The default-quote flip (`USDC_BASE_DENOM`, `QUOTE_COIN_MINIMAL_DENOM`, the e2e monitoring constants) is #4447. It needs its own production release coordinated with the SQS deploy and the monitoring wallets funded with allUSDC first — none of which apply to the three changes above.

## Note on what a deployed build shows

The alloy needs `symbol: USDC` and `categories: ["stablecoin"]` in the **generated** assetlist before the Buy/Limit dropdown will offer it. The source change is merged, but the generation cycle has not run since — so on a build from before that cycle the alloy still reads `USDC.osmosis` with empty categories and is filtered out at `price-selector.tsx:174`. Code is correct; the data lands separately.

## Checks

- ESLint clean on all three changed files.
- No typecheck: `packages/web` has no `typecheck` script and `npx tsc -p` fails to start on module resolution.
- Denoms verified against the generated assetlist, not retyped; Ethereum's numeric `BridgeChain` id (`1`) verified against `packages/bridge` types.
- Lint, Jest and Server E2E workflows green on the current head.


