### PR TITLE
fix(e2e): follow the USDC identity handover to the alloy

### DIFF
--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -159,12 +159,17 @@ jobs:
               if [ "$RECENT" -gt 0 ]; then
                 echo "Recent successful or in-flight topup within cooldown — skipping dispatch."
               else
+                # reserve_usdc guards allUSDC after the identity handover, and the
+                # converted alloy balance is far smaller than the old Noble one, so
+                # a 250/500 reserve left nothing distributable. Kept at the 100/3.0
+                # the other dispatchers use, which is what the README documents and
+                # what sweep-surplus's TOPUP_TARGET_MULTIPLIER assumes.
                 gh workflow run "E2E: Topup Test Accounts" \
                   --ref stage \
                   -f dry_run=false \
-                  -f topup_multiplier=1.5 \
+                  -f topup_multiplier=3.0 \
                   -f reserve_osmo=5 \
-                  -f reserve_usdc=250
+                  -f reserve_usdc=100
                 echo "Topup workflow dispatched (balance outcome: $OUTCOME)."
               fi
             else

--- a/.github/workflows/prod-frontend-e2e-tests.yml
+++ b/.github/workflows/prod-frontend-e2e-tests.yml
@@ -139,12 +139,17 @@ jobs:
               if [ "$RECENT" -gt 0 ]; then
                 echo "Recent successful or in-flight topup within cooldown — skipping dispatch."
               else
+                # reserve_usdc guards allUSDC after the identity handover, and the
+                # converted alloy balance is far smaller than the old Noble one, so
+                # a 250/500 reserve left nothing distributable. Kept at the 100/3.0
+                # the other dispatchers use, which is what the README documents and
+                # what sweep-surplus's TOPUP_TARGET_MULTIPLIER assumes.
                 gh workflow run "E2E: Topup Test Accounts" \
                   --ref stage \
                   -f dry_run=false \
-                  -f topup_multiplier=1.5 \
+                  -f topup_multiplier=3.0 \
                   -f reserve_osmo=5 \
-                  -f reserve_usdc=500
+                  -f reserve_usdc=100
                 echo "Topup workflow dispatched (balance outcome: $OUTCOME)."
               fi
             else

--- a/packages/e2e/scripts/sweep-surplus.ts
+++ b/packages/e2e/scripts/sweep-surplus.ts
@@ -15,6 +15,10 @@
  * drop a wallet low enough to trigger an auto-topup — no ping-pong between
  * the two workflows.
  *
