### PR TITLE
perf(web): reduce pool page Function invocations

### DIFF
--- a/packages/web/middleware.ts
+++ b/packages/web/middleware.ts
@@ -10,10 +10,6 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: [
-    /*
-     * Match all request paths
-     */
-    "/(.*)",
-  ],
+  // The bot check protects API backends; avoid invoking middleware for pages and assets.
+  matcher: "/api/:path*",
 };

--- a/packages/web/pages/api/pools.ts
+++ b/packages/web/pages/api/pools.ts
@@ -79,7 +79,7 @@ export default async function pools(req: Request) {
     return new Response(JSON.stringify(response), {
       status: 200,
       headers: {
-        "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300",
+        "Cache-Control": "public, s-maxage=60",
       },
     });
   }

--- a/packages/web/pages/api/pools.ts
+++ b/packages/web/pages/api/pools.ts
@@ -76,7 +76,12 @@ export default async function pools(req: Request) {
   const response: Response = { pools, totalNumberOfPools };
 
   if (pools) {
-    return new Response(JSON.stringify(response), { status: 200 });
+    return new Response(JSON.stringify(response), {
+      status: 200,
+      headers: {
+        "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300",
+      },
+    });
   }
   return new Response("", { status: 500 });
 }

--- a/packages/web/pages/api/pools.ts
+++ b/packages/web/pages/api/pools.ts
@@ -78,9 +78,10 @@ export default async function pools(req: Request) {
   if (pools) {
     return new Response(JSON.stringify(response), {
       status: 200,
-      headers: {
-        "Cache-Control": "public, s-maxage=60",
-      },
+      headers:
+        pools.length > 0
+          ? { "Cache-Control": "public, s-maxage=60" }
+          : undefined,
     });
   }
   return new Response("", { status: 500 });

--- a/packages/web/pages/api/pools/[id].ts
+++ b/packages/web/pages/api/pools/[id].ts
@@ -46,7 +46,12 @@ export default async function pools(req: Request) {
     return { ...pool.raw, ["@type"]: COSMWASM_POOL_TYPE };
   });
   const response: Response = { pool: pool as PoolRaw };
-  return new Response(JSON.stringify(response), { status: 200 });
+  return new Response(JSON.stringify(response), {
+    status: 200,
+    headers: {
+      "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300",
+    },
+  });
 }
 
 export const config = {

--- a/packages/web/pages/api/pools/[id].ts
+++ b/packages/web/pages/api/pools/[id].ts
@@ -46,12 +46,7 @@ export default async function pools(req: Request) {
     return { ...pool.raw, ["@type"]: COSMWASM_POOL_TYPE };
   });
   const response: Response = { pool: pool as PoolRaw };
-  return new Response(JSON.stringify(response), {
-    status: 200,
-    headers: {
-      "Cache-Control": "public, s-maxage=60",
-    },
-  });
+  return new Response(JSON.stringify(response), { status: 200 });
 }
 
 export const config = {

--- a/packages/web/pages/api/pools/[id].ts
+++ b/packages/web/pages/api/pools/[id].ts
@@ -49,7 +49,7 @@ export default async function pools(req: Request) {
   return new Response(JSON.stringify(response), {
     status: 200,
     headers: {
-      "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300",
+      "Cache-Control": "public, s-maxage=60",
     },
   });
 }

--- a/packages/web/pages/pool/[id].tsx
+++ b/packages/web/pages/pool/[id].tsx
@@ -1,6 +1,6 @@
 import { useRouter } from "next/router";
 import { NextSeo } from "next-seo";
-import { FunctionComponent, useEffect, useState } from "react";
+import { FunctionComponent, useEffect, useMemo, useState } from "react";
 
 import { SkeletonLoader } from "~/components/loaders/skeleton-loader";
 import {
@@ -10,7 +10,6 @@ import {
 } from "~/components/pool-detail";
 import { useTranslation, useWindowSize } from "~/hooks";
 import { useNavBar } from "~/hooks";
-import { useConst } from "~/hooks/use-const";
 import { TradeTokens } from "~/modals";
 import { api } from "~/utils/trpc";
 
@@ -33,10 +32,15 @@ const Pool: FunctionComponent = () => {
   const [showTradeModal, setShowTradeModal] = useState(false);
 
   useNavBar(
-    useConst({
-      title: t("pool.title", { id: poolId ?? "" }),
-      ctas: [{ label: t("pool.swap"), onClick: () => setShowTradeModal(true) }],
-    })
+    useMemo(
+      () => ({
+        title: t("pool.title", { id: poolId }),
+        ctas: [
+          { label: t("pool.swap"), onClick: () => setShowTradeModal(true) },
+        ],
+      }),
+      [poolId, t]
+    )
   );
 
   // Redirects

--- a/packages/web/pages/pool/[id].tsx
+++ b/packages/web/pages/pool/[id].tsx
@@ -1,4 +1,3 @@
-import { GetServerSideProps, InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import { NextSeo } from "next-seo";
 import { FunctionComponent, useEffect, useState } from "react";
@@ -15,28 +14,23 @@ import { useConst } from "~/hooks/use-const";
 import { TradeTokens } from "~/modals";
 import { api } from "~/utils/trpc";
 
-interface Props {
-  id: string;
-}
-
-const Pool: FunctionComponent<Props> = ({
-  poolId,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) => {
+const Pool: FunctionComponent = () => {
   const router = useRouter();
+  const poolId = typeof router.query.id === "string" ? router.query.id : "";
   const { t } = useTranslation();
   const { isMobile } = useWindowSize();
+  const isValidPoolId = Boolean(poolId && !isNaN(+poolId));
 
   const {
     data: pool,
     isError,
     error,
-  } = api.local.pools.getPool.useQuery({ poolId });
+  } = api.local.pools.getPool.useQuery(
+    { poolId },
+    { enabled: router.isReady && isValidPoolId }
+  );
 
   const [showTradeModal, setShowTradeModal] = useState(false);
-
-  const isValidPoolId = Boolean(
-    poolId && typeof poolId === "string" && Boolean(poolId) && !isNaN(+poolId)
-  );
 
   useNavBar(
     useConst({
@@ -119,13 +113,6 @@ const Pool: FunctionComponent<Props> = ({
       )}
     </>
   );
-};
-
-export const getServerSideProps: GetServerSideProps = async ({
-  resolvedUrl,
-}) => {
-  const splitUrl = resolvedUrl.split("/");
-  return { props: { poolId: splitUrl.pop() ?? "-" } };
 };
 
 export default Pool;


### PR DESCRIPTION
## Summary
Combines three Vercel agent PRs that currently target `master` onto `stage`:

- #4458 — statically serve `/pool/[id]` (remove `getServerSideProps`)
- #4459 — scope bot middleware to `/api/:path*`

These are independent, non-overlapping changes that cut Edge/Node Function invocations on public pool traffic.

## Validation
- Applied onto `origin/stage` with no conflicts
- Original PRs: #4458, #4459, #4460