### PR TITLE
Release to production

### DIFF
--- a/packages/e2e/pages/trade-page.ts
+++ b/packages/e2e/pages/trade-page.ts
@@ -396,6 +396,17 @@ export class TradePage extends BasePage {
     await expect(swapInfo, "Show Swap Info button not visible!").toBeVisible({
       timeout: 10000,
     });
+    // The disclosure renders as soon as there is an input amount but stays
+    // disabled until the quote fills the out amount, so wait for it to be
+    // enabled rather than racing the quote with the click timeout.
+    const swapInfoBtn = this.page.locator(
+      "//button[.//span[.='Show details']]"
+    );
+    await expect(swapInfoBtn, "Show Swap Info button is disabled!").toBeEnabled(
+      {
+        timeout: 15000,
+      }
+    );
     await swapInfo.click({ timeout: 5000 });
   }
 

--- a/packages/e2e/utils/price-utils.ts
+++ b/packages/e2e/utils/price-utils.ts
@@ -17,16 +17,22 @@
 import { SQS_BASE_URL } from "./config";
 
 // The denom SQS quotes prices in (the key of each inner price map). This is
-// SQS's quote asset, NOT the app's "USDC" identity: it stays Noble until the
-// sidecar repoints its quote denom to the alloy, independently of the
-// assetlist handover. Do not "fix" it alongside TOKEN_DENOMS.USDC.
-const USDC_DENOM =
+// SQS's quote asset, NOT the app's "USDC" identity, and it moves with the
+// sidecar's own quote-denom repoint rather than with the assetlist handover.
+//
+// A sidecar instance resolves the symbol "usdc" once at boot, so it quotes in
+// the alloy from its next restart onward and in Noble USDC until then. A
+// load-balanced deployment can therefore serve both keys at the same time
+// while a restart rolls through the fleet, so read the alloy first and fall
+// back to Noble instead of pinning either one. Mirrors `getQuotePrice` in
+// packages/server/src/queries/sidecar/prices.ts; drop the fallback only once
+// every instance is confirmed quoting in the alloy.
+const QUOTE_DENOM =
+  "factory/osmo147h5x9pcj7lm0cttlaefx6sqq5vdfnmwfcqxkmjd7exqm9gc7grqhr75m0/alloyed/allUSDC";
+const LEGACY_QUOTE_DENOM =
   "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4";
 
-type SQSPriceResponse = Record<
-  string,
-  Record<string, string>
->;
+type SQSPriceResponse = Record<string, Record<string, string>>;
 
 // Retry parameters for transient SQS pricing failures (e.g. Node `fetch failed`
 // from EAI_AGAIN, ECONNRESET, TLS handshake hiccups, or 30s timeouts on cold