+ * Legacy denoms listed in LEGACY_SWEEP_SYMBOLS (currently Noble USDC, since the
+ * app's "USDC" identity moved to the alloy) have no requirement and are swept in
+ * full, so they consolidate in the holding account for the one-off conversion.
+ *
  * Environment variables:
  * - `E2E_PRIVATE_KEY_TOPUP`   — topup account key (destination address).
  * - `E2E_PRIVATE_KEY_PREVIEW`, `TEST_PRIVATE_KEY_SG/EU/US` — source signers.
@@ -35,6 +39,14 @@ import type { Coin } from "@cosmjs/stargate";
 import BigNumber from "bignumber.js";
 
 import { ACCOUNT_REQUIREMENTS } from "../utils/balance-config";
+
+/**
+ * Symbols swept in full regardless of requirements. These are legacy denoms the
+ * tests no longer use (the app's "USDC" identity moved to the alloy), so any
+ * balance is surplus, and consolidating them in the holding account is where
+ * the one-off conversion to the alloy happens. Must be keys of TOKEN_DENOMS.
+ */
+const LEGACY_SWEEP_SYMBOLS = ["USDC.noble"];
 import { TOKEN_DENOMS } from "../utils/balance-checker";
 import { deriveAddress, createSigningClient, OSMOSIS_RPC } from "../utils/order-utils";
 import {
@@ -293,6 +305,21 @@ async function main(): Promise<void> {
             .toFixed(Math.min(bal.decimals, 4))} (keep ${target.toFixed(4)})`
         );
         coins.push({ denom: bal.denom, amount: rawSweep.toFixed(0) });
+      }
+
+      // Legacy denoms: no requirement keeps any of the balance, sweep it all.
+      for (const symbol of LEGACY_SWEEP_SYMBOLS) {
+        const bal = balances.find((b) => b.symbol === symbol);
+        if (!bal || new BigNumber(bal.rawAmount).lte(0)) continue;
+        console.log(
+          `      ${symbol}: ${bal.amount.toFixed(
+            Math.min(bal.decimals, 4)
+          )} legacy denom  → sweep all`
+        );
+        coins.push({
+          denom: bal.denom,
+          amount: new BigNumber(bal.rawAmount).toFixed(0),
+        });
       }
 
       if (coins.length === 0) {

--- a/packages/e2e/scripts/sweep-surplus.ts
+++ b/packages/e2e/scripts/sweep-surplus.ts
@@ -61,8 +61,9 @@ dotenv.config({ path: path.resolve(__dirname, "../.env") });
 
 const MINTSCAN_TX_URL = "https://www.mintscan.io/osmosis/txs";
 
-/** Matches the auto-topup refill target (topup_multiplier 3.0 dispatched by
- * the monitoring workflow's topup-dispatch job). */
+/** Matches the auto-topup refill target (topup_multiplier 3.0, now dispatched
+ * uniformly by every auto-dispatcher: monitoring-limit-geo, frontend-e2e and
+ * prod-frontend-e2e). */
 const TOPUP_TARGET_MULTIPLIER = 3.0;
 /** Derived from the topup target so the floor stays above it even if the
  * target changes — sweeping below it would trigger auto-topup ping-pong. */

--- a/packages/e2e/tests/portfolio.wallet.spec.ts
+++ b/packages/e2e/tests/portfolio.wallet.spec.ts
@@ -35,7 +35,7 @@ test.describe('Test Portfolio feature', () => {
     {
       name: 'USDC',
       minimalDenom:
-        'ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4',
+        'factory/osmo147h5x9pcj7lm0cttlaefx6sqq5vdfnmwfcqxkmjd7exqm9gc7grqhr75m0/alloyed/allUSDC',
     },
     {
       name: 'TIA',

--- a/packages/e2e/tests/swap.usdc.wallet.spec.ts
+++ b/packages/e2e/tests/swap.usdc.wallet.spec.ts
@@ -10,7 +10,7 @@ test.describe("Test Swap to/from USDC feature", () => {
   const privateKey = process.env.PRIVATE_KEY ?? "private_key";
   let tradePage: TradePage;
   const _USDC =
-    "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4";
+    "factory/osmo147h5x9pcj7lm0cttlaefx6sqq5vdfnmwfcqxkmjd7exqm9gc7grqhr75m0/alloyed/allUSDC";
   const _ATOM =
     "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2";
   const _TIA =

--- a/packages/e2e/tests/trade.wallet.spec.ts
+++ b/packages/e2e/tests/trade.wallet.spec.ts
@@ -10,7 +10,7 @@ test.describe("Test Trade feature", () => {
   const privateKey = process.env.PRIVATE_KEY ?? "private_key";
   let tradePage: TradePage;
   const USDC =
-    "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4";
+    "factory/osmo147h5x9pcj7lm0cttlaefx6sqq5vdfnmwfcqxkmjd7exqm9gc7grqhr75m0/alloyed/allUSDC";
   const ATOM =
     "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2";
 

--- a/packages/e2e/tests/trade.wallet.spec.ts
+++ b/packages/e2e/tests/trade.wallet.spec.ts
@@ -12,8 +12,10 @@ test.describe("Test Trade feature", () => {
   let tradePage: TradePage;
   // Resolved from the build under test in beforeAll: "USDC" is the alloy on
   // builds carrying the assetlist identity handover and Noble on builds that
-  // predate it. Derived, not hardcoded, so a handover build that regressed to
-  // routing through Noble would fail here instead of passing silently.
+  // predate it. Derived, not hardcoded, so the assertion follows whichever
+  // identity the build's token selector reports and fails when the selector
+  // and the swap route disagree. It does not prove the build carries the
+  // handover — if the assetlist still says Noble, this expects Noble.
   let USDC: string;
   const ATOM =
     "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2";
@@ -33,7 +35,9 @@ test.describe("Test Trade feature", () => {
   });
 
   test.afterAll(async () => {
-    await context.close();
+    // beforeAll resolves the USDC identity before the wallet exists, and that
+    // resolver throws by design, so context can still be undefined here.
+    await context?.close();
   });
 
   test.beforeEach(async () => {

--- a/packages/e2e/tests/trade.wallet.spec.ts
+++ b/packages/e2e/tests/trade.wallet.spec.ts
@@ -3,26 +3,23 @@ import { TradePage } from "../pages/trade-page";
 import { TransactionsPage } from "../pages/transactions-page";
 import { SetupKeplr } from "../setup-keplr";
 import { ensureBalances } from "../utils/balance-checker";
+import { resolveAppUsdcDenom } from "../utils/usdc-identity";
 import { deriveAddress } from "../utils/wallet-utils";
 
 test.describe("Test Trade feature", () => {
   let context: BrowserContext;
   const privateKey = process.env.PRIVATE_KEY ?? "private_key";
   let tradePage: TradePage;
-  // "USDC" resolves to the alloy on builds carrying the assetlist identity
-  // handover and to Noble on builds that predate it; the fleet is mid-
-  // transition (main's generated assetlist has not regenerated yet), so the
-  // signed message may name either. Tighten to the alloy once every build
-  // carries the handover.
-  const USDC_DENOMS = [
-    "factory/osmo147h5x9pcj7lm0cttlaefx6sqq5vdfnmwfcqxkmjd7exqm9gc7grqhr75m0/alloyed/allUSDC",
-    "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
-  ];
-  const USDC_DENOM_PATTERN = new RegExp(`denom: (${USDC_DENOMS.join("|")})`);
+  // Resolved from the build under test in beforeAll: "USDC" is the alloy on
+  // builds carrying the assetlist identity handover and Noble on builds that
+  // predate it. Derived, not hardcoded, so a handover build that regressed to
+  // routing through Noble would fail here instead of passing silently.
+  let USDC: string;
   const ATOM =
     "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2";
 
   test.beforeAll(async () => {
+    USDC = await resolveAppUsdcDenom();
     context = await new SetupKeplr().setupWallet(privateKey);
 
     const { address } = await deriveAddress(privateKey);
@@ -61,7 +58,7 @@ test.describe("Test Trade feature", () => {
     if (msgContentAmount) {
       expect(msgContentAmount).toContain(`denom: ${ATOM}`);
       expect(msgContentAmount).toContain("type: osmosis/poolmanager/");
-      expect(msgContentAmount).toMatch(USDC_DENOM_PATTERN);
+      expect(msgContentAmount).toContain(`denom: ${USDC}`);
     }
     await tradePage.getTransactionUrl();
   });
@@ -77,7 +74,7 @@ test.describe("Test Trade feature", () => {
     });
     // Only validate message content if Keplr popup appeared (not 1-click trading)
     if (msgContentAmount) {
-      expect(msgContentAmount).toMatch(USDC_DENOM_PATTERN);
+      expect(msgContentAmount).toContain(`denom: ${USDC}`);
       expect(msgContentAmount).toContain("type: osmosis/poolmanager/");
       expect(msgContentAmount).toContain(`denom: ${ATOM}`);
     }

--- a/packages/e2e/tests/trade.wallet.spec.ts
+++ b/packages/e2e/tests/trade.wallet.spec.ts
@@ -9,8 +9,16 @@ test.describe("Test Trade feature", () => {
   let context: BrowserContext;
   const privateKey = process.env.PRIVATE_KEY ?? "private_key";
   let tradePage: TradePage;
-  const USDC =
-    "factory/osmo147h5x9pcj7lm0cttlaefx6sqq5vdfnmwfcqxkmjd7exqm9gc7grqhr75m0/alloyed/allUSDC";
+  // "USDC" resolves to the alloy on builds carrying the assetlist identity
+  // handover and to Noble on builds that predate it; the fleet is mid-
+  // transition (main's generated assetlist has not regenerated yet), so the
+  // signed message may name either. Tighten to the alloy once every build
+  // carries the handover.
+  const USDC_DENOMS = [
+    "factory/osmo147h5x9pcj7lm0cttlaefx6sqq5vdfnmwfcqxkmjd7exqm9gc7grqhr75m0/alloyed/allUSDC",
+    "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
+  ];
+  const USDC_DENOM_PATTERN = new RegExp(`denom: (${USDC_DENOMS.join("|")})`);
   const ATOM =
     "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2";
 
@@ -53,7 +61,7 @@ test.describe("Test Trade feature", () => {
     if (msgContentAmount) {
       expect(msgContentAmount).toContain(`denom: ${ATOM}`);
       expect(msgContentAmount).toContain("type: osmosis/poolmanager/");
-      expect(msgContentAmount).toContain(`denom: ${USDC}`);
+      expect(msgContentAmount).toMatch(USDC_DENOM_PATTERN);
     }
     await tradePage.getTransactionUrl();
   });
@@ -69,7 +77,7 @@ test.describe("Test Trade feature", () => {
     });
     // Only validate message content if Keplr popup appeared (not 1-click trading)
     if (msgContentAmount) {
-      expect(msgContentAmount).toContain(`denom: ${USDC}`);
+      expect(msgContentAmount).toMatch(USDC_DENOM_PATTERN);
       expect(msgContentAmount).toContain("type: osmosis/poolmanager/");
       expect(msgContentAmount).toContain(`denom: ${ATOM}`);
     }

--- a/packages/e2e/tests/transactions.wallet.spec.ts
+++ b/packages/e2e/tests/transactions.wallet.spec.ts
@@ -47,7 +47,7 @@ test.describe('Test Transactions feature', () => {
     expect(msgContentAmount).toBeTruthy()
     expect(msgContentAmount).toContain(`sender: ${walletId}`)
     expect(msgContentAmount).toContain(
-      'denom: ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4',
+      'denom: factory/osmo147h5x9pcj7lm0cttlaefx6sqq5vdfnmwfcqxkmjd7exqm9gc7grqhr75m0/alloyed/allUSDC',
     )
     expect(swapPage.isTransactionBroadcasted(10))
     expect(swapPage.isTransactionSuccesful(10))

--- a/packages/e2e/utils/balance-checker.ts
+++ b/packages/e2e/utils/balance-checker.ts
@@ -50,8 +50,10 @@ export const TOKEN_DENOMS: Record<
     denom: "factory/osmo147h5x9pcj7lm0cttlaefx6sqq5vdfnmwfcqxkmjd7exqm9gc7grqhr75m0/alloyed/allUSDC",
     decimals: 6,
   },
-  // Legacy Noble USDC (now "USDC.noble" in the app). Kept so the fleet
-  // report and surplus sweep still see these balances; not a top-up target.
+  // Legacy Noble USDC (now "USDC.noble" in the app). Kept visible to the
+  // fleet report, and swept in full by sweep-surplus (legacy sweep) so the
+  // accounts' Noble consolidates in the holding account for the one-off
+  // conversion to the alloy. Not a top-up target.
   "USDC.noble": {
     denom: "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
     decimals: 6,

--- a/packages/e2e/utils/balance-checker.ts
+++ b/packages/e2e/utils/balance-checker.ts
@@ -42,7 +42,17 @@ export const TOKEN_DENOMS: Record<
   { denom: string; decimals: number }
 > = {
   OSMO: { denom: "uosmo", decimals: 6 },
+  // "USDC" follows the app's USDC identity. Since the assetlist handover
+  // (2026-08-25) the symbol resolves to the alloy, so tests that select
+  // "USDC" by symbol trade the alloy and balance checks / top-ups must
+  // fund the alloy, not Noble.
   USDC: {
+    denom: "factory/osmo147h5x9pcj7lm0cttlaefx6sqq5vdfnmwfcqxkmjd7exqm9gc7grqhr75m0/alloyed/allUSDC",
+    decimals: 6,
+  },
+  // Legacy Noble USDC (now "USDC.noble" in the app). Kept so the fleet
+  // report and surplus sweep still see these balances; not a top-up target.
+  "USDC.noble": {
     denom: "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
     decimals: 6,
   },

--- a/packages/e2e/utils/balance-config.ts
+++ b/packages/e2e/utils/balance-config.ts
@@ -54,7 +54,7 @@ export const ACCOUNT_REQUIREMENTS: Record<
     // trade.wallet.spec.ts: buy 1.12 USDC, sell 1.11+1.01 ATOM, limit 1.01 OSMO
     // swap.usdc.wallet.spec.ts: 0.5 USDC, 0.015 ATOM, 0.02 TIA, 0.01 INJ, 0.025 AKT
     // swap.osmo.wallet.spec.ts: 0.2 OSMO, 0.01 ATOM
-    { token: "USDC", minAmount: 1.7, warnAmount: 3.5, note: "~1.62 consumed (trade buy + swaps)" },
+    { token: "USDC", minAmount: 1.7, warnAmount: 3.5, note: "~1.62 consumed (trade buy + swaps). USDC is the alloy since the assetlist identity handover; the topup account must hold allUSDC (convert Noble 1:1 via the transmuter) for auto-topup to fund it." },
     { token: "ATOM", minAmount: 2.27, warnAmount: 4.5, note: "~2.16 consumed (trade sell + limit + swaps)" },
     { token: "OSMO", minAmount: 1.3, warnAmount: 2.5, unit: "usd", note: "USD-denominated (MTN-157): the limit sell is fiat-mode (~$1.01), so required OSMO scales inversely with price. Fixed token thresholds went stale as OSMO fell and created a topup dead-zone (3.4 OSMO cleared the old 2.5-token gate yet starved the sells). min covers the fiat sell (~$1.01) PLUS the swap.osmo 0.2 OSMO swap (token-denominated), with deliberate price headroom: at $1.3 the USD floor still funds the fixed 0.2 OSMO swap until OSMO reaches ~$1.45 (1.01 + 0.2*1.45 = 1.30), well above the current ~$0.04; warn≈2x. NB: the 0.2 OSMO swap is a fixed token need, so this USD floor under-provisions only once OSMO climbs past ~$1.45; revisit then. NB: the check-balances auto-topup dispatches --ref stage, so the scaled target only applies once this is merged to stage." },
     { token: "TIA", minAmount: 0.022, warnAmount: 0.05, note: "~0.02 consumed (swap TIA)" },

--- a/packages/e2e/utils/price-utils.ts
+++ b/packages/e2e/utils/price-utils.ts
@@ -16,6 +16,10 @@
 
 import { SQS_BASE_URL } from "./config";
 
+// The denom SQS quotes prices in (the key of each inner price map). This is
+// SQS's quote asset, NOT the app's "USDC" identity: it stays Noble until the
+// sidecar repoints its quote denom to the alloy, independently of the
+// assetlist handover. Do not "fix" it alongside TOKEN_DENOMS.USDC.
 const USDC_DENOM =
   "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4";
 

--- a/packages/e2e/utils/usdc-identity.ts
+++ b/packages/e2e/utils/usdc-identity.ts
@@ -9,8 +9,16 @@
  * resolve it to the alloy. Specs that assert on the USDC denom must derive
  * the expectation from the build they are running against rather than
  * hardcode it: hardcoding the alloy fails on pre-handover builds, and
- * accepting either denom would let a handover build silently regress to
- * routing through Noble.
+ * accepting either denom at the assertion would let a handover build
+ * silently regress to routing through Noble.
+ *
+ * What this does and does not prove. Pinning the assertion to the identity
+ * the build's own token selector reports catches the selector and the swap
+ * route disagreeing — a build that offers the alloy but trades Noble fails.
+ * It cannot prove that a build *ought* to carry the handover: if the
+ * assetlist itself still says Noble, this returns Noble and the assertion
+ * follows it. Deciding which identity a deployment should carry is the
+ * assetlist's job, not a spec's.
  */
 
 const ALLOY_DENOM =

--- a/packages/e2e/utils/usdc-identity.ts
+++ b/packages/e2e/utils/usdc-identity.ts
@@ -1,0 +1,55 @@
+/**
+ * @file usdc-identity.ts
+ * @description Resolves which denom the build under test attaches to the
+ * symbol "USDC".
+ *
+ * The assetlist identity handover moved "USDC" from Noble to the allUSDC
+ * alloy, but builds pick their assetlist up at build time, so during the
+ * transition some deployments still resolve "USDC" to Noble while others
+ * resolve it to the alloy. Specs that assert on the USDC denom must derive
+ * the expectation from the build they are running against rather than
+ * hardcode it: hardcoding the alloy fails on pre-handover builds, and
+ * accepting either denom would let a handover build silently regress to
+ * routing through Noble.
+ */
+
+const ALLOY_DENOM =
+  "factory/osmo147h5x9pcj7lm0cttlaefx6sqq5vdfnmwfcqxkmjd7exqm9gc7grqhr75m0/alloyed/allUSDC";
+const NOBLE_DENOM =
+  "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4";
+
+/**
+ * Asks the app's own asset endpoint what "USDC" resolves to. Uses the edge
+ * tRPC assets router (`/api/edge-trpc-assets`, the same route the UI calls),
+ * so the answer is exactly the identity the token selector will use.
+ *
+ * Fails loudly rather than falling back: a wrong guess here would either
+ * mask a regression or fail every USDC test for the wrong reason.
+ */
+export async function resolveAppUsdcDenom(
+  baseUrl: string = process.env.BASE_URL ?? "https://stage.osmosis.zone"
+): Promise<string> {
+  const input = encodeURIComponent(
+    JSON.stringify({ json: { findMinDenomOrSymbol: "USDC" } })
+  );
+  const url = `${baseUrl.replace(/\/+$/, "")}/api/edge-trpc-assets/assets.getUserAsset?input=${input}`;
+  const response = await fetch(url, { signal: AbortSignal.timeout(30_000) });
+  if (!response.ok) {
+    throw new Error(
+      `Failed to resolve the app's USDC identity: ${response.status} ${response.statusText} (${url})`
+    );
+  }
+  const body = (await response.json()) as {
+    result?: { data?: { json?: { coinMinimalDenom?: string } } };
+  };
+  const denom = body.result?.data?.json?.coinMinimalDenom;
+  if (denom !== ALLOY_DENOM && denom !== NOBLE_DENOM) {
+    throw new Error(
+      `Unexpected USDC identity from ${baseUrl}: ${denom ?? "<none>"}`
+    );
+  }
+  console.log(
+    `  App "USDC" identity: ${denom === ALLOY_DENOM ? "allUSDC (alloy)" : "Noble"} (${denom})`
+  );
+  return denom;
+}


