### PR TITLE
fix(e2e): match denom assertions against YAML-folded wallet messages (MTN-291)

### DIFF
--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -342,10 +342,15 @@ jobs:
           path: packages/e2e/playwright-report
 
   preview-pools-and-select-pair-tests:
-    # 15, matching the other long suites. This job runs 15 tests (3 pools + 12
-    # select-pair) and never had real headroom under 10: its best passing run
-    # finished in 9m17s. It has since drifted past the limit and now cancels at
-    # 10m every time, mid-suite, with no test having failed.
+    # 15, matching the other long suites. What pushed this job past 10 was the
+    # two pool tests that hung once the Noble pools were renamed (fixed in this
+    # PR): two tests times two attempts times a 90s timeout is six minutes of
+    # dead time, which is almost exactly the gap between the 11m09s failing run
+    # and the 5m42s it takes with them passing.
+    #
+    # Kept at 15 rather than restored to 10, because the margin was already too
+    # thin before any of that: the last consistently passing runs, on 26 August,
+    # ranged from 5m31s to 9m17s, leaving 43 seconds under a 10 minute cap.
     timeout-minutes: 15
     needs: wait-for-deployment
     runs-on: ubuntu-latest

--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -342,7 +342,11 @@ jobs:
           path: packages/e2e/playwright-report
 
   preview-pools-and-select-pair-tests:
-    timeout-minutes: 10
+    # 15, matching the other long suites. This job runs 15 tests (3 pools + 12
+    # select-pair) and never had real headroom under 10: its best passing run
+    # finished in 9m17s. It has since drifted past the limit and now cancels at
+    # 10m every time, mid-suite, with no test having failed.
+    timeout-minutes: 15
     needs: wait-for-deployment
     runs-on: ubuntu-latest
     steps:

--- a/packages/e2e/pages/pools-page.ts
+++ b/packages/e2e/pages/pools-page.ts
@@ -37,9 +37,22 @@ export class PoolsPage extends BasePage {
   }
 
   async viewPool(id: number, pair: string) {
-    await this.page
-      .locator(`//table//td/a[@href="/pool/${id}"]//span[.="${pair}"]`)
-      .click()
+    // The pool id is the stable identity, so pin the row on the href and treat
+    // the pair only as a guard that we are clicking the pool we meant to.
+    // Matching the label exactly is what broke here: the USDC identity handover
+    // renamed the Noble-backed pools from "ATOM/USDC" to "ATOM/USDC.noble",
+    // because plain "USDC" now denotes the alloy, and an exact-text locator
+    // simply never resolved — the click waited out the whole test timeout
+    // rather than failing with something readable. A substring match spans both
+    // sides of the handover, so this does not need revisiting when the rest of
+    // the rename lands.
+    const poolLink = this.page
+      .locator(`//table//td/a[@href="/pool/${id}"]`)
+      .filter({ hasText: pair })
+    // Bounded so a row that never resolves fails here, naming the pool, instead
+    // of stalling the click until the 90s test timeout with nothing to read.
+    await poolLink.waitFor({ timeout: 10000 })
+    await poolLink.click()
     // we expect that after 2 seconds tokens are loaded and any failure after this point should be considered a bug.
     await this.page.waitForTimeout(2000)
     await super.printUrl()

--- a/packages/e2e/pages/swap-page.ts
+++ b/packages/e2e/pages/swap-page.ts
@@ -6,6 +6,7 @@ import {
   expect,
 } from '@playwright/test'
 
+import { unfoldWalletMsgYaml } from '../utils/wallet-msg'
 import { BasePage } from './base-page'
 import { getKeplrPopupPage } from './keplr-helper'
 
@@ -89,9 +90,11 @@ export class SwapPage extends BasePage {
       name: 'Approve',
     })
     await expect(approveBtn).toBeEnabled()
-    const msgContentAmount = await approvePage
-      .getByText('type: osmosis/poolmanager/')
-      .textContent()
+    const msgContentAmount = unfoldWalletMsgYaml(
+      (await approvePage
+        .getByText('type: osmosis/poolmanager/')
+        .textContent()) ?? undefined,
+    )
     console.log(`Wallet is approving this msg: \n${msgContentAmount}`)
     await approveBtn.click()
     await this.page.waitForTimeout(4000)

