### PR TITLE
fix: keep uint64 account numbers and large fee amounts exact (MTN-278)

### DIFF
--- a/packages/stores/src/account/__tests__/utils.spec.ts
+++ b/packages/stores/src/account/__tests__/utils.spec.ts
@@ -40,4 +40,18 @@ describe("makeSignDocAmino", () => {
       makeSignDocAmino([], fee, "osmosis-1", "", "1.09e19", 2)
     ).rejects.toThrow("Invalid account number: 1.09e19");
   });
+
+  it("rejects a numeric account number that has already lost precision", async () => {
+    // Parsed as a JS number, 10937563465699879211 rounds to ...879000. Those
+    // digits are wrong before we ever see them, and they are all decimal digits,
+    // so the string check alone would let us sign for a different account.
+    const rounded = Number("10937563465699879211");
+    expect(rounded.toString()).toBe("10937563465699879000");
+
+    await expect(
+      makeSignDocAmino([], fee, "stride-1", "", rounded, 0)
+    ).rejects.toThrow(
+      "Account number 10937563465699879000 exceeds the safe integer range"
+    );
+  });
 });

--- a/packages/stores/src/account/__tests__/utils.spec.ts
+++ b/packages/stores/src/account/__tests__/utils.spec.ts
@@ -1,0 +1,43 @@
+import type { StdFee } from "@cosmjs/stargate";
+
+import { makeSignDocAmino } from "../utils";
+
+describe("makeSignDocAmino", () => {
+  const fee: StdFee = { amount: [], gas: "200000" };
+
+  it("keeps a uint64 account number exact above the safe integer range", async () => {
+    // A real Stride account number, assigned by Cosmos SDK 0.53+ GenerateID().
+    // Narrowing it to a JS number would round it to ...879000 and then throw.
+    const accountNumber = "10937563465699879211";
+
+    const signDoc = await makeSignDocAmino(
+      [],
+      fee,
+      "stride-1",
+      "",
+      accountNumber,
+      0
+    );
+
+    expect(signDoc.account_number).toBe(accountNumber);
+  });
+
+  it("passes a normal account number through unchanged", async () => {
+    const signDoc = await makeSignDocAmino(
+      [],
+      fee,
+      "osmosis-1",
+      "",
+      4681093,
+      2
+    );
+
+    expect(signDoc.account_number).toBe("4681093");
+  });
+
+  it("rejects an account number that is not a decimal integer", async () => {
+    await expect(
+      makeSignDocAmino([], fee, "osmosis-1", "", "1.09e19", 2)
+    ).rejects.toThrow("Invalid account number: 1.09e19");
+  });
+});

--- a/packages/stores/src/account/base.ts
+++ b/packages/stores/src/account/base.ts
@@ -9,7 +9,7 @@ import {
   type OfflineDirectSigner,
   type Registry,
 } from "@cosmjs/proto-signing";
