### PR TITLE
fix(bridge): retry failed supported-assets queries

### DIFF
--- a/packages/bridge/src/interface.ts
+++ b/packages/bridge/src/interface.ts
@@ -53,8 +53,12 @@ export interface BridgeProvider {
    * Restricted to assets that don't change the user's underlying asset exposure, in other words, is the same variant of the asset.
    * In practice, this can be used to offer a list of selectable assets for the user to choose from.
    *
-   * In general should avoid throwing errors, but return an empty array if no source assets are available with the given input.
-   * If an unexpected error occurs, perhaps if the provider is down, then no assets will be returned to prevent the user from selecting an asset that cannot be transferred.
+   * Return an empty array when no source assets are available for the given
+   * input — that means "this provider has no route for this asset".
+   * Providers backed by a remote registry (Skip, Squid) must instead THROW on
+   * infrastructure failures (registry down, rate limited): a swallowed error
+   * is indistinguishable from an unsupported asset, and the client relies on
+   * a rejected query to retry and re-poll until the provider recovers.
    *
    * @param params The parameters for the supported assets request.
    * @param params.chain The chain the asset is on.

--- a/packages/bridge/src/skip/__tests__/skip-bridge-provider.spec.ts
+++ b/packages/bridge/src/skip/__tests__/skip-bridge-provider.spec.ts
@@ -1095,4 +1095,45 @@ describe("SkipBridgeProvider getSupportedAssets failure propagation", () => {
       })
     ).resolves.toEqual([]);
   });
+
+  it("rejects (and does not cache) a degraded 200 registry response with an empty body", async () => {
+    // a rate-limited or degraded upstream can answer 200 with an empty map;
+    // treating that as truth would read as "asset unsupported" for the
+    // 30-minute cache lifetime, silently bypassing the client's retry and
+    // re-poll machinery
+    server.use(
+      rest.get("https://api.skip.money/v2/fungible/assets", (_req, res, ctx) =>
+        res(ctx.json({ chain_to_assets_map: {} }))
+      )
+    );
+
+    const degradedCtx: BridgeProviderContext = {
+      env: "mainnet",
+      cache: new LRUCache<string, CacheEntry>({ max: 10 }),
+      assetLists: MockAssetLists,
+      chainList: [],
+      getTimeoutHeight: jest.fn().mockResolvedValue({
+        revisionNumber: "1",
+        revisionHeight: "1000",
+      }),
+    };
+    const degradedProvider = new SkipBridgeProvider(degradedCtx);
+
+    await expect(
+      degradedProvider.getSupportedAssets({
+        chain: {
+          chainId: "osmosis-1",
+          chainName: "osmosis",
+          chainType: "cosmos",
+        },
+        asset: {
+          denom: "USDC",
+          address:
+            "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
+          decimals: 6,
+        },
+        direction: "deposit",
+      })
+    ).rejects.toThrow();
+  });
 });

--- a/packages/bridge/src/skip/__tests__/skip-bridge-provider.spec.ts
+++ b/packages/bridge/src/skip/__tests__/skip-bridge-provider.spec.ts
@@ -464,21 +464,10 @@ describe("SkipBridgeProvider", () => {
   });
 
   it("should handle unsupported asset error", async () => {
-    server.use(
-      rest.get(
-        "https://api.skip.money/v2/fungible/assets",
-        (_req, res, ctx) => {
-          return res(
-            ctx.json({
-              chain_to_assets_map: {
-                "1": { assets: [] },
-              },
-            })
-          );
-        }
-      )
-    );
-
+    // the global fixture serves a POPULATED chain-1 registry that simply
+    // lacks the requested asset: that is what "unsupported" means. (An
+    // empty chain asset list is the degraded-registry shape and is
+    // rejected by the cache guard instead.)
     const params: GetBridgeQuoteParams = {
       fromAmount: "1000",
       fromAsset: {
@@ -1094,6 +1083,63 @@ describe("SkipBridgeProvider getSupportedAssets failure propagation", () => {
         direction: "deposit",
       })
     ).resolves.toEqual([]);
+  });
+
+  it("rejects a scoped empty-chain response and recovers on the next populated one via the same cache", async () => {
+    // the degraded shape observed in production: a scoped request answered
+    // with the chain present but zero assets — it must be rejected (NOT
+    // cached for 30 minutes), so a later healthy response recovers
+    let assetRequests = 0;
+    server.use(
+      rest.get(
+        "https://api.skip.money/v2/fungible/assets",
+        (_req, res, ctx) => {
+          assetRequests++;
+          if (assetRequests === 1) {
+            return res(
+              ctx.json({
+                chain_to_assets_map: { "osmosis-1": { assets: [] } },
+              })
+            );
+          }
+          return res(ctx.json(SkipAssets));
+        }
+      )
+    );
+
+    const sharedCacheCtx: BridgeProviderContext = {
+      env: "mainnet",
+      cache: new LRUCache<string, CacheEntry>({ max: 10 }),
+      assetLists: MockAssetLists,
+      chainList: [],
+      getTimeoutHeight: jest.fn().mockResolvedValue({
+        revisionNumber: "1",
+        revisionHeight: "1000",
+      }),
+    };
+    const sharedCacheProvider = new SkipBridgeProvider(sharedCacheCtx);
+
+    const request = {
+      chain: {
+        chainId: "osmosis-1",
+        chainName: "osmosis",
+        chainType: "cosmos",
+      },
+      asset: {
+        denom: "USDC",
+        address:
+          "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
+        decimals: 6,
+      },
+      direction: "deposit",
+    } as const;
+
+    await expect(
+      sharedCacheProvider.getSupportedAssets(request)
+    ).rejects.toThrow();
+
+    const recovered = await sharedCacheProvider.getSupportedAssets(request);
+    expect(recovered.length).toBeGreaterThan(0);
   });
 
   it("rejects (and does not cache) a degraded 200 registry response with an empty body", async () => {

--- a/packages/bridge/src/skip/__tests__/skip-bridge-provider.spec.ts
+++ b/packages/bridge/src/skip/__tests__/skip-bridge-provider.spec.ts
@@ -1061,4 +1061,38 @@ describe("SkipBridgeProvider getSupportedAssets failure propagation", () => {
       })
     ).rejects.toThrow();
   });
+
+  it("resolves empty when the asset is not in the (healthy) registry", async () => {
+    // registry responds fine (global fixture handlers); the asset is simply
+    // not listed — an ordinary unsupported asset, NOT an outage, so the
+    // result must resolve to [] rather than reject (a rejection would make
+    // the client retry forever and never render other transfer options)
+    const healthyCtx: BridgeProviderContext = {
+      env: "mainnet",
+      cache: new LRUCache<string, CacheEntry>({ max: 10 }),
+      assetLists: MockAssetLists,
+      chainList: [],
+      getTimeoutHeight: jest.fn().mockResolvedValue({
+        revisionNumber: "1",
+        revisionHeight: "1000",
+      }),
+    };
+    const healthyProvider = new SkipBridgeProvider(healthyCtx);
+
+    await expect(
+      healthyProvider.getSupportedAssets({
+        chain: {
+          chainId: "osmosis-1",
+          chainName: "osmosis",
+          chainType: "cosmos",
+        },
+        asset: {
+          denom: "FAKE",
+          address: "ibc/NOTINREGISTRY",
+          decimals: 6,
+        },
+        direction: "deposit",
+      })
+    ).resolves.toEqual([]);
+  });
 });

--- a/packages/bridge/src/skip/__tests__/skip-bridge-provider.spec.ts
+++ b/packages/bridge/src/skip/__tests__/skip-bridge-provider.spec.ts
@@ -1020,3 +1020,45 @@ describe("SkipBridgeProvider.getExternalUrl", () => {
     expect(result?.url.toString()).toBe(expectedUrl);
   });
 });
+
+describe("SkipBridgeProvider getSupportedAssets failure propagation", () => {
+  it("rejects when the provider registry is unavailable", async () => {
+    server.use(
+      rest.get("https://api.skip.money/v2/fungible/assets", (_req, res, ctx) =>
+        res(ctx.status(500), ctx.json({ message: "registry unavailable" }))
+      )
+    );
+
+    const failingCtx: BridgeProviderContext = {
+      env: "mainnet",
+      cache: new LRUCache<string, CacheEntry>({ max: 10 }),
+      assetLists: MockAssetLists,
+      chainList: [],
+      getTimeoutHeight: jest.fn().mockResolvedValue({
+        revisionNumber: "1",
+        revisionHeight: "1000",
+      }),
+    };
+    const failingProvider = new SkipBridgeProvider(failingCtx);
+
+    // A registry failure must reject rather than resolve to an empty list:
+    // an empty list means "asset unsupported", which the client settles on
+    // without retrying, while a rejected query is retried and re-polled.
+    await expect(
+      failingProvider.getSupportedAssets({
+        chain: {
+          chainId: "osmosis-1",
+          chainName: "osmosis",
+          chainType: "cosmos",
+        },
+        asset: {
+          denom: "USDC",
+          address:
+            "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
+          decimals: 6,
+        },
+        direction: "deposit",
+      })
+    ).rejects.toThrow();
+  });
+});

--- a/packages/bridge/src/skip/__tests__/skip-bridge-provider.spec.ts
+++ b/packages/bridge/src/skip/__tests__/skip-bridge-provider.spec.ts
@@ -811,6 +811,39 @@ describe("SkipBridgeProvider", () => {
       ]);
     });
 