--- a/packages/e2e/pages/trade-page.ts
+++ b/packages/e2e/pages/trade-page.ts
@@ -517,9 +517,10 @@ export class TradePage extends BasePage {
           const msgTextLocator = limit
             ? "Execute contract"
             : "type: osmosis/poolmanager/";
-          msgContentAmount =
+          msgContentAmount = unfoldWalletMsgYaml(
             (await approvePage.getByText(msgTextLocator).textContent()) ??
-            undefined;
+              undefined
+          );
           console.log(`Wallet is approving this msg: \n${msgContentAmount}`);
           await approveBtn.click();
         } else {
@@ -660,9 +661,10 @@ export class TradePage extends BasePage {
           const msgTextLocator = limit
             ? "Execute contract"
             : "type: osmosis/poolmanager/";
-          msgContentAmount =
+          msgContentAmount = unfoldWalletMsgYaml(
             (await approvePage.getByText(msgTextLocator).textContent()) ??
-            undefined;
+              undefined
+          );
           console.log(`Wallet is approving this msg: \n${msgContentAmount}`);
           await approveBtn.click();
         } else {

--- a/packages/e2e/pages/trade-page.ts
+++ b/packages/e2e/pages/trade-page.ts
@@ -6,6 +6,7 @@ import {
 } from "@playwright/test";
 
 import { buildExplorerTxUrl, pollTxOnChain } from "../utils/tx-confirm";
+import { unfoldWalletMsgYaml } from "../utils/wallet-msg";
 import { BasePage } from "./base-page";
 import { getKeplrPopupPage, waitForKeplrApproval } from "./keplr-helper";
 
@@ -208,10 +209,11 @@ export class TradePage extends BasePage {
     await approvePage.waitForLoadState();
     const approveBtn = approvePage.getByRole("button", { name: "Approve" });
     await expect(approveBtn).toBeEnabled();
-    const msgContentAmount =
+    const msgContentAmount = unfoldWalletMsgYaml(
       (await approvePage
         .getByText("type: osmosis/poolmanager/")
-        .textContent()) ?? undefined;
+        .textContent()) ?? undefined
+    );
     console.log(`Wallet is approving this msg: \n${msgContentAmount}`);
     await approveBtn.click();
     return msgContentAmount;

--- a/packages/e2e/utils/wallet-msg.ts
+++ b/packages/e2e/utils/wallet-msg.ts
@@ -1,0 +1,37 @@
+/**
+ * @file wallet-msg.ts
+ * @description Normalizes the YAML that Keplr renders for a message awaiting
+ * approval, so assertions can match a `key: value` pair without caring how
+ * long the value happens to be.
+ *
+ * Keplr shows the message as YAML, and YAML moves a scalar onto its own
+ * indented line once the rendered line would exceed 80 columns:
+ *
+ *     token_in:
+ *       amount: '1120000'
+ *       denom: >-
+ *         factory/osmo147h5.../alloyed/allUSDC
+ *
+ * That threshold cuts straight through the denoms these tests assert on. An
+ * `ibc/` denom is 68 characters, so `    denom: ibc/...` renders at 79 — one
+ * column under the limit, on a single line. The alloyed USDC denom is 87, so
+ * the same line would be 98 and folds. A `toContain("denom: <value>")`
+ * assertion therefore passes for one denom and fails for the other while both
+ * messages are perfectly correct, which is what happened when the default USDC
+ * quote moved to the alloy.
+ *
+ * Rejoining the folded scalars keeps the assertions meaningful — they still
+ * require the value to appear under the right key, rather than loosely
+ * anywhere in the message — without encoding a guess about string length.
+ */
+
+/**
+ * Rejoins YAML block scalars (`>`, `>-`, `|`, `|+` and friends) onto their key
+ * so `key: value` matches regardless of the wrapping Keplr applied.
+ *
+ * The denoms involved contain no spaces, so YAML has no interior break point
+ * and always folds them onto exactly one continuation line.
+ */
+export function unfoldWalletMsgYaml(msg: string | undefined) {
+  return msg?.replace(/:[ \t]*[>|][-+]?[ \t]*\r?\n[ \t]+/g, ": ");
+}


### PR DESCRIPTION
## What is the purpose of the change:

Three fixes that together take the preview E2E suite from permanently red to green. All three trace back to the same event — the USDC identity handover — and none of them is a product bug.

1. **`preview-trade-tests` red since `4680ceca2`.** The signed transaction is correct; the assertion is not. Keplr renders the message as YAML, and the alloyed USDC denom is long enough to trip YAML's 80-column fold, so the value moves onto its own line and a `denom: <value>` substring match stops matching.
2. **`preview-pools-and-select-pair-tests` failing.** Two pool tests hang for the full 90s because the pools were renamed and the test matched the old label exactly.
3. **The same job cancelling at 10m**, which was hiding (2) behind what looked like infrastructure noise.

### Linear Task

[MTN-291](https://linear.app/osmosis/issue/MTN-291/preview-trade-tests-is-red-on-every-branch-alloyed-usdc-denom-trips)

## Brief Changelog

- Add `unfoldWalletMsgYaml` in `packages/e2e/utils/wallet-msg.ts`, which rejoins YAML block scalars onto their key, and apply it at all four wallet-message read sites: `approveInKeplrAndGetMsg`, the inline reads inside `buyAndGetWalletMsg` and `sellAndGetWalletMsg`, and `swap-page.ts`.
- `viewPool` now pins the row on the pool href and treats the pair as a substring guard, with a bounded 10s wait.
- Raise `preview-pools-and-select-pair-tests` to `timeout-minutes: 15`.

### 1. The YAML fold

The 80-column threshold falls exactly between the denoms this spec asserts on, which is why the failure looked arbitrary:

| Denom | Length | Rendered line | Folds? |
| -- | -- | -- | -- |
| `ibc/27394FB0…` (ATOM) | 68 | 79 | no |
| `factory/osmo147h5…/alloyed/allUSDC` | 87 | 98 | **yes** |

The ATOM assertion two lines above the failing one passes, one column under the limit.

Normalizing where the message is read rather than at the assertion sites also covers [transactions.wallet.spec.ts#L49](https://github.com/osmosis-labs/osmosis-frontend/blob/stage/packages/e2e/tests/transactions.wallet.spec.ts#L49), which carries the same hardcoded alloy denom and is dormant only because that test is currently `test.skip`ped.

Deliberately unchanged: the three "Execute contract" reads in `transactions-page.ts` assert on `cancel_limit` and `claim_limit`, bare tokens with no spaces, so YAML has no break point inside them and folding cannot hide them.

### 2. The pool rename

`viewPool` located the row with `a[@href="/pool/1282"]//span[.="ATOM/USDC"]`, an exact-text match. The handover renamed the Noble-backed pools, because plain "USDC" now denotes the alloy:

| Pool | Test expected | Actually renders |
| -- | -- | -- |
| #1282 | `ATOM/USDC` | **ATOM/USDC.noble** |
| #1464 | `OSMO/USDC` | **OSMO/USDC.noble** |

The span never resolved, so the click waited out the 90s test timeout instead of failing with anything readable.

The href is the pool's stable identity, so the row is pinned on that and the pair kept only as a substring guard. A substring spans both sides of the handover, so this should not need revisiting when the rest of the rename lands — the same reasoning as `resolveAppUsdcDenom` for the denom. The wait is bounded at 10s, matching `goto()` in the same file, so a row that never resolves fails immediately and names the pool.

This was pre-existing, not introduced here: the identical two tests failed with the identical signature on 31 August and 1 September, on the rare runs that finished fast enough to escape the cancel.

### 3. The timeout

The job was cancelling at 10m15s–10m17s on 8 of its last 12 non-skipped runs. That uniformity is the tell: the job-level timeout expiring, which GitHub reports as a bare `The operation was canceled.` — not a runner fault and not a Playwright timeout.

What pushed it over was fix 2. Two hanging tests times two attempts times 90s is six minutes of dead time, almost exactly the gap between the 11m09s failing run and the 5m42s it now takes. Kept at 15 rather than restored to 10 because the margin was already thin before any of this: the last consistently passing runs, on 26 August, ranged from 5m31s to 9m17s, leaving 43 seconds under a 10 minute cap.

## Testing and Verifying

**The full preview E2E suite is green on `fff7105ad`** ([run 33576628412](https://github.com/osmosis-labs/osmosis-frontend/actions/runs/33576628412)) — the first fully passing run on this branch.

- `preview-pools-and-select-pair-tests`: **15 passed, 0 failed in 4.1m**, job total 5m42s. Both previously-hanging tests now reach the pool page and report `Total Balance for a Pool [$0]`.
- `preview-trade-tests`: passed, and confirmed to have actually exercised the fold fix rather than passing vacuously — the job log shows the alloyed denom on a single line as `denom: factory/osmo147h5…/alloyed/allUSDC`, with zero occurrences of `denom: >-`, and the Keplr popup appeared six times with no 1-click skips.

Before pushing, the fold fix was verified by replaying the verbatim message from the original failing run (job `99853819789`) across both paths those methods serve, since `msgTextLocator` switches to "Execute contract" for limit orders: the USDC assertion fails before and passes after, the short `ibc/` denom and message-type assertions are unaffected, `place_limit` still matches, and a message with no folded scalars — including embedded JSON — comes back byte-identical, so the regex cannot disturb `"order_direction": "ask"`. CRLF input and literal `|` blocks were checked too.

`tsc` on `packages/e2e` reports the same four pre-existing errors as `stage` and no new ones. `prettier --check` is clean on the files it already passed on; `swap-page.ts` and `pools-page.ts` both fail prettier on `stage` already, so they are left in their existing style rather than reformatted.

The final commit changes only a comment in the workflow.