-import type { AminoTypes, SignerData } from "@cosmjs/stargate";
+import type { AminoTypes } from "@cosmjs/stargate";
 import {
   MainWalletBase,
   WalletConnectOptions,
@@ -91,6 +91,17 @@ import {
 import { WalletConnectionInProgressError } from "./wallet-errors";
 
 export const GasMultiplier = 1.5;
+
+/**
+ * CosmJS's own SignerData declares `accountNumber: number`, which cannot hold a
+ * uint64 — chains on Cosmos SDK 0.53+ assign account numbers above 2^53. Carry
+ * it as a decimal string and convert at the encoder instead.
+ */
+type SignerData = {
+  accountNumber: string;
+  sequence: number;
+  chainId: string;
+};
 
 export class AccountStore<Injects extends Record<string, any>[] = []> {
   protected accountSetCreators: ChainedFunctionifyTuple<
@@ -1042,7 +1053,9 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
       txBodyBytes,
       authInfoBytes,
       chainId,
-      accountNumber
+      // Typed as a number upstream, but only ever handed to BigInt(), which is
+      // exact on a decimal string. Cast goes away on the @cosmjs 0.39.0 upgrade.
+      accountNumber as unknown as number
     );
 
     const sig = privateKey.signDigest32(
@@ -1333,7 +1346,9 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
       txBodyBytes,
       authInfoBytes,
       chainId,
-      accountNumber
+      // Typed as a number upstream, but only ever handed to BigInt(), which is
+      // exact on a decimal string. Cast goes away on the @cosmjs 0.39.0 upgrade.
+      accountNumber as unknown as number
     );
 
     const { signature, signed } = await (wallet.client.signDirect
@@ -1419,7 +1434,7 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
 
   public async getSequence(
     wallet: AccountStoreWallet
-  ): Promise<{ accountNumber: number; sequence: number }> {
+  ): Promise<{ accountNumber: string; sequence: number }> {
     const account = await this.getAccountFromNode(wallet);
     if (!account) {
       throw new Error(
@@ -1428,7 +1443,9 @@ export class AccountStore<Injects extends Record<string, any>[] = []> {
     }
 
     return {
-      accountNumber: Number(account.accountNumber.toString()),
+      // account_number is a uint64 and can exceed Number.MAX_SAFE_INTEGER, so
+      // keep the exact decimal string the node returned.
+      accountNumber: account.accountNumber.toString(),
       sequence: Number(account.sequence.toString()),
     };
   }

--- a/packages/stores/src/account/utils.ts
+++ b/packages/stores/src/account/utils.ts
@@ -79,9 +79,17 @@ export async function makeSignDocAmino(
   timeout_height?: bigint
 ): Promise<StdSignDoc> {
   const { Uint53 } = await import("@cosmjs/math");
+
+  // account_number is a uint64 on chain and can exceed JS's safe integer range,
+  // so validate it as a decimal string instead of narrowing it to 53 bits.
+  const account_number = accountNumber.toString();
+  if (!/^\d+$/.test(account_number)) {
+    throw new Error(`Invalid account number: ${account_number}`);
+  }
+
   return {
     chain_id: chainId,
-    account_number: Uint53.fromString(accountNumber.toString()).toString(),
+    account_number,
     sequence: Uint53.fromString(sequence.toString()).toString(),
     fee: fee,
     msgs: msgs,

--- a/packages/stores/src/account/utils.ts
+++ b/packages/stores/src/account/utils.ts
@@ -80,6 +80,18 @@ export async function makeSignDocAmino(
 ): Promise<StdSignDoc> {
   const { Uint53 } = await import("@cosmjs/math");
 
+  // A `number` above the safe integer range has already been rounded before it
+  // reaches us, so its digits cannot be trusted and signing would use the wrong
+  // account. Callers must pass a uint64 account number as a string.
+  if (
+    typeof accountNumber === "number" &&
+    !Number.isSafeInteger(accountNumber)
+  ) {
+    throw new Error(
+      `Account number ${accountNumber} exceeds the safe integer range; pass it as a string`
+    );
+  }
+
   // account_number is a uint64 on chain and can exceed JS's safe integer range,
   // so validate it as a decimal string instead of narrowing it to 53 bits.
   const account_number = accountNumber.toString();

--- a/packages/tx/src/__tests__/gas.spec.ts
+++ b/packages/tx/src/__tests__/gas.spec.ts
@@ -19,6 +19,7 @@ import {
   getGasFeeAmount,
   getGasPriceByFeeDenom,
   InsufficientFeeError,
+  selectFeeAmountFromBalances,
   simulateCosmosTxBody,
   SimulateNotAvailableError,
 } from "../gas";
@@ -915,7 +916,8 @@ describe("getGasFeeAmount", () => {
       expect(queryFeeTokenSpotPrice).toBeCalledWith({
         chainId,
         chainList: MockChains,
-        denom: "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
+        denom:
+          "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
       });
 
       expect(gasAmount.denom).toBe(
@@ -981,7 +983,9 @@ describe("getGasFeeAmount", () => {
       base_denom: "uosmo",
     } as Awaited<ReturnType<typeof queryFeesBaseDenom>>);
     (queryFeeTokenSpotPrice as jest.Mock).mockImplementation(() =>
-      Promise.reject(new Error("error getting spot price: no liquidity in pool"))
+      Promise.reject(
+        new Error("error getting spot price: no liquidity in pool")
+      )
     );
 
     const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
@@ -1638,5 +1642,53 @@ describe("getDefaultGasPrice", () => {
 
     expect(queryFeesBaseGasPrice).not.toHaveBeenCalled();
     expect(queryFeeTokenSpotPrice).not.toHaveBeenCalled();
+  });
+});
+
+describe("selectFeeAmountFromBalances", () => {
+  // Large enough that the balance check never short-circuits the cases below.
+  const ampleBalance = "100000000000000000000000000";
+
+  it("keeps a fee amount above 2^53 exact", async () => {
+    const [fee] = await selectFeeAmountFromBalances({
+      feeBalances: [{ denom: "inj", amount: ampleBalance }],
+      gasLimit: "7654321",
+      getGasPriceByDenom: () => ({ gasPrice: new Dec("2500000000.7") }),
+    });
+
+    // A Number round-trip would have returned ...024 for this product.
+    expect(fee.amount).toBe("19135802505358025");
+  });
+
+  it("does not emit exponential notation above 1e21", async () => {
+    const [fee] = await selectFeeAmountFromBalances({
+      feeBalances: [{ denom: "inj", amount: ampleBalance }],
+      gasLimit: "1234567",
+      getGasPriceByDenom: () => ({ gasPrice: new Dec("1000000000000000") }),
+    });
+
+    // Number.prototype.toString() would have produced "1.234567e+21" here,
+    // which is not a valid Cosmos coin amount.
+    expect(fee.amount).toBe("1234567000000000000000");
+  });
+
+  it("floors a zero fee amount at 1", async () => {
+    const [fee] = await selectFeeAmountFromBalances({
+      feeBalances: [{ denom: "uosmo", amount: "1000" }],
+      gasLimit: "200000",
+      getGasPriceByDenom: () => ({ gasPrice: new Dec("0") }),
+    });
+
+    expect(fee.amount).toBe("1");
+  });
+
+  it("is unchanged for a 6-decimal fee denom", async () => {
+    const [fee] = await selectFeeAmountFromBalances({
+      feeBalances: [{ denom: "uosmo", amount: "1000000" }],
+      gasLimit: "200000",
+      getGasPriceByDenom: () => ({ gasPrice: new Dec("0.025") }),
+    });
+
+    expect(fee.amount).toBe("5000");
   });
 });

--- a/packages/tx/src/__tests__/gas.spec.ts
+++ b/packages/tx/src/__tests__/gas.spec.ts
@@ -1691,4 +1691,16 @@ describe("selectFeeAmountFromBalances", () => {
 
     expect(fee.amount).toBe("5000");
   });
+
+  it("does not select a zero balance floored up to a fee of 1", async () => {
+    // The raw fee is zero here, so a balance check made before the floor sees
+    // 0 > 0 and lets the denom through, then charges a fee of 1 against nothing.
+    await expect(
+      selectFeeAmountFromBalances({
+        feeBalances: [{ denom: "uosmo", amount: "0" }],
+        gasLimit: "200000",
+        getGasPriceByDenom: () => ({ gasPrice: new Dec("0") }),
+      })
+    ).rejects.toThrow(InsufficientFeeError);
+  });
 });

--- a/packages/tx/src/gas.ts
+++ b/packages/tx/src/gas.ts
@@ -416,13 +416,7 @@ export async function selectFeeAmountFromBalances({
       continue;
     }
 
-    // Calculate the raw fee amount first before applying Math.max
     const rawFeeAmount = feeDenomGasPrice.mul(new Dec(gasLimit)).roundUp();
-
-    // Only skip if the fee amount is greater than balance
-    if (rawFeeAmount.gt(new Int(amount))) {
-      continue;
-    }
 
     // Ensure a minimum of 1.
     // This covers cases where the fee amount precision is too small to be represented in the balance.
@@ -430,6 +424,12 @@ export async function selectFeeAmountFromBalances({
     // Stay in integer arithmetic: a Number round-trip corrupts fee amounts above
     // 2^53, which is only 0.009 tokens for an 18-decimal fee denom.
     const feeAmount = rawFeeAmount.isZero() ? "1" : rawFeeAmount.toString();
+
+    // Skip a denom we cannot actually pay with. Compared after the floor above,
+    // so a zero balance is not selected on the strength of a zero raw fee.
+    if (new Int(feeAmount).gt(new Int(amount))) {
+      continue;
+    }
 
     const spentAmount =
       coinsSpent.find((coinSpent) => coinSpent.denom === denom)?.amount || "0";

--- a/packages/tx/src/gas.ts
+++ b/packages/tx/src/gas.ts
@@ -420,14 +420,16 @@ export async function selectFeeAmountFromBalances({
     const rawFeeAmount = feeDenomGasPrice.mul(new Dec(gasLimit)).roundUp();
 
     // Only skip if the fee amount is greater than balance
-    if (new Int(rawFeeAmount.toString()).gt(new Int(amount))) {
+    if (rawFeeAmount.gt(new Int(amount))) {
       continue;
     }
 
     // Ensure a minimum of 1.
     // This covers cases where the fee amount precision is too small to be represented in the balance.
     // This is common for WBTC and similar tokens.
-    const feeAmount = Math.max(1, Number(rawFeeAmount.toString())).toString();
+    // Stay in integer arithmetic: a Number round-trip corrupts fee amounts above
+    // 2^53, which is only 0.009 tokens for an 18-decimal fee denom.
+    const feeAmount = rawFeeAmount.isZero() ? "1" : rawFeeAmount.toString();
 
     const spentAmount =
       coinsSpent.find((coinSpent) => coinSpent.denom === denom)?.amount || "0";


### PR DESCRIPTION
## What is the purpose of the change:

Users whose chain `account_number` exceeds 2^53 cannot transact at all: our Cosmos signing path narrowed the value to a JavaScript number and then rejected it with CosmJS `Uint53`, before the wallet even opened. Cosmos SDK 0.53+ assigns such numbers to newly created accounts, so the affected population grows with every new account on an upgraded chain. This carries the account number as an exact decimal string end to end, and fixes the same float64 narrowing where it silently corrupts fee amounts.

### Linear Task

[MTN-278](https://linear.app/osmosis/issue/MTN-278/cosmos-transactions-fail-for-accounts-whose-account-number-exceeds-253)

## Brief Changelog

- `makeSignDocAmino` validates `account_number` as a decimal string rather than narrowing it to 53 bits, and rejects a numeric argument outside the safe integer range. `sequence` keeps its `Uint53` check.
- `getSequence` returns the exact string the node gave us, and a local `SignerData` replaces CosmJS's, whose `accountNumber: number` cannot represent a `uint64`.
- The two `makeSignDoc` call sites cast past CosmJS 0.32.3's `number` parameter, which its implementation only ever hands to `BigInt()`. The cast goes away on the 0.39.0 upgrade, where that parameter accepts a string.
- Fee selection in `gas.ts` stays in integer arithmetic — `rawFeeAmount.isZero() ? "1" : rawFeeAmount.toString()` — and compares the final fee amount against the balance rather than the raw one. Behaviour is identical for 6-decimal fee denoms, where the `Number` round-trip was lossless anyway.
- Nine unit tests added across the two packages. The commit also formats two pre-existing Prettier violations in `gas.spec.ts`, which is the only part of the diff unrelated to this work.

## Why not just bump CosmJS to 0.39.0?

Because it would not have fixed this. Upstream did fix the same class of bug in [cosmos/cosmjs#1956](https://github.com/cosmos/cosmjs/pull/1956), but neither of the two lossy sites in our signing path goes through the functions they changed — both are our own code:

- `getSequence` reads the account with `@keplr-wallet/cosmos`'s `BaseAccount.fetchFromRest`, not CosmJS's account parser, so upstream's `accountFromBaseAccount` change from `.toNumber()` to `.toBigInt()` never applied to us. Keplr's `Int` held the value exactly; our own `Number(...)` was what rounded it.
- We call a vendored `makeSignDocAmino` in `packages/stores/src/account/utils.ts`, not `@cosmjs/amino`'s `makeSignDoc`. Upstream fixed theirs by no longer calling `Uint53` — but `Uint53` still exists and still enforces 53 bits in 0.39.0, so our copy would have carried on throwing on every version.

So the upgrade is orthogonal to this bug rather than a shortcut past it, and it is substantial work in its own right. Nine workspace packages depend on `@cosmjs/*`, and the repo is not on a single line: declared pins span `0.24.0-alpha.25`, `0.24.1`, `0.27.1` and `0.32.3`, with the lockfile resolving ranges from `^0.20.0` to `^0.36.2`. `packages/stores` alone mixes `0.32.3` with `@cosmjs/launchpad@^0.27.1`, and `keplr-hooks`/`keplr-stores` sit on 0.24 alphas. On top of that, 0.39.0 makes `Account.accountNumber` and `SignerData.accountNumber` `bigint`, which is a breaking public type change. (Node is not a constraint: 0.39.0 needs ≥ 22 and `engines.node` is already `22.x`.)

None of this is throwaway work either. Upstream's `makeSignDoc` accepts `number | string | bigint`, so carrying the value as a string is correct both before and after an upgrade, and the two `as unknown as number` casts self-delete when it lands. The upgrade is tracked as a separate follow-up.

## Behaviour changes worth a reviewer's eye

Both are deliberate, and both came out of review on this PR. Neither is a pure refactor, so here is what actually changes.

**1. A fee denom whose balance cannot cover the floored fee is now skipped, so `InsufficientFeeError` is raised where a fee of `1` used to be returned.**

`selectFeeAmountFromBalances` floors a fee amount at `1`, for tokens whose true fee is too small to represent. That floor used to be applied *after* the balance check, so with a zero gas price the raw fee was `0`, `0 > 0` was false, and a zero balance was accepted — then charged the floored fee of `1` it could not cover. It was recorded as a subtractive fee, which is returned whenever no denom yields an alternative, so it displaced the `InsufficientFeeError` that should have fired. The user saw a later chain rejection instead of "Please add funds to continue."

The comparison now runs on the floored amount. The affected input set is provably just `{raw fee == 0, balance == 0}`: when the raw fee is positive the floored and raw values are equal and the two checks are byte-identical, and when it is zero the old check (`0 > balance`) was never true for a non-negative balance while the new one (`1 > balance`) is true only at zero. The WBTC-style case the floor exists for is untouched — those balances are positive, so the denom is still selected with a fee of `1`, and the pre-existing test covering it passes unmodified.

What is *not* established: whether a zero balance actually reaches `feeBalances` in practice. `getFeeBalancesFromDenoms` does not filter zero amounts, so it is plausible rather than demonstrated. Treat this as defensive correctness on a path that has not been reproduced, not as a user-facing bug that was.

**2. `makeSignDocAmino` now throws on a numeric `accountNumber` outside the safe integer range, rather than signing with it.**

Validating the value as a digit string — the first commit here — accepted a `number` that JavaScript had already rounded: `Number("10937563465699879211")` is `10937563465699879000`, which is all decimal digits and passed. `Uint53.fromString` had thrown on that, so the string check alone was a regression, and signing would have used the wrong account. This restores the rejection rather than adding a new one.

Two consequences. Numeric `1.5`, `NaN` and `Infinity` previously fell through to the digit-string check and produced `Invalid account number: …`; they now produce the safe-integer message instead — same rejection, different text, so anything matching on that string should be checked. And because `@osmosis-labs/stores` is published, an external consumer passing an unsafe `number` now gets a clear error where it would previously have produced an invalid signature. No in-repo call site changes: the sole caller takes its value from the local `SignerData`, whose `accountNumber` is a `string`.

## Testing and Verifying

This change has been tested locally by reproducing the failure on `stage` first, so the tests exercise the real bug: a brand-new Stride account (`account_number` `10937563465699879211`, `sequence` 0) fails a STRD deposit with `Input not in int53 range: 10937563465699879000`, matching the user report character-for-character.

New tests assert the 20-digit account number comes back verbatim from the Amino sign doc, that a numeric account number which has already lost precision is rejected, that a fee amount above 2^53 is returned digit-for-digit rather than rounded with no exponential notation above 1e21, and that a zero balance is not selected on the strength of a zero raw fee. Full suites pass — 77 tests in `packages/tx`, 21 in the `packages/stores` account tests — and `tsc` is clean on both packages.

**Verified end to end on chain.** The Stride → Osmosis STRD deposit on `stride1cv7…cwl90` (`account_number` `10937563465699879211`) now signs and broadcasts successfully with Keplr. On `stage` it threw `Input not in int53 range` before the wallet could open. The account has moved from `sequence: 0` with a `null` `pub_key` to `sequence: 1` with its public key recorded, and its balance has decreased.

The advancing sequence is the load-bearing evidence, not just the absence of an error. `account_number` is part of the sign bytes, so had we signed with the rounded `10937563465699879000` the chain would have failed signature verification and the sequence would have stayed at `0`. It advanced, which proves the exact 20-digit value reached the sign doc and was accepted. That also settles wallet acceptance for Keplr, which had until now been inference from its published packages rather than an observation.

Still outstanding, tracked in MTN-278: the same check against the other wallets we support.