+    it("does not mutate the shared asset list when computing variants", async () => {
+      const request = {
+        chain: {
+          chainId: "osmosis-1",
+          chainType: "cosmos" as const,
+        },
+        asset: {
+          denom: "USDC",
+          address:
+            "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
+          decimals: 6,
+        },
+        direction: "deposit" as const,
+      };
+
+      const assetListAsset = ctx.assetLists
+        .flatMap(({ assets }) => assets)
+        .find((a) => a.coinMinimalDenom === request.asset.address)!;
+      const counterpartyCountBefore = assetListAsset.counterparty.length;
+
+      const first = await provider.getSupportedAssets(request);
+      // Aliasing the shared counterparty array previously doubled it on
+      // every call until the variant spread threw, permanently emptying
+      // results for the process.
+      for (let i = 0; i < 5; i++) {
+        await provider.getSupportedAssets(request);
+      }
+      const last = await provider.getSupportedAssets(request);
+
+      expect(assetListAsset.counterparty.length).toBe(counterpartyCountBefore);
+      expect(last).toEqual(first);
+    });
+
     it("should not return shared origin assets where the origin chain Packet Forward Middleware (PFM) is disabled", async () => {
       server.use(
         rest.get("https://api.skip.money/v2/info/chains", (_req, res, ctx) => {

--- a/packages/bridge/src/skip/index.ts
+++ b/packages/bridge/src/skip/index.ts
@@ -325,7 +325,12 @@ export class SkipBridgeProvider implements BridgeProvider {
             a.coinMinimalDenom.toLowerCase() === asset.address.toLowerCase()
         );
 
-      const counterparties = assetListAsset?.counterparty ?? [];
+      // Copy, never alias: assetLists is module-static and shared across
+      // requests, and variantAssets below includes assetListAsset itself, so
+      // pushing into the original array doubles it on every request until
+      // the spread blows the argument limit ("Maximum call stack size
+      // exceeded") and this provider returns empty until instance recycle.
+      const counterparties = [...(assetListAsset?.counterparty ?? [])];
       // since skip supports cosmos swap, we can include other asset list
       // counterparties of the same variant
       if (assetListAsset) {

--- a/packages/bridge/src/skip/index.ts
+++ b/packages/bridge/src/skip/index.ts
@@ -685,10 +685,28 @@ export class SkipBridgeProvider implements BridgeProvider {
       cache: this.ctx.cache,
       key: SkipBridgeProvider.ID + `_assets_${chainID}`,
       ttl: 1000 * 60 * 30, // 30 minutes
+      // A degraded registry response (e.g. a rate-limited 200 with an empty
+      // body) must not be cached as 30 minutes of truth: an empty registry
+      // reads as "asset unsupported" downstream, which silently bypasses the
+      // client's retry and re-poll machinery (observed in QA as a Skip-only
+      // asset intermittently rendering external-only). Failing the check
+      // makes cachified throw instead, so it propagates as a provider
+      // failure the client retries.
       getFreshValue: () =>
         this.skipClient.assets({
           chainID,
         }),
+      checkValue: (value) => {
+        // cachified types the checked value as {}; it is the fresh/cached
+        // return of skipClient.assets. An entirely empty map is the
+        // degraded shape; a present chain with an empty asset list is an
+        // ordinary lookup miss and stays cacheable.
+        const registry = value as Awaited<ReturnType<SkipApiClient["assets"]>>;
+        return (
+          Object.keys(registry ?? {}).length > 0 ||
+          "degraded or empty Skip asset registry response"
+        );
+      },
     });
   }
 
@@ -698,6 +716,11 @@ export class SkipBridgeProvider implements BridgeProvider {
       key: SkipBridgeProvider.ID + "_chains",
       ttl: 1000 * 60 * 30, // 30 minutes
       getFreshValue: () => this.skipClient.chains(),
+      // see getAssets: never cache a degraded/empty registry response
+      checkValue: (value) => {
+        const chains = value as Awaited<ReturnType<SkipApiClient["chains"]>>;
+        return (chains?.length ?? 0) > 0 || "empty Skip chains response";
+      },
     });
   }
 

--- a/packages/bridge/src/skip/index.ts
+++ b/packages/bridge/src/skip/index.ts
@@ -449,14 +449,18 @@ export class SkipBridgeProvider implements BridgeProvider {
       // a bug or malformed registry data, never a normal condition. Log it
       // in production too: a silent catch here hid the counterparty
       // mutation bug as unexplainable empty results for months.
+      // Uses the already-resolved assets/skipChains from above: re-awaiting
+      // the cachified getters here could itself throw (evicted entry plus a
+      // failed refresh), which would escape this catch and turn the
+      // intended empty-result degradation into a rejection.
       console.warn(
         `[Skip] supported-assets lookup threw for ${asset.address} on ${
           chain.chainId
         }: ${
           e instanceof Error ? e.message : String(e)
         }; unscoped registry chains=${
-          Object.keys((await this.getAssets()) ?? {}).length
-        }, chain list=${(await this.getChains())?.length ?? 0}`
+          Object.keys(assets ?? {}).length
+        }, chain list=${skipChains?.length ?? 0}`
       );
       return [];
     }

--- a/packages/bridge/src/skip/index.ts
+++ b/packages/bridge/src/skip/index.ts
@@ -287,8 +287,21 @@ export class SkipBridgeProvider implements BridgeProvider {
     // a miss legitimately means "no route for this asset".
     const chainAsset = await this.getAsset(chain, asset);
     // Asset not in Skip's registry: unsupported by this provider, not an
-    // outage — resolve empty so other transfer options can render.
-    if (!chainAsset) return [];
+    // outage — resolve empty so other transfer options can render. Logged
+    // unconditionally (production included) because a miss for an asset the
+    // app offers is exceptional: it is either a real registry gap or a
+    // degraded PARTIAL upstream response, which the cache guard cannot see
+    // when the list is populated. The registry size in the log line is what
+    // disambiguates the two.
+    if (!chainAsset) {
+      const registry = await this.getAssets(chain.chainId.toString());
+      const registrySize =
+        registry?.[chain.chainId.toString()]?.assets?.length ?? 0;
+      console.warn(
+        `[Skip] supported-assets miss: ${asset.address} not in ${chain.chainId} registry of ${registrySize} assets`
+      );
+      return [];
+    }
 
     // find variants
     const [assets, skipChains] = await Promise.all([

--- a/packages/bridge/src/skip/index.ts
+++ b/packages/bridge/src/skip/index.ts
@@ -448,6 +448,23 @@ export class SkipBridgeProvider implements BridgeProvider {
       // * CCTP variants
       // * EVM swappable variants
 
+      // An empty result for an asset that IS in Skip's scoped registry means
+      // both variant loops starved. That can only come from the unscoped
+      // registry data, so log its breadth to distinguish a genuinely
+      // route-less asset from a degraded PARTIAL all-chains response that
+      // passed the non-empty cache guard.
+      if (foundVariants.assets.length === 0) {
+        console.warn(
+          `[Skip] supported-assets empty: ${asset.address} on ${
+            chain.chainId
+          }; unscoped registry chains=${
+            Object.keys(assets).length
+          }, chain list=${skipChains.length}, counterparties=${
+            counterparties.length
+          }`
+        );
+      }
+
       return foundVariants.assets;
     } catch (e) {
       if (process.env.NODE_ENV !== "production") {

--- a/packages/bridge/src/skip/index.ts
+++ b/packages/bridge/src/skip/index.ts
@@ -467,17 +467,21 @@ export class SkipBridgeProvider implements BridgeProvider {
 
       return foundVariants.assets;
     } catch (e) {
-      if (process.env.NODE_ENV !== "production") {
-        console.error(
-          SkipBridgeProvider.ID,
-          "failed to get supported assets:",
-          e
-        );
-      }
       // Only pure lookup over already-fetched registry data can land here
-      // (infra failures reject above, before the try), so degrade to "no
-      // options from this provider" rather than an error the client would
-      // retry forever.
+      // (infra failures reject above, before the try). A throw therefore
+      // means the cached registry data is malformed, which the size-based
+      // cache guards cannot see, so log it in production too: a silent
+      // catch here turns a 30-minute poisoned cache entry into an
+      // unexplainable empty result.
+      console.warn(
+        `[Skip] supported-assets lookup threw for ${asset.address} on ${
+          chain.chainId
+        }: ${
+          e instanceof Error ? e.message : String(e)
+        }; unscoped registry chains=${
+          Object.keys((await this.getAssets()) ?? {}).length
+        }, chain list=${(await this.getChains())?.length ?? 0}`
+      );
       return [];
     }
   }

--- a/packages/bridge/src/skip/index.ts
+++ b/packages/bridge/src/skip/index.ts
@@ -698,12 +698,17 @@ export class SkipBridgeProvider implements BridgeProvider {
         }),
       checkValue: (value) => {
         // cachified types the checked value as {}; it is the fresh/cached
-        // return of skipClient.assets. An entirely empty map is the
-        // degraded shape; a present chain with an empty asset list is an
-        // ordinary lookup miss and stays cacheable.
+        // return of skipClient.assets. A scoped request must return the
+        // requested chain with a POPULATED asset list: a genuinely
+        // unsupported asset is a denom absent from a populated registry,
+        // while a missing or empty chain entry is the degraded shape
+        // (observed cached from a rate-limited upstream, reproducing the
+        // success-with-empty bug). Unscoped requests must be non-empty.
         const registry = value as Awaited<ReturnType<SkipApiClient["assets"]>>;
         return (
-          Object.keys(registry ?? {}).length > 0 ||
+          (chainID
+            ? Boolean(registry?.[chainID]?.assets?.length)
+            : Object.keys(registry ?? {}).length > 0) ||
           "degraded or empty Skip asset registry response"
         );
       },

--- a/packages/bridge/src/skip/index.ts
+++ b/packages/bridge/src/skip/index.ts
@@ -431,7 +431,6 @@ export class SkipBridgeProvider implements BridgeProvider {
 
       return foundVariants.assets;
     } catch (e) {
-      // Avoid returning options if there's an unexpected error, such as the provider being down
       if (process.env.NODE_ENV !== "production") {
         console.error(
           SkipBridgeProvider.ID,
@@ -439,7 +438,12 @@ export class SkipBridgeProvider implements BridgeProvider {
           e
         );
       }
-      return [];
+      // Propagate the failure instead of returning []: a swallowed error is
+      // indistinguishable from "asset unsupported for quoting", which parks
+      // the bridge modal on its external-providers fallback with nothing
+      // ever re-asking this provider. A rejected query is retried and
+      // re-polled by the client until the provider recovers.
+      throw e;
     }
   }
 

--- a/packages/bridge/src/skip/index.ts
+++ b/packages/bridge/src/skip/index.ts
@@ -287,21 +287,10 @@ export class SkipBridgeProvider implements BridgeProvider {
     // a miss legitimately means "no route for this asset".
     const chainAsset = await this.getAsset(chain, asset);
     // Asset not in Skip's registry: unsupported by this provider, not an
-    // outage — resolve empty so other transfer options can render. Logged
-    // unconditionally (production included) because a miss for an asset the
-    // app offers is exceptional: it is either a real registry gap or a
-    // degraded PARTIAL upstream response, which the cache guard cannot see
-    // when the list is populated. The registry size in the log line is what
-    // disambiguates the two.
-    if (!chainAsset) {
-      const registry = await this.getAssets(chain.chainId.toString());
-      const registrySize =
-        registry?.[chain.chainId.toString()]?.assets?.length ?? 0;
-      console.warn(
-        `[Skip] supported-assets miss: ${asset.address} not in ${chain.chainId} registry of ${registrySize} assets`
-      );
-      return [];
-    }
+    // outage. Resolve empty so other transfer options can render. This is a
+    // normal condition (every provider is asked about every asset), so it is
+    // deliberately not logged.
+    if (!chainAsset) return [];
 
     // find variants
     const [assets, skipChains] = await Promise.all([
@@ -453,31 +442,13 @@ export class SkipBridgeProvider implements BridgeProvider {
       // * CCTP variants
       // * EVM swappable variants
 
-      // An empty result for an asset that IS in Skip's scoped registry means
-      // both variant loops starved. That can only come from the unscoped
-      // registry data, so log its breadth to distinguish a genuinely
-      // route-less asset from a degraded PARTIAL all-chains response that
-      // passed the non-empty cache guard.
-      if (foundVariants.assets.length === 0) {
-        console.warn(
-          `[Skip] supported-assets empty: ${asset.address} on ${
-            chain.chainId
-          }; unscoped registry chains=${
-            Object.keys(assets).length
-          }, chain list=${skipChains.length}, counterparties=${
-            counterparties.length
-          }`
-        );
-      }
-
       return foundVariants.assets;
     } catch (e) {
       // Only pure lookup over already-fetched registry data can land here
-      // (infra failures reject above, before the try). A throw therefore
-      // means the cached registry data is malformed, which the size-based
-      // cache guards cannot see, so log it in production too: a silent
-      // catch here turns a 30-minute poisoned cache entry into an
-      // unexplainable empty result.
+      // (infra failures reject above, before the try), so a throw is always
+      // a bug or malformed registry data, never a normal condition. Log it
+      // in production too: a silent catch here hid the counterparty
+      // mutation bug as unexplainable empty results for months.
       console.warn(
         `[Skip] supported-assets lookup threw for ${asset.address} on ${
           chain.chainId

--- a/packages/bridge/src/skip/index.ts
+++ b/packages/bridge/src/skip/index.ts
@@ -281,19 +281,25 @@ export class SkipBridgeProvider implements BridgeProvider {
   }: GetBridgeSupportedAssetsParams): Promise<
     (BridgeChain & BridgeSupportedAsset)[]
   > {
-    try {
-      const chainAsset = await this.getAsset(chain, asset);
-      if (!chainAsset) throw new Error("Asset not found: " + asset.address);
+    // Registry fetches live OUTSIDE the try/catch: their failures (registry
+    // down, rate limited) must reject so the client's query retries and
+    // re-polls. Everything below is pure lookup over the fetched data, where
+    // a miss legitimately means "no route for this asset".
+    const chainAsset = await this.getAsset(chain, asset);
+    // Asset not in Skip's registry: unsupported by this provider, not an
+    // outage — resolve empty so other transfer options can render.
+    if (!chainAsset) return [];
 
+    // find variants
+    const [assets, skipChains] = await Promise.all([
+      this.getAssets(),
+      this.getChains(),
+    ]);
+
+    try {
       // Use of toLowerCase is advised due to registry (Skip + others) differences
       // in casing of asset addresses. May be somewhat unsafe.
       // See original usage in `getAsset` method.
-
-      // find variants
-      const [assets, skipChains] = await Promise.all([
-        this.getAssets(),
-        this.getChains(),
-      ]);
       const foundVariants = new BridgeAssetMap<
         BridgeChain & BridgeSupportedAsset
       >();
@@ -438,12 +444,11 @@ export class SkipBridgeProvider implements BridgeProvider {
           e
         );
       }
-      // Propagate the failure instead of returning []: a swallowed error is
-      // indistinguishable from "asset unsupported for quoting", which parks
-      // the bridge modal on its external-providers fallback with nothing
-      // ever re-asking this provider. A rejected query is retried and
-      // re-polled by the client until the provider recovers.
-      throw e;
+      // Only pure lookup over already-fetched registry data can land here
+      // (infra failures reject above, before the try), so degrade to "no
+      // options from this provider" rather than an error the client would
+      // retry forever.
+      return [];
     }
   }
 
@@ -641,7 +646,11 @@ export class SkipBridgeProvider implements BridgeProvider {
 
     const chainAssets = await this.getAssets(chainID);
 
-    for (const skipAsset of chainAssets[chainID].assets) {
+    // A registry response that omits the requested chain is a lookup miss
+    // ("no assets on this chain"), not an outage: guard it so callers see
+    // "asset not found" rather than a TypeError rejection that clients
+    // would classify as a provider failure and retry forever.
+    for (const skipAsset of chainAssets[chainID]?.assets ?? []) {
       if (chain.chainType === "evm") {
         // For the chain's native EVM token, only match assets without token_contract.
         // For Ethereum specifically, Skip may have two ETH entries: one with token_contract

--- a/packages/bridge/src/squid/__tests__/squid-bridge-provider.spec.ts
+++ b/packages/bridge/src/squid/__tests__/squid-bridge-provider.spec.ts
@@ -3837,3 +3837,51 @@ describe("SquidBridgeProvider.getExternalUrl", () => {
     expect(result?.url.toString()).toBe(expectedUrl);
   });
 });
+
+describe("SquidBridgeProvider getSupportedAssets failure propagation", () => {
+  it("rejects when the provider registry is unavailable", async () => {
+    server.use(
+      rest.get("https://v2.api.squidrouter.com/v2/tokens", (_req, res, ctx) =>
+        res(ctx.status(500), ctx.json({ message: "registry unavailable" }))
+      )
+    );
+
+    const failingCtx: BridgeProviderContext = {
+      env: "mainnet",
+      cache: new LRUCache<string, CacheEntry>({ max: 10 }),
+      assetLists: MockAssetLists,
+      chainList: [],
+      getTimeoutHeight: jest.fn().mockResolvedValue({
+        revisionNumber: "1",
+        revisionHeight: "1000",
+      }),
+    };
+    const failingProvider = new SquidBridgeProvider("integratorId", failingCtx);
+
+    // A registry failure must reject rather than resolve to an empty list:
+    // an empty list means "asset unsupported", which the client settles on
+    // without retrying, while a rejected query is retried and re-polled.
+    // (getTokens rethrows the API error body, a plain object rather than an
+    // Error, so assert the rejection outcome directly instead of toThrow.)
+    const outcome = await failingProvider
+      .getSupportedAssets({
+        chain: {
+          chainId: "osmosis-1",
+          chainName: "osmosis",
+          chainType: "cosmos",
+        },
+        asset: {
+          denom: "USDC",
+          address:
+            "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
+          decimals: 6,
+        },
+        direction: "deposit",
+      })
+      .then(
+        () => "resolved",
+        () => "rejected"
+      );
+    expect(outcome).toBe("rejected");
+  });
+});

--- a/packages/bridge/src/squid/__tests__/squid-bridge-provider.spec.ts
+++ b/packages/bridge/src/squid/__tests__/squid-bridge-provider.spec.ts
@@ -3884,4 +3884,38 @@ describe("SquidBridgeProvider getSupportedAssets failure propagation", () => {
       );
     expect(outcome).toBe("rejected");
   });
+
+  it("resolves empty when the token is not in the (healthy) registry", async () => {
+    // registry responds fine (global fixture handlers); the token is simply
+    // not listed — an ordinary unsupported asset, NOT an outage, so the
+    // result must resolve to [] rather than reject (a rejection would make
+    // the client retry forever and never render other transfer options)
+    const healthyCtx: BridgeProviderContext = {
+      env: "mainnet",
+      cache: new LRUCache<string, CacheEntry>({ max: 10 }),
+      assetLists: MockAssetLists,
+      chainList: [],
+      getTimeoutHeight: jest.fn().mockResolvedValue({
+        revisionNumber: "1",
+        revisionHeight: "1000",
+      }),
+    };
+    const healthyProvider = new SquidBridgeProvider("integratorId", healthyCtx);
+
+    await expect(
+      healthyProvider.getSupportedAssets({
+        chain: {
+          chainId: "osmosis-1",
+          chainName: "osmosis",
+          chainType: "cosmos",
+        },
+        asset: {
+          denom: "FAKE",
+          address: "ibc/NOTINREGISTRY",
+          decimals: 6,
+        },
+        direction: "deposit",
+      })
+    ).resolves.toEqual([]);
+  });
 });

--- a/packages/bridge/src/squid/__tests__/squid-bridge-provider.spec.ts
+++ b/packages/bridge/src/squid/__tests__/squid-bridge-provider.spec.ts
@@ -3918,4 +3918,48 @@ describe("SquidBridgeProvider getSupportedAssets failure propagation", () => {
       })
     ).resolves.toEqual([]);
   });