@@ -75,7 +81,9 @@ export async function fetchTokenPrices(
 
       const result: Record<string, number> = {};
       for (const [denom, priceMap] of Object.entries(data)) {
-        const usdcPrice = priceMap[USDC_DENOM] ?? Object.values(priceMap)[0];
+        // Never fall back to an arbitrary key: an unrecognised quote denom
+        // would silently price the token in the wrong asset.
+        const usdcPrice = priceMap[QUOTE_DENOM] ?? priceMap[LEGACY_QUOTE_DENOM];
         if (usdcPrice) {
           const parsed = parseFloat(usdcPrice);
           if (!isNaN(parsed)) {

--- a/packages/server/src/queries/complex/assets/price/providers/sidecar.ts
+++ b/packages/server/src/queries/complex/assets/price/providers/sidecar.ts
@@ -5,8 +5,8 @@ import cachified, { CacheEntry } from "cachified";
 import { LRUCache } from "lru-cache";
 
 import {
+  getQuotePrice,
   queryPrices,
-  QUOTE_COIN_MINIMAL_DENOM,
 } from "../../../../../queries/sidecar/prices";
 import { EdgeDataLoader } from "../../../../../utils/batching";
 import { LARGE_LRU_OPTIONS } from "../../../../../utils/cache";
@@ -35,8 +35,15 @@ function getBatchLoader() {
           queryPrices(coinMinimalDenoms as string[]).then((priceMap) =>
             coinMinimalDenoms.map((baseCoinMinimalDenom) => {
               try {
-                const price =
-                  priceMap[baseCoinMinimalDenom][QUOTE_COIN_MINIMAL_DENOM];
+                // Accepts the current or legacy quote key: sidecar flips its
+                // quote denom on restart, independently of this deploy.
+                const price = getQuotePrice(priceMap[baseCoinMinimalDenom]);
+
+                if (isNil(price)) {
+                  return new Error(
+                    `No SQS price result for ${baseCoinMinimalDenom} and USDC`
+                  );
+                }
 
                 // trim to 18 decimals to silence Dec warnings
                 const p = price.replace(/(\.\d{18})\d*/, "$1");

--- a/packages/server/src/queries/sidecar/__tests__/prices.spec.ts
+++ b/packages/server/src/queries/sidecar/__tests__/prices.spec.ts
@@ -1,0 +1,31 @@
+import {
+  getQuotePrice,
+  LEGACY_QUOTE_COIN_MINIMAL_DENOM,
+  QUOTE_COIN_MINIMAL_DENOM,
+} from "../prices";
+
+describe("getQuotePrice", () => {
+  it("reads the current (alloy) quote key", () => {
+    expect(getQuotePrice({ [QUOTE_COIN_MINIMAL_DENOM]: "1.5" })).toBe("1.5");
+  });
+
+  it("falls back to the legacy (Noble) quote key while sidecar has not restarted", () => {
+    expect(getQuotePrice({ [LEGACY_QUOTE_COIN_MINIMAL_DENOM]: "1.5" })).toBe(
+      "1.5"
+    );
+  });
+
+  it("prefers the current key when a response carries both", () => {
+    expect(
+      getQuotePrice({
+        [LEGACY_QUOTE_COIN_MINIMAL_DENOM]: "1.4",
+        [QUOTE_COIN_MINIMAL_DENOM]: "1.5",
+      })
+    ).toBe("1.5");
+  });
+
+  it("returns undefined, never zero, when neither key is present", () => {
+    expect(getQuotePrice({ "some/other/denom": "1.5" })).toBeUndefined();
+    expect(getQuotePrice(undefined)).toBeUndefined();
+  });
+});

--- a/packages/server/src/queries/sidecar/prices.ts
+++ b/packages/server/src/queries/sidecar/prices.ts
@@ -2,14 +2,47 @@ import { apiClient } from "@osmosis-labs/utils";
 
 import { SIDECAR_BASE_URL } from "../../env";
 
-/** Current quote denom for prices returned by sidecar. Currently Noble USDC. */
+/**
+ * The quote denom the app expects sidecar prices in: Alloyed USDC.
+ *
+ * Sidecar does not hardcode its quote denom; it resolves the human symbol
+ * "usdc" against the assetlist once at boot. Since the assetlist identity
+ * handover that symbol resolves to the alloy, so a sidecar instance quotes in
+ * the alloy from its next restart onward and in Noble USDC until then. The two
+ * deployments therefore cannot be assumed to flip together, and the lookup
+ * below accepts either key so price reads keep working on both sides of the
+ * sidecar restart.
+ */
 export const QUOTE_COIN_MINIMAL_DENOM =
+  "factory/osmo147h5x9pcj7lm0cttlaefx6sqq5vdfnmwfcqxkmjd7exqm9gc7grqhr75m0/alloyed/allUSDC";
+
+/**
+ * The quote denom sidecar returned before the identity handover (Noble USDC).
+ * Transitional: remove this constant and the fallback in `getQuotePrice` once
+ * every production sidecar instance is confirmed quoting in the alloy.
+ */
+export const LEGACY_QUOTE_COIN_MINIMAL_DENOM =
   "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4";
 
+/**
+ * Reads a base asset's quote price out of a sidecar price map, preferring the
+ * current quote denom and falling back to the legacy one. Returns undefined
+ * when neither key is present; callers must treat that as "no price", never
+ * as zero.
+ */
+export function getQuotePrice(
+  quotes: Record<string, string> | undefined
+): string | undefined {
+  if (!quotes) return undefined;
+  return (
+    quotes[QUOTE_COIN_MINIMAL_DENOM] ?? quotes[LEGACY_QUOTE_COIN_MINIMAL_DENOM]
+  );
+}
+
 export type PriceMap = {
-  [baseCoinMinimalDenom: string]: {
-    [QUOTE_COIN_MINIMAL_DENOM]: string;
-  };
+  /** Inner map is keyed by the quote denom the responding sidecar instance
+   *  uses (see `getQuotePrice`). */
+  [baseCoinMinimalDenom: string]: Record<string, string>;
 };
 
 export async function queryPrices(coinMinimalDenoms: string[]) {

--- a/packages/web/components/place-limit-tool/defaults.ts
+++ b/packages/web/components/place-limit-tool/defaults.ts
@@ -1,6 +1,9 @@
 export const ATOM_BASE_DENOM =
   "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2";
 export const USDC_BASE_DENOM =
+  "factory/osmo147h5x9pcj7lm0cttlaefx6sqq5vdfnmwfcqxkmjd7exqm9gc7grqhr75m0/alloyed/allUSDC";
+/** USDC via Noble. Retained as a selectable quote while users still hold it. */
+export const USDC_NOBLE_BASE_DENOM =
   "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4";
 export const USDT_BASE_DENOM =
   "factory/osmo1em6xs47hd82806f5cxgyufguxrrc7l0aqx7nzzptjuqgswczk8csavdxek/alloyed/allUSDT";

--- a/packages/web/components/swap-tool/price-selector.tsx
+++ b/packages/web/components/swap-tool/price-selector.tsx
@@ -13,14 +13,12 @@ import { Icon } from "~/components/assets";
 import {
   ATOM_BASE_DENOM,
   USDC_BASE_DENOM,
+  USDC_NOBLE_BASE_DENOM,
   USDT_BASE_DENOM,
 } from "~/components/place-limit-tool/defaults";
 import { EntityImage } from "~/components/ui/entity-image";
 import { EventName } from "~/config";
-import {
-  AssetLists,
-  MainnetAssetSymbols,
-} from "~/config/generated/asset-lists";
+import { AssetLists } from "~/config/generated/asset-lists";
 import {
   Breakpoint,
   useAmplitudeAnalytics,
@@ -38,32 +36,42 @@ type AssetWithBalance = Asset & MaybeUserAssetCoin;
 
 const UI_DEFAULT_QUOTES: string[] = [USDC_BASE_DENOM, USDT_BASE_DENOM];
 
+/**
+ * Quotes a user may receive when selling. Sell mode is deliberately limited
+ * to the canonical stables, but Noble USDC stays selectable (not default)
+ * while pairs that only have a Noble-quoted orderbook remain: dropping it
+ * here would make limit sells on those pairs impossible while limit buys
+ * still work. Keeps default ordering (UI_DEFAULT_QUOTES) separate from the
+ * Sell allowlist.
+ */
+const SELL_QUOTES: string[] = [...UI_DEFAULT_QUOTES, USDC_NOBLE_BASE_DENOM];
+
+/**
+ * Quotes selectable in Buy and Limit mode: the two canonical stables and the
+ * constituents that redeem 1:1 into them through their transmuter pools.
+ * Constituent sets read from the pool contracts (allUSDC
+ * osmo147h5x9p...hr75m0, allUSDT osmo1em6xs47...avdxek), not inferred from
+ * variant grouping. Other variants are not quotes, except where noted.
+ */
 const VALID_QUOTES: string[] = [
   ...UI_DEFAULT_QUOTES,
-  // "allUSDC",
-  "factory/osmo147h5x9pcj7lm0cttlaefx6sqq5vdfnmwfcqxkmjd7exqm9gc7grqhr75m0/alloyed/allUSDC",
-  // "USDC.sol.wh",
-  "ibc/F08DE332018E8070CC4C68FE06E04E254F527556A614F5F8F9A68AF38D367E45",
-  // "USDC.eth.grv",
-  "ibc/9F9B07EF9AD291167CF5700628145DE1DEB777C2CFC7907553B24446515F6D0E",
-  // "USDC.eth.wh",
-  "ibc/6B99DB46AA9FF47162148C1726866919E44A6A5E0274B90912FD17E19A337695",
-  // "USDC.e.matic.axl",
-  "ibc/231FD77ECCB2DB916D314019DA30FE013202833386B1908A191D16989AD80B5A",
-  // "USDC.avax.axl",
-  "ibc/F17C9CA112815613C5B6771047A093054F837C3020CBA59DFFD9D780A8B2984C",
-  // "USDC.eth.axl",
+  // allUSDC constituents
+  // "USDC.noble"
+  USDC_NOBLE_BASE_DENOM,
+  // "USDC.eth.axl"
   "ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858",
-  // "USDT.eth.grv",
-  "ibc/71B441E27F1BBB44DD0891BCD370C2794D404D60A4FFE5AECCD9B1E28BC89805",
-  // "USDT.eth.wh",
-  "ibc/2108F2D81CBE328F371AD0CEF56691B18A86E08C3651504E42487D9EE92DDE9C",
-  // "USDT.kava",
+  // "USDC.inj"
+  "ibc/794C7D7F3B857713878A3A1927251FA6AC1EEE520424C1F6FAFE9BA26D476138",
+  // allUSDT constituents
+  // "USDT.eth.axl"
+  "ibc/8242AD24008032E457D2E12D46588FD39FB54FB29680C6C7663D296B383C37C4",
+  // "USDT.eth.inj"
+  "ibc/2AD3C64D19ADFBB522CD738B58F421102143F827C1CAFF574A8BF0B81017D53D",
+  // "USDT.eth.atom"
+  "ibc/7BC2F718C47C0749791F2612A914C8C39D1A4F533A27AF7285D924D4B617DDA6",
+  // Kept as a quote in its own right; not an alloy constituent.
+  // "USDT.kava"
   "ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB",
-  // "USDT.eth.pica",
-  "ibc/078AD6F581E8115CDFBD8FFA29D8C71AFE250CE952AFF80040CBC64868D44AD3",
-  // "USDT.sol.pica",
-  "ibc/0233A3F2541FD43DBCA569B27AF886E97F5C03FC0305E4A8A3FAC6AC26249C7A",
 ];
 
 function sortByAmount(
@@ -155,7 +163,7 @@ export const PriceSelector = memo(
           data.items
             .map((walletAsset) => {
               if (
-                !(tab === "sell" ? UI_DEFAULT_QUOTES : VALID_QUOTES).includes(
+                !(tab === "sell" ? SELL_QUOTES : VALID_QUOTES).includes(
                   walletAsset.coinMinimalDenom
                 )
               ) {
@@ -199,13 +207,17 @@ export const PriceSelector = memo(
 
     /**
      * Stablecoin balances or Add funds CTA not shown in Sell trade mode.
-     * Sell trades limited to canonical USDC and alloyed USDT.
+     * Sell trades limited to the canonical stables plus legacy Noble USDC
+     * (see SELL_QUOTES).
      */
     const defaultQuotesWithBalances = useMemo(
       () =>
-        userQuotes?.filter(({ amount, symbol }) => {
-          if (UI_DEFAULT_QUOTES.includes(symbol as MainnetAssetSymbols))
-            return true;
+        userQuotes?.filter(({ amount, coinMinimalDenom }) => {
+          // UI_DEFAULT_QUOTES holds minimal denoms, so the zero-balance
+          // exemption for the default quotes must compare denoms: comparing
+          // the symbol never matched, which balance-gated the defaults and
+          // would hide the new default from anyone not yet holding it.
+          if (UI_DEFAULT_QUOTES.includes(coinMinimalDenom)) return true;
           return amount?.toDec().gt(new Dec(0)) ?? false;
         }) ?? [],
       [userQuotes]


### PR DESCRIPTION
## Release to production

Ships #4447: Alloyed USDC becomes the app's default USDC, and the sidecar price read becomes tolerant of either quote key.

### Why this one matters now

Production sidecar quotes prices in the denom it resolves from the symbol `usdc` at boot. Since the assetlist identity handover that symbol resolves to the alloy, so instances moved from the Noble key to the alloy key as they restarted, with no frontend deploy involved. Master still reads the Noble key by a fixed constant, so every sidecar price lookup on production returns no value and the swap widget cannot price a trade.

The production fleet has now finished restarting: 24 paced samples of `/tokens/prices?base=uosmo` returned the alloy key 24 times and the Noble key 0 times, where the same sampling during the rollout returned 10 alloy and 14 Noble. Master is therefore reading the wrong key on every request rather than intermittently, and this release is what restores pricing.

The price read prefers the alloy key and falls back to the Noble key, returning no price rather than zero when neither is present, so it is correct against a restarted instance, an un-restarted one, and a fleet mid-rollout. Stage sidecar is still quoting in Noble (10 of 10 samples), which that fallback covers.

### Contents

- Default USDC quote moves to the alloy across the limit tool, swap tool, quote dropdowns and URL defaults, with Noble still selectable on both sides of the trade flow.
- Quote allowlists narrowed to the canonical stables and the constituents that redeem 1:1 through their transmuter pools.
- Zero-balance exemption now compares `coinMinimalDenom` instead of `symbol`, so the default quote is not balance-gated.
- Sidecar price read accepts either quote key, with unit tests for both.
- e2e: price helper given the same either-key tolerance, and the swap details disclosure is now waited on for enabled rather than visible before clicking.

### Follow-ups not in this release

- `LEGACY_QUOTE_COIN_MINIMAL_DENOM` and its fallback stay until the alloy key is confirmed everywhere, including stage. Removing them is a separate change.
- `preview-pools-and-select-pair-tests` has been failing on a timing issue unrelated to this work: the pools table renders no rows inside the helper's 10s budget. This branch touches none of the pools files, and the pools list query does not read asset prices. Tracked separately.
