### PR TITLE
Release to production

### DIFF
--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -159,12 +159,17 @@ jobs:
               if [ "$RECENT" -gt 0 ]; then
                 echo "Recent successful or in-flight topup within cooldown — skipping dispatch."
               else
+                # reserve_usdc guards allUSDC after the identity handover, and the
+                # converted alloy balance is far smaller than the old Noble one, so
+                # a 250/500 reserve left nothing distributable. Kept at the 100/3.0
+                # the other dispatchers use, which is what the README documents and
+                # what sweep-surplus's TOPUP_TARGET_MULTIPLIER assumes.
                 gh workflow run "E2E: Topup Test Accounts" \
                   --ref stage \
                   -f dry_run=false \
-                  -f topup_multiplier=1.5 \
+                  -f topup_multiplier=3.0 \
                   -f reserve_osmo=5 \
-                  -f reserve_usdc=250
+                  -f reserve_usdc=100
                 echo "Topup workflow dispatched (balance outcome: $OUTCOME)."
               fi
             else

--- a/.github/workflows/prod-frontend-e2e-tests.yml
+++ b/.github/workflows/prod-frontend-e2e-tests.yml
@@ -139,12 +139,17 @@ jobs:
               if [ "$RECENT" -gt 0 ]; then
                 echo "Recent successful or in-flight topup within cooldown — skipping dispatch."
               else
+                # reserve_usdc guards allUSDC after the identity handover, and the
+                # converted alloy balance is far smaller than the old Noble one, so
+                # a 250/500 reserve left nothing distributable. Kept at the 100/3.0
+                # the other dispatchers use, which is what the README documents and
+                # what sweep-surplus's TOPUP_TARGET_MULTIPLIER assumes.
                 gh workflow run "E2E: Topup Test Accounts" \
                   --ref stage \
                   -f dry_run=false \
-                  -f topup_multiplier=1.5 \
+                  -f topup_multiplier=3.0 \
                   -f reserve_osmo=5 \
-                  -f reserve_usdc=500
+                  -f reserve_usdc=100
                 echo "Topup workflow dispatched (balance outcome: $OUTCOME)."
               fi
             else

--- a/packages/e2e/scripts/sweep-surplus.ts
+++ b/packages/e2e/scripts/sweep-surplus.ts
@@ -15,6 +15,10 @@
  * drop a wallet low enough to trigger an auto-topup — no ping-pong between
  * the two workflows.
  *