+
+  it("rejects (and does not cache) a degraded 200 registry response with an empty body", async () => {
+    // a rate-limited or degraded upstream can answer 200 with an empty
+    // token list; treating that as truth would read as "asset unsupported"
+    // for the 30-minute cache lifetime, silently bypassing the client's
+    // retry and re-poll machinery
+    server.use(
+      rest.get("https://v2.api.squidrouter.com/v2/tokens", (_req, res, ctx) =>
+        res(ctx.json({ tokens: [] }))
+      )
+    );
+
+    const degradedCtx: BridgeProviderContext = {
+      env: "mainnet",
+      cache: new LRUCache<string, CacheEntry>({ max: 10 }),
+      assetLists: MockAssetLists,
+      chainList: [],
+      getTimeoutHeight: jest.fn().mockResolvedValue({
+        revisionNumber: "1",
+        revisionHeight: "1000",
+      }),
+    };
+    const degradedProvider = new SquidBridgeProvider(
+      "integratorId",
+      degradedCtx
+    );
+
+    await expect(
+      degradedProvider.getSupportedAssets({
+        chain: {
+          chainId: "osmosis-1",
+          chainName: "osmosis",
+          chainType: "cosmos",
+        },
+        asset: {
+          denom: "USDC",
+          address:
+            "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
+          decimals: 6,
+        },
+        direction: "deposit",
+      })
+    ).rejects.toThrow();
+  });
 });