### PR DESCRIPTION
## What is the purpose of the change

Since the assetlist identity handover (assetlists#3727, merged 2026-08-25) the app resolves the symbol `USDC` to the allUSDC alloy and renames Noble to `USDC.noble`. The e2e specs select tokens by symbol, so on any build carrying the handover they now trade the alloy, while the balance checker, the auto-topup and the specs' denom assertions still pointed at Noble.

Observed on the #4445 preview (which carries the handover via `ASSET_LIST_COMMIT_HASH`): the swap.usdc suite's first leg, AKT→USDC, routed into allUSDC (tx `D898B511…`, through transmuter pool 3497), and every USDC-selling leg then failed with "Insufficient balance" because the E2E account holds 5.14 Noble USDC and about 0.10 of the asset the UI now calls USDC. The check-balances precursor passed, because `TOKEN_DENOMS.USDC` was still Noble and so it checked the wrong asset.

The same thing will happen to the scheduled monitoring suites (which spend real funds) as soon as the next [AUTO] assetlists generation lands the handover on `main`, independently of any frontend change. This PR is split out of the default-quote flip (#4447) for that reason: its trigger is data, not the repoint, and it needs to be on `stage` first.

## Brief Changelog

**packages/e2e/utils/balance-checker.ts**
- `TOKEN_DENOMS.USDC` now maps to the alloy denom, so `ensureBalances`, the check-balances precursor and the auto-dispatched top-up all fund the asset the tests actually trade.
- New `USDC.noble` entry keeps the legacy Noble balances visible to the fleet report. It is not a top-up target (no `balance-config` requirement references it).

**.github/workflows/frontend-e2e-tests.yml, .github/workflows/prod-frontend-e2e-tests.yml**
- `reserve_usdc` 250 and 500 → 100, `topup_multiplier` 1.5 → 3.0, aligning both auto-dispatchers with `monitoring-limit-geo` and the `e2e-topup-accounts` defaults.
- Needed here rather than in a follow-up: `reserve_usdc` is applied by an exact `symbol === "USDC"` match in `fund-utils.ts`, so the moment `TOKEN_DENOMS.USDC` becomes the alloy the reserve guards allUSDC instead of Noble. The converted alloy balance is much smaller than the old Noble one, and a 250/500 reserve against it left nothing distributable — a dispatch would send nothing, still conclude `success`, and then rate-limit real dispatches for the whole 45-minute cooldown. That is the same class of failure this PR fixes, in the new denom.
- `100` / `3.0` is what the other two dispatchers already use and what `packages/e2e/README.md` documents as the defaults, so this is convergence rather than new policy.

**packages/e2e/scripts/sweep-surplus.ts**
- Explicit legacy-denom pass: symbols in `LEGACY_SWEEP_SYMBOLS` (currently `USDC.noble`) are swept in full regardless of requirements, so the accounts' Noble consolidates in the holding account where the one-off conversion to the alloy happens. Without this the legacy balance would have been visible but never swept.
- `TOPUP_TARGET_MULTIPLIER` docstring corrected: it claimed only the monitoring workflow's topup-dispatch job ran at 3.0, which is now true of every dispatcher.

**packages/e2e/utils/usdc-identity.ts** (new)
- `resolveAppUsdcDenom()` asks the build under test (the same edge tRPC assets route the token selector uses) which denom `USDC` resolves to, and fails loudly on anything other than the alloy or Noble.

**packages/e2e/tests** (`swap.usdc`, `trade`, `portfolio`, `transactions` wallet specs)
- `trade.wallet.spec` derives its expected USDC denom from the build via `resolveAppUsdcDenom()` in `beforeAll` and asserts exactly that: a pre-handover build expects Noble, a handover build expects the alloy, and a handover build that regressed to routing through Noble fails rather than passing. `selectPair("USDC", …)` needs no change: it already follows the symbol.
- `portfolio`, `swap.usdc` (unused constant) and `transactions` (assertion inside a skipped test) move their hardcoded denoms to the alloy.

**packages/e2e/utils/price-utils.ts**
- Deliberately unchanged in value: the denom here is the sidecar's price *quote* asset (the key of each inner price map), which stays Noble until SQS repoints its quote denom, independently of the assetlist handover. A comment now says so, so it is not "fixed" alongside `TOKEN_DENOMS.USDC`.

**packages/e2e/utils/balance-config.ts**
- Note on the E2E account's USDC requirement recording the identity and the funding prerequisite below.

## Funding prerequisite — completed 2026-08-26

The auto-topup chain (check-balances → "E2E: Topup Test Accounts", dispatched `--ref stage`) bank-sends from the holding account `osmo1nz4a9cjyz6fg0udacuhjkmpwqr7xxsfatvzavm`, and nothing in `packages/e2e` can swap, so the alloy had to be funded by hand before the top-up could distribute it.

- [x] Converted 330 Noble USDC → allUSDC in the holding account through the transmuter (pool 3497, 1:1). It now holds 270.00 allUSDC and 567.24 Noble. Sizing under the uniform dispatcher settings above: worst-case fleet demand is 44.1 allUSDC (E2E 10.5 + US 19.8 + EU 6.9 + SG 6.9, each `warnAmount × 3.0`) plus the 100 `reserve_usdc`, so 144.1 needed against 270 held.
- [x] Hand-funded all four test accounts directly so the suites can run before merge: E2E `osmo1m0dqs32zd4gsyq06wehltjk2cdgt3qt6ysglp7` about 19, and 20 each to Monitoring US, EU and SG. Every account is now above its allUSDC `warnAmount`, so `check-balances` reports `pass` and dispatches nothing.
- [ ] After merge to `stage`, confirm the next auto-topup funds allUSDC from the converted holding balance.

Transitional note: until the monitoring builds regenerate their assetlist, those suites keep trading Noble (which the accounts hold) while the balance check reports the alloy; a top-up of allUSDC in that window is harmless.

## Transition handling

The fleet is mid-handover: `main`'s generated assetlist has not regenerated yet, so builds from it still resolve `USDC` to Noble, while handover-carrying builds resolve it to the alloy. Rather than hardcode either or accept both, the trade spec asks the build which identity it carries and asserts that exactly, so it is correct on both sides of the transition and still catches a regression. Verified against both previews at the time: this PR's resolved to Noble, #4445's to the alloy.

Note on ordering: #4445 merged to `stage` on 2026-08-26 at 13:22 UTC, ahead of this PR rather than after it. With `ASSET_LIST_COMMIT_HASH` unset, builds resolve the latest assetlist at build time, so `stage` can now trade the alloy while `stage`'s own balance gate still measures Noble. That is harmless only because both denoms are currently funded in every wallet, which is a reason to land this sooner rather than later.

## Testing and Verifying

- `tsc --noEmit` on `packages/e2e`: no errors in the changed files (the reported errors in `trade-page.ts` and `unzip-extension.ts` are pre-existing).
- CI on this PR: with all four accounts funded in both denoms, the `check-balances` precursor now reports `pass` and the USDC and trade suites run. On a pre-handover build they trade Noble, with the trade spec expecting Noble via the resolver. Earlier runs on this branch failed the precursor on the E2E account's allUSDC shortfall (0.10 < 1.7), before the manual funding above.
- The dispatcher change is self-testing: `pull_request` runs take the workflow file from the merge ref, so this PR's own preview run exercises the new `reserve_usdc` and `topup_multiplier` values.
- The real verification is a handover-carrying build once this is on `stage`: its USDC suite should go green, and the monitoring suites should survive the [AUTO] regeneration.

### Linear Task

https://linear.app/osmosis/issue/MTN-284/e2e-follow-the-usdc-identity-handover-alloy-denom-top-up-funding