+ * Legacy denoms listed in LEGACY_SWEEP_SYMBOLS (currently Noble USDC, since the
+ * app's "USDC" identity moved to the alloy) have no requirement and are swept in
+ * full, so they consolidate in the holding account for the one-off conversion.
+ *
  * Environment variables:
  * - `E2E_PRIVATE_KEY_TOPUP`   — topup account key (destination address).
  * - `E2E_PRIVATE_KEY_PREVIEW`, `TEST_PRIVATE_KEY_SG/EU/US` — source signers.
@@ -35,6 +39,14 @@ import type { Coin } from "@cosmjs/stargate";
 import BigNumber from "bignumber.js";
 
 import { ACCOUNT_REQUIREMENTS } from "../utils/balance-config";
+
+/**
+ * Symbols swept in full regardless of requirements. These are legacy denoms the
+ * tests no longer use (the app's "USDC" identity moved to the alloy), so any
+ * balance is surplus, and consolidating them in the holding account is where
+ * the one-off conversion to the alloy happens. Must be keys of TOKEN_DENOMS.
+ */
+const LEGACY_SWEEP_SYMBOLS = ["USDC.noble"];
 import { TOKEN_DENOMS } from "../utils/balance-checker";
 import { deriveAddress, createSigningClient, OSMOSIS_RPC } from "../utils/order-utils";
 import {
@@ -49,8 +61,9 @@ dotenv.config({ path: path.resolve(__dirname, "../.env") });
 
 const MINTSCAN_TX_URL = "https://www.mintscan.io/osmosis/txs";
 
-/** Matches the auto-topup refill target (topup_multiplier 3.0 dispatched by
- * the monitoring workflow's topup-dispatch job). */
+/** Matches the auto-topup refill target (topup_multiplier 3.0, now dispatched
+ * uniformly by every auto-dispatcher: monitoring-limit-geo, frontend-e2e and
+ * prod-frontend-e2e). */
 const TOPUP_TARGET_MULTIPLIER = 3.0;
 /** Derived from the topup target so the floor stays above it even if the
  * target changes — sweeping below it would trigger auto-topup ping-pong. */
@@ -293,6 +306,21 @@ async function main(): Promise<void> {
             .toFixed(Math.min(bal.decimals, 4))} (keep ${target.toFixed(4)})`
         );
         coins.push({ denom: bal.denom, amount: rawSweep.toFixed(0) });
+      }
+
+      // Legacy denoms: no requirement keeps any of the balance, sweep it all.
+      for (const symbol of LEGACY_SWEEP_SYMBOLS) {
+        const bal = balances.find((b) => b.symbol === symbol);
+        if (!bal || new BigNumber(bal.rawAmount).lte(0)) continue;
+        console.log(
+          `      ${symbol}: ${bal.amount.toFixed(
+            Math.min(bal.decimals, 4)
+          )} legacy denom  → sweep all`
+        );
+        coins.push({
+          denom: bal.denom,
+          amount: new BigNumber(bal.rawAmount).toFixed(0),
+        });
       }
 
       if (coins.length === 0) {

--- a/packages/e2e/tests/portfolio.wallet.spec.ts
+++ b/packages/e2e/tests/portfolio.wallet.spec.ts
@@ -35,7 +35,7 @@ test.describe('Test Portfolio feature', () => {
     {
       name: 'USDC',
       minimalDenom:
-        'ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4',
+        'factory/osmo147h5x9pcj7lm0cttlaefx6sqq5vdfnmwfcqxkmjd7exqm9gc7grqhr75m0/alloyed/allUSDC',
     },
     {
       name: 'TIA',

--- a/packages/e2e/tests/swap.usdc.wallet.spec.ts
+++ b/packages/e2e/tests/swap.usdc.wallet.spec.ts
@@ -10,7 +10,7 @@ test.describe("Test Swap to/from USDC feature", () => {
   const privateKey = process.env.PRIVATE_KEY ?? "private_key";
   let tradePage: TradePage;
   const _USDC =
-    "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4";
+    "factory/osmo147h5x9pcj7lm0cttlaefx6sqq5vdfnmwfcqxkmjd7exqm9gc7grqhr75m0/alloyed/allUSDC";
   const _ATOM =
     "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2";
   const _TIA =

--- a/packages/e2e/tests/trade.wallet.spec.ts
+++ b/packages/e2e/tests/trade.wallet.spec.ts
@@ -3,18 +3,25 @@ import { TradePage } from "../pages/trade-page";
 import { TransactionsPage } from "../pages/transactions-page";
 import { SetupKeplr } from "../setup-keplr";
 import { ensureBalances } from "../utils/balance-checker";
+import { resolveAppUsdcDenom } from "../utils/usdc-identity";
 import { deriveAddress } from "../utils/wallet-utils";
 
 test.describe("Test Trade feature", () => {
   let context: BrowserContext;
   const privateKey = process.env.PRIVATE_KEY ?? "private_key";
   let tradePage: TradePage;
-  const USDC =
-    "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4";
+  // Resolved from the build under test in beforeAll: "USDC" is the alloy on
+  // builds carrying the assetlist identity handover and Noble on builds that
+  // predate it. Derived, not hardcoded, so the assertion follows whichever
+  // identity the build's token selector reports and fails when the selector
+  // and the swap route disagree. It does not prove the build carries the
+  // handover — if the assetlist still says Noble, this expects Noble.
+  let USDC: string;
   const ATOM =
     "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2";
 
   test.beforeAll(async () => {
+    USDC = await resolveAppUsdcDenom();
     context = await new SetupKeplr().setupWallet(privateKey);
 
     const { address } = await deriveAddress(privateKey);
@@ -28,7 +35,9 @@ test.describe("Test Trade feature", () => {
   });
 
   test.afterAll(async () => {
-    await context.close();
+    // beforeAll resolves the USDC identity before the wallet exists, and that
+    // resolver throws by design, so context can still be undefined here.
+    await context?.close();
   });
 
   test.beforeEach(async () => {

--- a/packages/e2e/tests/transactions.wallet.spec.ts
+++ b/packages/e2e/tests/transactions.wallet.spec.ts
@@ -47,7 +47,7 @@ test.describe('Test Transactions feature', () => {
     expect(msgContentAmount).toBeTruthy()
     expect(msgContentAmount).toContain(`sender: ${walletId}`)
     expect(msgContentAmount).toContain(
-      'denom: ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4',
+      'denom: factory/osmo147h5x9pcj7lm0cttlaefx6sqq5vdfnmwfcqxkmjd7exqm9gc7grqhr75m0/alloyed/allUSDC',
     )
     expect(swapPage.isTransactionBroadcasted(10))
     expect(swapPage.isTransactionSuccesful(10))

--- a/packages/e2e/utils/balance-checker.ts
+++ b/packages/e2e/utils/balance-checker.ts
@@ -42,7 +42,19 @@ export const TOKEN_DENOMS: Record<
   { denom: string; decimals: number }
 > = {
   OSMO: { denom: "uosmo", decimals: 6 },
+  // "USDC" follows the app's USDC identity. Since the assetlist handover
+  // (2026-08-25) the symbol resolves to the alloy, so tests that select
+  // "USDC" by symbol trade the alloy and balance checks / top-ups must
+  // fund the alloy, not Noble.
   USDC: {
+    denom: "factory/osmo147h5x9pcj7lm0cttlaefx6sqq5vdfnmwfcqxkmjd7exqm9gc7grqhr75m0/alloyed/allUSDC",
+    decimals: 6,
+  },
+  // Legacy Noble USDC (now "USDC.noble" in the app). Kept visible to the
+  // fleet report, and swept in full by sweep-surplus (legacy sweep) so the
+  // accounts' Noble consolidates in the holding account for the one-off
+  // conversion to the alloy. Not a top-up target.
+  "USDC.noble": {
     denom: "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
     decimals: 6,
   },

--- a/packages/e2e/utils/balance-config.ts
+++ b/packages/e2e/utils/balance-config.ts
@@ -54,7 +54,7 @@ export const ACCOUNT_REQUIREMENTS: Record<
     // trade.wallet.spec.ts: buy 1.12 USDC, sell 1.11+1.01 ATOM, limit 1.01 OSMO
     // swap.usdc.wallet.spec.ts: 0.5 USDC, 0.015 ATOM, 0.02 TIA, 0.01 INJ, 0.025 AKT
     // swap.osmo.wallet.spec.ts: 0.2 OSMO, 0.01 ATOM
-    { token: "USDC", minAmount: 1.7, warnAmount: 3.5, note: "~1.62 consumed (trade buy + swaps)" },
+    { token: "USDC", minAmount: 1.7, warnAmount: 3.5, note: "~1.62 consumed (trade buy + swaps). USDC is the alloy since the assetlist identity handover; the topup account must hold allUSDC (convert Noble 1:1 via the transmuter) for auto-topup to fund it." },
     { token: "ATOM", minAmount: 2.27, warnAmount: 4.5, note: "~2.16 consumed (trade sell + limit + swaps)" },
     { token: "OSMO", minAmount: 1.3, warnAmount: 2.5, unit: "usd", note: "USD-denominated (MTN-157): the limit sell is fiat-mode (~$1.01), so required OSMO scales inversely with price. Fixed token thresholds went stale as OSMO fell and created a topup dead-zone (3.4 OSMO cleared the old 2.5-token gate yet starved the sells). min covers the fiat sell (~$1.01) PLUS the swap.osmo 0.2 OSMO swap (token-denominated), with deliberate price headroom: at $1.3 the USD floor still funds the fixed 0.2 OSMO swap until OSMO reaches ~$1.45 (1.01 + 0.2*1.45 = 1.30), well above the current ~$0.04; warn≈2x. NB: the 0.2 OSMO swap is a fixed token need, so this USD floor under-provisions only once OSMO climbs past ~$1.45; revisit then. NB: the check-balances auto-topup dispatches --ref stage, so the scaled target only applies once this is merged to stage." },
     { token: "TIA", minAmount: 0.022, warnAmount: 0.05, note: "~0.02 consumed (swap TIA)" },

--- a/packages/e2e/utils/price-utils.ts
+++ b/packages/e2e/utils/price-utils.ts
@@ -16,6 +16,10 @@
 
 import { SQS_BASE_URL } from "./config";
 
+// The denom SQS quotes prices in (the key of each inner price map). This is
+// SQS's quote asset, NOT the app's "USDC" identity: it stays Noble until the
+// sidecar repoints its quote denom to the alloy, independently of the
+// assetlist handover. Do not "fix" it alongside TOKEN_DENOMS.USDC.
 const USDC_DENOM =
   "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4";
 

--- a/packages/e2e/utils/usdc-identity.ts
+++ b/packages/e2e/utils/usdc-identity.ts
@@ -1,0 +1,63 @@
+/**
+ * @file usdc-identity.ts
+ * @description Resolves which denom the build under test attaches to the
+ * symbol "USDC".
+ *
+ * The assetlist identity handover moved "USDC" from Noble to the allUSDC
+ * alloy, but builds pick their assetlist up at build time, so during the
+ * transition some deployments still resolve "USDC" to Noble while others
+ * resolve it to the alloy. Specs that assert on the USDC denom must derive
+ * the expectation from the build they are running against rather than
+ * hardcode it: hardcoding the alloy fails on pre-handover builds, and
+ * accepting either denom at the assertion would let a handover build
+ * silently regress to routing through Noble.
+ *
+ * What this does and does not prove. Pinning the assertion to the identity
+ * the build's own token selector reports catches the selector and the swap
+ * route disagreeing — a build that offers the alloy but trades Noble fails.
+ * It cannot prove that a build *ought* to carry the handover: if the
+ * assetlist itself still says Noble, this returns Noble and the assertion
+ * follows it. Deciding which identity a deployment should carry is the
+ * assetlist's job, not a spec's.
+ */
+
+const ALLOY_DENOM =
+  "factory/osmo147h5x9pcj7lm0cttlaefx6sqq5vdfnmwfcqxkmjd7exqm9gc7grqhr75m0/alloyed/allUSDC";
+const NOBLE_DENOM =
+  "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4";
+
+/**
+ * Asks the app's own asset endpoint what "USDC" resolves to. Uses the edge
+ * tRPC assets router (`/api/edge-trpc-assets`, the same route the UI calls),
+ * so the answer is exactly the identity the token selector will use.
+ *
+ * Fails loudly rather than falling back: a wrong guess here would either
+ * mask a regression or fail every USDC test for the wrong reason.
+ */
+export async function resolveAppUsdcDenom(
+  baseUrl: string = process.env.BASE_URL ?? "https://stage.osmosis.zone"
+): Promise<string> {
+  const input = encodeURIComponent(
+    JSON.stringify({ json: { findMinDenomOrSymbol: "USDC" } })
+  );
+  const url = `${baseUrl.replace(/\/+$/, "")}/api/edge-trpc-assets/assets.getUserAsset?input=${input}`;
+  const response = await fetch(url, { signal: AbortSignal.timeout(30_000) });
+  if (!response.ok) {
+    throw new Error(
+      `Failed to resolve the app's USDC identity: ${response.status} ${response.statusText} (${url})`
+    );
+  }
+  const body = (await response.json()) as {
+    result?: { data?: { json?: { coinMinimalDenom?: string } } };
+  };
+  const denom = body.result?.data?.json?.coinMinimalDenom;
+  if (denom !== ALLOY_DENOM && denom !== NOBLE_DENOM) {
+    throw new Error(
+      `Unexpected USDC identity from ${baseUrl}: ${denom ?? "<none>"}`
+    );
+  }
+  console.log(
+    `  App "USDC" identity: ${denom === ALLOY_DENOM ? "allUSDC (alloy)" : "Noble"} (${denom})`
+  );
+  return denom;
+}