--- a/packages/bridge/src/squid/index.ts
+++ b/packages/bridge/src/squid/index.ts
@@ -437,7 +437,6 @@ export class SquidBridgeProvider implements BridgeProvider {
 
       return foundVariants.assets;
     } catch (e) {
-      // Avoid returning options if there's an unexpected error, such as the provider being down
       if (process.env.NODE_ENV !== "production") {
         console.error(
           SquidBridgeProvider.ID,
@@ -445,7 +444,12 @@ export class SquidBridgeProvider implements BridgeProvider {
           e
         );
       }
-      return [];
+      // Propagate the failure instead of returning []: a swallowed error is
+      // indistinguishable from "asset unsupported for quoting", which parks
+      // the bridge modal on its external-providers fallback with nothing
+      // ever re-asking this provider. A rejected query is retried and
+      // re-polled by the client until the provider recovers.
+      throw e;
     }
   }
 

--- a/packages/bridge/src/squid/index.ts
+++ b/packages/bridge/src/squid/index.ts
@@ -682,6 +682,16 @@ export class SquidBridgeProvider implements BridgeProvider {
           throw error.data;
         }
       },
+      // A degraded registry response (e.g. a rate-limited 200 with an empty
+      // body) must not be cached as 30 minutes of truth: an empty registry
+      // reads as "asset unsupported" downstream, which silently bypasses
+      // the client's retry and re-poll machinery. Failing the check makes
+      // cachified throw instead, so it propagates as a provider failure
+      // the client retries. (cachified types the checked value as {}.)
+      checkValue: (value) => {
+        const chains = value as ChainsResponse["chains"];
+        return (chains?.length ?? 0) > 0 || "empty Squid chains response";
+      },
     });
   }
 
@@ -705,6 +715,13 @@ export class SquidBridgeProvider implements BridgeProvider {
           const error = e as ApiClientError;
           throw error.data;
         }
+      },
+      // see getChains: never cache a degraded/empty registry response
+      checkValue: (value) => {
+        const tokens = value as TokensResponse["tokens"];
+        return (
+          (tokens?.length ?? 0) > 0 || "empty Squid token registry response"
+        );
       },
     });
   }

--- a/packages/bridge/src/squid/index.ts
+++ b/packages/bridge/src/squid/index.ts
@@ -319,21 +319,27 @@ export class SquidBridgeProvider implements BridgeProvider {
   }: GetBridgeSupportedAssetsParams): Promise<
     (BridgeChain & BridgeSupportedAsset)[]
   > {
+    // Registry fetches live OUTSIDE the try/catch: their failures (registry
+    // down, rate limited) must reject so the client's query retries and
+    // re-polls. Everything below is pure lookup over the fetched data, where
+    // a miss legitimately means "no route for this asset".
+    const [tokens, chains] = await Promise.all([
+      this.getTokens(),
+      this.getChains(),
+    ]);
+    const token = tokens.find(
+      (t) =>
+        (t.address.toLowerCase() === asset.address.toLowerCase() ||
+          t.ibcDenom?.toLowerCase() === asset.address.toLowerCase()) &&
+        // squid uses canonical chain IDs (numerical and string)
+        String(t.chainId) === String(chain.chainId)
+    );
+
+    // Token not in Squid's registry: unsupported by this provider, not an
+    // outage — resolve empty so other transfer options can render.
+    if (!token) return [];
+
     try {
-      const [tokens, chains] = await Promise.all([
-        this.getTokens(),
-        this.getChains(),
-      ]);
-      const token = tokens.find(
-        (t) =>
-          (t.address.toLowerCase() === asset.address.toLowerCase() ||
-            t.ibcDenom?.toLowerCase() === asset.address.toLowerCase()) &&
-          // squid uses canonical chain IDs (numerical and string)
-          String(t.chainId) === String(chain.chainId)
-      );
-
-      if (!token) throw new Error("Token not found: " + asset.address);
-
       const foundVariants = new BridgeAssetMap<
         BridgeChain & BridgeSupportedAsset
       >();
@@ -444,12 +450,11 @@ export class SquidBridgeProvider implements BridgeProvider {
           e
         );
       }
-      // Propagate the failure instead of returning []: a swallowed error is
-      // indistinguishable from "asset unsupported for quoting", which parks
-      // the bridge modal on its external-providers fallback with nothing
-      // ever re-asking this provider. A rejected query is retried and
-      // re-polled by the client until the provider recovers.
-      throw e;
+      // Only pure lookup over already-fetched registry data can land here
+      // (infra failures reject above, before the try), so degrade to "no
+      // options from this provider" rather than an error the client would
+      // retry forever.
+      return [];
     }
   }
 

--- a/packages/web/components/bridge/__tests__/use-bridges-supported-assets.spec.tsx
+++ b/packages/web/components/bridge/__tests__/use-bridges-supported-assets.spec.tsx
@@ -161,6 +161,39 @@ describe("useBridgesSupportedAssets loading and error state", () => {
     expect(result.current.supportedChains).toHaveLength(1);
   });
 