--- a/packages/web/components/bridge/use-bridges-supported-assets.ts
+++ b/packages/web/components/bridge/use-bridges-supported-assets.ts
@@ -278,8 +278,10 @@ export const useBridgesSupportedAssets = ({
     // selects the single family member whose halt flags represent the hoisted
     // destination route (undefined => the same predicate as `matchesAsset`, used
     // when the asset and its destination route are the same entry).
+    // `chainId` is a string for Cosmos chains and a number for EVM ones, so it
+    // is compared by identity below rather than assumed to be a string.
     type HoistRule = {
-      chainId: string;
+      chainId: string | number;
       matchesAsset: (asset: MinimalAsset) => boolean | undefined;
       matchesRouteVariant?: (asset: MinimalAsset) => boolean | undefined;
     };
@@ -298,13 +300,14 @@ export const useBridgesSupportedAssets = ({
       asset.coinGeckoId === "cosmos";
 
     const hoistRules: HoistRule[] = [
-      // USDC -> Noble. The destination route is *native Noble* USDC, i.e. the
-      // canonical `USDC` entry (bridged variants are chain-qualified: USDC.eth.grv,
-      // USDC.avax.axl, ...). The route-variant matcher must be narrow: reusing the
-      // broad `isUsdcAsset` would let a halted bridged sibling (e.g. USDC.eth.grv)
-      // wrongly suppress the Noble default even when native Noble USDC is fine.
+      // USDC -> Ethereum, which holds the large majority of USDC supply.
+      // Routing is left to the bridge providers (Skip may use CCTP, Axelar or
+      // another path), so the route variant is the canonical `USDC` alloy that
+      // a routed transfer settles in, not any single bridge's wrapped variant.
+      // Gating on e.g. USDC.eth.axl would suppress the default whenever Axelar
+      // was halted, even with other Ethereum routes healthy.
       {
-        chainId: "noble-1",
+        chainId: 1,
         matchesAsset: isUsdcAsset,
         matchesRouteVariant: (asset) =>
           asset.coinDenom?.toUpperCase() === "USDC",

--- a/packages/web/components/complex/pool/create/cl-pool.tsx
+++ b/packages/web/components/complex/pool/create/cl-pool.tsx
@@ -25,14 +25,14 @@ export type SelectionToken = {
 };
 
 const USDC_ASSET: SelectionToken = {
-  chainName: "noble",
+  chainName: "osmosis",
   token: {
     coinDenom: "USDC",
     coinDecimals: 6,
     // Testnet
     // coinMinimalDenom: "ibc/DE6792CF9E521F6AD6E9A4BDF6225C9571A3B74ACC0A529F92BC5122A39D2E58"
     coinMinimalDenom:
-      "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
+      "factory/osmo147h5x9pcj7lm0cttlaefx6sqq5vdfnmwfcqxkmjd7exqm9gc7grqhr75m0/alloyed/allUSDC",
     coinImageUrl:
       "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.svg",
   },

--- a/packages/web/components/swap-tool/price-selector.tsx
+++ b/packages/web/components/swap-tool/price-selector.tsx
@@ -40,6 +40,8 @@ const UI_DEFAULT_QUOTES: string[] = [USDC_BASE_DENOM, USDT_BASE_DENOM];
 
 const VALID_QUOTES: string[] = [
   ...UI_DEFAULT_QUOTES,
+  // "allUSDC",
+  "factory/osmo147h5x9pcj7lm0cttlaefx6sqq5vdfnmwfcqxkmjd7exqm9gc7grqhr75m0/alloyed/allUSDC",
   // "USDC.sol.wh",
   "ibc/F08DE332018E8070CC4C68FE06E04E254F527556A614F5F8F9A68AF38D367E45",
   // "USDC.eth.grv",


### PR DESCRIPTION
## What is the purpose of the change:

Release `stage` to production. A small release: the USDC alloy becomes a selectable quote asset in swap, two related defaults repoint at it, and the E2E suite is updated to follow the assetlist identity handover that now resolves the symbol `USDC` to the alloy.

**Noble USDC remains the app's default quote.** `USDC_BASE_DENOM` and `UI_DEFAULT_QUOTES` are untouched by this release; that flip is #4447, targeted at early September and requiring its own coordination with the SQS deploy.

### Linear Task

Per-change tasks are linked in the individual PRs below (MTN-284).

## Brief Changelog

**Features**

- #4445 — feat(swap): allow `allUSDC` as a selectable quote. Three additive defaults pointing at the USDC alloy and its constituent:
  - The alloy joins `VALID_QUOTES` in `price-selector.tsx`, scoped to Buy and Limit mode. Sell mode filters on `UI_DEFAULT_QUOTES` by design, so the alloy correctly does not appear there yet.
  - Supercharged pool creation (`cl-pool.tsx`) defaults its quote to the alloy rather than Noble, so new CL pools are no longer created against the asset being migrated away from.
  - USDC deposit/withdraw defaults to Ethereum (`use-bridges-supported-assets.ts`) rather than Noble, which stays selectable. `HoistRule.chainId` widens to `string | number` so the EVM numeric chain id can match at all — under strict equality a string `"1"` could never have matched Ethereum's numeric `1`, so that hoist would have silently never fired.

**Fixes**

- #4448 — fix(e2e): follow the USDC identity handover to the alloy. Since assetlists#3727 the app resolves `USDC` to the alloy and renames Noble to `USDC.noble`, while the balance checker, auto-topup and denom assertions still pointed at Noble. `TOKEN_DENOMS.USDC` now maps to the alloy, a new `resolveAppUsdcDenom()` helper asks the build under test which identity it carries so the trade spec is correct on both sides of the transition, the two auto-dispatchers converge on the documented `reserve_usdc=100` / `topup_multiplier=3.0` defaults, and `sweep-surplus` gains an explicit legacy-denom pass so stranded Noble balances consolidate.

## Testing and Verifying

Each change was tested and verified in its own PR.

- **#4445** merged with the full suite green, including all five preview E2E suites (`check-balances`, claim, portfolio-trx, swap-osmo, swap-usdc, trade), lint, and production build. Verified end to end on the branch: a TIA/allUSDC orderbook was created through the interface (pool 3566), and withdrawals to Noble, Injective and Ethereum all settled.
- **#4448** had a full green suite (Jest, Lint and Format, Server E2E, Preview frontend E2E) at `c56cf3cae`. The final commit `6955d59ff` hit a GitHub `startup_failure` on the E2E workflow rather than a test failure. That commit is test-scaffolding only: comment corrections plus one `context?.close()` optional chain in `afterAll`, with no production code touched. Both E2E workflow files on `stage` were re-parsed as valid YAML (8 and 4 jobs) and the new `reserve_usdc` / `topup_multiplier` values confirmed present, so the startup failure was not caused by the workflow edits in this PR.

## Post-merge follow-up

Carried over from #4448: confirm the next auto-topup funds allUSDC from the converted holding balance. All four test accounts were hand-funded above their allUSDC `warnAmount` on 2026-08-26, so `check-balances` reports `pass` and dispatches nothing in the meantime.

## Note on merge method

This PR must be merged with a **merge commit, not a squash**. Squashing #4427 broke shared ancestry between `stage` and `master` and required a repair PR; `stage` again has commits `master` does not, so a squash here would repeat that.