+  it("holds the loading state when a provider is failing and only external-url chains were found", () => {
+    // Wormhole always succeeds with an external-url-only Solana suggestion
+    // for assets with a solana counterparty. That must not release the
+    // failing-provider hold: with the only quote provider down, releasing
+    // would settle the withdraw on Solana and land the modal on the
+    // external-providers view.
+    mockQueryResults = [
+      errorResult,
+      successResult({
+        providerName: "Wormhole",
+        availableChains: [
+          { chainId: "solana", chainType: "solana", prettyName: "Solana" },
+        ],
+        assetsByChainId: {
+          solana: [
+            {
+              chainId: "solana",
+              chainType: "solana",
+              address: "solanaUSDCaddress",
+              denom: "USDC",
+              decimals: 6,
+              transferTypes: ["external-url"],
+            },
+          ],
+        },
+      }),
+    ];
+
+    const { result } = renderSupportedAssets();
+
+    expect(result.current.isLoading).toBe(true);
+  });
+
   it("settles into the empty (external-only) state only when every query succeeded with no chains", () => {
     mockQueryResults = [
       successResult(),

--- a/packages/web/components/bridge/__tests__/use-bridges-supported-assets.spec.tsx
+++ b/packages/web/components/bridge/__tests__/use-bridges-supported-assets.spec.tsx
@@ -106,6 +106,24 @@ describe("useBridgesSupportedAssets loading and error state", () => {
     expect(result.current.isLoading).toBe(true);
   });
 
+  it("proceeds when one provider is still fetching but another already returned an in-app route", () => {
+    // one provider's slow first fetch (or its automatic retries) must not
+    // hide another provider's usable quote route behind a skeleton
+    mockQueryResults = [
+      loadingResult,
+      successResult({
+        providerName: "Squid",
+        availableChains: [ethereumChain],
+        assetsByChainId: ethereumAssetsByChainId,
+      }),
+    ];
+
+    const { result } = renderSupportedAssets();
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.supportedChains).toHaveLength(1);
+  });
+
   it("holds the loading state when a provider failed and no chains were found", () => {
     // A failed provider (e.g. a rate-limited registry) must not be mistaken
     // for "asset unsupported for quoting": with zero supported chains the

--- a/packages/web/components/bridge/__tests__/use-bridges-supported-assets.spec.tsx
+++ b/packages/web/components/bridge/__tests__/use-bridges-supported-assets.spec.tsx
@@ -69,12 +69,13 @@ const successResult = ({
     },
   },
 });
-/** Retries exhausted; the error-only refetchInterval re-polls it later. */
+/** Retries exhausted; the hook's manual 30s re-poll refetches it later. */
 const errorResult = {
   isSuccess: false,
   isLoading: false,
   isError: true,
   errorUpdateCount: 1,
+  refetch: jest.fn(),
   data: undefined,
 };
 /** First fetch in flight, no failures yet. */
@@ -85,7 +86,7 @@ const loadingResult = {
   errorUpdateCount: 0,
   data: undefined,
 };
-/** Re-polling after a settled error (the error-only refetchInterval):
+/** Re-polling after a settled error (the hook's manual re-poll):
  *  react-query reports isLoading because the query has never had data, and
  *  resets failureCount at fetch start — errorUpdateCount is what persists. */
 const retryingResult = {
@@ -192,6 +193,47 @@ describe("useBridgesSupportedAssets loading and error state", () => {
     const { result } = renderSupportedAssets();
 
     expect(result.current.isLoading).toBe(true);
+  });
+
+  it("re-polls errored queries with backoff (5s, 10s, 20s, then 30s) while a provider is failing", () => {
+    // react-query v4 never interval-refetches a query that settled into an
+    // error without data, so the hook drives this itself
+    jest.useFakeTimers();
+    try {
+      const refetch = jest.fn();
+      mockQueryResults = [{ ...errorResult, refetch }, successResult()];
+
+      renderSupportedAssets();
+
+      expect(refetch).not.toHaveBeenCalled();
+      jest.advanceTimersByTime(5_000);
+      expect(refetch).toHaveBeenCalledTimes(1);
+      jest.advanceTimersByTime(10_000);
+      expect(refetch).toHaveBeenCalledTimes(2);
+      jest.advanceTimersByTime(20_000);
+      expect(refetch).toHaveBeenCalledTimes(3);
+      jest.advanceTimersByTime(30_000);
+      expect(refetch).toHaveBeenCalledTimes(4);
+      jest.advanceTimersByTime(30_000);
+      expect(refetch).toHaveBeenCalledTimes(5);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("does not schedule re-polls when no query is failing", () => {
+    jest.useFakeTimers();
+    try {
+      const refetch = jest.fn();
+      mockQueryResults = [{ ...successResult(), refetch }];
+
+      renderSupportedAssets();
+
+      jest.advanceTimersByTime(90_000);
+      expect(refetch).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it("settles into the empty (external-only) state only when every query succeeded with no chains", () => {

--- a/packages/web/components/bridge/__tests__/use-bridges-supported-assets.spec.tsx
+++ b/packages/web/components/bridge/__tests__/use-bridges-supported-assets.spec.tsx
@@ -260,6 +260,39 @@ describe("useBridgesSupportedAssets loading and error state", () => {
     expect(result.current.isLoading).toBe(true);
   });
 
+  it("holds the loading state while an error-recovered empty result refetches", () => {
+    // A query that errored, recovered with empty data, and is refetching
+    // carries errorUpdateCount > 0. The dataless-re-poll exclusion must not
+    // apply to it: it has (possibly stale-empty) data in hand, so settling
+    // the modal mid-refetch would commit the external-only view before the
+    // fresh result lands.
+    mockQueryResults = [
+      { ...refetchingResult(), errorUpdateCount: 1 },
+      successResult({
+        providerName: "Wormhole",
+        availableChains: [
+          { chainId: "solana", chainType: "solana", prettyName: "Solana" },
+        ],
+        assetsByChainId: {
+          solana: [
+            {
+              chainId: "solana",
+              chainType: "solana",
+              address: "solanaUSDCaddress",
+              denom: "USDC",
+              decimals: 6,
+              transferTypes: ["external-url"],
+            },
+          ],
+        },
+      }),
+    ];
+
+    const { result } = renderSupportedAssets();
+
+    expect(result.current.isLoading).toBe(true);
+  });
+
   it("renders instantly from hydrated results that contain an in-app route", () => {
     // Healthy persisted data must not skeleton behind its own mount
     // refetch: the hold releases as soon as any provider shows an in-app

--- a/packages/web/components/bridge/__tests__/use-bridges-supported-assets.spec.tsx
+++ b/packages/web/components/bridge/__tests__/use-bridges-supported-assets.spec.tsx
@@ -58,6 +58,7 @@ const successResult = ({
 } = {}) => ({
   isSuccess: true,
   isLoading: false,
+  isFetching: false,
   isError: false,
   errorUpdateCount: 0,
   data: {
@@ -73,6 +74,7 @@ const successResult = ({
 const errorResult = {
   isSuccess: false,
   isLoading: false,
+  isFetching: false,
   isError: true,
   errorUpdateCount: 1,
   refetch: jest.fn(),
@@ -82,6 +84,7 @@ const errorResult = {
 const loadingResult = {
   isSuccess: false,
   isLoading: true,
+  isFetching: true,
   isError: false,
   errorUpdateCount: 0,
   data: undefined,
@@ -92,10 +95,20 @@ const loadingResult = {
 const retryingResult = {
   isSuccess: false,
   isLoading: true,
+  isFetching: true,
   isError: false,
   errorUpdateCount: 1,
   data: undefined,
 };
+/** Hydrated-stale: data restored from the persisted (localStorage) query
+ *  cache, background refetch in flight. isLoading is false because data
+ *  exists; isFetching is what reveals the refetch. */
+const refetchingResult = (
+  overrides: Parameters<typeof successResult>[0] = {}
+) => ({
+  ...successResult(overrides),
+  isFetching: true,
+});
 
 describe("useBridgesSupportedAssets loading and error state", () => {
   it("is loading while any provider query is in flight", () => {
@@ -211,6 +224,59 @@ describe("useBridgesSupportedAssets loading and error state", () => {
     const { result } = renderSupportedAssets();
 
     expect(result.current.isLoading).toBe(true);
+  });
+
+  it("holds the loading state while hydrated results refetch and no in-app routes were found", () => {
+    // The query cache is persisted to localStorage, so a previous session's
+    // results hydrate as settled data and refetch on mount. A hydrated
+    // success-with-empty (e.g. one persisted from a degraded provider
+    // response) plus an external-url-only suggestion must not release the
+    // hold mid-refetch, or the modal commits a default chain (observed:
+    // Solana via Wormhole) from stale data before the fresh response lands.
+    mockQueryResults = [
+      refetchingResult(),
+      refetchingResult({
+        providerName: "Wormhole",
+        availableChains: [
+          { chainId: "solana", chainType: "solana", prettyName: "Solana" },
+        ],
+        assetsByChainId: {
+          solana: [
+            {
+              chainId: "solana",
+              chainType: "solana",
+              address: "solanaUSDCaddress",
+              denom: "USDC",
+              decimals: 6,
+              transferTypes: ["external-url"],
+            },
+          ],
+        },
+      }),
+    ];
+
+    const { result } = renderSupportedAssets();
+
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("renders instantly from hydrated results that contain an in-app route", () => {
+    // Healthy persisted data must not skeleton behind its own mount
+    // refetch: the hold releases as soon as any provider shows an in-app
+    // route.
+    mockQueryResults = [
+      refetchingResult({
+        providerName: "Squid",
+        availableChains: [ethereumChain],
+        assetsByChainId: ethereumAssetsByChainId,
+      }),
+      loadingResult,
+    ];
+
+    const { result } = renderSupportedAssets();
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.supportedChains).toHaveLength(1);
   });
 
   it("re-polls errored queries with backoff (5s, 10s, 20s, then 30s) while a provider is failing", () => {

--- a/packages/web/components/bridge/__tests__/use-bridges-supported-assets.spec.tsx
+++ b/packages/web/components/bridge/__tests__/use-bridges-supported-assets.spec.tsx
@@ -1,0 +1,133 @@
+import type { MinimalAsset } from "@osmosis-labs/types";
+import { renderHook } from "@testing-library/react";
+
+import { useBridgesSupportedAssets } from "../use-bridges-supported-assets";
+
+/**
+ * Simulated per-provider query results. `api.useQueries` is mocked to return
+ * these directly; the hook only consumes the results array, so the query
+ * builder callback is irrelevant here.
+ */
+let mockQueryResults: unknown[] = [];
+
+jest.mock("~/utils/trpc", () => ({
+  api: {
+    useQueries: () => mockQueryResults,
+  },
+}));
+
+const osmosisChain = { chainId: "osmosis-1", chainType: "cosmos" as const };
+const testAsset = {
+  coinMinimalDenom: "ibc/TESTDENOM",
+  coinDenom: "TEST",
+  coinDecimals: 6,
+} as MinimalAsset;
+
+const renderSupportedAssets = () =>
+  renderHook(() =>
+    useBridgesSupportedAssets({
+      assets: [testAsset],
+      chain: osmosisChain,
+      direction: "withdraw",
+    })
+  );
+
+const ethereumChain = {
+  chainId: 1,
+  chainType: "evm",
+  chainName: "Ethereum",
+  prettyName: "Ethereum",
+};
+const ethereumAssetsByChainId = {
+  "1": [
+    {
+      chainId: 1,
+      chainType: "evm",
+      address: "0xTEST",
+      denom: "TEST",
+      decimals: 6,
+      transferTypes: ["quote"],
+    },
+  ],
+};
+
+const successResult = ({
+  providerName = "Skip",
+  availableChains = [] as unknown[],
+  assetsByChainId = {} as Record<string, unknown[]>,
+} = {}) => ({
+  isSuccess: true,
+  isLoading: false,
+  isError: false,
+  data: {
+    supportedAssets: {
+      providerName,
+      inputAssetAddress: "ibc/TESTDENOM",
+      assetsByChainId,
+      availableChains,
+    },
+  },
+});
+const errorResult = {
+  isSuccess: false,
+  isLoading: false,
+  isError: true,
+  data: undefined,
+};
+const loadingResult = {
+  isSuccess: false,
+  isLoading: true,
+  isError: false,
+  data: undefined,
+};
+
+describe("useBridgesSupportedAssets loading and error state", () => {
+  it("is loading while any provider query is in flight", () => {
+    mockQueryResults = [loadingResult, successResult()];
+
+    const { result } = renderSupportedAssets();
+
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("holds the loading state when a provider failed and no chains were found", () => {
+    // A failed provider (e.g. a rate-limited registry) must not be mistaken
+    // for "asset unsupported for quoting": with zero supported chains the
+    // modal would settle onto its external-providers fallback.
+    mockQueryResults = [errorResult, successResult()];
+
+    const { result } = renderSupportedAssets();
+
+    expect(result.current.supportedChains).toHaveLength(0);
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("proceeds with available chains when one provider failed but another returned routes", () => {
+    mockQueryResults = [
+      errorResult,
+      successResult({
+        providerName: "Squid",
+        availableChains: [ethereumChain],
+        assetsByChainId: ethereumAssetsByChainId,
+      }),
+    ];
+
+    const { result } = renderSupportedAssets();
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.supportedChains).toHaveLength(1);
+    expect(result.current.supportedChains[0].chainId).toBe(1);
+  });
+
+  it("settles into the empty (external-only) state only when every query succeeded with no chains", () => {
+    mockQueryResults = [
+      successResult(),
+      successResult({ providerName: "Squid" }),
+    ];
+
+    const { result } = renderSupportedAssets();
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.supportedChains).toHaveLength(0);
+  });
+});

--- a/packages/web/components/bridge/__tests__/use-bridges-supported-assets.spec.tsx
+++ b/packages/web/components/bridge/__tests__/use-bridges-supported-assets.spec.tsx
@@ -59,6 +59,7 @@ const successResult = ({
   isSuccess: true,
   isLoading: false,
   isError: false,
+  errorUpdateCount: 0,
   data: {
     supportedAssets: {
       providerName,
@@ -68,16 +69,30 @@ const successResult = ({
     },
   },
 });
+/** Retries exhausted; the error-only refetchInterval re-polls it later. */
 const errorResult = {
   isSuccess: false,
   isLoading: false,
   isError: true,
+  errorUpdateCount: 1,
   data: undefined,
 };
+/** First fetch in flight, no failures yet. */
 const loadingResult = {
   isSuccess: false,
   isLoading: true,
   isError: false,
+  errorUpdateCount: 0,
+  data: undefined,
+};
+/** Re-polling after a settled error (the error-only refetchInterval):
+ *  react-query reports isLoading because the query has never had data, and
+ *  resets failureCount at fetch start — errorUpdateCount is what persists. */
+const retryingResult = {
+  isSuccess: false,
+  isLoading: true,
+  isError: false,
+  errorUpdateCount: 1,
   data: undefined,
 };
 
@@ -117,6 +132,33 @@ describe("useBridgesSupportedAssets loading and error state", () => {
     expect(result.current.isLoading).toBe(false);
     expect(result.current.supportedChains).toHaveLength(1);
     expect(result.current.supportedChains[0].chainId).toBe(1);
+  });
+
+  it("holds the loading state while a provider is retrying and no chains were found", () => {
+    mockQueryResults = [retryingResult, successResult()];
+
+    const { result } = renderSupportedAssets();
+
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("does not flash loading when a failing provider re-polls while chains are available", () => {
+    // an error-interval re-poll reports isLoading (the query never had
+    // data); the modal must keep rendering the chains other providers
+    // returned instead of dropping to a skeleton every poll cycle
+    mockQueryResults = [
+      retryingResult,
+      successResult({
+        providerName: "Squid",
+        availableChains: [ethereumChain],
+        assetsByChainId: ethereumAssetsByChainId,
+      }),
+    ];
+
+    const { result } = renderSupportedAssets();
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.supportedChains).toHaveLength(1);
   });
 
   it("settles into the empty (external-only) state only when every query succeeded with no chains", () => {

--- a/packages/web/components/bridge/__tests__/use-bridges-supported-assets.spec.tsx
+++ b/packages/web/components/bridge/__tests__/use-bridges-supported-assets.spec.tsx
@@ -338,6 +338,29 @@ describe("useBridgesSupportedAssets loading and error state", () => {
     }
   });
 
+  it("does not restart a recovery refetch that is still in flight", () => {
+    // A query stays isError while its recovery refetch runs; calling
+    // refetch() again would cancel the active request (cancelRefetch
+    // defaults to true), so a response slower than the backoff delay
+    // could never complete.
+    jest.useFakeTimers();
+    try {
+      const refetch = jest.fn();
+      mockQueryResults = [
+        { ...errorResult, isFetching: true, refetch },
+        successResult(),
+      ];
+
+      renderSupportedAssets();
+
+      jest.advanceTimersByTime(5_000);
+      jest.advanceTimersByTime(10_000);
+      expect(refetch).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it("does not schedule re-polls when no query is failing", () => {
     jest.useFakeTimers();
     try {

--- a/packages/web/components/bridge/use-bridges-supported-assets.ts
+++ b/packages/web/components/bridge/use-bridges-supported-assets.ts
@@ -100,15 +100,34 @@ export const useBridgesSupportedAssets = ({
   );
 
   const isFetchingAny = useMemo(
-    () => supportedAssetsResults.some((data) => isNil(data) || data.isLoading),
+    () =>
+      supportedAssetsResults.some(
+        (data) =>
+          isNil(data) ||
+          // First fetches only: a query re-polling after failures also
+          // reports isLoading (it has never had data), but must not drop
+          // the whole modal back to a skeleton when other providers already
+          // returned usable chains. errorUpdateCount is the discriminator:
+          // unlike failureCount, which react-query resets to 0 at the start
+          // of every fetch, it increments on each settled error and never
+          // resets, so a re-poll after an error is always distinguishable
+          // from a first fetch. Failing queries are handled below.
+          (data.isLoading && data.errorUpdateCount === 0)
+      ),
     [supportedAssetsResults]
   );
 
-  /** A provider's query failed (all retries exhausted). Remote providers
-   *  (Skip, Squid) reject on infrastructure failures rather than returning
-   *  an empty result, so this is the "provider down" signal. */
-  const hasErroredQueries = useMemo(
-    () => supportedAssetsResults.some((data) => !isNil(data) && data.isError),
+  /** A provider's query failed (retries exhausted) or is re-attempting
+   *  after failures. Remote providers (Skip, Squid) reject on
+   *  infrastructure failures rather than returning an empty result, so
+   *  this is the "provider down" signal. */
+  const hasFailingQueries = useMemo(
+    () =>
+      supportedAssetsResults.some(
+        (data) =>
+          !isNil(data) &&
+          (data.isError || (data.isLoading && data.errorUpdateCount > 0))
+      ),
     [supportedAssetsResults]
   );
 
@@ -409,17 +428,23 @@ export const useBridgesSupportedAssets = ({
   }, [successfulQueries, direction, assets, variantAssets]);
 
   /**
-   * Loading while any query is in flight (retries included), and ALSO while
-   * a provider has failed and nothing has produced a supported chain: an
-   * errored provider must not be mistaken for "asset unsupported for
+   * Loading while any query is on its first fetch, and ALSO while a
+   * provider is failing and nothing has produced a supported chain: a
+   * failing provider must not be mistaken for "asset unsupported for
    * quoting", which would settle the modal onto its external-providers
    * fallback. The error-only refetch above keeps re-asking the failed
-   * provider, so this state resolves either into supported chains or into a
-   * genuine all-settled empty result. When other providers DID return
+   * provider, so this state resolves either into supported chains or into
+   * a genuine all-settled empty result. When other providers DID return
    * chains, the flow proceeds with those rather than holding.
+   *
+   * By design, a full outage of every quote-capable provider holds this
+   * screen in its loading state indefinitely (re-polling every 30s) rather
+   * than degrading to the external-providers view: misrepresenting a
+   * quotable asset as external-only routes users to third-party sites for
+   * transfers the app itself supports, which is worse than a visible wait.
    */
   const isLoading =
-    isFetchingAny || (hasErroredQueries && supportedChains.length === 0);
+    isFetchingAny || (hasFailingQueries && supportedChains.length === 0);
 
   return { supportedAssetsByChainId, supportedChains, isLoading };
 };

--- a/packages/web/components/bridge/use-bridges-supported-assets.ts
+++ b/packages/web/components/bridge/use-bridges-supported-assets.ts
@@ -132,6 +132,30 @@ export const useBridgesSupportedAssets = ({
   );
 
   /**
+   * Whether any successful provider returned a chain the app itself can
+   * transfer through (a quote or deposit-address route). External-url-only
+   * results (e.g. Wormhole's Solana suggestion) don't count: they exist for
+   * assets that ALSO have in-app routes, and must not release the failing-
+   * provider hold below — otherwise a Skip outage on a Skip-only asset
+   * settles the modal on the external-url chain (observed as a withdraw
+   * "defaulting to Solana" and landing on the external-providers view).
+   */
+  const hasInAppTransferSupport = useMemo(
+    () =>
+      successfulQueries.some(({ data }) =>
+        Object.values(data?.supportedAssets.assetsByChainId ?? {}).some(
+          (assets) =>
+            assets.some((asset) =>
+              asset.transferTypes.some(
+                (type) => type === "quote" || type === "deposit-address"
+              )
+            )
+        )
+      ),
+    [successfulQueries]
+  );
+
+  /**
    * Aggregate supported assets from all successful queries.
    * This would be an object with chain id as key and an array of supported Osmosis variants as value.
    *
@@ -444,7 +468,7 @@ export const useBridgesSupportedAssets = ({
    * transfers the app itself supports, which is worse than a visible wait.
    */
   const isLoading =
-    isFetchingAny || (hasFailingQueries && supportedChains.length === 0);
+    isFetchingAny || (hasFailingQueries && !hasInAppTransferSupport);
 
   return { supportedAssetsByChainId, supportedChains, isLoading };
 };

--- a/packages/web/components/bridge/use-bridges-supported-assets.ts
+++ b/packages/web/components/bridge/use-bridges-supported-assets.ts
@@ -170,7 +170,12 @@ export const useBridgesSupportedAssets = ({
       attempt++;
       timeoutId = setTimeout(() => {
         resultsRef.current.forEach((result) => {
-          if (!isNil(result) && result.isError) result.refetch();
+          // !isFetching: a query stays isError while its recovery refetch
+          // is in flight, and refetch()'s default cancelRefetch would
+          // cancel that active request, so a response slower than the
+          // backoff delay could never complete.
+          if (!isNil(result) && result.isError && !result.isFetching)
+            result.refetch();
         });
         schedule();
       }, delay);

--- a/packages/web/components/bridge/use-bridges-supported-assets.ts
+++ b/packages/web/components/bridge/use-bridges-supported-assets.ts
@@ -99,8 +99,16 @@ export const useBridgesSupportedAssets = ({
     [supportedAssetsResults]
   );
 
-  const isLoading = useMemo(
+  const isFetchingAny = useMemo(
     () => supportedAssetsResults.some((data) => isNil(data) || data.isLoading),
+    [supportedAssetsResults]
+  );
+
+  /** A provider's query failed (all retries exhausted). Remote providers
+   *  (Skip, Squid) reject on infrastructure failures rather than returning
+   *  an empty result, so this is the "provider down" signal. */
+  const hasErroredQueries = useMemo(
+    () => supportedAssetsResults.some((data) => !isNil(data) && data.isError),
     [supportedAssetsResults]
   );
 
@@ -399,6 +407,19 @@ export const useBridgesSupportedAssets = ({
       ).values()
     );
   }, [successfulQueries, direction, assets, variantAssets]);
+
+  /**
+   * Loading while any query is in flight (retries included), and ALSO while
+   * a provider has failed and nothing has produced a supported chain: an
+   * errored provider must not be mistaken for "asset unsupported for
+   * quoting", which would settle the modal onto its external-providers
+   * fallback. The error-only refetch above keeps re-asking the failed
+   * provider, so this state resolves either into supported chains or into a
+   * genuine all-settled empty result. When other providers DID return
+   * chains, the flow proceeds with those rather than holding.
+   */
+  const isLoading =
+    isFetchingAny || (hasErroredQueries && supportedChains.length === 0);
 
   return { supportedAssetsByChainId, supportedChains, isLoading };
 };

--- a/packages/web/components/bridge/use-bridges-supported-assets.ts
+++ b/packages/web/components/bridge/use-bridges-supported-assets.ts
@@ -78,6 +78,10 @@ export const useBridgesSupportedAssets = ({
             // quoting. Bounded so a provider that is truly down still
             // settles within a few seconds.
             retry: 2,
+            // Refocus refetches would re-trigger the fetching hold below
+            // (a brief skeleton) on assets with no in-app routes; supported
+            // chains change rarely, so mount refetches are enough.
+            refetchOnWindowFocus: false,
             // NOTE: no refetchInterval — react-query v4 never interval-
             // refetches a query that settled into an error without data
             // (verified against the installed version), so the self-heal
@@ -102,15 +106,27 @@ export const useBridgesSupportedAssets = ({
       supportedAssetsResults.some(
         (data) =>
           isNil(data) ||
-          // First fetches only: a query re-polling after failures also
-          // reports isLoading (it has never had data), but must not drop
-          // the whole modal back to a skeleton when other providers already
-          // returned usable chains. errorUpdateCount is the discriminator:
-          // unlike failureCount, which react-query resets to 0 at the start
-          // of every fetch, it increments on each settled error and never
-          // resets, so a re-poll after an error is always distinguishable
-          // from a first fetch. Failing queries are handled below.
-          (data.isLoading && data.errorUpdateCount === 0)
+          // isFetching (not isLoading): background refetches of already-
+          // settled data must also count. The query cache is persisted to
+          // localStorage, so a previous session's results (including a
+          // degraded success-with-empty) hydrate as settled truth and
+          // immediately refetch on mount; treating that refetch as "not
+          // fetching" let the modal commit a default chain from stale data
+          // before the fresh response corrected it (observed as USDC
+          // defaulting to Wormhole's Solana suggestion). Note the hold this
+          // feeds is still released the moment any provider shows an in-app
+          // route, so healthy hydrated data still renders instantly.
+          //
+          // errorUpdateCount === 0 restricts this to first fetches: a query
+          // re-polling after failures also reports isFetching, but must not
+          // drop the whole modal back to a skeleton when other providers
+          // already returned usable chains. errorUpdateCount is the
+          // discriminator: unlike failureCount, which react-query resets to
+          // 0 at the start of every fetch, it increments on each settled
+          // error and never resets, so a re-poll after an error is always
+          // distinguishable from a first fetch. Failing queries are handled
+          // below.
+          (data.isFetching && data.errorUpdateCount === 0)
       ),
     [supportedAssetsResults]
   );

--- a/packages/web/components/bridge/use-bridges-supported-assets.ts
+++ b/packages/web/components/bridge/use-bridges-supported-assets.ts
@@ -70,13 +70,20 @@ export const useBridgesSupportedAssets = ({
             enabled: !isNil(assets),
             staleTime: 30_000,
             cacheTime: 30_000,
-            // Disable retries, as useQueries
-            // will block successful queries from being returned
-            // if failed queries are being returned
-            // until retry starts returning false.
-            // This causes slow UX even though there's a
-            // query that the user can use.
-            retry: false,
+            // Retry transient provider failures a couple of times. While
+            // retries run, the query counts as loading, so the modal keeps
+            // its loading state instead of settling into the external-only
+            // fallback screen: a single provider hiccup (e.g. a rate-limited
+            // Skip response) must not make an asset look unsupported for
+            // quoting. Bounded so a provider that is truly down still
+            // settles within a few seconds.
+            retry: 2,
+            // A provider that exhausted its retries self-heals while the
+            // modal stays open, instead of staying failed for the session.
+            // Healthy queries are left alone: refetching is only scheduled
+            // for errored ones.
+            refetchInterval: (_data, query) =>
+              query.state.status === "error" ? 30_000 : false,
           }
         )
       )

--- a/packages/web/components/bridge/use-bridges-supported-assets.ts
+++ b/packages/web/components/bridge/use-bridges-supported-assets.ts
@@ -5,7 +5,7 @@ import type {
 } from "@osmosis-labs/bridge";
 import { MinimalAsset } from "@osmosis-labs/types";
 import { isNil } from "@osmosis-labs/utils";
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 
 import { api, RouterOutputs } from "~/utils/trpc";
 
@@ -78,12 +78,10 @@ export const useBridgesSupportedAssets = ({
             // quoting. Bounded so a provider that is truly down still
             // settles within a few seconds.
             retry: 2,
-            // A provider that exhausted its retries self-heals while the
-            // modal stays open, instead of staying failed for the session.
-            // Healthy queries are left alone: refetching is only scheduled
-            // for errored ones.
-            refetchInterval: (_data, query) =>
-              query.state.status === "error" ? 30_000 : false,
+            // NOTE: no refetchInterval — react-query v4 never interval-
+            // refetches a query that settled into an error without data
+            // (verified against the installed version), so the self-heal
+            // re-poll of failed queries is driven manually below.
           }
         )
       )
@@ -130,6 +128,36 @@ export const useBridgesSupportedAssets = ({
       ),
     [supportedAssetsResults]
   );
+
+  // Self-heal: while any provider query is failing, re-ask the errored ones
+  // on a gentle backoff (5s, 10s, 20s, then every 30s) so a short blip
+  // doesn't cost the user half a minute of skeleton, while a sustained
+  // outage isn't hammered (the original failure mode was a rate-limited
+  // upstream). Driven manually because react-query v4 never interval-
+  // refetches a query that settled into an error without data. The results
+  // ref keeps the timer chain stable across render-to-render result churn;
+  // the chain resets to the short delays whenever failures clear and later
+  // reappear.
+  const resultsRef = useRef(supportedAssetsResults);
+  resultsRef.current = supportedAssetsResults;
+  useEffect(() => {
+    if (!hasFailingQueries) return;
+    const delaysMs = [5_000, 10_000, 20_000];
+    let attempt = 0;
+    let timeoutId: ReturnType<typeof setTimeout>;
+    const schedule = () => {
+      const delay = delaysMs[attempt] ?? 30_000;
+      attempt++;
+      timeoutId = setTimeout(() => {
+        resultsRef.current.forEach((result) => {
+          if (!isNil(result) && result.isError) result.refetch();
+        });
+        schedule();
+      }, delay);
+    };
+    schedule();
+    return () => clearTimeout(timeoutId);
+  }, [hasFailingQueries]);
 
   /**
    * Whether any successful provider returned a chain the app itself can
@@ -456,7 +484,7 @@ export const useBridgesSupportedAssets = ({
    * provider is failing and nothing has produced a supported chain: a
    * failing provider must not be mistaken for "asset unsupported for
    * quoting", which would settle the modal onto its external-providers
-   * fallback. The error-only refetch above keeps re-asking the failed
+   * fallback. The manual re-poll above keeps re-asking the failed
    * provider, so this state resolves either into supported chains or into
    * a genuine all-settled empty result. When other providers DID return
    * chains, the flow proceeds with those rather than holding.

--- a/packages/web/components/bridge/use-bridges-supported-assets.ts
+++ b/packages/web/components/bridge/use-bridges-supported-assets.ts
@@ -480,23 +480,26 @@ export const useBridgesSupportedAssets = ({
   }, [successfulQueries, direction, assets, variantAssets]);
 
   /**
-   * Loading while any query is on its first fetch, and ALSO while a
-   * provider is failing and nothing has produced a supported chain: a
-   * failing provider must not be mistaken for "asset unsupported for
-   * quoting", which would settle the modal onto its external-providers
-   * fallback. The manual re-poll above keeps re-asking the failed
-   * provider, so this state resolves either into supported chains or into
-   * a genuine all-settled empty result. When other providers DID return
-   * chains, the flow proceeds with those rather than holding.
+   * Loading until any provider has produced a chain the app itself can
+   * transfer through. While that's missing, both first fetches and failing
+   * providers hold the state: a failing provider must not be mistaken for
+   * "asset unsupported for quoting", which would settle the modal onto its
+   * external-providers fallback. Once ANY in-app route is available, the
+   * flow proceeds with it immediately — one provider's slow first fetch or
+   * retries must not hide another provider's usable route. The manual
+   * re-poll above keeps re-asking failed providers, so a held state
+   * resolves either into supported chains or a genuine all-settled empty
+   * result.
    *
    * By design, a full outage of every quote-capable provider holds this
-   * screen in its loading state indefinitely (re-polling every 30s) rather
-   * than degrading to the external-providers view: misrepresenting a
-   * quotable asset as external-only routes users to third-party sites for
-   * transfers the app itself supports, which is worse than a visible wait.
+   * screen in its loading state indefinitely (re-polling with backoff)
+   * rather than degrading to the external-providers view: misrepresenting
+   * a quotable asset as external-only routes users to third-party sites
+   * for transfers the app itself supports, which is worse than a visible
+   * wait.
    */
   const isLoading =
-    isFetchingAny || (hasFailingQueries && !hasInAppTransferSupport);
+    (isFetchingAny || hasFailingQueries) && !hasInAppTransferSupport;
 
   return { supportedAssetsByChainId, supportedChains, isLoading };
 };

--- a/packages/web/components/bridge/use-bridges-supported-assets.ts
+++ b/packages/web/components/bridge/use-bridges-supported-assets.ts
@@ -117,16 +117,20 @@ export const useBridgesSupportedAssets = ({
           // feeds is still released the moment any provider shows an in-app
           // route, so healthy hydrated data still renders instantly.
           //
-          // errorUpdateCount === 0 restricts this to first fetches: a query
-          // re-polling after failures also reports isFetching, but must not
-          // drop the whole modal back to a skeleton when other providers
-          // already returned usable chains. errorUpdateCount is the
-          // discriminator: unlike failureCount, which react-query resets to
-          // 0 at the start of every fetch, it increments on each settled
-          // error and never resets, so a re-poll after an error is always
-          // distinguishable from a first fetch. Failing queries are handled
+          // Dataless re-polls are excluded: a query re-polling after
+          // failures also reports isFetching, but must not drop the whole
+          // modal back to a skeleton on every poll cycle when other
+          // providers already returned usable chains. errorUpdateCount is
+          // the discriminator for those: unlike failureCount, which
+          // react-query resets to 0 at the start of every fetch, it
+          // increments on each settled error and never resets. A refetch
+          // that HAS data still counts even after past errors (a query that
+          // errored, then recovered with empty data, refetches with
+          // errorUpdateCount > 0, and its stale empty result must not
+          // settle the modal mid-refetch). Failing queries are handled
           // below.
-          (data.isFetching && data.errorUpdateCount === 0)
+          (data.isFetching &&
+            (data.errorUpdateCount === 0 || !isNil(data.data)))
       ),
     [supportedAssetsResults]
   );

--- a/packages/web/utils/trpc.ts
+++ b/packages/web/utils/trpc.ts
@@ -100,7 +100,10 @@ export const api = createTRPCNext<AppRouter>({
       // and data respecting the new model is fetched from the server.
       // Otherwise, the old data will be served from cache
       // and unexpected data structures will be run through the app.
-      buster: "v2",
+      // v3: drop caches that may hold poisoned success-with-empty
+      // supported-assets results persisted before the Skip counterparty
+      // mutation fix.
+      buster: "v3",
     });
 
     return {


### PR DESCRIPTION
## What

Fixes the bridge modal sometimes landing directly on the trimmed external-options ("More Withdraw Options") view and never recovering, when a provider's supported-assets lookup fails on modal open.

Linear: MTN-288

## Why

Four compounding defects: `useBridgesSupportedAssets` ran its per-provider queries with `retry: false` and no refetch interval; Skip and Squid swallowed registry failures into empty results, indistinguishable from "asset unsupported"; the amount screen treats settled-and-zero-chains as a legitimately external-only asset; and (found last, the primary trigger in production) Skip's `getSupportedAssets` mutated the module-static asset list, poisoning the serverless instance until it recycled (details in the provider section below). A single failure from the only quote-capable provider therefore made the asset look external-only for the life of the modal, with nothing ever re-asking the provider.

## How

**Client queries** (`use-bridges-supported-assets.ts`)
- `retry: 2`: retries count as loading, so the modal waits through transient failures instead of falling through to the fallback.
- Manual self-heal re-poll: while any provider query is failing, errored queries are refetched on a gentle backoff (5s, 10s, 20s, then every 30s), so short blips recover within seconds and sustained outages are not hammered. Driven by the hook itself because react-query v4 never interval-refetches a query that settled into an error without data (verified against the installed version; a `refetchInterval` here would be dead code). Healthy queries are not re-polled.
- The hook holds its loading state while a provider query is failing AND no chain the app itself can transfer through (quote or deposit-address) was found, so an exhausted provider is not mistaken for a genuinely external-only asset between re-polls. External-url-only successes (e.g. Wormhole's Solana suggestion for assets with a solana counterparty) do not release the hold: for a Skip-only asset like the USDC alloy, releasing on them settled the withdraw on Solana and landed the modal on the external-providers view. The modal proceeds as soon as ANY provider returns an in-app route: one provider's slow first fetch or automatic retries never hide another provider's usable route behind a skeleton. Re-polls are discriminated from first fetches via `errorUpdateCount` (persists across fetches) rather than `failureCount` (react-query resets it to 0 at the start of every fetch), so outage re-polls don't flash the modal.
- By design, a full outage of every quote-capable provider holds the loading state indefinitely (re-polling every 30s) rather than degrading to the external-providers view: misrepresenting a quotable asset as external-only routes users to third-party sites for transfers the app supports.
- Hydrated-stale data no longer commits the default chain: the query cache is persisted to localStorage for 24h, so a previous session's supported-assets results (including a success-with-empty persisted while the mutation bug below was live) hydrate as settled truth and the one-shot default-chain effect committed to whatever they contained (observed: USDC defaulting to Wormhole's Solana suggestion and sticking) before the mount refetch corrected them. The hold now keys on `isFetching` rather than `isLoading`, so it also covers background refetches of settled data while no in-app route is visible; healthy hydrated data still renders instantly because any in-app route releases the hold. Refocus refetches are disabled for these queries so external-only assets don't skeleton on window focus, and the persist buster is bumped (v2 to v3) to purge already-poisoned payloads from browsers. That Solana was the chain these failures defaulted to is its own gap: Wormhole's external-url suggestion is currently the only Solana path the modal knows, even though Skip quotes allUSDC to Solana as a single-tx CCTP route today. Making Solana a first-class in-app withdrawal is tracked as MTN-293.

**Providers** (`skip/index.ts`, `squid/index.ts`, `interface.ts`)
- Registry fetches are hoisted OUT of the try/catch, so infrastructure failures (registry down, rate limited) reject and the client's retry/re-poll machinery engages.
- Lookup misses (asset/token absent from a healthy registry) still resolve `[]`: an ordinary unsupported asset must not be classified as an outage, or external-only assets would skeleton forever.
- Skip's `getAsset` guards a registry response that omits the requested chain (previously a TypeError, which would now read as an outage).
- Degraded registry responses are never cached (preventive hardening; the live flip-flop initially attributed to this turned out to be the mutation bug below): the server caches Skip/Squid registry fetches for 30 minutes, so a rate-limited 200 with an empty body would be cached as truth, making supported-assets resolve success-with-empty for the cache lifetime on whichever serverless instance held it. Success-with-empty reads as "asset unsupported" and silently bypasses every client-side defense. `cachified checkValue` now rejects degraded registry responses so they throw instead of caching: an entirely empty map, and for scoped (per-chain) requests any response whose requested chain is missing or has an empty asset list. A genuinely unsupported asset is a denom absent from a POPULATED registry.
- IBC/Nitro intentionally keep their `return []` catches: they are assetlist-backed, and their misses mean "no route for this asset", not infra failure. The `getSupportedAssets` contract doc now states the distinction.
- **Root cause of the intermittent production empties** (caught live on this PR's preview via runtime logging): Skip's variant computation did `const counterparties = assetListAsset?.counterparty ?? []` (an alias into the module-static asset list, shared across requests on a serverless instance) and then pushed the variant group's counterparties into it. Since the variant group includes the asset itself, the shared array roughly doubled on every supported-assets request (observed: 2 entries to 2161 after seven calls) until the spread in `push(...)` exceeded V8's argument limit and threw "Maximum call stack size exceeded". The catch swallowed that into `[]` silently in production, so the instance served success-with-empty for every variant-grouped asset until it recycled, while fresh instances answered correctly: exactly the observed flip-flop between the full chain list and nothing on the same URL. Fixed by copying instead of aliasing, with a regression test asserting repeated calls leave the asset list untouched. The catch now also logs swallowed lookup errors in production, since this class of failure is otherwise invisible.

## Manual repro

Simulating a provider outage in DevTools:

0. Use a private window (or DevTools -> Application -> Clear site data first). The app persists its query cache to localStorage, so a previous session's supported-assets results rehydrate on load and mask the block entirely: the modal renders from cache and the blocked refetch fails silently in the background.

1. Open the Network request blocking drawer: DevTools menu (three dots) -> More tools -> Network request blocking. (Or, easiest: open the withdraw modal once, filter the Network tab for the request below, right-click it -> Block request URL, which adds and enables the block in one step.)
2. Tick "Enable network request blocking" and add the pattern `*://osmosis-frontend-git-johnnywyles-mtn-288-supported-assets-retry.vercel.dev-osmosis.zone/api/trpc/bridgeTransfer.getSupportedAssetsByBridge*`. (The supported-assets lookups are tRPC queries against the app's own `/api/trpc` endpoint; the procedure name appears in the request URL. tRPC batches all providers' lookups into one request, so this simulates a full provider outage rather than a Skip-only one.)
   Note the DevTools three-dot menu is the one INSIDE the DevTools panel (next to the gear), not the browser menu. If your browser lacks the drawer entirely, a browser-agnostic alternative is pasting this in the Console before opening the modal (restore with `window.fetch = origFetch` or a reload):

   ```js
   const origFetch = window.fetch;
   window.fetch = (...args) => {
     const url = String(args[0]?.url ?? args[0]);
     if (url.includes("getSupportedAssetsByBridge"))
       return Promise.reject(new TypeError("Simulated provider outage"));
     return origFetch(...args);
   };
   ```

3. Open the withdraw modal for a Skip-only asset (e.g. the USDC alloy).
   - Before this PR: the modal settles onto the external-providers view immediately (with the withdraw chain defaulted to Solana via Wormhole's external-url suggestion) and never recovers.
   - After: the modal stays in its loading state through the retries and the 30s re-polls.
4. Untick the blocking checkbox: the modal self-heals into the normal quote flow within seconds (re-poll backoff runs 5s/10s/20s, then every 30s) with the expected default chain.

An asset genuinely absent from Skip/Squid (external-only, e.g. one whose only transfer methods are external interfaces) still reaches the external-options view immediately, since a registry miss resolves as unsupported rather than as an outage.








